### PR TITLE
fix: Disallow multi-valued fields in `partition_by` or `sort_by`.

### DIFF
--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -205,6 +205,50 @@ unsafe fn validate_index_config(index_relation: &PgSearchRelation) {
             });
         }
     }
+
+    // Validate that `sort_by` and `partition_by` fields are single-valued
+    let check_single_valued = |field_name: &FieldName, context: &str| {
+        let attributes = options.attributes();
+        // Resolve alias if needed
+        let resolved_name = match options
+            .aliased_text_configs()
+            .into_iter()
+            .chain(options.aliased_json_configs())
+            .find(|(name, _)| name == field_name)
+        {
+            Some((_, config)) => FieldName::from(config.alias().unwrap().to_string()),
+            None => field_name.clone(),
+        };
+
+        if resolved_name.is_ctid() {
+            return;
+        }
+
+        if let Some(attr) = attributes.get(&resolved_name) {
+            let (_, is_array) =
+                crate::postgres::utils::resolve_base_type(PgOid::from_untagged(attr.inner_typoid))
+                    .unwrap_or_else(|| panic!("failed to resolve base type for `{resolved_name}`"));
+
+            let is_multi_valued = is_array
+                || matches!(
+                    attr.tantivy_type,
+                    SearchFieldType::Json(_) | SearchFieldType::Range(_)
+                );
+
+            if is_multi_valued {
+                panic!(
+                    "`{field_name}` cannot be used in `{context}` because it is a multi-valued field"
+                );
+            }
+        }
+    };
+
+    for sort_field in options.sort_by() {
+        check_single_valued(&sort_field.field_name, "sort_by");
+    }
+    for partition_field in options.partition_by() {
+        check_single_valued(&partition_field, "partition_by");
+    }
 }
 
 fn validate_field_config(

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -208,38 +208,13 @@ unsafe fn validate_index_config(index_relation: &PgSearchRelation) {
 
     // Validate that `sort_by` and `partition_by` fields are single-valued
     let check_single_valued = |field_name: &FieldName, context: &str| {
-        let attributes = options.attributes();
-        // Resolve alias if needed
-        let resolved_name = match options
-            .aliased_text_configs()
-            .into_iter()
-            .chain(options.aliased_json_configs())
-            .find(|(name, _)| name == field_name)
-        {
-            Some((_, config)) => FieldName::from(config.alias().unwrap().to_string()),
-            None => field_name.clone(),
-        };
-
-        if resolved_name.is_ctid() {
-            return;
+        if options.get_field_type(field_name).is_none() {
+            panic!("`{field_name}` in `{context}` does not exist");
         }
-
-        if let Some(attr) = attributes.get(&resolved_name) {
-            let (_, is_array) =
-                crate::postgres::utils::resolve_base_type(PgOid::from_untagged(attr.inner_typoid))
-                    .unwrap_or_else(|| panic!("failed to resolve base type for `{resolved_name}`"));
-
-            let is_multi_valued = is_array
-                || matches!(
-                    attr.tantivy_type,
-                    SearchFieldType::Json(_) | SearchFieldType::Range(_)
-                );
-
-            if is_multi_valued {
-                panic!(
-                    "`{field_name}` cannot be used in `{context}` because it is a multi-valued field"
-                );
-            }
+        if options.is_multi_valued(field_name) {
+            panic!(
+                "`{field_name}` cannot be used in `{context}` because it is a multi-valued field"
+            );
         }
     };
 

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -720,6 +720,47 @@ impl BM25IndexOptions {
         self.lazy.attributes.borrow()
     }
 
+    pub fn is_multi_valued(&self, field_name: &FieldName) -> bool {
+        if field_name.is_ctid() {
+            return false;
+        }
+
+        let mut current_name = field_name.clone();
+        loop {
+            if let Some(attr) = self.attributes().get(&current_name) {
+                let (_, is_array) = crate::postgres::utils::resolve_base_type(
+                    PgOid::from_untagged(attr.inner_typoid),
+                )
+                .unwrap_or_else(|| panic!("failed to resolve base type for `{current_name}`"));
+
+                return is_array
+                    || matches!(
+                        attr.tantivy_type,
+                        SearchFieldType::Json(_) | SearchFieldType::Range(_)
+                    );
+            }
+
+            let mut found_alias = false;
+            for (aliased_name, config) in self
+                .aliased_text_configs()
+                .into_iter()
+                .chain(self.aliased_json_configs())
+            {
+                if aliased_name == current_name {
+                    if let Some(alias) = config.alias() {
+                        current_name = FieldName::from(alias.to_string());
+                        found_alias = true;
+                        break;
+                    }
+                }
+            }
+
+            if !found_alias {
+                return false;
+            }
+        }
+    }
+
     #[inline(always)]
     fn options_data(&self) -> &BM25IndexOptionsData {
         unsafe {

--- a/pg_search/src/scan/range_partitioning.rs
+++ b/pg_search/src/scan/range_partitioning.rs
@@ -39,7 +39,7 @@ impl RangePartitioning {
     ///
     /// **Consumer Caveats**:
     /// - A row whose partition field is NULL will be deterministically routed to partition 0.
-    /// - A multi-valued field can fall into multiple partition ranges and duplicate the row.
+    /// - A multi-valued field can fall into multiple partition ranges and duplicate the row. This is statically prevented during index configuration for `partition_by` columns.
     pub fn partition_bounds(&self, partition: usize) -> SearchQueryInput {
         let lower = if partition > 0 {
             let val = &self.split_points[partition - 1];

--- a/pg_search/tests/pg_regress/expected/partition_by.out
+++ b/pg_search/tests/pg_regress/expected/partition_by.out
@@ -79,3 +79,25 @@ CREATE INDEX partition_by_test_idx ON partition_by_test
     WITH (key_field='id', partition_by=' , ');
 ERROR:  invalid partition_by value: must specify at least one field
 DROP TABLE partition_by_test CASCADE;
+-- SECTION 3: Multi-valued fields (should error)
+\echo '=== SECTION 3: Multi-valued fields ==='
+=== SECTION 3: Multi-valued fields ===
+DROP TABLE IF EXISTS partition_by_multi_test CASCADE;
+CREATE TABLE partition_by_multi_test (
+    id SERIAL PRIMARY KEY,
+    tags TEXT[],
+    meta JSONB
+);
+\echo 'Test 3.1: partition_by with array field (should error)'
+Test 3.1: partition_by with array field (should error)
+CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', partition_by='tags');
+ERROR:  `tags` cannot be used in `partition_by` because it is a multi-valued field
+\echo 'Test 3.2: partition_by with json field (should error)'
+Test 3.2: partition_by with json field (should error)
+CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', partition_by='meta');
+ERROR:  `meta` cannot be used in `partition_by` because it is a multi-valued field
+DROP TABLE partition_by_multi_test CASCADE;

--- a/pg_search/tests/pg_regress/expected/partition_by.out
+++ b/pg_search/tests/pg_regress/expected/partition_by.out
@@ -52,12 +52,12 @@ Test 2.1: partition_by with nonexistent field (should error)
 CREATE INDEX partition_by_test_idx ON partition_by_test
     USING bm25 (id, name, score)
     WITH (key_field='id', partition_by='nonexistent');
+ERROR:  `nonexistent` in `partition_by` does not exist
 \echo 'Test 2.2: partition_by with invalid syntax / empty string (should error)'
 Test 2.2: partition_by with invalid syntax / empty string (should error)
 CREATE INDEX partition_by_test_idx ON partition_by_test
     USING bm25 (id, name, score)
     WITH (key_field='id', partition_by='');
-ERROR:  relation "partition_by_test_idx" already exists
 -- Empty string disables it, so it succeeds. We drop it.
 DROP INDEX partition_by_test_idx;
 \echo 'Test 2.3: partition_by with whitespace only (should error)'
@@ -86,7 +86,8 @@ DROP TABLE IF EXISTS partition_by_multi_test CASCADE;
 CREATE TABLE partition_by_multi_test (
     id SERIAL PRIMARY KEY,
     tags TEXT[],
-    meta JSONB
+    meta JSONB,
+    int_array INTEGER[]
 );
 \echo 'Test 3.1: partition_by with array field (should error)'
 Test 3.1: partition_by with array field (should error)
@@ -100,4 +101,10 @@ CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
     USING bm25 (id, tags, meta)
     WITH (key_field='id', partition_by='meta');
 ERROR:  `meta` cannot be used in `partition_by` because it is a multi-valued field
+\echo 'Test 3.3: partition_by with aliased array expression (should error)'
+Test 3.3: partition_by with aliased array expression (should error)
+CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
+    USING bm25 (id, (int_array::pdb.alias('aliased_array')))
+    WITH (key_field='id', partition_by='aliased_array');
+ERROR:  `aliased_array` cannot be used in `partition_by` because it is a multi-valued field
 DROP TABLE partition_by_multi_test CASCADE;

--- a/pg_search/tests/pg_regress/expected/sort_by.out
+++ b/pg_search/tests/pg_regress/expected/sort_by.out
@@ -86,7 +86,7 @@ Test 3.1: sort_by with nonexistent field (should error)
 CREATE INDEX sort_by_test_idx ON sort_by_test
     USING bm25 (id, name, score)
     WITH (key_field='id', sort_by='nonexistent ASC NULLS FIRST');
-ERROR:  sort_by field 'nonexistent' does not exist in the index schema
+ERROR:  `nonexistent` in `sort_by` does not exist
 \echo 'Test 3.2: sort_by with non-fast field (should error)'
 Test 3.2: sort_by with non-fast field (should error)
 CREATE INDEX sort_by_test_idx ON sort_by_test
@@ -185,7 +185,8 @@ DROP TABLE IF EXISTS sort_by_multi_test CASCADE;
 CREATE TABLE sort_by_multi_test (
     id SERIAL PRIMARY KEY,
     tags TEXT[],
-    meta JSONB
+    meta JSONB,
+    int_array INTEGER[]
 );
 \echo 'Test 6.1: sort_by with array field (should error)'
 Test 6.1: sort_by with array field (should error)
@@ -199,4 +200,10 @@ CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
     USING bm25 (id, tags, meta)
     WITH (key_field='id', sort_by='meta ASC NULLS FIRST');
 ERROR:  `meta` cannot be used in `sort_by` because it is a multi-valued field
+\echo 'Test 6.3: sort_by with aliased array expression (should error)'
+Test 6.3: sort_by with aliased array expression (should error)
+CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
+    USING bm25 (id, (int_array::pdb.alias('aliased_array')))
+    WITH (key_field='id', sort_by='aliased_array ASC NULLS FIRST');
+ERROR:  `aliased_array` cannot be used in `sort_by` because it is a multi-valued field
 DROP TABLE sort_by_multi_test CASCADE;

--- a/pg_search/tests/pg_regress/expected/sort_by.out
+++ b/pg_search/tests/pg_regress/expected/sort_by.out
@@ -178,3 +178,25 @@ CREATE TABLE sort_by_alias (id SERIAL PRIMARY KEY, price INTEGER, qty INTEGER);
 CREATE INDEX idx ON sort_by_alias USING bm25 (id, ((price * qty)::pdb.alias('total')))
     WITH (key_field='id', sort_by='total DESC NULLS LAST');
 DROP TABLE sort_by_alias CASCADE;
+-- SECTION 6: Multi-valued fields (should error)
+\echo '=== SECTION 6: Multi-valued fields ==='
+=== SECTION 6: Multi-valued fields ===
+DROP TABLE IF EXISTS sort_by_multi_test CASCADE;
+CREATE TABLE sort_by_multi_test (
+    id SERIAL PRIMARY KEY,
+    tags TEXT[],
+    meta JSONB
+);
+\echo 'Test 6.1: sort_by with array field (should error)'
+Test 6.1: sort_by with array field (should error)
+CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', sort_by='tags ASC NULLS FIRST');
+ERROR:  `tags` cannot be used in `sort_by` because it is a multi-valued field
+\echo 'Test 6.2: sort_by with json field (should error)'
+Test 6.2: sort_by with json field (should error)
+CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', sort_by='meta ASC NULLS FIRST');
+ERROR:  `meta` cannot be used in `sort_by` because it is a multi-valued field
+DROP TABLE sort_by_multi_test CASCADE;

--- a/pg_search/tests/pg_regress/sql/partition_by.sql
+++ b/pg_search/tests/pg_regress/sql/partition_by.sql
@@ -84,7 +84,8 @@ DROP TABLE IF EXISTS partition_by_multi_test CASCADE;
 CREATE TABLE partition_by_multi_test (
     id SERIAL PRIMARY KEY,
     tags TEXT[],
-    meta JSONB
+    meta JSONB,
+    int_array INTEGER[]
 );
 
 \echo 'Test 3.1: partition_by with array field (should error)'
@@ -96,5 +97,10 @@ CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
 CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
     USING bm25 (id, tags, meta)
     WITH (key_field='id', partition_by='meta');
+
+\echo 'Test 3.3: partition_by with aliased array expression (should error)'
+CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
+    USING bm25 (id, (int_array::pdb.alias('aliased_array')))
+    WITH (key_field='id', partition_by='aliased_array');
 
 DROP TABLE partition_by_multi_test CASCADE;

--- a/pg_search/tests/pg_regress/sql/partition_by.sql
+++ b/pg_search/tests/pg_regress/sql/partition_by.sql
@@ -76,3 +76,25 @@ CREATE INDEX partition_by_test_idx ON partition_by_test
     WITH (key_field='id', partition_by=' , ');
 
 DROP TABLE partition_by_test CASCADE;
+
+-- SECTION 3: Multi-valued fields (should error)
+\echo '=== SECTION 3: Multi-valued fields ==='
+
+DROP TABLE IF EXISTS partition_by_multi_test CASCADE;
+CREATE TABLE partition_by_multi_test (
+    id SERIAL PRIMARY KEY,
+    tags TEXT[],
+    meta JSONB
+);
+
+\echo 'Test 3.1: partition_by with array field (should error)'
+CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', partition_by='tags');
+
+\echo 'Test 3.2: partition_by with json field (should error)'
+CREATE INDEX partition_by_multi_test_idx ON partition_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', partition_by='meta');
+
+DROP TABLE partition_by_multi_test CASCADE;

--- a/pg_search/tests/pg_regress/sql/sort_by.sql
+++ b/pg_search/tests/pg_regress/sql/sort_by.sql
@@ -184,7 +184,8 @@ DROP TABLE IF EXISTS sort_by_multi_test CASCADE;
 CREATE TABLE sort_by_multi_test (
     id SERIAL PRIMARY KEY,
     tags TEXT[],
-    meta JSONB
+    meta JSONB,
+    int_array INTEGER[]
 );
 
 \echo 'Test 6.1: sort_by with array field (should error)'
@@ -196,5 +197,10 @@ CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
 CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
     USING bm25 (id, tags, meta)
     WITH (key_field='id', sort_by='meta ASC NULLS FIRST');
+
+\echo 'Test 6.3: sort_by with aliased array expression (should error)'
+CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
+    USING bm25 (id, (int_array::pdb.alias('aliased_array')))
+    WITH (key_field='id', sort_by='aliased_array ASC NULLS FIRST');
 
 DROP TABLE sort_by_multi_test CASCADE;

--- a/pg_search/tests/pg_regress/sql/sort_by.sql
+++ b/pg_search/tests/pg_regress/sql/sort_by.sql
@@ -176,3 +176,25 @@ CREATE TABLE sort_by_alias (id SERIAL PRIMARY KEY, price INTEGER, qty INTEGER);
 CREATE INDEX idx ON sort_by_alias USING bm25 (id, ((price * qty)::pdb.alias('total')))
     WITH (key_field='id', sort_by='total DESC NULLS LAST');
 DROP TABLE sort_by_alias CASCADE;
+
+-- SECTION 6: Multi-valued fields (should error)
+\echo '=== SECTION 6: Multi-valued fields ==='
+
+DROP TABLE IF EXISTS sort_by_multi_test CASCADE;
+CREATE TABLE sort_by_multi_test (
+    id SERIAL PRIMARY KEY,
+    tags TEXT[],
+    meta JSONB
+);
+
+\echo 'Test 6.1: sort_by with array field (should error)'
+CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', sort_by='tags ASC NULLS FIRST');
+
+\echo 'Test 6.2: sort_by with json field (should error)'
+CREATE INDEX sort_by_multi_test_idx ON sort_by_multi_test
+    USING bm25 (id, tags, meta)
+    WITH (key_field='id', sort_by='meta ASC NULLS FIRST');
+
+DROP TABLE sort_by_multi_test CASCADE;


### PR DESCRIPTION
## What

Disallow multi-valued columns in `partition_by` or `sort_by`.

## Why

Partitioning and sorting are undefined in the presence of multi-valued columns.

## Tests

New regress tests.