### PR TITLE
fix: ignore ProbeStats returned by vector collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1809,7 +1809,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.117",
 ]
 
@@ -5376,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6263,7 +6262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7911,7 +7910,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7967,7 +7966,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "bitpacking",
 ]
@@ -7975,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7990,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8023,7 +8022,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8035,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8048,7 +8047,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8085,7 +8084,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=055cfd0afffa7823aa9e835d67ae290c765d616a#055cfd0afffa7823aa9e835d67ae290c765d616a"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7d3c62369ad074a4cd480b02e75089f885356c96#7d3c62369ad074a4cd480b02e75089f885356c96"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ debug-assertions = false
 inherits = "dev"
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "055cfd0afffa7823aa9e835d67ae290c765d616a", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "7d3c62369ad074a4cd480b02e75089f885356c96", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -52,7 +52,7 @@ pgrx-tests = "=0.19.0"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "055cfd0afffa7823aa9e835d67ae290c765d616a" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "7d3c62369ad074a4cd480b02e75089f885356c96" }
 
 # datafusion 54.0.0 + the null-aware anti-join dynamic-filter fix (paradedb/datafusion PR #2, backported
 # to a 54.0.0 branch so it stays on arrow 58). Patch every datafusion crate, or two `datafusion-common`

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-jRBgooiyYH7aIBc+akXaeje8hqfWo1egfuvRfQAKUXE=";
+  cargoHash = "sha256-BikwYAlNR8qrws4c1Ql7TiIa0uPnyEbSVj+0xm0PHKo=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -42,11 +42,6 @@ static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true)
 /// default is `false`.
 static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(false);
 
-/// When `true`, a vector (IVF) ORDER BY scan emits one `probe_stats …` NOTICE
-/// per query with the aggregated probe-loop counters. Off by default and
-/// zero-cost when off (no `ProbeStats` is collected).
-static LOG_PROBE_STATS: GucSetting<bool> = GucSetting::<bool>::new(false);
-
 /// Allows the user to toggle the use of custom scan for queries that include non-indexed fields.
 /// When enabled, queries with non-indexed predicates will use HeapExpr for heap filtering.
 static ENABLE_FILTER_PUSHDOWN: GucSetting<bool> = GucSetting::<bool>::new(true);
