### PR TITLE
docs: vector search

### DIFF
--- a/.github/scripts/create_code_snippet_indexes.sql
+++ b/.github/scripts/create_code_snippet_indexes.sql
@@ -8,6 +8,7 @@ USING bm25 (
   created_at,
   metadata,
   weight_range,
+  embedding vector_cosine_ops,
   (description::pdb.simple('alias=description_simple')),
   (lower(description)::pdb.literal('alias=literal_description'))
 )

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -43,6 +43,14 @@ sed -i "s/^shared_preload_libraries = .*/shared_preload_libraries = 'citus,pg_se
 
 Here's a complete example of setting up distributed search with Citus:
 
+<Note>
+  As of `0.25.0`, `pg_search` requires the
+  [`pgvector`](https://github.com/pgvector/pgvector) extension because it relies
+  on `pgvector`'s `vector` type. `pgvector` must be installed on the server
+  before `pg_search` is created — `CASCADE` then runs `CREATE EXTENSION vector`
+  automatically if it has not already been created.
+</Note>
+
 ```sql
 CREATE EXTENSION citus;
 CREATE EXTENSION pg_search CASCADE;

--- a/docs/deploy/logical-replication/getting-started.mdx
+++ b/docs/deploy/logical-replication/getting-started.mdx
@@ -159,6 +159,14 @@ initial copy behavior of `CREATE SUBSCRIPTION`.
 CREATE EXTENSION pg_search CASCADE;
 ```
 
+<Note>
+  As of `0.25.0`, `pg_search` requires the
+  [`pgvector`](https://github.com/pgvector/pgvector) extension because it relies
+  on `pgvector`'s `vector` type. `pgvector` must be installed on the server
+  before `pg_search` is created — `CASCADE` then runs `CREATE EXTENSION vector`
+  automatically if it has not already been created.
+</Note>
+
 ### 5. Create a Publication on the Publisher
 
 ```sql

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -18,6 +18,10 @@ This can be done by installing the `pg_search` extension, which powers all of Pa
 
 Ensure that you have superuser access to the Postgres database.
 
+As of `0.25.0`, `pg_search` relies on [`pgvector`](https://github.com/pgvector/pgvector)'s `vector` type, making it a required
+extension. `pgvector` must be installed on the server before `pg_search` — see the [`pgvector` installation
+instructions](https://github.com/pgvector/pgvector?tab=readme-ov-file#installation).
+
 ## Install the ParadeDB Postgres Extension
 
 ### ParadeDB Community
@@ -116,10 +120,10 @@ CREATE EXTENSION pg_search CASCADE;
 ```
 
 <Note>
-  `pg_search` requires [`pgvector`](https://github.com/pgvector/pgvector).
-  `CASCADE` creates it automatically if it is not already installed, so
-  `pgvector` must be available on the server — see the [`pgvector` installation
-  instructions](https://github.com/pgvector/pgvector?tab=readme-ov-file#installation).
-  Without `CASCADE`, `CREATE EXTENSION pg_search` fails with `required extension
-  "vector" is not installed`.
+  As of `0.25.0`, `pg_search` requires the
+  [`pgvector`](https://github.com/pgvector/pgvector) extension because it relies
+  on `pgvector`'s `vector` type. `CASCADE` runs `CREATE EXTENSION vector`
+  automatically if it has not already been created. Without `CASCADE`, `CREATE
+  EXTENSION pg_search` fails with `required extension "vector" is not
+  installed`.
 </Note>

--- a/docs/deploy/third-party-extensions.mdx
+++ b/docs/deploy/third-party-extensions.mdx
@@ -17,7 +17,7 @@ Postgres has a rich ecosystem of extensions. ParadeDB is designed to work alongs
 
 To keep the ParadeDB Docker image size manageable, the following extensions are pre-installed:
 
-- **`pg_search`** — Full-text search with BM25, vector search, and hybrid search
+- **`pg_search`** — Full-text search with BM25, vector, and hybrid search
 - **`pgvector`** — Vector similarity search
 - **`postgis`** — Geospatial queries and indexing
 - **`pg_ivm`** — Incremental materialized views

--- a/docs/deploy/third-party-extensions.mdx
+++ b/docs/deploy/third-party-extensions.mdx
@@ -17,7 +17,7 @@ Postgres has a rich ecosystem of extensions. ParadeDB is designed to work alongs
 
 To keep the ParadeDB Docker image size manageable, the following extensions are pre-installed:
 
-- **`pg_search`** — Full-text and hybrid search with BM25
+- **`pg_search`** — Full-text search with BM25, vector search, and hybrid search
 - **`pgvector`** — Vector similarity search
 - **`postgis`** — Geospatial queries and indexing
 - **`pg_ivm`** — Incremental materialized views

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -9,8 +9,9 @@ canonical: https://docs.paradedb.com/deploy/upgrading
 ParadeDB ships its functionality inside a Postgres extension, `pg_search`. Upgrading ParadeDB is as simple as updating the `pg_search` extension.
 
 <Note>
-  ParadeDB uses `pgvector` for vector search. This extension is not managed by
-  ParadeDB. Please refer to the [pgvector
+  ParadeDB depends on `pgvector` for its vector types, which are used by [native
+  vector search](/documentation/vector/overview). This extension is not managed
+  by ParadeDB. Please refer to the [pgvector
   documentation](https://github.com/pgvector/pgvector?tab=readme-ov-file#upgrading)
   for instructions on how to upgrade it.
 </Note>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,6 +57,7 @@
                         "group": "Indexing",
                         "pages": [
                           "documentation/indexing/create-index",
+                          "documentation/indexing/indexing-vectors",
                           "documentation/indexing/indexing-expressions",
                           "documentation/indexing/indexing-json",
                           "documentation/indexing/indexing-arrays",
@@ -114,18 +115,34 @@
                           "documentation/full-text/phrase",
                           "documentation/full-text/term",
                           "documentation/full-text/fuzzy",
+                          "documentation/sorting/score",
+                          "documentation/sorting/boost",
                           "documentation/full-text/highlight",
-                          "documentation/full-text/proximity"
+                          "documentation/full-text/proximity",
+                          {
+                            "group": "Advanced Query Functions",
+                            "pages": [
+                              "documentation/query-builder/overview",
+                              "documentation/query-builder/compound/all",
+                              "documentation/query-builder/specialized/more-like-this",
+                              "documentation/query-builder/phrase/phrase-prefix",
+                              "documentation/query-builder/compound/query-parser",
+                              "documentation/query-builder/term/range-term",
+                              "documentation/query-builder/term/regex",
+                              "documentation/query-builder/phrase/regex-phrase"
+                            ]
+                          }
                         ]
                       },
                       {
-                        "group": "Sorting",
+                        "group": "Vector Search",
                         "pages": [
-                          "documentation/sorting/score",
-                          "documentation/sorting/boost",
-                          "documentation/sorting/topk"
+                          "documentation/vector/overview",
+                          "documentation/vector/querying",
+                          "documentation/vector/tuning"
                         ]
                       },
+                      "documentation/sorting/topk",
                       "documentation/filtering",
                       {
                         "group": "Aggregates",
@@ -163,19 +180,6 @@
                         "group": "Joins",
                         "pages": [
                           "documentation/joins/overview"
-                        ]
-                      },
-                      {
-                        "group": "Advanced Query Functions",
-                        "pages": [
-                          "documentation/query-builder/overview",
-                          "documentation/query-builder/compound/all",
-                          "documentation/query-builder/specialized/more-like-this",
-                          "documentation/query-builder/phrase/phrase-prefix",
-                          "documentation/query-builder/compound/query-parser",
-                          "documentation/query-builder/term/range-term",
-                          "documentation/query-builder/term/regex",
-                          "documentation/query-builder/phrase/regex-phrase"
                         ]
                       },
                       {

--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -74,18 +74,6 @@ await dbContext
 
 </CodeGroup>
 
-## Search Operators
-
-For the ParadeDB index to accelerate a query, at least one of ParadeDB's search operators must be present in the `WHERE` clause. Any of the following qualify:
-
-| Operator | Meaning                                                                                           |
-| -------- | ------------------------------------------------------------------------------------------------- |
-| `@@@`    | [General search predicate](/documentation/full-text/overview)                                     |
-| `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
-| `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
-| `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
-| `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
-
 ## Filter Pushdown
 
 ### Non-Text Fields
@@ -162,6 +150,16 @@ Filter pushdown is currently supported for the following combinations of types a
   [`pdb.all`](/documentation/query-builder/compound/all) to force the ParadeDB
   index without changing the query output.
 </Note>
+
+Any of the following search operators qualify:
+
+| Operator | Meaning                                                                                           |
+| -------- | ------------------------------------------------------------------------------------------------- |
+| `@@@`    | [General search predicate](/documentation/full-text/overview)                                     |
+| `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
+| `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
+| `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
+| `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
 
 ### Text Fields
 

--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -4,7 +4,7 @@ description: Filter search results based on metadata from other fields
 canonical: https://docs.paradedb.com/documentation/filtering
 ---
 
-Adding filters to text search is as simple as using PostgreSQL's built-in `WHERE` clauses and operators.
+Adding filters to a search query is as simple as using PostgreSQL's built-in `WHERE` clauses and operators.
 For instance, the following query filters out results that do not meet `rating > 2`.
 
 <CodeGroup>
@@ -73,6 +73,18 @@ await dbContext
 ```
 
 </CodeGroup>
+
+## Search Operators
+
+For the ParadeDB index to accelerate a query, at least one of ParadeDB's search operators must be present in the `WHERE` clause. Any of the following qualify:
+
+| Operator | Meaning                                                                                           |
+| -------- | ------------------------------------------------------------------------------------------------- |
+| `@@@`    | [General search predicate](/documentation/full-text/overview)                                     |
+| `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
+| `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
+| `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
+| `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
 
 ## Filter Pushdown
 
@@ -143,6 +155,13 @@ Filter pushdown is currently supported for the following combinations of types a
 |                                            | `timestamp`       |                    |
 |                                            | `timestamptz`     |                    |
 |                                            | `uuid`            |                    |
+
+<Note>
+  In order for the ParadeDB index to be used, at least one ParadeDB operator
+  must be present in the query. For queries that do not require text search, add
+  [`pdb.all`](/documentation/query-builder/compound/all) to force the ParadeDB
+  index without changing the query output.
+</Note>
 
 ### Text Fields
 

--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -74,6 +74,21 @@ await dbContext
 
 </CodeGroup>
 
+<Note>
+In order for the ParadeDB index to be used, at least one ParadeDB operator must be present in the query. Any of the following search operators qualify:
+
+| Operator | Meaning                                                                                           |
+| -------- | ------------------------------------------------------------------------------------------------- |
+| `@@@`    | [General search predicate](/documentation/full-text/overview)                                     |
+| `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
+| `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
+| `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
+| `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
+
+For queries that do not require text search, add [`pdb.all`](/documentation/query-builder/compound/all) to force the ParadeDB
+index without changing the query output.
+</Note>
+
 ## Filter Pushdown
 
 ### Non-Text Fields
@@ -144,23 +159,6 @@ Filter pushdown is currently supported for the following combinations of types a
 |                                            | `timestamptz`     |                    |
 |                                            | `uuid`            |                    |
 
-<Note>
-  In order for the ParadeDB index to be used, at least one ParadeDB operator
-  must be present in the query. For queries that do not require text search, add
-  [`pdb.all`](/documentation/query-builder/compound/all) to force the ParadeDB
-  index without changing the query output.
-</Note>
-
-Any of the following search operators qualify:
-
-| Operator | Meaning                                                                                           |
-| -------- | ------------------------------------------------------------------------------------------------- |
-| `@@@`    | [General search predicate](/documentation/full-text/overview)                                     |
-| `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
-| `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
-| `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
-| `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
-
 ### Text Fields
 
 Suppose we have a text filter that looks for an exact string match like `category = 'Footwear'`:
@@ -169,7 +167,7 @@ Suppose we have a text filter that looks for an exact string match like `categor
 ```sql SQL
 SELECT description, rating, category
 FROM mock_items
-WHERE description @@@ 'shoes' AND category = 'Footwear';
+WHERE description === 'shoes' AND category = 'Footwear';
 ```
 
 ```ts Drizzle
@@ -246,7 +244,7 @@ Pushdown of set filters over text fields also requires the literal tokenizer:
 ```sql SQL
 SELECT description, rating, category
 FROM mock_items
-WHERE description @@@ 'shoes' AND category IN ('Footwear', 'Apparel');
+WHERE description === 'shoes' AND category IN ('Footwear', 'Apparel');
 ```
 
 ```ts Drizzle

--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -87,6 +87,7 @@ In order for the ParadeDB index to be used, at least one ParadeDB operator must 
 
 For queries that do not require text search, add [`pdb.all`](/documentation/query-builder/compound/all) to force the ParadeDB
 index without changing the query output.
+
 </Note>
 
 ## Filter Pushdown

--- a/docs/documentation/full-text/overview.mdx
+++ b/docs/documentation/full-text/overview.mdx
@@ -28,9 +28,4 @@ Token matching is a much more versatile and powerful technique. It enables relev
 Text search is different from similarity search, also known as vector search. Whereas text search matches based on token matches, similarity search
 matches based on semantic meaning.
 
-Today, most ParadeDB users install [pgvector](https://github.com/pgvector/pgvector) alongside ParadeDB for vector search and hybrid search.
-That remains our recommended setup when you need embeddings in Postgres right now.
-
-We are also actively working on a native vector search experience inside ParadeDB indexes that is intended to improve on the current `pgvector`
-workflow, especially for filtered and hybrid search. You can follow that work in our [roadmap](/welcome/roadmap#vector-search-improvements) or
-[reach out](mailto:support@paradedb.com) if it is important for your use case.
+As of `0.25.0`, ParadeDB natively supports vector search inside its indexes. See [Vector Search](/documentation/vector/overview) to learn more.

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -39,9 +39,11 @@ Next, let's create a ParadeDB index called `search_idx` on this table. A ParadeD
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+USING paradedb (id, description, embedding vector_cosine_ops, category, rating, in_stock, created_at, metadata, weight_range)
 WITH (key_field='id');
 ```
+
+Note that this includes text, vector, and metadata fields.
 
 <Note>
   As a general rule of thumb, any columns that you want to filter, `GROUP BY`,

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -286,13 +286,36 @@ await dbContext
 The `mock_items` table also contains an `embedding` column. Let's execute the same query above, but order results by vector similarity
 instead of BM25 score:
 
-```sql
+<CodeGroup>
+```sql SQL
 SELECT description, embedding
 FROM mock_items
 WHERE description ||| 'running shoes' AND rating > 2
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
+
+```ts Drizzle
+// Vector search support for Drizzle is coming very soon.
+```
+
+```python Django
+# Vector search support for Django is coming very soon.
+```
+
+```python SQLAlchemy
+# Vector search support for SQLAlchemy is coming very soon.
+```
+
+```ruby Rails
+# Vector search support for Rails is coming very soon.
+```
+
+```cs EF Core
+// Vector search support for EF Core is coming very soon.
+```
+
+</CodeGroup>
 
 ```ini Expected Response
      description     |                                  embedding

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -287,7 +287,7 @@ The `mock_items` table also contains an `embedding` column. Let's execute the sa
 instead of BM25 score:
 
 ```sql
-SELECT description
+SELECT description, embedding
 FROM mock_items
 WHERE description ||| 'running shoes' AND rating > 2
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
@@ -295,11 +295,11 @@ LIMIT 5;
 ```
 
 ```ini Expected Response
-     description
----------------------
- White jogging shoes
- Sleek running shoes
- Generic shoes
+     description     |                                  embedding
+---------------------+------------------------------------------------------------------------------
+ White jogging shoes | [-0.042016,0.399574,-0.663812,-0.071006,0.430261,0.21037,0.392919,-0.095506]
+ Sleek running shoes | [-0.01708,0.467566,-0.757486,0.134082,0.33933,0.04403,0.185394,-0.194613]
+ Generic shoes       | [-0.28609,0.368785,-0.810201,0.011777,0.132327,0.199342,0.056281,-0.255287]
 (3 rows)
 ```
 

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -309,7 +309,7 @@ Postgres vector index is a standalone index that requires separate pre/post filt
 
 ## Top K Ordering
 
-In addition to BM25 and vector similarity, ParadeDB is also optimized for quickly sorting by an arbitrary field, also known as a [Top K](/documentation/sorting/topk) query. 
+In addition to BM25 and vector similarity, ParadeDB is also optimized for quickly sorting by an arbitrary field, also known as a [Top K](/documentation/sorting/topk) query.
 In SQL, this means queries that contain an `ORDER BY <field>...LIMIT`:
 
 <CodeGroup>
@@ -389,7 +389,8 @@ await dbContext
 ```
 
 <Note>
-The ordering field, in this case `rating`, must be indexed inside the ParadeDB index.
+  The ordering field, in this case `rating`, must be indexed inside the ParadeDB
+  index.
 </Note>
 
 ## Highlighting

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -6,7 +6,7 @@ canonical: https://docs.paradedb.com/documentation/getting-started/queries
 
 Now that your [environment is configured](/documentation/getting-started/environment), select the codetab for your tool and run some queries.
 
-## Match Query
+## Text Match Query
 
 We're now ready to execute a basic text search query. We'll look for matches where `description` matches `running shoes` where `rating` is greater than `2`.
 
@@ -275,6 +275,23 @@ await dbContext
  Generic shoes       | 3.8772602
  White jogging shoes | 3.4849067
 (3 rows)
+```
+
+## Vector Search
+
+<Note>
+Native vector search support for ParadeDB requires version `0.25.0` or above.
+</Note>
+
+The `mock_items` table also contains an `embedding` column. Let's execute the same query above, but order results by vector similarity
+instead of BM25 score:
+
+```sql
+SELECT description
+FROM mock_items
+WHERE description ||| 'running shoes' AND rating > 2
+ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
+LIMIT 5;
 ```
 
 ## Highlighting

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -6,7 +6,7 @@ canonical: https://docs.paradedb.com/documentation/getting-started/queries
 
 Now that your [environment is configured](/documentation/getting-started/environment), select the codetab for your tool and run some queries.
 
-## Text Match Query
+## Text Search
 
 We're now ready to execute a basic text search query. We'll look for matches where `description` matches `running shoes` where `rating` is greater than `2`.
 
@@ -303,10 +303,94 @@ LIMIT 5;
 (3 rows)
 ```
 
-Because `embedding` is part of the same index as `description` and `rating`, the entire query — the full-text match, the rating filter,
-and the nearest-neighbor ordering — executes inside the ParadeDB index. With a standalone vector index, Postgres would find the
-nearest neighbors first and only afterward filter them against the other predicates, which is slower and can return fewer than the
-requested number of rows. See [Querying Vectors](/documentation/vector/querying) for more details.
+Because `embedding` is part of the same index as `description` and `rating`, the entire query (the full-text match, the rating filter,
+and the nearest-neighbor ordering) executes inside the ParadeDB index. ParadeDB is the only Postgres index that can do this — every other
+Postgres vector index is a standalone index that requires separate pre/post filtering, which hurts performance and recall.
+
+## Top K Ordering
+
+In addition to BM25 and vector similarity, ParadeDB is also optimized for quickly sorting by an arbitrary field, also known as a [Top K](/documentation/sorting/topk) query. 
+In SQL, this means queries that contain an `ORDER BY <field>...LIMIT`:
+
+<CodeGroup>
+```sql SQL
+SELECT description, rating, category
+FROM mock_items
+WHERE description ||| 'running shoes'
+ORDER BY rating
+LIMIT 5;
+```
+
+```ts Drizzle
+import { search } from "@paradedb/drizzle-paradedb";
+
+await db
+  .select({
+    description: mockItems.description,
+    rating: mockItems.rating,
+    category: mockItems.category,
+  })
+  .from(mockItems)
+  .where(search.matchAny(mockItems.description, "running shoes"))
+  .orderBy(mockItems.rating)
+  .limit(5);
+```
+
+```python Django
+from paradedb import MatchAny, ParadeDB
+
+MockItem.objects.filter(
+    description=ParadeDB(MatchAny('running shoes'))
+).values('description', 'rating', 'category').order_by('rating')[:5]
+```
+
+```python SQLAlchemy
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from paradedb.sqlalchemy import search
+
+stmt = (
+    select(MockItem.description, MockItem.rating, MockItem.category)
+    .where(search.match_any(MockItem.description, "running shoes"))
+    .order_by(MockItem.rating)
+    .limit(5)
+)
+
+with Session(engine) as session:
+    session.execute(stmt).all()
+```
+
+```ruby Rails
+MockItem.search(:description)
+        .match_any("running shoes")
+        .select(:description, :rating, :category)
+        .order(:rating)
+        .limit(5)
+```
+
+```cs EF Core
+await dbContext
+    .MockItems.Where(item => EF.Functions.MatchAny(item.Description, "running shoes"))
+    .OrderBy(item => item.Rating)
+    .Select(item => new { item.Description, item.Rating, item.Category })
+    .Take(5)
+    .ToListAsync();
+```
+
+</CodeGroup>
+
+```ini Expected Response
+     description     | rating | category
+---------------------+--------+----------
+ White jogging shoes |      3 | Footwear
+ Generic shoes       |      4 | Footwear
+ Sleek running shoes |      5 | Footwear
+(3 rows)
+```
+
+<Note>
+The ordering field, in this case `rating`, must be indexed inside the ParadeDB index.
+</Note>
 
 ## Highlighting
 
@@ -410,86 +494,6 @@ await dbContext
  Sleek running shoes | Sleek <b>running</b> <b>shoes</b> |  6.817111
  Generic shoes       | Generic <b>shoes</b>              | 3.8772602
  White jogging shoes | White jogging <b>shoes</b>        | 3.4849067
-(3 rows)
-```
-
-## Top K
-
-ParadeDB is highly optimized for quickly returning the [Top K](/documentation/sorting/topk) results out of the index. In SQL, this means queries that contain an `ORDER BY...LIMIT`:
-
-<CodeGroup>
-```sql SQL
-SELECT description, rating, category
-FROM mock_items
-WHERE description ||| 'running shoes'
-ORDER BY rating
-LIMIT 5;
-```
-
-```ts Drizzle
-import { search } from "@paradedb/drizzle-paradedb";
-
-await db
-  .select({
-    description: mockItems.description,
-    rating: mockItems.rating,
-    category: mockItems.category,
-  })
-  .from(mockItems)
-  .where(search.matchAny(mockItems.description, "running shoes"))
-  .orderBy(mockItems.rating)
-  .limit(5);
-```
-
-```python Django
-from paradedb import MatchAny, ParadeDB
-
-MockItem.objects.filter(
-    description=ParadeDB(MatchAny('running shoes'))
-).values('description', 'rating', 'category').order_by('rating')[:5]
-```
-
-```python SQLAlchemy
-from sqlalchemy import select
-from sqlalchemy.orm import Session
-from paradedb.sqlalchemy import search
-
-stmt = (
-    select(MockItem.description, MockItem.rating, MockItem.category)
-    .where(search.match_any(MockItem.description, "running shoes"))
-    .order_by(MockItem.rating)
-    .limit(5)
-)
-
-with Session(engine) as session:
-    session.execute(stmt).all()
-```
-
-```ruby Rails
-MockItem.search(:description)
-        .match_any("running shoes")
-        .select(:description, :rating, :category)
-        .order(:rating)
-        .limit(5)
-```
-
-```cs EF Core
-await dbContext
-    .MockItems.Where(item => EF.Functions.MatchAny(item.Description, "running shoes"))
-    .OrderBy(item => item.Rating)
-    .Select(item => new { item.Description, item.Rating, item.Category })
-    .Take(5)
-    .ToListAsync();
-```
-
-</CodeGroup>
-
-```ini Expected Response
-     description     | rating | category
----------------------+--------+----------
- White jogging shoes |      3 | Footwear
- Generic shoes       |      4 | Footwear
- Sleek running shoes |      5 | Footwear
 (3 rows)
 ```
 

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -280,7 +280,7 @@ await dbContext
 ## Vector Search
 
 <Note>
-Native vector search support for ParadeDB requires version `0.25.0` or above.
+  Native vector search support for ParadeDB requires version `0.25.0` or above.
 </Note>
 
 The `mock_items` table also contains an `embedding` column. Let's execute the same query above, but order results by vector similarity
@@ -293,6 +293,20 @@ WHERE description ||| 'running shoes' AND rating > 2
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
+
+```ini Expected Response
+     description
+---------------------
+ White jogging shoes
+ Sleek running shoes
+ Generic shoes
+(3 rows)
+```
+
+Because `embedding` is part of the same index as `description` and `rating`, the entire query — the full-text match, the rating filter,
+and the nearest-neighbor ordering — executes inside the ParadeDB index. With a standalone vector index, Postgres would find the
+nearest neighbors first and only afterward filter them against the other predicates, which is slower and can return fewer than the
+requested number of rows. See [Querying Vectors](/documentation/vector/querying) for more details.
 
 ## Highlighting
 

--- a/docs/documentation/indexing/create-index.mdx
+++ b/docs/documentation/indexing/create-index.mdx
@@ -8,7 +8,7 @@ canonical: https://docs.paradedb.com/documentation/indexing/create-index
   In version `0.25.0`, the BM25 index was renamed to the ParadeDB index, and
   `paradedb` was added as the index access method name. The rename reflects the
   fact that the index is now much more than BM25 scoring — it also powers
-  [vector search](/welcome/roadmap#vector-search-improvements),
+  [vector search](/documentation/vector/overview),
   [aggregates](/documentation/aggregates/overview), [top
   K](/documentation/sorting/topk), and [filtering](/documentation/filtering).
   `USING bm25` remains supported as a backwards-compatible alias for `USING

--- a/docs/documentation/indexing/create-index.mdx
+++ b/docs/documentation/indexing/create-index.mdx
@@ -4,17 +4,6 @@ description: Index a Postgres table for full text search
 canonical: https://docs.paradedb.com/documentation/indexing/create-index
 ---
 
-<Note>
-  In version `0.25.0`, the BM25 index was renamed to the ParadeDB index, and
-  `paradedb` was added as the index access method name. The rename reflects the
-  fact that the index is now much more than BM25 scoring — it also powers
-  [vector search](/documentation/vector/overview),
-  [aggregates](/documentation/aggregates/overview), [top
-  K](/documentation/sorting/topk), and [filtering](/documentation/filtering).
-  `USING bm25` remains supported as a backwards-compatible alias for `USING
-  paradedb`.
-</Note>
-
 Before a table can be searched, it must be indexed. ParadeDB uses a custom index type called the ParadeDB index.
 The following code block creates a ParadeDB index over several columns in the `mock_items` table.
 
@@ -90,6 +79,17 @@ modelBuilder.Entity<MockItem>()
 ```
 
 </CodeGroup>
+
+<Note>
+  In version `0.25.0`, the BM25 index was renamed to the ParadeDB index, and
+  `paradedb` was added as the index access method name. The rename reflects the
+  fact that the index is now much more than BM25 scoring — it also powers
+  [vector search](/documentation/vector/overview),
+  [aggregates](/documentation/aggregates/overview), [top
+  K](/documentation/sorting/topk), and [filtering](/documentation/filtering).
+  `USING bm25` remains supported as a backwards-compatible alias for `USING
+  paradedb`.
+</Note>
 
 <Note>
   See the [getting started guide](/documentation/getting-started/environment)

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -1,0 +1,103 @@
+---
+title: Indexing Vectors
+description: Add pgvector's vector type to the index
+canonical: https://docs.paradedb.com/documentation/indexing/indexing-vectors
+---
+
+<Note>
+  This is a beta feature available in versions `0.25.0` and above. See [How
+  Vector Search Works](/documentation/vector/overview) for background.
+</Note>
+
+<Note>
+  Make sure the [pgvector](https://github.com/pgvector/pgvector) extension is
+  installed first. ParadeDB uses pgvector's vector types, but not its HNSW or
+  IVF indexes.
+</Note>
+
+The BM25 index can index pgvector's `vector` type alongside your text and other columns. This lets you combine vector search with full text search and filters in a single index.
+
+To start, let's add a vector column to the `mock_items` table and populate it with mock embeddings.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+ALTER TABLE mock_items ADD COLUMN embedding vector(3);
+
+UPDATE mock_items
+SET embedding = ARRAY[id, id + 1, id + 2]::vector;
+```
+
+## Create the Index
+
+To include a vector field in the index, simply add it alongside the other fields you wish to index.
+
+<CodeGroup>
+```sql SQL
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, description, category, embedding vector_cosine_ops)
+WITH (key_field='id');
+```
+
+{/\* TODO: uncomment and fill in these tabs once the ORMs support indexing vectors in a BM25 index.
+
+```ts Drizzle
+// TODO: bm25 vector index example
+```
+
+```python Django
+# TODO: bm25 vector index example
+```
+
+```python SQLAlchemy
+# TODO: bm25 vector index example
+```
+
+\*/}
+
+</CodeGroup>
+
+The desired distance function is encoded into the index definition. Use `vector_l2_ops` for L2 distance,
+`vector_ip_ops` for inner product, or `vector_cosine_ops` for cosine distance.
+
+<Note>
+  Only pgvector's `vector` type is supported. The `halfvec`, `sparsevec`, and
+  `bit` types are not yet indexable.
+</Note>
+
+<Note>
+  If you track index build progress with
+  [`pg_stat_progress_create_index`](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING),
+  you may notice progress appear to "stop" at intervals. This is expected:
+  vectors are clustered with k-means at these points, which is computationally
+  expensive.
+</Note>
+
+## Index Options
+
+ParadeDB uses a SPANN-style vector index, which is similar to an IVF index but with additional structures to improve
+recall and latency, especially over large datasets. The following `WITH` options control how vectors are clustered and indexed. All are set at index build time and apply to every vector field in the index. An example:
+
+```sql
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, description, category, embedding vector_cosine_ops)
+WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, cluster_replication=1);
+```
+
+<ParamField body="centroid_ratio" default={0.01}>
+  The number of IVF centroids to build, as a fraction of the number of indexed
+  vectors (`num_centroids = centroid_ratio * num_vectors`). More centroids
+  produce smaller clusters, improving recall at the cost of a slower, more
+  memory-intensive build. Must be between `0.000001` and `1.0`.
+</ParamField>
+<ParamField body="training_samples_per_centroid" default={32}>
+  The number of vectors sampled per centroid to train the k-means clustering at
+  build time. Higher values yield better-quality centroids at the cost of a
+  slower build. Must be between `1` and `100000`.
+</ParamField>
+<ParamField body="cluster_replication" default={1}>
+  The number of clusters each vector is written into: its primary cluster plus
+  up to `cluster_replication - 1` next-nearest clusters. Higher values improve
+  recall for filtered queries at the cost of a larger index. `1` disables
+  replication.
+</ParamField>

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -71,9 +71,9 @@ WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, clu
   build time. Higher values yield better-quality centroids at the cost of a
   slower build. Must be between `1` and `100000`.
 </ParamField>
-<ParamField body="cluster_replication" default={7}>
+<ParamField body="cluster_replication" default={1}>
   The number of clusters each vector is written into: its primary cluster plus
-  up to `cluster_replication - 1` next-nearest clusters. Higher values improve
-  recall for filtered queries at the cost of a larger index. `1` disables
-  replication.
+  up to `cluster_replication - 1` next-nearest clusters. Higher values can
+  improve recall for filtered queries at the cost of a larger index. The default
+  of `1` disables replication.
 </ParamField>

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -31,7 +31,7 @@ USING paradedb (id, description, category, embedding vector_cosine_ops)
 WITH (key_field='id');
 ```
 
-The desired distance function is encoded into the index definition, and cannot be changed without reindexing. 
+The desired distance function is encoded into the index definition, and cannot be changed without reindexing.
 Use `vector_l2_ops` for L2 distance, `vector_ip_ops` for inner product, or `vector_cosine_ops` for cosine distance.
 
 <Note>
@@ -59,11 +59,12 @@ WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, clu
 ```
 
 <ParamField body="centroid_ratio" default={0.01}>
-  Vectors are clustered by proximity, and a centroid is a cluster's representative vector.
-  This setting controls the number of centroids to build, as a fraction of the number of indexed
-  vectors (`num_centroids = centroid_ratio * num_vectors`). More centroids
-  produce smaller clusters, improving recall at the cost of a slower, more
-  memory-intensive build. Must be between `0.000001` and `1.0`.
+  Vectors are clustered by proximity, and a centroid is a cluster's
+  representative vector. This setting controls the number of centroids to build,
+  as a fraction of the number of indexed vectors (`num_centroids =
+  centroid_ratio * num_vectors`). More centroids produce smaller clusters,
+  improving recall at the cost of a slower, more memory-intensive build. Must be
+  between `0.000001` and `1.0`.
 </ParamField>
 <ParamField body="training_samples_per_centroid" default={32}>
   The number of vectors sampled per centroid to train the k-means clustering at

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -15,7 +15,7 @@ canonical: https://docs.paradedb.com/documentation/indexing/indexing-vectors
   IVF indexes.
 </Note>
 
-The BM25 index can index pgvector's `vector` type alongside your text and other columns. This lets you combine vector search with full text search and filters in a single index.
+The ParadeDB index can index pgvector's `vector` type alongside your text and other columns. This lets you combine vector search with full text search and filters in a single index.
 
 The `mock_items` table comes with an `embedding` column of type `vector(8)`, already populated with sample embeddings.
 
@@ -23,11 +23,11 @@ The `mock_items` table comes with an `embedding` column of type `vector(8)`, alr
 
 To include a vector field in the index, simply add it alongside the other fields you wish to index.
 
-{/* TODO: add Drizzle, Django, and SQLAlchemy tabs once the ORMs support indexing vectors in a BM25 index. */}
+{/* TODO: add Drizzle, Django, and SQLAlchemy tabs once the ORMs support indexing vectors in a ParadeDB index. */}
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, description, category, embedding vector_cosine_ops)
+USING paradedb (id, description, category, embedding vector_cosine_ops)
 WITH (key_field='id');
 ```
 
@@ -54,7 +54,7 @@ recall and latency, especially over large datasets. The following `WITH` options
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, description, category, embedding vector_cosine_ops)
+USING paradedb (id, description, category, embedding vector_cosine_ops)
 WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, cluster_replication=1);
 ```
 

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -23,13 +23,34 @@ which can significantly improve latency/recall for selective queries.
 The `mock_items` table comes with an `embedding` column of type `vector(8)` populated with sample embeddings.
 In this example, `embedding` is added to the ParadeDB index with cosine similarity as the distance function.
 
-{/* TODO: add Drizzle, Django, and SQLAlchemy tabs once the ORMs support indexing vectors in a ParadeDB index. */}
-
-```sql
+<CodeGroup>
+```sql SQL
 CREATE INDEX search_idx ON mock_items
 USING paradedb (id, description, category, embedding vector_cosine_ops)
 WITH (key_field='id');
 ```
+
+```ts Drizzle
+// Vector search support for Drizzle is coming very soon.
+```
+
+```python Django
+# Vector search support for Django is coming very soon.
+```
+
+```python SQLAlchemy
+# Vector search support for SQLAlchemy is coming very soon.
+```
+
+```ruby Rails
+# Vector search support for Rails is coming very soon.
+```
+
+```cs EF Core
+// Vector search support for EF Core is coming very soon.
+```
+
+</CodeGroup>
 
 The desired distance function is encoded into the index definition, and cannot be changed without reindexing.
 Use `vector_l2_ops` for L2 distance, `vector_ip_ops` for inner product, or `vector_cosine_ops` for cosine distance.
@@ -52,11 +73,34 @@ Use `vector_l2_ops` for L2 distance, `vector_ip_ops` for inner product, or `vect
 ParadeDB uses a SPANN-style vector index, which is similar to an IVF index but with additional structures to improve
 recall and latency, especially over large datasets. The following `WITH` options control how vectors are clustered and indexed. All are set at index build time and apply to every vector field in the index. An example:
 
-```sql
+<CodeGroup>
+```sql SQL
 CREATE INDEX search_idx ON mock_items
 USING paradedb (id, description, category, embedding vector_cosine_ops)
 WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, cluster_replication=1);
 ```
+
+```ts Drizzle
+// Vector search support for Drizzle is coming very soon.
+```
+
+```python Django
+# Vector search support for Django is coming very soon.
+```
+
+```python SQLAlchemy
+# Vector search support for SQLAlchemy is coming very soon.
+```
+
+```ruby Rails
+# Vector search support for Rails is coming very soon.
+```
+
+```cs EF Core
+// Vector search support for EF Core is coming very soon.
+```
+
+</CodeGroup>
 
 <ParamField body="centroid_ratio" default={0.01}>
   Vectors are clustered by proximity, and a centroid is a cluster's

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Indexing Vectors
-description: Add pgvector's vector type to the index
+description: Add vectors to the ParadeDB index
 canonical: https://docs.paradedb.com/documentation/indexing/indexing-vectors
 ---
 
@@ -17,45 +17,19 @@ canonical: https://docs.paradedb.com/documentation/indexing/indexing-vectors
 
 The BM25 index can index pgvector's `vector` type alongside your text and other columns. This lets you combine vector search with full text search and filters in a single index.
 
-To start, let's add a vector column to the `mock_items` table and populate it with mock embeddings.
-
-```sql
-CREATE EXTENSION IF NOT EXISTS vector;
-
-ALTER TABLE mock_items ADD COLUMN embedding vector(3);
-
-UPDATE mock_items
-SET embedding = ARRAY[id, id + 1, id + 2]::vector;
-```
+The `mock_items` table comes with an `embedding` column of type `vector(8)`, already populated with sample embeddings.
 
 ## Create the Index
 
 To include a vector field in the index, simply add it alongside the other fields you wish to index.
 
-<CodeGroup>
-```sql SQL
+{/* TODO: add Drizzle, Django, and SQLAlchemy tabs once the ORMs support indexing vectors in a BM25 index. */}
+
+```sql
 CREATE INDEX search_idx ON mock_items
 USING bm25 (id, description, category, embedding vector_cosine_ops)
 WITH (key_field='id');
 ```
-
-{/\* TODO: uncomment and fill in these tabs once the ORMs support indexing vectors in a BM25 index.
-
-```ts Drizzle
-// TODO: bm25 vector index example
-```
-
-```python Django
-# TODO: bm25 vector index example
-```
-
-```python SQLAlchemy
-# TODO: bm25 vector index example
-```
-
-\*/}
-
-</CodeGroup>
 
 The desired distance function is encoded into the index definition. Use `vector_l2_ops` for L2 distance,
 `vector_ip_ops` for inner product, or `vector_cosine_ops` for cosine distance.

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Indexing Vectors
-description: Add vectors to the ParadeDB index
+description: Vectors live alongside text and filters in the ParadeDB index
 canonical: https://docs.paradedb.com/documentation/indexing/indexing-vectors
 ---
 
@@ -15,13 +15,13 @@ canonical: https://docs.paradedb.com/documentation/indexing/indexing-vectors
   IVF indexes.
 </Note>
 
-The ParadeDB index can index pgvector's `vector` type alongside your text and other columns. This lets you combine vector search with full text search and filters in a single index.
-
-The `mock_items` table comes with an `embedding` column of type `vector(8)`, already populated with sample embeddings.
+The ParadeDB index can index pgvector's `vector` type alongside your text and other columns. This lets you combine vector search with full text search and filters in a single index,
+which can significantly improve latency/recall for selective queries.
 
 ## Create the Index
 
-To include a vector field in the index, simply add it alongside the other fields you wish to index.
+The `mock_items` table comes with an `embedding` column of type `vector(8)` populated with sample embeddings.
+In this example, `embedding` is added to the ParadeDB index with cosine similarity as the distance function.
 
 {/* TODO: add Drizzle, Django, and SQLAlchemy tabs once the ORMs support indexing vectors in a ParadeDB index. */}
 
@@ -31,8 +31,8 @@ USING paradedb (id, description, category, embedding vector_cosine_ops)
 WITH (key_field='id');
 ```
 
-The desired distance function is encoded into the index definition. Use `vector_l2_ops` for L2 distance,
-`vector_ip_ops` for inner product, or `vector_cosine_ops` for cosine distance.
+The desired distance function is encoded into the index definition, and cannot be changed without reindexing. 
+Use `vector_l2_ops` for L2 distance, `vector_ip_ops` for inner product, or `vector_cosine_ops` for cosine distance.
 
 <Note>
   Only pgvector's `vector` type is supported. The `halfvec`, `sparsevec`, and
@@ -59,7 +59,8 @@ WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, clu
 ```
 
 <ParamField body="centroid_ratio" default={0.01}>
-  The number of IVF centroids to build, as a fraction of the number of indexed
+  Vectors are clustered by proximity, and a centroid is a cluster's representative vector.
+  This setting controls the number of centroids to build, as a fraction of the number of indexed
   vectors (`num_centroids = centroid_ratio * num_vectors`). More centroids
   produce smaller clusters, improving recall at the cost of a slower, more
   memory-intensive build. Must be between `0.000001` and `1.0`.
@@ -69,7 +70,7 @@ WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, clu
   build time. Higher values yield better-quality centroids at the cost of a
   slower build. Must be between `1` and `100000`.
 </ParamField>
-<ParamField body="cluster_replication" default={1}>
+<ParamField body="cluster_replication" default={7}>
   The number of clusters each vector is written into: its primary cluster plus
   up to `cluster_replication - 1` next-nearest clusters. Higher values improve
   recall for filtered queries at the cost of a larger index. `1` disables

--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -4,6 +4,11 @@ description: ParadeDB is optimized for quickly finding the Top K results in a ta
 canonical: https://docs.paradedb.com/documentation/sorting/topk
 ---
 
+<Note>
+  This section covers sorting by a field. To sort by BM25 relevance score, see
+  [BM25 Scoring](/documentation/sorting/score).
+</Note>
+
 ParadeDB is highly optimized for quickly returning the Top K results out of the index. In SQL, this means queries that contain an `ORDER BY...LIMIT`:
 
 <CodeGroup>

--- a/docs/documentation/vector/overview.mdx
+++ b/docs/documentation/vector/overview.mdx
@@ -1,0 +1,15 @@
+---
+title: How Vector Search Works
+description: Understand how ParadeDB natively supports vector types
+canonical: https://docs.paradedb.com/documentation/vector/overview
+---
+
+<Note>This is a beta feature available in versions `0.25.0` and above.</Note>
+
+Today, most Postgres users rely on the [pgvector](https://github.com/pgvector/pgvector) extension for similarity (i.e. vector) search. pgvector works well for many use cases, but has a few limitations:
+
+- **Filtering Performance:** Its indexes are separate from the ParadeDB index, so performance suffers when composing vector search with text search and other filters.
+- **Memory Constraints:** Index build times balloon when the entire index does not fit in memory, preventing pgvector from scaling to large datasets.
+- **Index Quality Under Updates:** Indexes can degrade over time under update-heavy workloads.
+
+The ParadeDB index supports pgvector's `vector` type and is designed to solve these limitations. Vectors are indexed with a SPANN-style index, the state-of-the-art approach for billion-scale vector search.

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -13,8 +13,6 @@ canonical: https://docs.paradedb.com/documentation/vector/querying
 
 Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query over a vector column in the ParadeDB index.
 
-## Unfiltered Nearest Neighbors
-
 ParadeDB only accelerates a query when one of its search operators is present at the same level as the `ORDER BY ... LIMIT`. Any of the following qualify:
 
 | Operator | Meaning                                                                                           |
@@ -24,6 +22,8 @@ ParadeDB only accelerates a query when one of its search operators is present at
 | `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
 | `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
 | `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
+
+## Unfiltered Nearest Neighbors
 
 When you are not filtering, pair `@@@` with `pdb.all()`, which matches every row:
 

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -30,11 +30,11 @@ When you are not filtering, pair `@@@` with `pdb.all()`, which matches every row
 SELECT id, description
 FROM mock_items
 WHERE id @@@ pdb.all()
-ORDER BY embedding <=> '[1, 2, 3]'
+ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
 
-The `<=>` operator computes cosine distance, so this returns the five rows whose embeddings are nearest the query vector `[1, 2, 3]`.
+The `<=>` operator computes cosine distance, so this returns the five rows whose embeddings are nearest the query vector `[1, 2, 3, 4, 5, 6, 7, 8]`.
 
 This operator must match the operator class the column was indexed with. Otherwise, ParadeDB cannot use the index to order results and falls back to a slower brute force sort.
 
@@ -53,7 +53,7 @@ For instance, the following query finds the nearest neighbors among results whos
 SELECT id, description
 FROM mock_items
 WHERE category === 'Footwear'
-ORDER BY embedding <=> '[1, 2, 3]'
+ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
 
@@ -72,7 +72,7 @@ Use `EXPLAIN` to confirm ParadeDB is executing the search. Look for a `Custom Sc
 EXPLAIN SELECT id
 FROM mock_items
 WHERE id @@@ pdb.all()
-ORDER BY embedding <=> '[1, 2, 3]'
+ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
 

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -13,15 +13,7 @@ canonical: https://docs.paradedb.com/documentation/vector/querying
 
 Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query over a vector column in the ParadeDB index.
 
-When one of ParadeDB's search operators is present at the same level as the `ORDER BY ... LIMIT`, ParadeDB can accelerate the vector search query. Any of the following qualify:
-
-| Operator | Meaning                                                                                           |
-| -------- | ------------------------------------------------------------------------------------------------- |
-| `@@@`    | [General search predicate](/documentation/full-text/overview)                                     |
-| `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
-| `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
-| `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
-| `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
+When one of ParadeDB's [search operators](/documentation/filtering#search-operators) is present at the same level as the `ORDER BY ... LIMIT`, ParadeDB can accelerate the vector search query.
 
 ## Unfiltered Nearest Neighbors
 
@@ -47,7 +39,7 @@ This operator must match the operator class the column was indexed with. Otherwi
 
 ## Filtered Nearest Neighbors
 
-To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the search operators above.
+To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the [search operators](/documentation/filtering#search-operators).
 For instance, the following query finds the nearest neighbors among results whose `category` contains the term `Footwear`.
 
 ```sql
@@ -93,8 +85,6 @@ LIMIT 5;
 ```
 </Accordion>
 
-Notice that the `category === 'Footwear'` filter was pushed down into the same index scan that performs the `ORDER BY`: the
-`Tantivy Query` line shows the term filter, and the `TopK Order By` line shows the vector ordering, both inside a single
-`ParadeDB Base Scan`. Without pushdown, the filter would run as a separate step after the nearest neighbors were fetched.
+Notice that the `category === 'Footwear'` filter was pushed down into the same index scan that performs the vector search. Without pushdown, the filter would run as a separate step after the nearest neighbors were fetched.
 
 If you do not see a `TopKScanExecState`, the query fell back to a less efficient sort. This usually means the distance operator does not match the index operator class, the query is missing a `LIMIT`, or an `ORDER BY` or filter field is not indexed.

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -60,8 +60,8 @@ LIMIT 5;
 
 <Note>
   Every field you filter on (e.g. `category` above) must also be part of the
-  ParadeDB index. Filters on unindexed fields cannot be evaluated by the ParadeDB index, 
-  forcing Postgres to recheck them afterward and eliminating the
+  ParadeDB index. Filters on unindexed fields cannot be evaluated by the
+  ParadeDB index, forcing Postgres to recheck them afterward and eliminating the
   benefit of combining vector search with [filtering](/documentation/filtering).
 </Note>
 
@@ -70,9 +70,9 @@ LIMIT 5;
 Use `EXPLAIN` to confirm ParadeDB is accelerating the vector search. Look for a `Custom Scan` with an `Exec Method` of `TopKScanExecState` in the query plan:
 
 ```sql
-EXPLAIN SELECT id
+EXPLAIN SELECT id, description
 FROM mock_items
-WHERE id @@@ pdb.all()
+WHERE category === 'Footwear'
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
@@ -89,8 +89,12 @@ LIMIT 5;
          Scores: false
             TopK Order By: embedding <=> vector asc
             TopK Limit: 5
-         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"Footwear"}}}}
 ```
 </Accordion>
+
+Notice that the `category === 'Footwear'` filter was pushed down into the same index scan that performs the `ORDER BY`: the
+`Tantivy Query` line shows the term filter, and the `TopK Order By` line shows the vector ordering, both inside a single
+`ParadeDB Base Scan`. Without pushdown, the filter would run as a separate step after the nearest neighbors were fetched.
 
 If you do not see a `TopKScanExecState`, the query fell back to a less efficient sort. This usually means the distance operator does not match the index operator class, the query is missing a `LIMIT`, or an `ORDER BY` or filter field is not indexed.

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -1,0 +1,95 @@
+---
+title: Querying Vectors
+description: Run nearest-neighbor vector search inside the BM25 index
+canonical: https://docs.paradedb.com/documentation/vector/querying
+---
+
+<Note>
+  This is a beta feature available in versions `0.25.0` and above. See [How
+  Vector Search Works](/documentation/vector/overview) for background, and
+  [Indexing Vectors](/documentation/indexing/indexing-vectors) to set up the
+  index used in these examples.
+</Note>
+
+Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query — a [Top K](/documentation/sorting/topk) query — over a vector column in the BM25 index.
+
+## Approximate Nearest Neighbors
+
+ParadeDB only accelerates a query when one of its search operators is present at the same level as the `ORDER BY ... LIMIT`. Any of the following qualify:
+
+| Operator | Meaning                                                                                           |
+| -------- | ------------------------------------------------------------------------------------------------- |
+| `@@@`    | [General search predicate](/documentation/full-text/overview)                                     |
+| `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
+| `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
+| `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
+
+When you are not filtering, pair `@@@` with `pdb.all()`, which matches every row:
+
+```sql
+SELECT id, description
+FROM mock_items
+WHERE id @@@ pdb.all()
+ORDER BY embedding <=> '[1, 2, 3]'
+LIMIT 5;
+```
+
+The `<=>` operator computes cosine distance, so this returns the five rows whose embeddings are nearest the query vector `[1, 2, 3]`.
+
+This operator must match the operator class the column was indexed with. Otherwise, ParadeDB cannot use the index to order results and falls back to a slower brute force sort.
+
+| Operator | Distance      | Operator class      |
+| -------- | ------------- | ------------------- |
+| `<->`    | L2            | `vector_l2_ops`     |
+| `<=>`    | Cosine        | `vector_cosine_ops` |
+| `<#>`    | Inner product | `vector_ip_ops`     |
+
+## Filtered Vector Search
+
+To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the search operators above.
+For instance, the following query finds the nearest neighbors among results whose `category` contains the term `Footwear`.
+
+```sql
+SELECT id, description
+FROM mock_items
+WHERE category === 'Footwear'
+ORDER BY embedding <=> '[1, 2, 3]'
+LIMIT 5;
+```
+
+<Note>
+  Every field you filter on (e.g. `category` above) must also be part of the
+  BM25 index. Filters on unindexed fields cannot be evaluated inside the index
+  scan, forcing Postgres to recheck them afterward and eliminating the benefit
+  of combining vector search with [filtering](/documentation/filtering).
+</Note>
+
+## Verifying Pushdown
+
+Use `EXPLAIN` to confirm ParadeDB is executing the search. Look for a `Custom Scan (ParadeDB Base Scan)` with an `Exec Method` of `TopKScanExecState`:
+
+```sql
+EXPLAIN SELECT id
+FROM mock_items
+WHERE id @@@ pdb.all()
+ORDER BY embedding <=> '[1, 2, 3]'
+LIMIT 5;
+```
+
+<Accordion title="Expected Response">
+```csv
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items
+         Table: mock_items
+         Index: search_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: embedding <=> vector asc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+```
+</Accordion>
+
+If you do not see a `TopKScanExecState`, the query fell back to a less efficient sort. This usually means the distance operator does not match the index operator class, the query is missing a `LIMIT`, or an `ORDER BY` or filter field is not indexed.

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -11,9 +11,9 @@ canonical: https://docs.paradedb.com/documentation/vector/querying
   index used in these examples.
 </Note>
 
-Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query — a [Top K](/documentation/sorting/topk) query — over a vector column in the ParadeDB index.
+Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query over a vector column in the ParadeDB index.
 
-## Approximate Nearest Neighbors
+## Unfiltered Nearest Neighbors
 
 ParadeDB only accelerates a query when one of its search operators is present at the same level as the `ORDER BY ... LIMIT`. Any of the following qualify:
 
@@ -23,6 +23,7 @@ ParadeDB only accelerates a query when one of its search operators is present at
 | `\|\|\|` | [Match disjunction](/documentation/full-text/match#match-disjunction) — contains any of the terms |
 | `&&&`    | [Match conjunction](/documentation/full-text/match#match-conjunction) — contains all of the terms |
 | `===`    | [Term](/documentation/full-text/term) — exact token match                                         |
+| `###`    | [Phrase](/documentation/full-text/phrase) — tokens in order and position                          |
 
 When you are not filtering, pair `@@@` with `pdb.all()`, which matches every row:
 
@@ -44,7 +45,7 @@ This operator must match the operator class the column was indexed with. Otherwi
 | `<=>`    | Cosine        | `vector_cosine_ops` |
 | `<#>`    | Inner product | `vector_ip_ops`     |
 
-## Filtered Vector Search
+## Filtered Nearest Neighbors
 
 To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the search operators above.
 For instance, the following query finds the nearest neighbors among results whose `category` contains the term `Footwear`.

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -13,7 +13,7 @@ canonical: https://docs.paradedb.com/documentation/vector/querying
 
 Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query over a vector column in the ParadeDB index.
 
-When one of ParadeDB's [search operators](/documentation/filtering#non-text-fields) is present at the same level as the `ORDER BY ... LIMIT`, ParadeDB can accelerate the vector search query.
+When one of ParadeDB's [search operators](/documentation/filtering) is present at the same level as the `ORDER BY ... LIMIT`, ParadeDB can accelerate the vector search query.
 
 ## Unfiltered Nearest Neighbors
 

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -13,7 +13,7 @@ canonical: https://docs.paradedb.com/documentation/vector/querying
 
 Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query over a vector column in the ParadeDB index.
 
-ParadeDB only accelerates a query when one of its search operators is present at the same level as the `ORDER BY ... LIMIT`. Any of the following qualify:
+When one of ParadeDB's search operators is present at the same level as the `ORDER BY ... LIMIT`, ParadeDB can accelerate the vector search query. Any of the following qualify:
 
 | Operator | Meaning                                                                                           |
 | -------- | ------------------------------------------------------------------------------------------------- |
@@ -25,7 +25,7 @@ ParadeDB only accelerates a query when one of its search operators is present at
 
 ## Unfiltered Nearest Neighbors
 
-When you are not filtering, pair `@@@` with `pdb.all()`, which matches every row:
+When you are not filtering, use `pdb.all()`, which matches every row:
 
 ```sql
 SELECT id, description
@@ -60,14 +60,14 @@ LIMIT 5;
 
 <Note>
   Every field you filter on (e.g. `category` above) must also be part of the
-  ParadeDB index. Filters on unindexed fields cannot be evaluated inside the
-  index scan, forcing Postgres to recheck them afterward and eliminating the
+  ParadeDB index. Filters on unindexed fields cannot be evaluated by the ParadeDB index, 
+  forcing Postgres to recheck them afterward and eliminating the
   benefit of combining vector search with [filtering](/documentation/filtering).
 </Note>
 
 ## Verifying Pushdown
 
-Use `EXPLAIN` to confirm ParadeDB is executing the search. Look for a `Custom Scan (ParadeDB Base Scan)` with an `Exec Method` of `TopKScanExecState`:
+Use `EXPLAIN` to confirm ParadeDB is accelerating the vector search. Look for a `Custom Scan` with an `Exec Method` of `TopKScanExecState` in the query plan:
 
 ```sql
 EXPLAIN SELECT id

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -1,6 +1,6 @@
 ---
 title: Querying Vectors
-description: Run nearest-neighbor vector search inside the BM25 index
+description: Run nearest-neighbor vector search inside the ParadeDB index
 canonical: https://docs.paradedb.com/documentation/vector/querying
 ---
 
@@ -11,7 +11,7 @@ canonical: https://docs.paradedb.com/documentation/vector/querying
   index used in these examples.
 </Note>
 
-Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query — a [Top K](/documentation/sorting/topk) query — over a vector column in the BM25 index.
+Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query — a [Top K](/documentation/sorting/topk) query — over a vector column in the ParadeDB index.
 
 ## Approximate Nearest Neighbors
 
@@ -59,9 +59,9 @@ LIMIT 5;
 
 <Note>
   Every field you filter on (e.g. `category` above) must also be part of the
-  BM25 index. Filters on unindexed fields cannot be evaluated inside the index
-  scan, forcing Postgres to recheck them afterward and eliminating the benefit
-  of combining vector search with [filtering](/documentation/filtering).
+  ParadeDB index. Filters on unindexed fields cannot be evaluated inside the
+  index scan, forcing Postgres to recheck them afterward and eliminating the
+  benefit of combining vector search with [filtering](/documentation/filtering).
 </Note>
 
 ## Verifying Pushdown

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -63,13 +63,14 @@ This operator must match the operator class the column was indexed with. Otherwi
 ## Filtered Nearest Neighbors
 
 To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the [search operators](/documentation/filtering#non-text-fields).
-For instance, the following query finds the nearest neighbors among results whose `category` contains the term `Footwear`.
+For instance, the following query finds the nearest neighbors among results whose `category` contains the term `footwear`.
+Note the lowercase `footwear` — the default tokenizer lowercases terms, so `Footwear` would not match.
 
 <CodeGroup>
 ```sql SQL
 SELECT id, description
 FROM mock_items
-WHERE category === 'Footwear'
+WHERE category === 'footwear'
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
@@ -110,7 +111,7 @@ Use `EXPLAIN` to confirm ParadeDB is accelerating the vector search. Look for a 
 ```sql
 EXPLAIN SELECT id, description
 FROM mock_items
-WHERE category === 'Footwear'
+WHERE category === 'footwear'
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
@@ -127,10 +128,10 @@ LIMIT 5;
          Scores: false
             TopK Order By: embedding <=> vector asc
             TopK Limit: 5
-         Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"Footwear"}}}}
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"footwear"}}}}
 ```
 </Accordion>
 
-Notice that the `category === 'Footwear'` filter was pushed down into the same index scan that performs the vector search. Without pushdown, the filter would run as a separate step after the nearest neighbors were fetched.
+Notice that the `category === 'footwear'` filter was pushed down into the same index scan that performs the vector search. Without pushdown, the filter would run as a separate step after the nearest neighbors were fetched.
 
 If you do not see a `TopKScanExecState`, the query fell back to a less efficient sort. This usually means the distance operator does not match the index operator class, the query is missing a `LIMIT`, or an `ORDER BY` or filter field is not indexed.

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -19,13 +19,36 @@ When one of ParadeDB's [search operators](/documentation/filtering) is present a
 
 When you are not filtering, use `pdb.all()`, which matches every row:
 
-```sql
+<CodeGroup>
+```sql SQL
 SELECT id, description
 FROM mock_items
 WHERE id @@@ pdb.all()
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
+
+```ts Drizzle
+// Vector search support for Drizzle is coming very soon.
+```
+
+```python Django
+# Vector search support for Django is coming very soon.
+```
+
+```python SQLAlchemy
+# Vector search support for SQLAlchemy is coming very soon.
+```
+
+```ruby Rails
+# Vector search support for Rails is coming very soon.
+```
+
+```cs EF Core
+// Vector search support for EF Core is coming very soon.
+```
+
+</CodeGroup>
 
 The `<=>` operator computes cosine distance, so this returns the five rows whose embeddings are nearest the query vector `[1, 2, 3, 4, 5, 6, 7, 8]`.
 
@@ -42,13 +65,36 @@ This operator must match the operator class the column was indexed with. Otherwi
 To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the [search operators](/documentation/filtering#non-text-fields).
 For instance, the following query finds the nearest neighbors among results whose `category` contains the term `Footwear`.
 
-```sql
+<CodeGroup>
+```sql SQL
 SELECT id, description
 FROM mock_items
 WHERE category === 'Footwear'
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]'
 LIMIT 5;
 ```
