### PR TITLE
ci: fix Antithesis OpenBLAS packaging

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -158,7 +158,7 @@ jobs:
 
           # Install PostgreSQL + build tooling
           DEBIAN_FRONTEND=noninteractive sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y postgresql-${{ env.PG_VERSION }} postgresql-server-dev-${{ env.PG_VERSION }} debhelper devscripts dput gnupg binutils
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y postgresql-${{ env.PG_VERSION }} postgresql-server-dev-${{ env.PG_VERSION }} debhelper devscripts dput gnupg binutils libopenblas-dev
 
           # Add Postgres bin dir to PATH for subsequent steps
           echo "/usr/lib/postgresql/${{ env.PG_VERSION }}/bin" >> "$GITHUB_PATH"
@@ -250,7 +250,7 @@ jobs:
           echo 'Section: database' >> $CONTROL_FILE
           echo 'Priority: optional' >> $CONTROL_FILE
           echo 'Architecture: amd64' >> $CONTROL_FILE
-          echo 'Depends: postgresql-${{ env.PG_VERSION }}' >> $CONTROL_FILE
+          echo 'Depends: postgresql-${{ env.PG_VERSION }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Postgres for Search and Analytics' >> $CONTROL_FILE
 

--- a/docker/Dockerfile.antithesis-18
+++ b/docker/Dockerfile.antithesis-18
@@ -10,8 +10,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 # Install the locally built, Antithesis-instrumented pg_search package.
 ARG COMMIT_SHA
 COPY pg_search-antithesis-trixie-amd64-pg18-${COMMIT_SHA}.deb /tmp/pg_search.deb
-RUN dpkg -i /tmp/pg_search.deb && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends /tmp/pg_search.deb && \
     rm /tmp/pg_search.deb && \
+    rm -rf /var/lib/apt/lists/* && \
     mkdir /symbols && \
     ln -s /usr/lib/postgresql/18/lib/pg_search.so /symbols/pg_search.so
 

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -11,8 +11,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 # Install the locally built, Antithesis-instrumented pg_search package.
 ARG COMMIT_SHA
 COPY pg_search-antithesis-trixie-amd64-pg@@PG_VERSION_MAJOR@@-${COMMIT_SHA}.deb /tmp/pg_search.deb
-RUN dpkg -i /tmp/pg_search.deb && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends /tmp/pg_search.deb && \
     rm /tmp/pg_search.deb && \
+    rm -rf /var/lib/apt/lists/* && \
     mkdir /symbols && \
     ln -s /usr/lib/postgresql/@@PG_VERSION_MAJOR@@/lib/pg_search.so /symbols/pg_search.so
 # %%ANTITHESIS_END%%


### PR DESCRIPTION
## Summary

- Install `libopenblas-dev` in the Antithesis `pg_search` package build job so the Linux `superkmeans-rs` OpenBLAS backend can link.
- Add `libopenblas0` to the Antithesis `.deb` dependencies.
- Install the local Antithesis `.deb` with `apt-get install /tmp/pg_search.deb` in the generated/template Dockerfiles so runtime dependencies are resolved in the workload image.

## Root Cause

The recent vector search work added `superkmeans-rs` with the Linux `openblas` feature. The Antithesis packaging workflow was missing OpenBLAS in its build environment, causing `rust-lld` to fail while linking `pg_search.so` with `unable to find library -lopenblas` in `paradedb/paradedb-enterprise` scheduled run `30233625061`, job `89877026568`.

## Validation

- `git diff --check`
- `npx --yes prettier --check .github/workflows/test-pg_search-antithesis.yml`
- pre-commit hooks during commit, including `check-yaml` and `prettier`

The full Antithesis package/image build was not run locally because it requires the CI-generated `.deb` artifact and Antithesis workflow environment.