@@ -274,17 +269,6 @@ pub fn init() {
         c"Enable ParadeDB's experimental join custom scan",
         c"Enable ParadeDB's experimental join custom scan. Default is false.",
         &ENABLE_JOIN_CUSTOM_SCAN,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_bool_guc(
-        c"paradedb.log_probe_stats",
-        c"Emit a NOTICE with IVF probe-loop counters per vector query",
-        c"When on, a vector (IVF) ORDER BY scan emits one `probe_stats ...` NOTICE per query \
-          with the aggregated probe counters (visited/pruned/scored/clusters/termination). \
-          Off by default and zero-cost when off.",
-        &LOG_PROBE_STATS,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -659,10 +643,6 @@ pub fn enable_custom_scan() -> bool {
 
 pub fn enable_aggregate_custom_scan() -> bool {
     ENABLE_AGGREGATE_CUSTOM_SCAN.get()
-}
-
-pub fn log_probe_stats() -> bool {
-    LOG_PROBE_STATS.get()
 }
 
 pub fn check_aggregate_scan() -> bool {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -19,7 +19,7 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use std::ptr::NonNull;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::aggregate::mvcc_collector::MVCCFilterCollector;
 use crate::api::operator::keyset::KeySet;
@@ -51,7 +51,6 @@ use tantivy::index::{Index, Order, SegmentId};
 use tantivy::query::{EnableScoring, QueryClone, QueryParser, Weight};
 use tantivy::snippet::SnippetGenerator;
 use tantivy::vector::ivf::AdaptiveProbeParams;
-use tantivy::vector::{ProbeStats, ProbeTermination};
 use tantivy::{
     query::Query, schema::OwnedValue, DateTime, DocAddress, DocId, DocSet, Executor, IndexReader,
     ReloadPolicy, Score, Searcher, SegmentOrdinal, SegmentReader, TantivyDocument,
@@ -60,75 +59,6 @@ use tantivy::{
 /// The maximum number of sort-features/`OrderByInfo`s supported for
 /// `SearchIndexReader::search_top_k_in_segments`.
 pub const MAX_TOPK_FEATURES: usize = 5;
-
-/// Aggregate the per-segment IVF [`ProbeStats`] of one vector query into a
-/// single parseable `probe_stats …` line. Scalars sum across segments;
-/// `termination` is tallied per variant (so a `Ceiling` on any segment stays
-/// visible). The summed line preserves the per-segment invariant
-/// `visited == pruned_filter + pruned_dead + pruned_seen + scored`.
-///
-/// Line-grammar note: tantivy's `ProbeStats::routing.visited_count` is
-/// surfaced as `router_scored=`. It counts centroids the router actually
-/// scored — the beam's visit set when routing went through the persisted
-/// RNG, or all of them on the linear fallback.
-///
-/// The two trailing compound tokens reuse `termination=`'s `key:N` comma
-/// style and sit at the end of the line so prefix parsers are unaffected.
-/// They always print, zeros included — the grammar is constant-shape.
-/// `postings=` buckets probed IVF clusters by posting-fetch outcome (one
-/// stride-sized read per surviving row / skipped outright when the gate
-/// pre-pass leaves zero survivors); the two buckets partition the probed
-/// clusters, so `row + skipped == clusters_probed` — asserted in the unit
-/// tests. `exact_rows=` counts flat-path stride-sized row reads (one per
-/// survivor scored). At 0% selectivity the empty-filter short-circuit
-/// returns before the probe loop, so every posting counter is zero by
-/// design and the partition invariant holds trivially (0 == 0 clusters
-/// probed).
-fn format_probe_stats(per_segment: &[ProbeStats]) -> String {
-    let mut visited = 0usize;
-    let mut pruned_filter = 0usize;
-    let mut pruned_dead = 0usize;
-    let mut pruned_seen = 0usize;
-    let mut scored = 0usize;
-    let mut clusters_probed = 0usize;
-    let mut router_scored = 0usize;
-    let mut min_candidates = 0usize;
-    let (mut ceiling, mut gate, mut exhausted) = (0usize, 0usize, 0usize);
-    let (mut postings_row, mut postings_skipped) = (0usize, 0usize);
-    let mut exact_rows = 0usize;
-    for s in per_segment {
-        visited += s.vectors_visited;
-        pruned_filter += s.pruned_filter;
-        pruned_dead += s.pruned_dead;
-        pruned_seen += s.pruned_seen;
-        scored += s.candidates_scored;
-        clusters_probed += s.probed_clusters.len();
-        router_scored += s.routing.visited_count;
-        min_candidates += s.min_candidates;
-        match s.termination {
-            ProbeTermination::Ceiling => ceiling += 1,
-            ProbeTermination::Gate => gate += 1,
-            ProbeTermination::Exhausted => exhausted += 1,
-        }
-        postings_row += s.postings_row;
-        postings_skipped += s.postings_skipped;
-        exact_rows += s.exact_rows_read;
-    }
-    format!(
-        "probe_stats visited={visited} pruned_filter={pruned_filter} \
-         pruned_dead={pruned_dead} pruned_seen={pruned_seen} scored={scored} \
-         clusters_probed={clusters_probed} router_scored={router_scored} \
-         min_candidates={min_candidates} termination=ceiling:{ceiling},gate:{gate},exhausted:{exhausted} \
-         postings=row:{postings_row},skipped:{postings_skipped} \
-         exact_rows={exact_rows}"
-    )
-}
-
-/// Emit the aggregated probe stats as one NOTICE. Only called when
-/// `paradedb.log_probe_stats` is on (off by default, zero-cost when off).
-fn emit_probe_stats_notice(per_segment: &[ProbeStats]) {
-    pgrx::notice!("{}", format_probe_stats(per_segment));
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct DocsEstimate {
@@ -1046,22 +976,8 @@ impl SearchIndexReader {
                         max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
                         ..Default::default()
                     });
-                // Probe-stats NOTICE (GUC `paradedb.log_probe_stats`, off by
-                // default, zero-cost when off). The collector pushes one
-                // ProbeStats per segment into the sink; we aggregate the scalars
-                // and tally `termination`, then emit a single line. This vector
-                // search runs once per scan, so the NOTICE is once per query.
-                let probe_stats_sink =
-                    crate::gucs::log_probe_stats().then(|| Arc::new(Mutex::new(Vec::new())));
-                let collector = match &probe_stats_sink {
-                    Some(sink) => collector.with_probe_stats_sink(Arc::clone(sink)),
-                    None => collector,
-                };
                 let (top_docs, aggregation_results) =
                     self.collect_maybe_auxiliary(segment_ids, collector, aux_collector);
-                if let Some(sink) = probe_stats_sink {
-                    emit_probe_stats_notice(&sink.lock().unwrap());
-                }
                 TopKSearchResults::new_for_score(top_docs, aggregation_results)
             }
         }
@@ -1698,95 +1614,5 @@ impl ErasedFeatures {
             OwnedValue::Null => None,
             _ => panic!("expected a f64 for the score"),
         })
-    }
-}
-
-#[cfg(test)]
-mod probe_stats_tests {
-    use super::*;
-    use tantivy::vector::IvfSearchMetrics;
-
-    fn seg(termination: ProbeTermination) -> ProbeStats {
-        // visited (25) == pruned_filter(5) + pruned_dead(2) + pruned_seen(8) + scored(10);
-        // postings row(2) + skipped(1) == probed_clusters.len() (3).
-        ProbeStats {
-            probed_clusters: vec![0, 1, 2],
-            candidates_scored: 10,
-            vectors_visited: 25,
-            pruned_filter: 5,
-            pruned_dead: 2,
-            pruned_seen: 8,
-            postings_row: 2,
-            postings_skipped: 1,
-            exact_rows_read: 0,
-            routing: IvfSearchMetrics {
-                visited_count: 9,
-                graph: None,
-            },
-            min_candidates: 16,
-            termination,
-        }
-    }
-
-    /// Pull `key=N` off the formatted line.
-    fn scalar(line: &str, key: &str) -> usize {
-        let tail = line.split(&format!("{key}=")).nth(1).unwrap();
-        tail.split(' ').next().unwrap().parse().unwrap()
-    }
-
-    /// Pull `sub:N` out of a `key=a:N,b:N,…` compound token.
-    fn compound(line: &str, key: &str, sub: &str) -> usize {
-        let tail = line.split(&format!("{key}=")).nth(1).unwrap();
-        let token = tail.split(' ').next().unwrap();
-        let entry = token
-            .split(',')
-            .find(|e| e.starts_with(&format!("{sub}:")))
-            .unwrap();
-        entry.split(':').nth(1).unwrap().parse().unwrap()
-    }
-
-    #[test]
-    fn format_probe_stats_sums_scalars_and_tallies_termination() {
-        let line =
-            format_probe_stats(&[seg(ProbeTermination::Gate), seg(ProbeTermination::Ceiling)]);
-        // Scalars summed; termination tallied per variant; summed invariant
-        // holds (visited 50 == 10+4+16+20).
-        assert_eq!(
-            line,
-            "probe_stats visited=50 pruned_filter=10 pruned_dead=4 pruned_seen=16 scored=20 clusters_probed=6 router_scored=18 min_candidates=32 termination=ceiling:1,gate:1,exhausted:0 postings=row:4,skipped:2 exact_rows=0"
-        );
-    }
-
-    #[test]
-    fn format_probe_stats_empty() {
-        assert_eq!(
-            format_probe_stats(&[]),
-            "probe_stats visited=0 pruned_filter=0 pruned_dead=0 pruned_seen=0 scored=0 clusters_probed=0 router_scored=0 min_candidates=0 termination=ceiling:0,gate:0,exhausted:0 postings=row:0,skipped:0 exact_rows=0"
-        );
-    }
-
-    /// The two trailing tokens: `postings=` sums the per-segment fetch-mode
-    /// buckets, `exact_rows=` the flat-path row reads, and the emitted line
-    /// upholds the partition invariant `row + skipped == clusters_probed`
-    /// (an IVF segment's buckets partition its probed clusters; a flat
-    /// segment contributes zero to all three sides).
-    #[test]
-    fn format_probe_stats_posting_and_exact_tokens() {
-        // One IVF-shaped segment plus one flat-shaped segment, which fills
-        // only the `exact_rows_read` counter (everything else default).
-        let flat = ProbeStats {
-            exact_rows_read: 11,
-            ..Default::default()
-        };
-        let line = format_probe_stats(&[seg(ProbeTermination::Exhausted), flat]);
-        assert_eq!(
-            line,
-            "probe_stats visited=25 pruned_filter=5 pruned_dead=2 pruned_seen=8 scored=10 clusters_probed=3 router_scored=9 min_candidates=16 termination=ceiling:0,gate:0,exhausted:2 postings=row:2,skipped:1 exact_rows=11"
-        );
-        // Partition invariant, parsed back off the emitted line.
-        assert_eq!(
-            compound(&line, "postings", "row") + compound(&line, "postings", "skipped"),
-            scalar(&line, "clusters_probed"),
-        );
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -976,9 +976,11 @@ impl SearchIndexReader {
                         max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
                         ..Default::default()
                     });
-                let (top_docs, aggregation_results) =
+                // Fruit is `VectorSimilarityFruit { results, stats }`. Drop probe
+                // stats for now; EXPLAIN plumbing lands in a follow-up.
+                let (fruit, aggregation_results) =
                     self.collect_maybe_auxiliary(segment_ids, collector, aux_collector);
-                TopKSearchResults::new_for_score(top_docs, aggregation_results)
+                TopKSearchResults::new_for_score(fruit.results, aggregation_results)
             }
         }
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Removes the GUC which enabled a notice that logged vector search statistics

## Why

This is being replaced with stats that are emitted via `EXPLAIN ANALYZE VERBOSE`

## How

## Tests
