### PR TITLE
fix: declare vector opclasses for the paradedb access method

### DIFF
--- a/pg_search/sql/pg_search--0.24.3--0.25.0.sql
+++ b/pg_search/sql/pg_search--0.24.3--0.25.0.sql
@@ -47,16 +47,6 @@ STRICT
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'vector_info_wrapper';
 
--- Vector opclasses (pgvector convention). Pure metric tags: STORAGE only,
--- no strategy operators or support functions. bm25 reads the metric back at
--- build time; vector_l2_ops is DEFAULT so a bare `(embedding)` resolves to L2.
-CREATE OPERATOR CLASS public.vector_l2_ops DEFAULT FOR TYPE public.vector USING bm25 AS
-    STORAGE public.vector;
-CREATE OPERATOR CLASS public.vector_cosine_ops FOR TYPE public.vector USING bm25 AS
-    STORAGE public.vector;
-CREATE OPERATOR CLASS public.vector_ip_ops FOR TYPE public.vector USING bm25 AS
-    STORAGE public.vector;
-
 -- Introduce `paradedb` as the primary name for the index access method (sharing the
 -- existing `bm25_handler`), a default operator class for it, and refresh the
 -- `index_layer_info` views so they recognize any index whose access method uses
@@ -73,3 +63,19 @@ CREATE OPERATOR CLASS anyelement_paradedb_ops DEFAULT FOR TYPE anyelement USING 
     OPERATOR 1 pg_catalog.@@@(anyelement, text),                         /* for querying with a tantivy-compatible text query */
     OPERATOR 2 pg_catalog.@@@(anyelement, paradedb.searchqueryinput),    /* for querying with a paradedb.searchqueryinput structure */
     STORAGE anyelement;
+
+-- Vector opclasses (pgvector convention). Pure metric tags: STORAGE only,
+-- no strategy operators or support functions. bm25 reads the metric back at
+-- build time; vector_l2_ops is DEFAULT so a bare `(embedding)` resolves to L2.
+CREATE OPERATOR CLASS public.vector_l2_ops DEFAULT FOR TYPE public.vector USING bm25 AS
+    STORAGE public.vector;
+CREATE OPERATOR CLASS public.vector_cosine_ops FOR TYPE public.vector USING bm25 AS
+    STORAGE public.vector;
+CREATE OPERATOR CLASS public.vector_ip_ops FOR TYPE public.vector USING bm25 AS
+    STORAGE public.vector;
+CREATE OPERATOR CLASS public.vector_l2_ops DEFAULT FOR TYPE public.vector USING paradedb AS
+    STORAGE public.vector;
+CREATE OPERATOR CLASS public.vector_cosine_ops FOR TYPE public.vector USING paradedb AS
+    STORAGE public.vector;
+CREATE OPERATOR CLASS public.vector_ip_ops FOR TYPE public.vector USING paradedb AS
+    STORAGE public.vector;

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -1106,6 +1106,15 @@ CREATE OPERATOR CLASS public.vector_cosine_ops FOR TYPE public.vector USING bm25
 
 CREATE OPERATOR CLASS public.vector_ip_ops FOR TYPE public.vector USING bm25 AS
     STORAGE public.vector;
