### PR TITLE
test: dst feature lowers to debug_assert

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -184,22 +184,22 @@ jobs:
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           cargo pgrx init --pg${{ env.PG_VERSION }}=$PG_CONFIG_PATH
 
-      # The Antithesis build adds a sancov pass (-Cpasses=sancov-module) for coverage instrumentation.
-      # ThinLTO drops Rust symbols under that pass, producing a pg_search.so that fails to dlopen, so disable LTO here.
+      # `dev` profile: full debug assertions in the SUT. `--features dst` adds the Antithesis
+      # coverage instrumentation; --target scopes the sancov flags off host build scripts.
+      # See docs/reference/sdk/rust/instrumentation.
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id"
         run: |
-          sudo curl -fsSL -o /usr/lib/libvoidstar.so https://antithesis.com/assets/instrumentation/libvoidstar.so
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
-          RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -lvoidstar" \
-          CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
-            cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH" --features dst
+          cargo pgrx package --profile=dev --target x86_64-unknown-linux-gnu --pg-config "$PG_CONFIG_PATH" --features dst
 
       # Catch the broken-symbol case above before shipping to Antithesis.
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.
       - name: Verify pg_search Has No Unresolved Rust Symbols
         run: |
-          LIB_PATH="target/release-with-debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
+          LIB_PATH="target/x86_64-unknown-linux-gnu/debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
           undefined_rust="$(nm -D -u "$LIB_PATH" | awk '{print $NF}' | grep -E '^_(ZN|R)' || true)"
           if [ -n "$undefined_rust" ]; then
             echo "::error::pg_search.so has unresolved Rust symbols — the build is broken and would fail to load:"
@@ -208,9 +208,23 @@ jobs:
           fi
           echo "OK: pg_search.so has no unresolved Rust symbols"
 
+      # Fail on a silently-uninstrumented .so (shim symbol + sancov section); before stripping.
+      - name: Verify pg_search Is Antithesis-Instrumented
+        run: |
+          LIB_PATH="target/x86_64-unknown-linux-gnu/debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
+          if ! nm "$LIB_PATH" | grep -q "antithesis_load_libvoidstar"; then
+            echo "::error::pg_search.so is missing the antithesis_load_libvoidstar shim — the instrumentation runtime was not linked"
+            exit 1
+          fi
+          if ! readelf -S "$LIB_PATH" | grep -qi "sancov"; then
+            echo "::error::pg_search.so has no sancov section — the coverage pass did not run"
+            exit 1
+          fi
+          echo "OK: pg_search.so is instrumented (shim linked + sancov section present)"
+
       - name: Split pg_search Debug Symbols
         run: |
-          LIB_PATH="target/release-with-debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
+          LIB_PATH="target/x86_64-unknown-linux-gnu/debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
           objcopy --only-keep-debug "${LIB_PATH}" "${LIB_PATH}.dbg"
           objcopy --strip-debug "${LIB_PATH}"
           objcopy --add-gnu-debuglink="${LIB_PATH}.dbg" "${LIB_PATH}"
@@ -219,7 +233,7 @@ jobs:
         run: |
           # Create installable package
           mkdir archive
-          cp `find target/release-with-debug -type f -name "pg_search*"` archive
+          cp `find target/x86_64-unknown-linux-gnu/debug -type f -name "pg_search*"` archive
           package_dir=pg_search-antithesis-${{ steps.version.outputs.os_version }}-amd64-pg${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}
 
           mkdir -p ${package_dir}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -184,22 +184,22 @@ jobs:
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           cargo pgrx init --pg${{ env.PG_VERSION }}=$PG_CONFIG_PATH
 
-      # `dev` profile: full debug assertions in the SUT. `--features dst` adds the Antithesis
+      # `dst` profile: full debug assertions in the SUT. `--features dst` adds the Antithesis
       # coverage instrumentation; --target scopes the sancov flags off host build scripts.
-      # See docs/reference/sdk/rust/instrumentation.
+      # See https://antithesis.com/docs/reference/sdk/rust/instrumentation
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id"
         run: |
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
-          cargo pgrx package --profile=dev --target x86_64-unknown-linux-gnu --pg-config "$PG_CONFIG_PATH" --features dst
+          cargo pgrx package --profile=dst --target x86_64-unknown-linux-gnu --pg-config "$PG_CONFIG_PATH" --features dst
 
       # Catch the broken-symbol case above before shipping to Antithesis.
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.
       - name: Verify pg_search Has No Unresolved Rust Symbols
         run: |
