### PR TITLE
chore: Fix macOS build of stressgres

### DIFF
--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -65,7 +65,7 @@ RUN cargo fetch --manifest-path /home/app/Cargo.toml && \
     TARGET="$(rustc -vV | sed -n 's/^host: //p')" && \
     env "CARGO_TARGET_$(echo "$TARGET" | tr 'a-z-' 'A-Z_')_RUSTFLAGS=-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id" \
         cargo build --offline --profile dst --target "$TARGET" \
-        --manifest-path /home/app/Cargo.toml -p stressgres && \
+        --manifest-path /home/app/Cargo.toml -p stressgres --features dst && \
     ln -sf "/home/app/target/$TARGET/dst/stressgres" /symbols/stressgres
 
 CMD ["sleep", "infinity"]

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -8,6 +8,9 @@ license = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+dst = ["dst/enabled"]
+
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6", features = ["derive"] }
@@ -36,7 +39,7 @@ toml = "0.8.23"
 url = "2.5.8"
 postgres-openssl = "0.5.3"
 openssl = "0.10.78"
-dst = { path = "../dst", features = ["enabled"] }
+dst = { path = "../dst" }
 
 [dev-dependencies]
 tempfile = "3.27.0"


### PR DESCRIPTION
## What

Conditionally enable `dst` for `stressgres`.

## Why

`antithesis-instrumentation` does not build on macOS, but isn't intended to. Attempting to build it can cause `cargo check`/`cargo clippy` to fail with:
```console
  error: invalid Mach-O section specifier
    --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/antithesis-instrumentation-0.1.0/src/lib.rs:10:25
     |
  10 | #[unsafe(link_section = ".init_array")]
     |                         ^^^^^^^^^^^^^ not a valid Mach-O section specifier
     |
     = note: a Mach-O section specifier requires a segment and a section, separated by a comma
     = help: an example of a valid Mach-O section specifier is `__TEXT,__cstring`

  error: could not compile `antithesis-instrumentation` (lib) due to 1 previous error
```