+
+CREATE OPERATOR CLASS public.vector_l2_ops DEFAULT FOR TYPE public.vector USING paradedb AS
+    STORAGE public.vector;
+
+CREATE OPERATOR CLASS public.vector_cosine_ops FOR TYPE public.vector USING paradedb AS
+    STORAGE public.vector;
+
+CREATE OPERATOR CLASS public.vector_ip_ops FOR TYPE public.vector USING paradedb AS
+    STORAGE public.vector;
 "#,
     name = "bm25_ops_anyelement_operator",
     requires = [

--- a/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
@@ -19,11 +19,11 @@ CREATE TABLE vsp (
     vec   vector(3)
 );
 INSERT INTO vsp VALUES
-    (1, 'east',  '[1,    0,   0]'),
-    (2, 'east2', '[0.9,  0,   0.1]'),
-    (3, 'north', '[0,    1,   0]'),
-    (4, 'up',    '[0,    0,   1]'),
-    (5, 'mid',   '[0.7,  0.7, 0]');
+    (1, 'east wind',  '[1,    0,   0]'),
+    (2, 'east gate',  '[0.9,  0,   0.1]'),
+    (3, 'north wind', '[0,    1,   0]'),
+    (4, 'up draft',   '[0,    0,   1]'),
+    (5, 'mid point',  '[0.7,  0.7, 0]');
 -- ============================================================
 -- vector_l2_ops
 -- ============================================================
@@ -365,5 +365,179 @@ EXECUTE vsp_p('[1,0,0]');
 
 DEALLOCATE vsp_p;
 RESET plan_cache_mode;
+DROP INDEX vsp_idx;
+-- ============================================================
+-- USING paradedb access method
+-- ============================================================
+-- Opclasses are declared per access method: the `paradedb` AM accepts the
+-- same three opclasses as `bm25`, with vector_l2_ops as its DEFAULT too.
+CREATE INDEX vsp_idx ON vsp
+    USING paradedb (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+-- match: <=> pushes down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on vsp
+         Table: vsp
+         Index: vsp_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: vec <=> vector asc
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
+
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+ id 
+----
+  1
+  2
+(2 rows)
+
+DROP INDEX vsp_idx;
+CREATE INDEX vsp_idx ON vsp
+    USING paradedb (id, label, vec vector_ip_ops)
+    WITH (key_field = id);
+DROP INDEX vsp_idx;
+-- a bare vector column resolves to vector_l2_ops, the AM default
+CREATE INDEX vsp_idx ON vsp
+    USING paradedb (id, label, vec)
+    WITH (key_field = id);
+SELECT opc.opcname
+FROM pg_index i
+JOIN unnest(i.indclass) WITH ORDINALITY AS c(opcoid, ord) ON true
+JOIN pg_opclass opc ON opc.oid = c.opcoid
+WHERE i.indexrelid = 'vsp_idx'::regclass AND opc.opcname LIKE 'vector%';
+    opcname    
+---------------
+ vector_l2_ops
+(1 row)
+
+-- match: <-> pushes down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on vsp
+         Table: vsp
+         Index: vsp_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: vec <-> vector asc
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
+
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+ id 
+----
+  1
+  2
+(2 rows)
+
+DROP INDEX vsp_idx;
+-- ============================================================
+-- Search operators (=== / &&& / ||| / ###) with vector ORDER BY
+-- ============================================================
+-- The predicate doesn't have to be `@@@ pdb.all()`: the search operators
+-- combined with a vector ORDER BY must still push down through TopK,
+-- ranking only the rows the predicate matches.
+CREATE INDEX vsp_idx ON vsp
+    USING bm25 (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+-- === (term): rows 1 and 3 contain 'wind'; ranked 1 then 3 by distance
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label === 'wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on vsp
+         Table: vsp
+         Index: vsp_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: vec <=> vector asc
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"label","value":"wind"}}}}
+(9 rows)
+
+SELECT id FROM vsp WHERE label === 'wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+ id 
+----
+  1
+  3
+(2 rows)
+
+-- &&& (all terms): only row 1 has both 'east' and 'wind'
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label &&& 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on vsp
+         Table: vsp
+         Index: vsp_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: vec <=> vector asc
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}
+(9 rows)
+
+SELECT id FROM vsp WHERE label &&& 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+ id 
+----
+  1
+(1 row)
+
+-- ||| (any term): rows 1, 2, 3 match 'gate' or 'wind'; top-2 are 1 then 2
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label ||| 'gate wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on vsp
+         Table: vsp
+         Index: vsp_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: vec <=> vector asc
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"label","value":"gate wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
+
+SELECT id FROM vsp WHERE label ||| 'gate wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+ id 
+----
+  1
+  2
+(2 rows)
+
+-- ### (phrase): only row 1 contains the phrase 'east wind'
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label ### 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on vsp
+         Table: vsp
+         Index: vsp_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: vec <=> vector asc
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"tokenized_phrase":{"field":"label","phrase":"east wind","slop":null}}}}
+(9 rows)
+
+SELECT id FROM vsp WHERE label ### 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+ id 
+----
+  1
+(1 row)
+
 DROP INDEX vsp_idx;
 DROP TABLE vsp;