+
+```ts Drizzle
+// Vector search support for Drizzle is coming very soon.
+```
+
+```python Django
+# Vector search support for Django is coming very soon.
+```
+
+```python SQLAlchemy
+# Vector search support for SQLAlchemy is coming very soon.
+```
+
+```ruby Rails
+# Vector search support for Rails is coming very soon.
+```
+
+```cs EF Core
+// Vector search support for EF Core is coming very soon.
+```
+
+</CodeGroup>
 
 <Note>
   Every field you filter on (e.g. `category` above) must also be part of the

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -13,7 +13,7 @@ canonical: https://docs.paradedb.com/documentation/vector/querying
 
 Vector search returns the rows whose embeddings are closest to a query vector. In ParadeDB, this is an `ORDER BY <distance> ... LIMIT k` query over a vector column in the ParadeDB index.
 
-When one of ParadeDB's [search operators](/documentation/filtering#search-operators) is present at the same level as the `ORDER BY ... LIMIT`, ParadeDB can accelerate the vector search query.
+When one of ParadeDB's [search operators](/documentation/filtering#non-text-fields) is present at the same level as the `ORDER BY ... LIMIT`, ParadeDB can accelerate the vector search query.
 
 ## Unfiltered Nearest Neighbors
 
@@ -39,7 +39,7 @@ This operator must match the operator class the column was indexed with. Otherwi
 
 ## Filtered Nearest Neighbors
 
