### PR TITLE
perf: Avoid unnecessary score Vec clone in batch_scanner::next

### DIFF
--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -285,12 +285,12 @@ impl Scanner {
         // to keep them aligned with `ids`.
         let mut memoized_columns: Vec<Option<ArrayRef>> = vec![None; self.which_fast_fields.len()];
 
+        let scores_array = Arc::new(Float32Array::from(scores)) as ArrayRef;
         let mut lazy_score_array: Option<ArrayRef> = None;
         for (idx, ff) in self.which_fast_fields.iter().enumerate() {
             if matches!(ff, WhichFastField::Score) {
-                let score_array = lazy_score_array.get_or_insert_with(|| {
-                    Arc::new(Float32Array::from(scores.clone())) as ArrayRef
-                });
+                let score_array = lazy_score_array
+                    .get_or_insert_with(|| scores_array.clone());
                 memoized_columns[idx] = Some(score_array.clone());
             }
         }

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -289,8 +289,7 @@ impl Scanner {
         let mut lazy_score_array: Option<ArrayRef> = None;
         for (idx, ff) in self.which_fast_fields.iter().enumerate() {
             if matches!(ff, WhichFastField::Score) {
-                let score_array = lazy_score_array
-                    .get_or_insert_with(|| scores_array.clone());
+                let score_array = lazy_score_array.get_or_insert_with(|| scores_array.clone());
                 memoized_columns[idx] = Some(score_array.clone());
             }
         }

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -285,12 +285,16 @@ impl Scanner {
         // to keep them aligned with `ids`.
         let mut memoized_columns: Vec<Option<ArrayRef>> = vec![None; self.which_fast_fields.len()];
 
-        let scores_array = Arc::new(Float32Array::from(scores)) as ArrayRef;
-        let mut lazy_score_array: Option<ArrayRef> = None;
-        for (idx, ff) in self.which_fast_fields.iter().enumerate() {
-            if matches!(ff, WhichFastField::Score) {
-                let score_array = lazy_score_array.get_or_insert_with(|| scores_array.clone());
-                memoized_columns[idx] = Some(score_array.clone());
+        if self
+            .which_fast_fields
+            .iter()
+            .any(|ff| matches!(ff, WhichFastField::Score))
+        {
+            let scores_array = Arc::new(Float32Array::from(scores)) as ArrayRef;
+            for (idx, ff) in self.which_fast_fields.iter().enumerate() {
+                if matches!(ff, WhichFastField::Score) {
+                    memoized_columns[idx] = Some(scores_array.clone());
+                }
             }
         }
 


### PR DESCRIPTION
Ticket(s) Closed  
- Closes #5708

## What

Small cleanup in `Scanner::next()`: build the score `Float32Array` once per batch by moving the `Vec<Score>` into it, instead of cloning the `Vec` and then converting.

## Why

The previous code called `Float32Array::from(scores.clone())` inside `get_or_insert_with`. The clone was already memoized, so it ran at most **once per batch**, not once per score column — this is 2 allocations down to 1 in the score-projected path, not a per-row or per-column win.

To set expectations honestly: this is not expected to be measurable in a benchmark. `try_get_batch_ids` already allocates a `Vec` of the same size, and the removed `memcpy` is one ~512 KB copy per 128k rows. The change is worth making because the copy was plainly unnecessary and the resulting code is simpler, not because it moves a number.

## How

- Guard the whole thing on `which_fast_fields.iter().any(|ff| matches!(ff, WhichFastField::Score))`, so nothing is allocated when no score column is projected (the common case).
- Inside the guard, `Float32Array::from(scores)` takes ownership of the `Vec`'s buffer directly.
- Assign `scores_array.clone()` (an `Arc` refcount bump) into each `WhichFastField::Score` slot.
- This removes the `Option<ArrayRef>` / `get_or_insert_with` indirection entirely while keeping the laziness it provided.

### Known trade-off

`Float32Array::from` adopts the `Vec`'s full allocation, including spare capacity, whereas `scores.clone()` previously produced a right-sized `Vec` first. For the final partial batch of each segment, the score array therefore retains up to the full batch-size allocation for however many rows it actually holds, and it lives as long as the `RecordBatch` does. This is bounded by segment count and is small in practice, but it means the net memory effect is closer to a wash than a strict improvement. Fixing it would require a `shrink_to_fit()`, which reintroduces the copy this PR removes.

## Tests

No new tests — this is a pure refactor with no observable behaviour change. Output values, ordering, and top-K semantics are identical, and the score projection path is already covered by the existing suite (codecov reports the modified lines fully covered).