--- a/pg_search/tests/pg_regress/sql/vector_search_pushdown.sql
+++ b/pg_search/tests/pg_regress/sql/vector_search_pushdown.sql
@@ -22,11 +22,11 @@ CREATE TABLE vsp (
 );
 
 INSERT INTO vsp VALUES
-    (1, 'east',  '[1,    0,   0]'),
-    (2, 'east2', '[0.9,  0,   0.1]'),
-    (3, 'north', '[0,    1,   0]'),
-    (4, 'up',    '[0,    0,   1]'),
-    (5, 'mid',   '[0.7,  0.7, 0]');
+    (1, 'east wind',  '[1,    0,   0]'),
+    (2, 'east gate',  '[0.9,  0,   0.1]'),
+    (3, 'north wind', '[0,    1,   0]'),
+    (4, 'up draft',   '[0,    0,   1]'),
+    (5, 'mid point',  '[0.7,  0.7, 0]');
 
 
 -- ============================================================
@@ -159,6 +159,79 @@ EXECUTE vsp_p('[1,0,0]');
 
 DEALLOCATE vsp_p;
 RESET plan_cache_mode;
+DROP INDEX vsp_idx;
+
+
+-- ============================================================
+-- USING paradedb access method
+-- ============================================================
+-- Opclasses are declared per access method: the `paradedb` AM accepts the
+-- same three opclasses as `bm25`, with vector_l2_ops as its DEFAULT too.
+CREATE INDEX vsp_idx ON vsp
+    USING paradedb (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+
+-- match: <=> pushes down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+
+DROP INDEX vsp_idx;
+
+CREATE INDEX vsp_idx ON vsp
+    USING paradedb (id, label, vec vector_ip_ops)
+    WITH (key_field = id);
+DROP INDEX vsp_idx;
+
+-- a bare vector column resolves to vector_l2_ops, the AM default
+CREATE INDEX vsp_idx ON vsp
+    USING paradedb (id, label, vec)
+    WITH (key_field = id);
+
+SELECT opc.opcname
+FROM pg_index i
+JOIN unnest(i.indclass) WITH ORDINALITY AS c(opcoid, ord) ON true
+JOIN pg_opclass opc ON opc.oid = c.opcoid
+WHERE i.indexrelid = 'vsp_idx'::regclass AND opc.opcname LIKE 'vector%';
+
+-- match: <-> pushes down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+
+DROP INDEX vsp_idx;
+
+
+-- ============================================================
+-- Search operators (=== / &&& / ||| / ###) with vector ORDER BY
+-- ============================================================
+-- The predicate doesn't have to be `@@@ pdb.all()`: the search operators
+-- combined with a vector ORDER BY must still push down through TopK,
+-- ranking only the rows the predicate matches.
+CREATE INDEX vsp_idx ON vsp
+    USING bm25 (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+
+-- === (term): rows 1 and 3 contain 'wind'; ranked 1 then 3 by distance
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label === 'wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE label === 'wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+
+-- &&& (all terms): only row 1 has both 'east' and 'wind'
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label &&& 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE label &&& 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+
+-- ||| (any term): rows 1, 2, 3 match 'gate' or 'wind'; top-2 are 1 then 2
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label ||| 'gate wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE label ||| 'gate wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+
+-- ### (phrase): only row 1 contains the phrase 'east wind'
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE label ### 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE label ### 'east wind' ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+
 DROP INDEX vsp_idx;
 
 


### PR DESCRIPTION
# Ticket(s) Closed

## What

`vector_l2_ops`, `vector_cosine_ops`, and `vector_ip_ops` were declared for `bm25`, but not the new `paradedb` alias.