### PR TITLE
ci: Set target segment count for snapshot generation

### DIFF
--- a/.github/actions/setup-benchmark-cluster/action.yml
+++ b/.github/actions/setup-benchmark-cluster/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: "PostgreSQL major version."
     required: false
     default: "18"
+  global_target_segment_count:
+    description: >-
+      Cluster-wide `paradedb.global_target_segment_count`. A non-zero value overrides every
+      index's own `target_segment_count`; `0` (the extension's own default) honors each index's
+      per-index value. Defaults to `0`; callers that want a fixed cluster-wide count (e.g. the
+      stackoverflow bm25 indexes, which set no per-index count) pass their own.
+    required: false
+    default: "0"
 
 runs:
   using: composite
@@ -104,7 +112,7 @@ runs:
       run: |
         psql postgresql://localhost:288${{ inputs.pg_version }}/postgres -c "CREATE EXTENSION IF NOT EXISTS vector;"
         psql postgresql://localhost:288${{ inputs.pg_version }}/postgres -c "CREATE EXTENSION IF NOT EXISTS pg_search;"
-        psql postgresql://localhost:288${{ inputs.pg_version }}/postgres -c "ALTER SYSTEM SET paradedb.global_target_segment_count = 48;";
+        psql postgresql://localhost:288${{ inputs.pg_version }}/postgres -c "ALTER SYSTEM SET paradedb.global_target_segment_count = ${{ inputs.global_target_segment_count }};";
 
     - name: Restart Postgres
       shell: bash

--- a/.github/workflows/generate-benchmark-snapshots.yml
+++ b/.github/workflows/generate-benchmark-snapshots.yml
@@ -97,6 +97,10 @@ jobs:
         uses: ./.github/actions/setup-benchmark-cluster
         with:
           pg_version: ${{ env.pg_version }}
+          # stackoverflow's bm25 indexes set no per-index `target_segment_count`, so bake the
+          # standard 48-segment operating point into its snapshot. Every other dataset keeps the
+          # extension default of 0, so an index's own `target_segment_count` is honored.
+          global_target_segment_count: ${{ matrix.dataset == 'stackoverflow' && '48' || '0' }}
 
       # Load the heap only (no index, no queries) so the cluster can be captured as a snapshot.
       - name: Load Heap


### PR DESCRIPTION
Splits a general fix out of #5613.

`setup-benchmark-cluster` hardcoded `global_target_segment_count = 48`, which overrides *every* index's own `target_segment_count`. Only stackoverflow's bm25 indexes need a fixed cluster-wide count (they set no per-index value), so baking 48 into every snapshot silently overrode any index that set its own.

- Action gains a `global_target_segment_count` input, defaulting to `0` (the extension's own default — honors per-index counts).
- Snapshot generation passes `48` only for stackoverflow.

No-op for existing benchmarks: `generate-snapshots` passes explicit values, and `benchmark-pg_search-queries` restores a heap snapshot right after setup, overwriting the GUC. Touches the same two files as #5613, so expect a trivial conflict by merge order.