-          LIB_PATH="target/x86_64-unknown-linux-gnu/debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
+          LIB_PATH="target/x86_64-unknown-linux-gnu/dst/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
           undefined_rust="$(nm -D -u "$LIB_PATH" | awk '{print $NF}' | grep -E '^_(ZN|R)' || true)"
           if [ -n "$undefined_rust" ]; then
             echo "::error::pg_search.so has unresolved Rust symbols — the build is broken and would fail to load:"
@@ -211,7 +211,7 @@ jobs:
       # Fail on a silently-uninstrumented .so (shim symbol + sancov section); before stripping.
       - name: Verify pg_search Is Antithesis-Instrumented
         run: |
-          LIB_PATH="target/x86_64-unknown-linux-gnu/debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
+          LIB_PATH="target/x86_64-unknown-linux-gnu/dst/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
           if ! nm "$LIB_PATH" | grep -q "antithesis_load_libvoidstar"; then
             echo "::error::pg_search.so is missing the antithesis_load_libvoidstar shim — the instrumentation runtime was not linked"
             exit 1
@@ -224,7 +224,7 @@ jobs:
 
       - name: Split pg_search Debug Symbols
         run: |
-          LIB_PATH="target/x86_64-unknown-linux-gnu/debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
+          LIB_PATH="target/x86_64-unknown-linux-gnu/dst/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
           objcopy --only-keep-debug "${LIB_PATH}" "${LIB_PATH}.dbg"
           objcopy --strip-debug "${LIB_PATH}"
           objcopy --add-gnu-debuglink="${LIB_PATH}.dbg" "${LIB_PATH}"
@@ -233,7 +233,7 @@ jobs:
         run: |
           # Create installable package
           mkdir archive
-          cp `find target/x86_64-unknown-linux-gnu/debug -type f -name "pg_search*"` archive
+          cp `find target/x86_64-unknown-linux-gnu/dst -type f -name "pg_search*"` archive
           package_dir=pg_search-antithesis-${{ steps.version.outputs.os_version }}-amd64-pg${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}
 
           mkdir -p ${package_dir}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -143,7 +143,16 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "antithesis-instrumentation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6b548668212c6d3a942a4ac7be13bc4fc25715bf661328438f30e3fd342cf0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2665,7 +2674,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2720,6 +2729,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 name = "dst"
 version = "0.25.0"
 dependencies = [
+ "antithesis-instrumentation",
  "antithesis_sdk",
  "serde_json",
 ]