-To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the [search operators](/documentation/filtering#search-operators).
+To search within a subset of rows, replace `pdb.all()` with a real predicate using any of the [search operators](/documentation/filtering#non-text-fields).
 For instance, the following query finds the nearest neighbors among results whose `category` contains the term `Footwear`.
 
 ```sql

--- a/docs/documentation/vector/tuning.mdx
+++ b/docs/documentation/vector/tuning.mdx
@@ -4,7 +4,7 @@ description: Trade recall against latency for vector search
 canonical: https://docs.paradedb.com/documentation/vector/tuning
 ---
 
-Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall — how often the true nearest neighbors are returned — at the cost of higher latency. Two session-level settings control this tradeoff:
+Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. Two session-level settings control this tradeoff:
 
 ```sql
 SET paradedb.vector_cluster_probe_epsilon = 0.5;

--- a/docs/documentation/vector/tuning.mdx
+++ b/docs/documentation/vector/tuning.mdx
@@ -1,0 +1,32 @@
+---
+title: Tuning Recall and Latency
+description: Trade recall against latency for vector search
+canonical: https://docs.paradedb.com/documentation/vector/tuning
+---
+
+Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall — how often the true nearest neighbors are returned — at the cost of higher latency. Two session-level settings control this tradeoff:
+
+```sql
+SET paradedb.vector_cluster_probe_epsilon = 0.5;
+SET paradedb.vector_cluster_max_probe = 0.02;
+```
+
+<ParamField body="paradedb.vector_cluster_probe_epsilon" default={0.5}>
+  The primary recall driver. A higher epsilon improves recall by probing more
+  clusters at the expense of higher latency. Think of epsilon as an early
+  termination value, where lower epsilon terminates early more aggressively.
+  When tuning this value, we recommend sweeping in increments of `0.1`. Must be
+  between `0.0` and `100.0`.
+</ParamField>
+
+<ParamField body="paradedb.vector_cluster_max_probe" default={0.02}>
+  A control for tail latency. This setting enforces a ceiling on how many clusters a query may probe. For instance, at the default value of `0.02`, at most 2% of clusters are probed. Must be between `0.000001` and `1.0`, where `1.0` effectively means "no ceiling."
+
+Note that setting this value to `1.0` does not equal exhaustive search, since the epsilon value still drives early termination.
+
+</ParamField>
+
+<Note>
+  Recall also depends on the index's `centroid_ratio`, set at build time. See
+  [Index Options](/documentation/indexing/indexing-vectors#index-options).
+</Note>

--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -7,8 +7,7 @@ canonical: https://docs.paradedb.com/welcome/introduction
 
 ![ParadeDB Banner](/images/paradedb_banner.png)
 
-ParadeDB is a search engine built into Postgres. It's built on the **pg_search** extension, a Postgres index where vectors, text, BM25 scoring and filters
-live alongside each other. Everything runs inside your system of record with Postgres' transactional guarantees, not in
+ParadeDB is a search engine built into Postgres. It's built on the **pg_search** extension, a single Postgres index for efficient vector/text search, BM25 scoring, filtering, and aggregates. Everything runs inside your system of record with Postgres' transactional guarantees, not in
 a second system you have to keep in sync.
 
 <Note>
@@ -22,7 +21,7 @@ a second system you have to keep in sync.
 You're likely a good fit for ParadeDB if any of the following sound like you:
 
 1. **Postgres is your primary database** (managed or self-managed) and you'd rather build on it than around it.
-2. You've **outgrown Postgres' built-in search** (`tsvector` and the GIN index) and hit **performance bottlenecks** or **missing features** like BM25 scoring, fuzzy matching, or faceting.
+2. You've **outgrown Postgres' built-in search** (`tsvector` or `pgvector`) and hit **performance bottlenecks** or **missing features** with vector/text search.
 3. You're **evaluating a search engine** like Elasticsearch, but don't want to run (and continuously sync) a second system alongside your database.
 
 ## Why ParadeDB?
@@ -62,8 +61,7 @@ ParadeDB accelerates standard SQL queries. That includes:
 - **Text**: relevance-ranked full-text queries like the one above.
 - **Aggregations**: the same index serves faceted search and aggregations, pushing filters and aggregates directly into the index instead
   of computing them afterward.
-- **Vectors**: pair ParadeDB with [pgvector](https://github.com/pgvector/pgvector) to combine full-text and semantic search in one query,
-  with no separate vector database to keep in sync. A high-performance, drop-in compatible version is coming to the ParadeDB index soon.
+- **Vectors**: the ParadeDB index is a high-performance, drop-in compatible version with `pgvector`.
 
 ### One Index Behind Every Query
 

--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -7,8 +7,8 @@ canonical: https://docs.paradedb.com/welcome/introduction
 
 ![ParadeDB Banner](/images/paradedb_banner.png)
 
-ParadeDB is a search engine built into Postgres. Its **pg_search** extension brings BM25 relevance ranking, faceting, hybrid search, and
-aggregations to your tables in standard SQL. Everything runs inside your system of record with Postgres' transactional guarantees, not in
+ParadeDB is a search engine built into Postgres. It's built on the **pg_search** extension, a Postgres index where vectors, text, BM25 scoring and filters
+live alongside each other. Everything runs inside your system of record with Postgres' transactional guarantees, not in
 a second system you have to keep in sync.
 
 <Note>

--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -28,15 +28,15 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 - **Push Postgres visibility rules into the index**. This is currently a filter applied post index scan that adds overhead to large scans.
 - **Parallel aggregate execution**. Aggregate pushdown across joins currently runs single-threaded. Two-phase parallel aggregation (partial + final) will unlock multi-core execution for high-cardinality GROUP BY on joined tables.
 
-### Vector Search Improvements
-
-- Improve vector search performance in Postgres by addressing pgvector's limitations around filtered queries — specifically, queries that combine vector similarity with metadata filters or full-text search predicates.
-
 ### Managed Cloud
 
 - Today, you can [deploy ParadeDB](/deploy/overview) self-hosted, on cloud platforms, or with ParadeDB BYOC. We're also building ParadeDB Cloud, a fully managed ParadeDB: first-class search from Postgres, with a developer experience to match. [Join the waitlist](https://www.paradedb.com/cloud) to get notified when it launches.
 
 ## Completed
+
+### Vector Search
+
+- **[Native vector search](/documentation/vector/overview) (beta)**. The ParadeDB index natively indexes pgvector's `vector` type, addressing pgvector's limitations around filtered queries — specifically, queries that combine vector similarity with metadata filters or full-text search predicates.
 
 ### Analytics
 


### PR DESCRIPTION
## What

Stacked on #5700. Adds docs for native vector search:

- New `Vector Search` section (overview, querying, tuning) and an `Indexing Vectors` page
- Callouts in the full text overview and top K pages pointing to the new section
- Uses the post-rename `ParadeDB index` / `USING paradedb` naming, and points the create-index callout's vector search link at the new overview page