### PR TITLE
chore: bump tantivy to squashed main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5366,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7900,7 +7900,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7956,7 +7956,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "bitpacking",
 ]
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8037,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8074,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc388e16981e5ffff9e60befcd2d8654529b43d4#cc388e16981e5ffff9e60befcd2d8654529b43d4"
+source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "cc388e16981e5ffff9e60befcd2d8654529b43d4", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "055cfd0afffa7823aa9e835d67ae290c765d616a", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -45,7 +45,7 @@ pgrx-tests = "=0.19.0"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "cc388e16981e5ffff9e60befcd2d8654529b43d4" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "055cfd0afffa7823aa9e835d67ae290c765d616a" }
 
 # datafusion 54.0.0 + the null-aware anti-join dynamic-filter fix (paradedb/datafusion PR #2, backported
 # to a 54.0.0 branch so it stays on arrow 58). Patch every datafusion crate, or two `datafusion-common`

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-V5YUXxV5u0EizBu2lVaC76VASnKHMVMnTUfsvvAs+uc=";
+  cargoHash = "sha256-+6RYw08BNoFgtMR8vHrVsRQ0gwiK7F4N5ZfPFIhxsIQ=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
## What

Points the `tantivy` and `tantivy-tokenizer-api` git pins at the new tip of `paradedb/tantivy` `main` (`055cfd0af`).

## Why

`paradedb/tantivy` history was restructured: the vector work (#154–#183) was squashed into a single `feat: SPANN vector search impl` commit, with the two commits from the #171 squash-merge (#167, #162) restored as individual commits beneath it. `main` was then fast-forwarded to this history.

The previously pinned rev `cc388e169` is no longer reachable from any branch after the rewrite, so this bump is also needed for build reproducibility.