@@ -2993,7 +3003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3805,7 +3815,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4177,7 +4187,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5360,7 +5370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5523,6 +5533,7 @@ dependencies = [
 name = "pg_search"
 version = "0.25.0"
 dependencies = [
+ "antithesis-instrumentation",
  "anyhow",
  "arrow-array",
  "arrow-buffer",
@@ -6252,7 +6263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6976,7 +6987,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7034,7 +7045,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7463,7 +7474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8106,7 +8117,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9094,7 +9105,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,11 @@ panic = "unwind"
 opt-level = 3
 codegen-units = 1
 
+# Optimized + debug symbols, for profiling; debug-assertions off keeps dst asserts compiled out.
 [profile.release-with-debug]
 inherits = "release"
 debug = true
+debug-assertions = false
 
 [workspace.dependencies]
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "055cfd0afffa7823aa9e835d67ae290c765d616a", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ inherits = "release"
 debug = true
 debug-assertions = false
 
+# Antithesis build profile — `dev`-like (debug assertions on) but isolated so it can be tuned
+# without affecting `dev`.
+[profile.dst]
+inherits = "dev"
+
 [workspace.dependencies]
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "055cfd0afffa7823aa9e835d67ae290c765d616a", features = [
   "columnar-zstd-compression",

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -60,12 +60,12 @@ ENV PGCLIENTENCODING=UTF8
 # host triple (resolved here, not hardcoded, so it also builds on arm64 CI) via
 # CARGO_TARGET_<triple>_RUSTFLAGS + --target, keeping them off host build scripts. Coverage shim
 # comes from `--features dst`; its build script needs curl + a C toolchain.
-# See docs/reference/sdk/rust/instrumentation.
+# See https://antithesis.com/docs/reference/sdk/rust/instrumentation
 RUN cargo fetch --manifest-path /home/app/Cargo.toml && \
     TARGET="$(rustc -vV | sed -n 's/^host: //p')" && \
     env "CARGO_TARGET_$(echo "$TARGET" | tr 'a-z-' 'A-Z_')_RUSTFLAGS=-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id" \
-        cargo build --offline --target "$TARGET" \
+        cargo build --offline --profile dst --target "$TARGET" \
         --manifest-path /home/app/Cargo.toml -p stressgres && \
-    ln -sf "/home/app/target/$TARGET/debug/stressgres" /symbols/stressgres
+    ln -sf "/home/app/target/$TARGET/dst/stressgres" /symbols/stressgres
 
 CMD ["sleep", "infinity"]

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -13,6 +13,9 @@
 
 FROM rust:1.97-slim-trixie
 
+# pipefail for the piped build command below (hadolint DL4006).
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install build and runtime dependencies. Upgrade existing OS packages first so
 # we pick up the latest Debian security fixes regardless of the base layer's age.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
@@ -24,6 +27,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libjpeg-dev \
     libfontconfig1-dev \
     ca-certificates \
+    curl \
     postgresql-client \
     libpq5 \
     util-linux \
@@ -31,6 +35,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 
 # Create app user
 RUN useradd --create-home --shell /bin/bash app
+
+# Symbolization: Antithesis reads debug info from /symbols. The build step below symlinks the
+# (unstripped) binary in, so make it app-owned.
+RUN mkdir -p /symbols && chown app:app /symbols
 
 # Set working directory
 WORKDIR /home/app
@@ -48,9 +56,16 @@ USER app
 ENV RUST_LOG=info
 ENV PGCLIENTENCODING=UTF8
 
-# Prefetch deps and build Stressgres while we have Internet. This Docker image
-# will be run in an air-gapped environment in Antithesis
+# Prefetch while online; the image runs air-gapped in Antithesis. Sancov flags are scoped to the
+# host triple (resolved here, not hardcoded, so it also builds on arm64 CI) via
+# CARGO_TARGET_<triple>_RUSTFLAGS + --target, keeping them off host build scripts. Coverage shim
+# comes from `--features dst`; its build script needs curl + a C toolchain.
+# See docs/reference/sdk/rust/instrumentation.
 RUN cargo fetch --manifest-path /home/app/Cargo.toml && \
-    cargo build --offline --release --manifest-path /home/app/Cargo.toml -p stressgres
+    TARGET="$(rustc -vV | sed -n 's/^host: //p')" && \
+    env "CARGO_TARGET_$(echo "$TARGET" | tr 'a-z-' 'A-Z_')_RUSTFLAGS=-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id" \
+        cargo build --offline --target "$TARGET" \
+        --manifest-path /home/app/Cargo.toml -p stressgres && \
+    ln -sf "/home/app/target/$TARGET/debug/stressgres" /symbols/stressgres
 
 CMD ["sleep", "infinity"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ There are three flavors of files generated:
 
 - `paradedb`: The default ParadeDB Docker image, published to `paradedb/paradedb`. Includes Barman Cloud which is used in our CNPG deployments.
 - `official`: The image for Docker Official Images which will be published to `paradedb` once approved by Docker. Does not include Barman.
-- `antithesis`: The image used by Antithesis test runs. Includes `libvoidstar`, Antithesis' instrumentation library.
+- `antithesis`: The image used by Antithesis test runs. Its `pg_search` is built with Antithesis coverage instrumentation (see `docs/reference/sdk/rust/instrumentation`); `libvoidstar` is injected at runtime rather than baked into the image.
 
 `paradedb` and `official` both install Debian artifacts published to GitHub Releases. `antithesis` installs a locally built `.deb` so that it can be run on a per-commit basis.
 

--- a/dst/Cargo.toml
+++ b/dst/Cargo.toml
@@ -9,17 +9,15 @@ license.workspace = true
 workspace = true
 
 [features]
-# Off by default: with `enabled` unset the whole crate compiles to nothing — the assertion
-# macros expand to a dead `if false { … }` that still type-checks their arguments,
-# `GhostState<T>` is a zero-sized type, and `init()` is a no-op, so a build that does not opt
-# in never links the Antithesis SDK. Turning `enabled` on pulls in the SDK and dispatches for
-# real.
-enabled = ["dep:antithesis_sdk"]
+# Off by default the crate compiles to nothing; `enabled` links the SDK + coverage shim. See lib.rs.
+enabled = ["dep:antithesis_sdk", "dep:antithesis-instrumentation"]
 
 [dependencies]
 antithesis_sdk = { version = "0.2.9", default-features = false, features = [
   "full",
 ], optional = true }
+# Coverage shim: provides the sancov symbols and loads libvoidstar at runtime.
+antithesis-instrumentation = { version = "0.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/dst/src/lib.rs
+++ b/dst/src/lib.rs
@@ -18,12 +18,14 @@
 //! Deterministic-simulation-testing (DST) hooks — the one place that talks to the Antithesis
 //! Rust SDK.
 //!
-//! Everything here is gated on the crate's `enabled` feature. With `enabled` **off** (the
-//! default) the crate compiles to nothing: the assertion macros expand to a dead
-//! `if false { … }` that still type-checks their arguments, [`GhostState<T>`] is a zero-sized
-//! type, `observe!` closures are type-checked but never run, and [`init`] is a no-op — so a
-//! consumer that does not opt in never links the SDK. With `enabled` **on** the macros forward
-//! to `antithesis_sdk` and dispatch for real.
+//! Three build configurations, selected automatically:
+//!
+//! * **`enabled`** — macros forward to `antithesis_sdk`; used for Antithesis runs
+//!   (`pg_search --features dst`).
+//! * **`enabled` off, `debug_assertions` on** — the always/unreachable asserts lower to
+//!   `debug_assert!` and `GhostState`/`observe!` run, so invariants are also checked in normal
+//!   testing; `assert_sometimes!`/`assert_reachable!` need a whole run, so they only type-check.
+//! * **neither** (release) — compiles to nothing.
 //!
 //! The assertion wrappers mirror the SDK's signatures (`$message` must be a string literal) and
 //! are macros, not functions, so each assertion's location is captured at the real call site.
@@ -52,17 +54,73 @@ pub fn init() {
 #[cfg(not(feature = "enabled"))]
 pub fn init() {}
 
-// Two generator macros stamp out the wrappers (each forwards to the identically-named
-// `antithesis_sdk` macro when enabled, or a type-checking-only `if false { … }` when not — see
-// the crate docs). `$d` is bound to `$` at each call site so the generated macro can name its own
-// metavariables — the standard escape for a macro that defines a macro.
+// The leading `debug_assert` / `type_only` keyword selects the SDK-off lowering (see crate docs).
+// `$d` is bound to `$` so a generated macro can name its own metavariables (the escape for a macro
+// that defines a macro).
+
+// Type-check-only expansion for a compiled-out assertion: evaluates nothing.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __dst_typecheck_cond {
+    ($condition:expr, $message:literal $(, $details:expr)?) => {
+        if false {
+            let _: bool = $condition;
+            let _: &str = $message;
+            $(let _ = &$details;)?
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __dst_typecheck_msg {
+    ($message:literal $(, $details:expr)?) => {
+        if false {
+            let _: &str = $message;
+            $(let _ = &$details;)?
+        }
+    };
+}
 
 /// Generate a condition-style wrapper: `name!(condition, "message" [, &details])`.
 // rustfmt cannot format a `macro_rules!` that defines a `macro_rules!` idempotently — each pass
 // re-indents the nested arms further — so pin this generator's formatting by hand.
 #[rustfmt::skip]
 macro_rules! define_condition_assert {
-    ($d:tt $name:ident, $doc:literal) => {
+    (debug_assert $d:tt $name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[cfg(feature = "enabled")]
+        #[macro_export]
+        macro_rules! $name {
+            ($d condition:expr, $d message:literal $d(, $d details:expr)?) => {
+                $crate::antithesis_sdk::$name!($d condition, $d message $d(, $d details)?)
+            };
+        }
+
+        // `details` folds into the panic message.
+        #[doc = $doc]
+        #[cfg(all(not(feature = "enabled"), debug_assertions))]
+        #[macro_export]
+        macro_rules! $name {
+            ($d condition:expr, $d message:literal, $d details:expr) => {
+                ::core::debug_assert!($d condition, "{}: {:?}", $d message, $d details)
+            };
+            ($d condition:expr, $d message:literal) => {
+                ::core::debug_assert!($d condition, "{}", $d message)
+            };
+        }
+
+        #[doc = $doc]
+        #[cfg(all(not(feature = "enabled"), not(debug_assertions)))]
+        #[macro_export]
+        macro_rules! $name {
+            ($d condition:expr, $d message:literal $d(, $d details:expr)?) => {
+                $crate::__dst_typecheck_cond!($d condition, $d message $d(, $d details)?)
+            };
+        }
+    };
+
+    (type_only $d:tt $name:ident, $doc:literal) => {
         #[doc = $doc]
         #[cfg(feature = "enabled")]
         #[macro_export]
@@ -77,11 +135,7 @@ macro_rules! define_condition_assert {
         #[macro_export]
         macro_rules! $name {
             ($d condition:expr, $d message:literal $d(, $d details:expr)?) => {
-                if false {
-                    let _: bool = $d condition;
-                    let _: &str = $d message;
-                    $d(let _ = &$d details;)?
-                }
+                $crate::__dst_typecheck_cond!($d condition, $d message $d(, $d details)?)
             };
         }
     };
@@ -90,7 +144,40 @@ macro_rules! define_condition_assert {
 /// Generate a message-only wrapper: `name!("message" [, &details])`.
 #[rustfmt::skip]
 macro_rules! define_message_assert {
-    ($d:tt $name:ident, $doc:literal) => {
+    (debug_assert $d:tt $name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[cfg(feature = "enabled")]
+        #[macro_export]
+        macro_rules! $name {
+            ($d message:literal $d(, $d details:expr)?) => {
+                $crate::antithesis_sdk::$name!($d message $d(, $d details)?)
+            };
+        }
+
+        // Reaching this site is the violation, so panic.
+        #[doc = $doc]
+        #[cfg(all(not(feature = "enabled"), debug_assertions))]
+        #[macro_export]
+        macro_rules! $name {
+            ($d message:literal, $d details:expr) => {
+                ::core::debug_assert!(false, "{}: {:?}", $d message, $d details)
+            };
+            ($d message:literal) => {
+                ::core::debug_assert!(false, "{}", $d message)
+            };
+        }
+
+        #[doc = $doc]
+        #[cfg(all(not(feature = "enabled"), not(debug_assertions)))]
+        #[macro_export]
+        macro_rules! $name {
+            ($d message:literal $d(, $d details:expr)?) => {
+                $crate::__dst_typecheck_msg!($d message $d(, $d details)?)
+            };
+        }
+    };
+
+    (type_only $d:tt $name:ident, $doc:literal) => {
         #[doc = $doc]
         #[cfg(feature = "enabled")]
         #[macro_export]
@@ -105,41 +192,38 @@ macro_rules! define_message_assert {
         #[macro_export]
         macro_rules! $name {
             ($d message:literal $d(, $d details:expr)?) => {
-                if false {
-                    let _: &str = $d message;
-                    $d(let _ = &$d details;)?
-                }
+                $crate::__dst_typecheck_msg!($d message $d(, $d details)?)
             };
         }
     };
 }
 
-define_condition_assert!($ assert_always,
+define_condition_assert!(debug_assert $ assert_always,
     "Assert `condition` holds every time this site runs and that it is hit at least once. `message` must be a string literal; optional `details` is a `&serde_json::Value`.");
-define_condition_assert!($ assert_always_or_unreachable,
+define_condition_assert!(debug_assert $ assert_always_or_unreachable,
     "Like `assert_always!`, but the property still passes if the site is never hit.");
-define_condition_assert!($ assert_sometimes,
+define_condition_assert!(type_only $ assert_sometimes,
     "Assert `condition` holds at least once across the run.");
-define_message_assert!($ assert_reachable,
+define_message_assert!(type_only $ assert_reachable,
     "Assert this site is reached at least once across the run.");
-define_message_assert!($ assert_unreachable,
+define_message_assert!(debug_assert $ assert_unreachable,
     "Assert this site is never reached; reaching it reports a violation.");
 
 // Ghost state + read-only observation, ported from precept (orbitinghail/precept).
 
-/// Auxiliary *ghost state* that exists only to express properties: its inner `T` can be read
-/// only through [`observe!`] and mutated only through [`GhostState::mutate`]. When `enabled` is
-/// off it is a zero-sized type and every access compiles out.
-#[cfg(feature = "enabled")]
+/// Auxiliary *ghost state* for expressing properties: read only via [`observe!`], mutated only via
+/// [`GhostState::mutate`]. Value-carrying where assertions can fire (`enabled` or
+/// `debug_assertions`); a zero-sized no-op otherwise.
+#[cfg(any(feature = "enabled", debug_assertions))]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GhostState<T>(T);
 
-/// See the [`enabled` definition](GhostState).
-#[cfg(not(feature = "enabled"))]
+/// See the [value-carrying definition](GhostState).
+#[cfg(not(any(feature = "enabled", debug_assertions)))]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GhostState<T>(::core::marker::PhantomData<T>);
 
-#[cfg(feature = "enabled")]
+#[cfg(any(feature = "enabled", debug_assertions))]
 impl<T> GhostState<T> {
     /// Create ghost state, initializing the inner `T` with `init`. `init` is read-only (an `Fn`);
     /// when the crate is compiled out it is never called and no `T` is constructed.
@@ -160,15 +244,15 @@ impl<T> GhostState<T> {
     }
 }
 
-#[cfg(not(feature = "enabled"))]
+#[cfg(not(any(feature = "enabled", debug_assertions)))]
 impl<T> GhostState<T> {
-    /// See the enabled definition.
+    /// See the value-carrying definition.
     #[allow(unused_variables)]
     pub fn new<F: Fn() -> T>(init: F) -> Self {
         GhostState(::core::marker::PhantomData)
     }
 
-    /// See the enabled definition.
+    /// See the value-carrying definition.
     #[allow(unused_variables)]
     pub fn mutate<F: Fn(&mut T)>(&mut self, f: F) {}
 }
@@ -178,14 +262,14 @@ impl<T> GhostState<T> {
 // type-checked but never executed.
 macro_rules! define_observe_helpers {
     ($( $name:ident ( $($ty:ident : $arg:ident),* ) ),* $(,)?) => {$(
-        #[cfg(feature = "enabled")]
+        #[cfg(any(feature = "enabled", debug_assertions))]
         #[doc(hidden)]
         #[allow(clippy::too_many_arguments)]
         pub fn $name<$($ty,)* F: Fn($(&$ty),*)>($($arg: &$crate::GhostState<$ty>,)* f: F) {
             f($($arg.inner()),*)
         }
 
-        #[cfg(not(feature = "enabled"))]
+        #[cfg(not(any(feature = "enabled", debug_assertions)))]
         #[doc(hidden)]
         #[allow(unused_variables, clippy::too_many_arguments)]
         pub fn $name<$($ty,)* F: Fn($(&$ty),*)>($($arg: &$crate::GhostState<$ty>,)* f: F) {}
@@ -227,9 +311,7 @@ macro_rules! observe {
 mod tests {
     use crate::GhostState;
 
-    // Compiles and runs in both feature configurations. With `enabled` off the closures are
-    // type-checked but never executed and `GhostState` is zero-sized; either way this must not
-    // panic and the assertion macros must type-check.
+    // Must compile and not panic in every configuration (the asserts below all hold).
     #[test]
     fn compiles_and_runs_in_all_configs() {
         crate::init();
@@ -237,10 +319,8 @@ mod tests {
         let mut seen = GhostState::new(|| 0i64);
         seen.mutate(|n| *n += 1);
 
-        // NB: the assert wrappers are macro-generated `#[macro_export]` macros, which cannot be
-        // referred to by an absolute path (`crate::assert_always!`) from inside this crate — so
-        // call them unqualified (they are in textual scope). Consumer crates reference them
-        // cross-crate as `dst::assert_*!`, which is unaffected.
+        // Called unqualified: `#[macro_export]` macros aren't reachable by absolute path from
+        // within the defining crate (consumers use `dst::assert_*!`).
         crate::observe!(seen, |n: &i64| {
             assert_always!(
                 *n >= 0,
@@ -251,9 +331,28 @@ mod tests {
 
         crate::observe!(|| {
             assert_reachable!("observation ran");
-            assert_unreachable!("should not construct impossible state");
             assert_sometimes!(true, "sometimes true");
             assert_always_or_unreachable!(1 + 1 == 2, "arithmetic holds");
+        });
+    }
+
+    // A failing assert panics only where it lowers to `debug_assert!` (SDK off, debug_assertions
+    // on), so these two tests are gated to that config.
+    #[cfg(all(not(feature = "enabled"), debug_assertions))]
+    #[test]
+    #[should_panic(expected = "always-false correctness assert")]
+    fn failing_assert_always_panics_in_debug() {
+        crate::observe!(|| {
+            assert_always!(false, "always-false correctness assert");
+        });
+    }
+
+    #[cfg(all(not(feature = "enabled"), debug_assertions))]
+    #[test]
+    #[should_panic(expected = "reached an impossible state")]
+    fn reached_unreachable_panics_in_debug() {
+        crate::observe!(|| {
+            assert_unreachable!("reached an impossible state");
         });
     }
 }

--- a/dst/src/lib.rs
+++ b/dst/src/lib.rs
@@ -41,6 +41,10 @@
 #[doc(hidden)]
 pub use antithesis_sdk;
 
+// `as _` keeps the linker from dropping the coverage shim.
+#[cfg(feature = "enabled")]
+use antithesis_instrumentation as _;
+
 /// Register the Antithesis assertion catalog for this process. Required once per process that
 /// emits assertions; without it a never-hit `assert_unreachable!` would pass vacuously instead
 /// of being reported. `antithesis_init` is idempotent, so it is safe to call from every process

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-+6RYw08BNoFgtMR8vHrVsRQ0gwiK7F4N5ZfPFIhxsIQ=";
+  cargoHash = "sha256-jRBgooiyYH7aIBc+akXaeje8hqfWo1egfuvRfQAKUXE=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,7 +19,8 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = ["dep:proptest"]
 deferred_wal = []
-dst = ["dst/enabled"]
+# direct dep so the coverage shim survives into the cdylib (see lib.rs)
+dst = ["dst/enabled", "dep:antithesis-instrumentation"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 block_tracker = [] # for debugging when blocks are acquired and released
 debug-logging = [
@@ -29,6 +30,7 @@ debug-logging = [
 [dependencies]
 async-trait = "0.1.89"
 dst = { path = "../dst" }
+antithesis-instrumentation = { version = "0.1", optional = true } # coverage shim; see lib.rs
 stable_deref_trait = "1.2.1"
 anyhow = { version = "1.0.102", features = ["backtrace"] }
 arrow-array = "58.1.0"

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -16,6 +16,11 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 #![recursion_limit = "512"]
 
+// Direct dep, not just via `dst`: a cdylib drops the transitively-referenced shim, so reference it
+// here to keep its `.init_array` constructor.
+#[cfg(feature = "dst")]
+use antithesis_instrumentation as _;
+
 mod aggregate;
 mod api;
 mod bootstrap;

--- a/stressgres/suites/antithesis/helper_suite_setup.sh
+++ b/stressgres/suites/antithesis/helper_suite_setup.sh
@@ -7,7 +7,7 @@
 set -Eeuo pipefail
 
 SUITE_DIR=/home/app/stressgres/suites
-STRESSGRES=/home/app/target/release/stressgres
+STRESSGRES=/home/app/target/x86_64-unknown-linux-gnu/debug/stressgres
 
 # The paired singleton_driver runs this symlink; each first_ repoints it at its own suite.
 WORKLOAD_LINK=/tmp/stressgres-workload.toml

--- a/stressgres/suites/antithesis/helper_suite_setup.sh
+++ b/stressgres/suites/antithesis/helper_suite_setup.sh
@@ -7,7 +7,7 @@
 set -Eeuo pipefail
 
 SUITE_DIR=/home/app/stressgres/suites
-STRESSGRES=/home/app/target/x86_64-unknown-linux-gnu/debug/stressgres
+STRESSGRES=/home/app/target/x86_64-unknown-linux-gnu/dst/stressgres
 
 # The paired singleton_driver runs this symlink; each first_ repoints it at its own suite.
 WORKLOAD_LINK=/tmp/stressgres-workload.toml


### PR DESCRIPTION
This PR modifies the dst feature in stressgres and pg_search to lower conditional DST assertions to debug_asserts when compiled with debug_assertions enabled.