### PR TITLE
chore: Optimizer rule to enable range partitioning for joins

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -38,9 +38,10 @@ The planner hook builds a [`JoinCSClause`][joincsc] — a serializable IR captur
 
 [`scan_state.rs`](scan_state.rs) builds a DataFusion logical plan from the `JoinCSClause`, then runs [physical optimization][optimizer-rules]:
 
-1. **`LateMaterializationRule`** — injects [`TantivyLookupExec`][lookup-exec] to defer string materialization
-2. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)`, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
-3. **FilterPushdown (Post)** — pushes `SegmentedTopKExec`'s `DynamicFilterPhysicalExpr` down to the scan
+1. **[`RangePartitioningRule`](range_partitioning_rule.rs)** — coordinates split points across joins for MPP range partitioning
+2. **`LateMaterializationRule`** — injects [`TantivyLookupExec`][lookup-exec] to defer string materialization
+3. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)`, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
+4. **FilterPushdown (Post)** — pushes `SegmentedTopKExec`'s `DynamicFilterPhysicalExpr` down to the scan
 
 If `max_parallel_workers_per_gather > 0` and PostgreSQL has planned parallel execution, `DistributedPlanner` converts the finalized physical plan into an MPP execution tree (`DistributedExec`), slicing it into isolated tasks.
 
@@ -72,15 +73,16 @@ Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizin
 
 ## Key Files
 
-| File                             | Purpose                                                                               |
-| -------------------------------- | ------------------------------------------------------------------------------------- |
-| [`mod.rs`](mod.rs)               | Lifecycle, [activation checks][activation], parallel support                          |
-| [`build.rs`](build.rs)           | [`RelNode`][relnode], [`JoinCSClause`][joincsc], `JoinSource`                         |
-| [`scan_state.rs`](scan_state.rs) | DataFusion plan building, [optimizer registration][optimizer-rules], result streaming |
-| [`planning.rs`](planning.rs)     | Cost estimation, field validation, ORDER BY extraction                                |
-| [`predicate.rs`](predicate.rs)   | Postgres expression → `JoinLevelExpr`                                                 |
-| [`translator.rs`](translator.rs) | Postgres ↔ DataFusion expression mapping                                              |
-| [`explain.rs`](explain.rs)       | EXPLAIN output formatting                                                             |
+| File                                                       | Purpose                                                                               |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [`mod.rs`](mod.rs)                                         | Lifecycle, [activation checks][activation], parallel support                          |
+| [`build.rs`](build.rs)                                     | [`RelNode`][relnode], [`JoinCSClause`][joincsc], `JoinSource`                         |
+| [`scan_state.rs`](scan_state.rs)                           | DataFusion plan building, [optimizer registration][optimizer-rules], result streaming |
+| [`planning.rs`](planning.rs)                               | Cost estimation, field validation, ORDER BY extraction                                |
+| [`predicate.rs`](predicate.rs)                             | Postgres expression → `JoinLevelExpr`                                                 |
+| [`range_partitioning_rule.rs`](range_partitioning_rule.rs) | Optimizer rule for synchronizing Join-side MPP partition boundaries                   |
+| [`translator.rs`](translator.rs)                           | Postgres ↔ DataFusion expression mapping                                              |
+| [`explain.rs`](explain.rs)                                 | EXPLAIN output formatting                                                             |
 
 Execution-layer files under [`pg_search/src/scan/`](../../scan/):
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -142,6 +142,7 @@ pub mod build;
 pub mod planning;
 pub mod predicate;
 pub mod privdat;
+pub mod range_partitioning_rule;
 pub mod scan_state;
 pub mod visibility_filter;
 

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -1,0 +1,212 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion::catalog::default_table_source::DefaultTableSource;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::{Column, DataFusionError, Result};
+use datafusion::logical_expr::{Expr, LogicalPlan, TableScan};
+use datafusion::optimizer::{optimizer::ApplyOrder, OptimizerConfig, OptimizerRule};
+use rand::seq::SliceRandom;
+use tantivy::SegmentReader;
+
+use crate::api::FieldName;
+use crate::index::fast_fields_helper::FFType;
+use crate::index::fast_fields_helper::WhichFastField;
+use crate::index::mvcc::MvccSatisfies;
+use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::rel::PgSearchRelation;
+use crate::query::SearchQueryInput;
+
+use crate::scan::late_materialization::trace_column;
+use crate::scan::range_partitioning::RangePartitioningSample;
+use crate::scan::table_provider::PgSearchTableProvider;
+
+/// Optimizer rule that injects range partitioning boundaries into `PgSearchTableProvider`
+/// when it participates in a join on partitioned columns.
+#[derive(Debug, Default)]
+pub struct RangePartitioningRule;
+
+impl RangePartitioningRule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+fn pg_search_provider_from_scan(scan: &TableScan) -> Option<&PgSearchTableProvider> {
+    let source = scan.source.as_ref();
+    if let Some(default_source) = source.downcast_ref::<DefaultTableSource>() {
+        default_source
+            .table_provider
+            .downcast_ref::<PgSearchTableProvider>()
+    } else {
+        (source as &dyn std::any::Any).downcast_ref::<PgSearchTableProvider>()
+    }
+}
+
+impl OptimizerRule for RangePartitioningRule {
+    fn name(&self) -> &str {
+        "RangePartitioningRule"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        None
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        let mut base_join_keys = HashSet::new();
+
+        plan.apply(|node| {
+            if let LogicalPlan::Join(join) = node {
+                for (l, r) in &join.on {
+                    if let Expr::Column(c) = l {
+                        if let Some(base_col) = trace_column(node, c) {
+                            base_join_keys.insert(base_col);
+                        }
+                    }
+                    if let Expr::Column(c) = r {
+                        if let Some(base_col) = trace_column(node, c) {
+                            base_join_keys.insert(base_col);
+                        }
+                    }
+                }
+            }
+            Ok(datafusion::common::tree_node::TreeNodeRecursion::Continue)
+        })?;
+
+        if base_join_keys.is_empty() {
+            return Ok(Transformed::no(plan));
+        }
+
+        plan.transform_up(|node| {
+            if let LogicalPlan::TableScan(mut scan) = node {
+                if let Some(provider) = pg_search_provider_from_scan(&scan) {
+                    let mut matched_partition_by = None;
+
+                    for field in &provider.scan_info.partition_by {
+                        let col = Column::new_unqualified(field.as_ref());
+                        if base_join_keys.contains(&col) {
+                            matched_partition_by = Some(field.clone());
+                            break;
+                        }
+                    }
+
+                    if let Some(partition_by) = matched_partition_by {
+                        let sample = sample_fast_field(provider, &partition_by)?;
+                        let mut new_provider = provider.clone();
+                        new_provider.with_range_partitioning(Some(sample));
+
+                        let new_source = if scan
+                            .source
+                            .as_ref()
+                            .downcast_ref::<DefaultTableSource>()
+                            .is_some()
+                        {
+                            Arc::new(DefaultTableSource::new(Arc::new(new_provider)))
+                                as Arc<dyn datafusion::logical_expr::TableSource>
+                        } else {
+                            return Err(DataFusionError::Internal(
+                                "PgSearchTableProvider was not wrapped in a DefaultTableSource"
+                                    .to_string(),
+                            ));
+                        };
+
+                        scan.source = new_source;
+                        return Ok(Transformed::yes(LogicalPlan::TableScan(scan)));
+                    }
+                }
+                Ok(Transformed::no(LogicalPlan::TableScan(scan)))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })
+    }
+}
+
+fn sample_fast_field(
+    provider: &PgSearchTableProvider,
+    partition_by: &FieldName,
+) -> Result<RangePartitioningSample> {
+    let index_rel = PgSearchRelation::open(provider.scan_info.indexrelid);
+    // TODO: Reading the index during planning adds latency to DataFusion logical planning.
+    // This is a temporary situation for M1. In M2, we will migrate this sampling to
+    // something that happens prior to CREATE INDEX, or switch to using pg_statistic.
+    let reader = SearchIndexReader::open(
+        &index_rel,
+        SearchQueryInput::All,
+        false,
+        MvccSatisfies::LargestSegment,
+    )
+    .map_err(|e| DataFusionError::Internal(format!("Failed to open index for sampling: {e}")))?;
+
+    let segment_readers = reader.segment_readers();
+    if segment_readers.is_empty() {
+        return Ok(RangePartitioningSample {
+            partition_by: partition_by.clone(),
+            sample_points: vec![],
+        });
+    }
+
+    let largest_segment: &SegmentReader =
+        segment_readers.iter().max_by_key(|s| s.num_docs()).unwrap();
+
+    let num_docs = largest_segment.num_docs();
+    if num_docs == 0 {
+        return Ok(RangePartitioningSample {
+            partition_by: partition_by.clone(),
+            sample_points: vec![],
+        });
+    }
+
+    let ff_type = FFType::new(largest_segment.fast_fields(), partition_by.as_ref());
+
+    let search_field_type = provider.fields.iter().find_map(|f| {
+        if let WhichFastField::Named(name, sft) = f {
+            if name == partition_by.as_ref() {
+                return Some(*sft);
+            }
+        }
+        None
+    });
+
+    let target_samples = 512;
+    let mut rng = rand::rng();
+
+    let mut doc_ids: Vec<u32> = (0..num_docs).collect();
+    doc_ids.shuffle(&mut rng);
+    let sample_doc_ids: Vec<u32> = doc_ids.into_iter().take(target_samples).collect();
+
+    let mut sample_points = Vec::with_capacity(sample_doc_ids.len());
+    for doc_id in sample_doc_ids {
+        let val = ff_type.value(doc_id, search_field_type);
+        sample_points.push(val.0);
+    }
+
+    // Sort points ascending so that build() produces sequential ranges
+    sample_points.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    Ok(RangePartitioningSample {
+        partition_by: partition_by.clone(),
+        sample_points,
+    })
+}

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use datafusion::catalog::default_table_source::DefaultTableSource;
@@ -23,7 +22,6 @@ use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{Column, DataFusionError, Result};
 use datafusion::logical_expr::{Expr, LogicalPlan, TableScan};
 use datafusion::optimizer::{optimizer::ApplyOrder, OptimizerConfig, OptimizerRule};
-use rand::seq::SliceRandom;
 use tantivy::SegmentReader;
 
 use crate::api::FieldName;
@@ -34,12 +32,15 @@ use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::rel::PgSearchRelation;
 use crate::query::SearchQueryInput;
 
-use crate::scan::late_materialization::trace_column;
 use crate::scan::range_partitioning::RangePartitioningSample;
 use crate::scan::table_provider::PgSearchTableProvider;
 
-/// Optimizer rule that injects range partitioning boundaries into `PgSearchTableProvider`
-/// when it participates in a join on partitioned columns.
+/// Optimizer rule that coordinates range partitioning across a join.
+///
+/// It detects when both sides of an equi-join are partitioned on matching column types,
+/// accesses the existing partition sample from one side, and injects that synchronized sample
+/// into the `PgSearchTableProvider`s of both sides. This guarantees that both sides of
+/// the join produce identical partition boundaries during MPP execution.
 #[derive(Debug, Default)]
 pub struct RangePartitioningRule;
 
@@ -56,8 +57,212 @@ fn pg_search_provider_from_scan(scan: &TableScan) -> Option<&PgSearchTableProvid
             .table_provider
             .downcast_ref::<PgSearchTableProvider>()
     } else {
-        (source as &dyn std::any::Any).downcast_ref::<PgSearchTableProvider>()
+        None
     }
+}
+
+/// Recursively searches the logical plan tree to find the underlying `PgSearchTableProvider`
+/// and the original index field name that corresponds to a given `Column` expression at the top level
+/// of the plan. This resolves aliases, subqueries, and projections to trace a join key back to its source.
+fn find_provider_for_column<'a>(
+    plan: &'a LogicalPlan,
+    col: &Column,
+) -> Option<(&'a PgSearchTableProvider, FieldName)> {
+    match plan {
+        LogicalPlan::TableScan(scan) => {
+            if scan.projected_schema.has_column(col) {
+                let (_, sf) = scan
+                    .projected_schema
+                    .qualified_field_from_column(col)
+                    .ok()?;
+                let provider = pg_search_provider_from_scan(scan)?;
+                for field in &provider.scan_info.partition_by {
+                    if sf.name() == field.as_ref() {
+                        return Some((provider, field.clone()));
+                    }
+                }
+            }
+            None
+        }
+        LogicalPlan::Projection(proj) => {
+            let idx = proj.schema.index_of_column(col).ok()?;
+            let expr = &proj.expr[idx];
+            let unaliased = match expr {
+                Expr::Alias(alias) => alias.expr.as_ref(),
+                e => e,
+            };
+            if let Expr::Column(c) = unaliased {
+                find_provider_for_column(proj.input.as_ref(), c)
+            } else {
+                None
+            }
+        }
+        LogicalPlan::Filter(filter) => find_provider_for_column(filter.input.as_ref(), col),
+        LogicalPlan::Sort(sort) => find_provider_for_column(sort.input.as_ref(), col),
+        LogicalPlan::Limit(limit) => find_provider_for_column(limit.input.as_ref(), col),
+        LogicalPlan::SubqueryAlias(alias) => {
+            let idx = alias.schema.index_of_column(col).ok()?;
+            let (q, f) = alias.input.schema().qualified_field(idx);
+            find_provider_for_column(alias.input.as_ref(), &Column::new(q.cloned(), f.name()))
+        }
+        LogicalPlan::Join(join) => {
+            if join.left.schema().has_column(col) {
+                find_provider_for_column(join.left.as_ref(), col)
+            } else if join.right.schema().has_column(col) {
+                find_provider_for_column(join.right.as_ref(), col)
+            } else {
+                None
+            }
+        }
+        _ => {
+            let inputs = plan.inputs();
+            if inputs.len() == 1 {
+                let idx = plan.schema().index_of_column(col).ok()?;
+                let input_schema = inputs[0].schema();
+                if idx < input_schema.fields().len() {
+                    let (q, f) = input_schema.qualified_field(idx);
+                    find_provider_for_column(inputs[0], &Column::new(q.cloned(), f.name()))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Recursively traverses the logical plan to locate the specific `TableScan` node
+/// that produces the given `Column`. Applies the mutating function `f` to that scan
+/// and rebuilds the plan tree to reflect the transformation.
+fn map_scan_for_column<F>(
+    plan: LogicalPlan,
+    col: &Column,
+    f: &mut F,
+) -> Result<Transformed<LogicalPlan>>
+where
+    F: FnMut(TableScan) -> Result<Transformed<LogicalPlan>>,
+{
+    match plan {
+        LogicalPlan::TableScan(scan) => {
+            if scan.projected_schema.has_column(col) {
+                f(scan)
+            } else {
+                Ok(Transformed::no(LogicalPlan::TableScan(scan)))
+            }
+        }
+        LogicalPlan::Projection(mut proj) => {
+            if let Ok(idx) = proj.schema.index_of_column(col) {
+                let expr = &proj.expr[idx];
+                let unaliased = match expr {
+                    Expr::Alias(alias) => alias.expr.as_ref(),
+                    e => e,
+                };
+                if let Expr::Column(c) = unaliased {
+                    let res = map_scan_for_column(Arc::unwrap_or_clone(proj.input.clone()), c, f)?;
+                    if res.transformed {
+                        proj.input = Arc::new(res.data);
+                        return Ok(Transformed::yes(LogicalPlan::Projection(proj)));
+                    }
+                }
+            }
+            Ok(Transformed::no(LogicalPlan::Projection(proj)))
+        }
+        LogicalPlan::Filter(mut filter) => {
+            let res = map_scan_for_column(Arc::unwrap_or_clone(filter.input.clone()), col, f)?;
+            if res.transformed {
+                filter.input = Arc::new(res.data);
+                Ok(Transformed::yes(LogicalPlan::Filter(filter)))
+            } else {
+                Ok(Transformed::no(LogicalPlan::Filter(filter)))
+            }
+        }
+        LogicalPlan::Sort(mut sort) => {
+            let res = map_scan_for_column(Arc::unwrap_or_clone(sort.input.clone()), col, f)?;
+            if res.transformed {
+                sort.input = Arc::new(res.data);
+                Ok(Transformed::yes(LogicalPlan::Sort(sort)))
+            } else {
+                Ok(Transformed::no(LogicalPlan::Sort(sort)))
+            }
+        }
+        LogicalPlan::Limit(mut limit) => {
+            let res = map_scan_for_column(Arc::unwrap_or_clone(limit.input.clone()), col, f)?;
+            if res.transformed {
+                limit.input = Arc::new(res.data);
+                Ok(Transformed::yes(LogicalPlan::Limit(limit)))
+            } else {
+                Ok(Transformed::no(LogicalPlan::Limit(limit)))
+            }
+        }
+        LogicalPlan::SubqueryAlias(mut alias) => {
+            if let Ok(idx) = alias.schema.index_of_column(col) {
+                let (q, field) = alias.input.schema().qualified_field(idx);
+                let inner_col = Column::new(q.cloned(), field.name());
+                let res =
+                    map_scan_for_column(Arc::unwrap_or_clone(alias.input.clone()), &inner_col, f)?;
+                if res.transformed {
+                    alias.input = Arc::new(res.data);
+                    return Ok(Transformed::yes(LogicalPlan::SubqueryAlias(alias)));
+                }
+            }
+            Ok(Transformed::no(LogicalPlan::SubqueryAlias(alias)))
+        }
+        LogicalPlan::Join(mut join) => {
+            if join.left.schema().has_column(col) {
+                let res = map_scan_for_column(Arc::unwrap_or_clone(join.left.clone()), col, f)?;
+                if res.transformed {
+                    join.left = Arc::new(res.data);
+                    return Ok(Transformed::yes(LogicalPlan::Join(join)));
+                }
+            } else if join.right.schema().has_column(col) {
+                let res = map_scan_for_column(Arc::unwrap_or_clone(join.right.clone()), col, f)?;
+                if res.transformed {
+                    join.right = Arc::new(res.data);
+                    return Ok(Transformed::yes(LogicalPlan::Join(join)));
+                }
+            }
+            Ok(Transformed::no(LogicalPlan::Join(join)))
+        }
+        _ => {
+            let inputs = plan.inputs();
+            if inputs.len() == 1 {
+                if let Ok(idx) = plan.schema().index_of_column(col) {
+                    let input_schema = inputs[0].schema();
+                    if idx < input_schema.fields().len() {
+                        let (q, field) = input_schema.qualified_field(idx);
+                        let inner_col = Column::new(q.cloned(), field.name());
+
+                        return plan
+                            .map_children(|child| map_scan_for_column(child, &inner_col, f));
+                    }
+                }
+            }
+            Ok(Transformed::no(plan))
+        }
+    }
+}
+
+fn apply_sample_to_scan(
+    mut scan: TableScan,
+    sample: &RangePartitioningSample,
+) -> Result<Transformed<LogicalPlan>> {
+    let Some(provider) = pg_search_provider_from_scan(&scan) else {
+        return Ok(Transformed::no(LogicalPlan::TableScan(scan)));
+    };
+
+    if provider.range_sample() == Some(sample) {
+        return Ok(Transformed::no(LogicalPlan::TableScan(scan)));
+    }
+
+    let mut new_provider = provider.clone();
+    new_provider.with_range_partitioning(Some(sample.clone()));
+
+    let new_source = Arc::new(DefaultTableSource::new(Arc::new(new_provider)))
+        as Arc<dyn datafusion::logical_expr::TableSource>;
+
+    scan.source = new_source;
+    Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
 }
 
 impl OptimizerRule for RangePartitioningRule {
@@ -74,71 +279,66 @@ impl OptimizerRule for RangePartitioningRule {
         plan: LogicalPlan,
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
-        let mut base_join_keys = HashSet::new();
-
-        plan.apply(|node| {
-            if let LogicalPlan::Join(join) = node {
-                for (l, r) in &join.on {
-                    if let Expr::Column(c) = l {
-                        if let Some(base_col) = trace_column(node, c) {
-                            base_join_keys.insert(base_col);
-                        }
-                    }
-                    if let Expr::Column(c) = r {
-                        if let Some(base_col) = trace_column(node, c) {
-                            base_join_keys.insert(base_col);
-                        }
-                    }
-                }
-            }
-            Ok(datafusion::common::tree_node::TreeNodeRecursion::Continue)
-        })?;
-
-        if base_join_keys.is_empty() {
+        if !crate::postgres::customscan::mpp::glue::mpp_is_active() {
             return Ok(Transformed::no(plan));
         }
 
         plan.transform_up(|node| {
-            if let LogicalPlan::TableScan(mut scan) = node {
-                if let Some(provider) = pg_search_provider_from_scan(&scan) {
-                    let mut matched_partition_by = None;
+            if let LogicalPlan::Join(mut join) = node {
+                let mut transformed = false;
+                for (l, r) in &join.on {
+                    if let (Expr::Column(l_col), Expr::Column(r_col)) = (l, r) {
+                        let l_res = find_provider_for_column(&join.left, l_col);
+                        let r_res = find_provider_for_column(&join.right, r_col);
+                        if let (
+                            Some((l_provider, l_field_name)),
+                            Some((r_provider, r_field_name)),
+                        ) = (l_res, r_res)
+                        {
+                            let mut sample = None;
+                            if let Some(s) = l_provider.range_sample() {
+                                sample = Some(s.clone());
+                            } else if let Some(s) = r_provider.range_sample() {
+                                sample = Some(s.clone());
+                            }
 
-                    for field in &provider.scan_info.partition_by {
-                        let col = Column::new_unqualified(field.as_ref());
-                        if base_join_keys.contains(&col) {
-                            matched_partition_by = Some(field.clone());
-                            break;
+                            if sample.is_none() {
+                                sample = Some(sample_fast_field(l_provider, &l_field_name)?);
+                            }
+
+                            if let Some(mut shared_sample) = sample {
+                                shared_sample.partition_by = l_field_name;
+                                let left_res = map_scan_for_column(
+                                    Arc::unwrap_or_clone(join.left.clone()),
+                                    l_col,
+                                    &mut |scan| apply_sample_to_scan(scan, &shared_sample),
+                                )?;
+                                if left_res.transformed {
+                                    join.left = Arc::new(left_res.data);
+                                }
+
+                                shared_sample.partition_by = r_field_name;
+                                let right_res = map_scan_for_column(
+                                    Arc::unwrap_or_clone(join.right.clone()),
+                                    r_col,
+                                    &mut |scan| apply_sample_to_scan(scan, &shared_sample),
+                                )?;
+                                if right_res.transformed {
+                                    join.right = Arc::new(right_res.data);
+                                }
+                                transformed =
+                                    transformed || left_res.transformed || right_res.transformed;
+                            }
                         }
                     }
-
-                    if let Some(partition_by) = matched_partition_by {
-                        let sample = sample_fast_field(provider, &partition_by)?;
-                        let mut new_provider = provider.clone();
-                        new_provider.with_range_partitioning(Some(sample));
-
-                        let new_source = if scan
-                            .source
-                            .as_ref()
-                            .downcast_ref::<DefaultTableSource>()
-                            .is_some()
-                        {
-                            Arc::new(DefaultTableSource::new(Arc::new(new_provider)))
-                                as Arc<dyn datafusion::logical_expr::TableSource>
-                        } else {
-                            return Err(DataFusionError::Internal(
-                                "PgSearchTableProvider was not wrapped in a DefaultTableSource"
-                                    .to_string(),
-                            ));
-                        };
-
-                        scan.source = new_source;
-                        return Ok(Transformed::yes(LogicalPlan::TableScan(scan)));
-                    }
                 }
-                Ok(Transformed::no(LogicalPlan::TableScan(scan)))
-            } else {
-                Ok(Transformed::no(node))
+                if transformed {
+                    return Ok(Transformed::yes(LogicalPlan::Join(join)));
+                } else {
+                    return Ok(Transformed::no(LogicalPlan::Join(join)));
+                }
             }
+            Ok(Transformed::no(node))
         })
     }
 }
@@ -168,16 +368,17 @@ fn sample_fast_field(
     }
 
     let largest_segment: &SegmentReader =
-        segment_readers.iter().max_by_key(|s| s.num_docs()).unwrap();
+        segment_readers.iter().max_by_key(|s| s.max_doc()).unwrap();
 
-    let num_docs = largest_segment.num_docs();
-    if num_docs == 0 {
+    let max_doc = largest_segment.max_doc();
+    if max_doc == 0 {
         return Ok(RangePartitioningSample {
             partition_by: partition_by.clone(),
             sample_points: vec![],
         });
     }
 
+    // TODO: Validate that all partition_by columns are fast fields at `CREATE INDEX` time.
     let ff_type = FFType::new(largest_segment.fast_fields(), partition_by.as_ref());
 
     let search_field_type = provider.fields.iter().find_map(|f| {
@@ -189,12 +390,12 @@ fn sample_fast_field(
         None
     });
 
-    let target_samples = 512;
-    let mut rng = rand::rng();
+    let target_samples = std::cmp::min(512, max_doc as usize);
+    let step = (max_doc as f64) / (target_samples as f64);
 
-    let mut doc_ids: Vec<u32> = (0..num_docs).collect();
-    doc_ids.shuffle(&mut rng);
-    let sample_doc_ids: Vec<u32> = doc_ids.into_iter().take(target_samples).collect();
+    let sample_doc_ids: Vec<u32> = (0..target_samples)
+        .map(|i| (i as f64 * step) as u32)
+        .collect();
 
     let mut sample_points = Vec::with_capacity(sample_doc_ids.len());
     for doc_id in sample_doc_ids {
@@ -203,7 +404,17 @@ fn sample_fast_field(
     }
 
     // Sort points ascending so that build() produces sequential ranges
-    sample_points.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sample_points.sort_unstable_by(|a, b| {
+        if let (
+            crate::postgres::pdb_owned_value::PdbOwnedValue::F64(f1),
+            crate::postgres::pdb_owned_value::PdbOwnedValue::F64(f2),
+        ) = (a, b)
+        {
+            f1.total_cmp(f2)
+        } else {
+            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+        }
+    });
 
     Ok(RangePartitioningSample {
         partition_by: partition_by.clone(),

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -274,6 +274,9 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
     builder = builder
         .with_optimizer_rule(Arc::new(VisibilityFilterOptimizerRule::new()))
         .with_optimizer_rule(Arc::new(
+            super::range_partitioning_rule::RangePartitioningRule::new(),
+        ))
+        .with_optimizer_rule(Arc::new(
             crate::scan::late_materialization::LateMaterializationRule,
         ));
 

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -396,7 +396,7 @@ mod tests {
 /// cached by stage.
 #[derive(Default)]
 pub struct StagePlanDispatchSource {
-    cache: std::sync::Mutex<std::collections::HashMap<usize, Vec<u8>>>,
+    cache: std::sync::Mutex<std::collections::HashMap<(usize, usize), Vec<u8>>>,
 }
 
 impl datafusion_distributed::DispatchPlanSource for StagePlanDispatchSource {
@@ -407,7 +407,9 @@ impl datafusion_distributed::DispatchPlanSource for StagePlanDispatchSource {
     ) -> Option<datafusion::common::Result<Vec<u8>>> {
         // One source per query execution, so the query id never varies here.
         let stage_id = task.stage_id;
-        if let Some(bytes) = self.cache.lock().unwrap().get(&stage_id) {
+        let task_number = task.task_number;
+        let key = (stage_id, task_number);
+        if let Some(bytes) = self.cache.lock().unwrap().get(&key) {
             return Some(Ok(bytes.clone()));
         }
         // The default converter stamps every expression with its `expression_id`, which is what
@@ -419,7 +421,7 @@ impl datafusion_distributed::DispatchPlanSource for StagePlanDispatchSource {
             Ok(bytes) => bytes,
             Err(e) => return Some(Err(e)),
         };
-        self.cache.lock().unwrap().insert(stage_id, bytes.clone());
+        self.cache.lock().unwrap().insert(key, bytes.clone());
         Some(Ok(bytes))
     }
 }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -655,6 +655,36 @@ fn strategy_name(strategy: tantivy::query::StrategyTag) -> &'static str {
 impl DisplayAs for PgSearchScanPlan {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "PgSearchScan: segments={}", self.segment_count)?;
+        if let Some(range_sample) = &self.range_sample {
+            if let Some(assigned) = self.assigned_partition {
+                let partitioning =
+                    range_sample.build(self.properties.output_partitioning().partition_count());
+
+                let lower = if assigned > 0 {
+                    let val = &partitioning.split_points[assigned - 1];
+                    serde_json::to_string(val).unwrap_or_else(|_| format!("{:?}", val))
+                } else {
+                    "-∞".to_string()
+                };
+
+                let upper = if assigned < partitioning.split_points.len() {
+                    let val = &partitioning.split_points[assigned];
+                    serde_json::to_string(val).unwrap_or_else(|_| format!("{:?}", val))
+                } else {
+                    "∞".to_string()
+                };
+
+                write!(
+                    f,
+                    ", partition={}[{}..{})",
+                    range_sample.partition_by.as_ref(),
+                    lower,
+                    upper
+                )?;
+            } else {
+                write!(f, ", partition_by={}", range_sample.partition_by.as_ref())?;
+            }
+        }
         if !self.dynamic_filters.is_empty() {
             write!(f, ", dynamic_filters={}", self.dynamic_filters.len())?;
         }
@@ -675,9 +705,6 @@ impl DisplayAs for PgSearchScanPlan {
             } else {
                 write!(f, ", dynamic_filter_pushdown={}", strategy_name(strategy))?;
             }
-        }
-        if let Some(range_sample) = &self.range_sample {
-            write!(f, ", partition_by={}", range_sample.partition_by.as_ref())?;
         }
         write!(f, ", query={}", self.resolved_query.explain_format())
     }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -108,33 +108,29 @@ pub struct ScanState {
 
 /// Execution state for a single `PgSearchScanPlan`.
 ///
-/// In multi-partition distributed execution, operators like `NestedLoopJoinExec` or `datafusion-distributed`'s
-/// worker fragment runner execute all partitions of a plan concurrently across tasks.
-/// For plans initialized with a `ScanState`, the first `execute()` takes the reader. If the plan has multiple
-/// partitions (`partition_count > 1`), subsequent calls up to `partition_count` yield an empty stream (`Empty`).
-/// Once all budget calls are spent, the state transitions to `Consumed`.
+/// Under multi-partition distributed or parallel execution, a plan variant's `assigned_partition` indicates
+/// which partition should consume the state and yield data. Calling `execute()` on that assigned partition
+/// consumes the state exactly once and transitions it to `Consumed`.
 ///
-/// Because all tasks/variants in a single process share the exact same `ExecutionState` instance (cloned via `Arc`),
-/// this state machine is essential for correctness when a process hosts multiple tasks for the same scan stage.
-/// The first task to poll `execute()` takes the `Ready` state and returns a stream that dynamically claims segments
-/// from the `ParallelScanState`. The subsequent tasks encounter the `Empty` state and return empty streams, safely
-/// allowing the first stream to do all the work for that process's portion of segments.
-#[derive(Default)]
+/// Any calls to `execute()` for a partition that does not match `assigned_partition` will yield an
+/// empty stream and leave the state untouched. This ensures each plan variant only yields data for its
+/// explicitly assigned slice of the workload.
+#[derive(Default, Clone)]
 pub enum ExecutionState {
     /// In Shared mode, we optionally load-balance via ParallelScanState.
-    /// The state is consumed by the first partition.
+    /// The state is consumed by the assigned partition.
     Shared {
         parallel_state: Option<UnsafeSendSync<*mut crate::postgres::ParallelScanState>>,
-        scan_state: Option<Box<UnsafeSendSync<ScanState>>>,
-        spent_partitions: Vec<bool>,
+        scan_state: Box<UnsafeSendSync<ScanState>>,
     },
     /// In RangePartitioned mode, we static-partition using RangePartitioning.
-    /// The state is cloned for each partition.
+    /// The state is consumed by the assigned partition.
     RangePartitioned {
         range_boundaries: RangePartitioning,
         scan_state: Box<UnsafeSendSync<ScanState>>,
-        spent_partitions: Vec<bool>,
     },
+    /// The state has been consumed by a call to execute().
+    Consumed,
     /// Uninitialized placeholder state.
     #[default]
     Uninitialized,
@@ -142,11 +138,11 @@ pub enum ExecutionState {
 
 /// A DataFusion `ExecutionPlan` for scanning `pg_search` index segments.
 ///
-/// Under multi-partition distributed execution, this plan's `output_partitioning` declares
-/// a *capacity* (`min(segments, target_partitions)`). The partitions do not statically map
-/// to data; instead, tasks dynamically claim segments from the shared `ParallelScanState` as
-/// they process the stream returned by `execute()`. See `ExecutionState` for details on how
-/// multiple tasks safely share state within a single process.
+/// Under multi-partition parallel or distributed execution, this plan's `output_partitioning` declares
+/// a *capacity* (`min(segments, target_partitions)`). The plan is then cloned into multiple variants,
+/// where each variant has its `assigned_partition` explicitly set. When `execute()` is called, only
+/// the assigned partition actually consumes the scan state to produce a stream, guaranteeing exactly-once
+/// processing of the underlying data.
 pub struct PgSearchScanPlan {
     /// State for this single-partition scan.
     ///
@@ -198,6 +194,35 @@ pub struct PgSearchScanPlan {
     /// `=true` in that case.
     dynamic_filter_strategy: Arc<AtomicU8>,
     range_sample: Option<RangePartitioningSample>,
+    /// When executing in a multi-task distributed or parallel environment, this
+    /// indicates the specific execution partition this plan variant is responsible for.
+    /// It guarantees that the `ExecutionState` is consumed exactly once by the designated worker.
+    assigned_partition: Option<usize>,
+}
+
+impl Clone for PgSearchScanPlan {
+    fn clone(&self) -> Self {
+        let state_guard = self.state.lock().unwrap();
+        let new_state = state_guard.clone();
+        Self {
+            state: Mutex::new(new_state),
+            planner_estimated_rows: self.planner_estimated_rows,
+            segment_count: self.segment_count,
+            properties: Arc::clone(&self.properties),
+            resolved_query: self.resolved_query.clone(),
+            dynamic_filters: self.dynamic_filters.clone(),
+            metrics: self.metrics.clone(),
+            deferred_fields: self.deferred_fields.clone(),
+            ffhelper: self.ffhelper.clone(),
+            indexrelid: self.indexrelid,
+            deferred_ctid_plan_position: self.deferred_ctid_plan_position,
+            dynamic_filter_pushdown: Arc::clone(&self.dynamic_filter_pushdown),
+            sort_order: self.sort_order.clone(),
+            dynamic_filter_strategy: Arc::clone(&self.dynamic_filter_strategy),
+            range_sample: self.range_sample.clone(),
+            assigned_partition: self.assigned_partition,
+        }
+    }
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -276,13 +301,11 @@ impl PgSearchScanPlan {
                     ExecutionState::RangePartitioned {
                         range_boundaries: sample.build(partition_count),
                         scan_state: Box::new(UnsafeSendSync(s)),
-                        spent_partitions: vec![false; partition_count],
                     }
                 } else {
                     ExecutionState::Shared {
                         parallel_state: parallel_state.map(UnsafeSendSync),
-                        scan_state: Some(Box::new(UnsafeSendSync(s))),
-                        spent_partitions: vec![false; partition_count],
+                        scan_state: Box::new(UnsafeSendSync(s)),
                     }
                 }
             }
@@ -305,6 +328,7 @@ impl PgSearchScanPlan {
             sort_order: sort_order.cloned(),
             dynamic_filter_strategy: Arc::new(AtomicU8::new(0)),
             range_sample,
+            assigned_partition: None,
         }
     }
 
@@ -328,22 +352,19 @@ impl PgSearchScanPlan {
             ExecutionState::Shared {
                 parallel_state,
                 scan_state,
-                ..
             } => ExecutionState::Shared {
                 parallel_state: parallel_state.clone(),
                 scan_state: scan_state.clone(),
-                spent_partitions: vec![false; target_partitions],
             },
             ExecutionState::RangePartitioned { scan_state, .. } => {
                 ExecutionState::RangePartitioned {
                     range_boundaries: self.range_sample.as_ref().unwrap().build(target_partitions),
                     scan_state: Box::new(UnsafeSendSync(scan_state.0.clone())),
-                    spent_partitions: vec![false; target_partitions],
                 }
             }
             _ => {
                 return Err(DataFusionError::Internal(
-                    "Cannot repartition uninitialized plan".into(),
+                    "Cannot repartition uninitialized or consumed plan".into(),
                 ))
             }
         };
@@ -384,6 +405,7 @@ impl PgSearchScanPlan {
                 self.dynamic_filter_strategy.load(Ordering::Relaxed),
             )),
             range_sample: self.range_sample.clone(),
+            assigned_partition: self.assigned_partition,
         })
     }
 
@@ -411,10 +433,7 @@ impl PgSearchScanPlan {
             .lock()
             .map_err(|e| DataFusionError::Internal(format!("lock PgSearchScanPlan state: {e}")))?;
         let state = match &*state_guard {
-            ExecutionState::Shared {
-                scan_state: Some(scan_state),
-                ..
-            } => scan_state,
+            ExecutionState::Shared { scan_state, .. } => scan_state,
             ExecutionState::RangePartitioned { scan_state, .. } => scan_state,
             _ => {
                 return Err(DataFusionError::Internal(
@@ -449,6 +468,7 @@ impl PgSearchScanPlan {
             planner_estimated_rows,
             partition_count: self.properties.output_partitioning().partition_count(),
             range_sample: self.range_sample.clone(),
+            assigned_partition: self.assigned_partition,
         };
         serde_json::to_vec(&descriptor).map_err(|e| {
             DataFusionError::Internal(format!("PgSearchScan dispatch: serialize: {e}"))
@@ -539,7 +559,7 @@ impl PgSearchScanPlan {
             Some(ffhelper)
         };
 
-        Ok(Arc::new(PgSearchScanPlan::new(
+        let mut plan = PgSearchScanPlan::new(
             Some(state),
             schema,
             query,
@@ -547,11 +567,13 @@ impl PgSearchScanPlan {
             deferred,
             ffhelper_arg,
             descriptor.indexrelid,
-            deferred_ctid_plan_position,
+            descriptor.deferred_ctid_plan_position,
             descriptor.partition_count,
             parallel_state,
             descriptor.range_sample,
-        )))
+        );
+        plan.assigned_partition = descriptor.assigned_partition;
+        Ok(Arc::new(plan))
     }
 }
 
@@ -577,6 +599,7 @@ struct ScanDispatchDescriptor {
     planner_estimated_rows: u64,
     partition_count: usize,
     range_sample: Option<RangePartitioningSample>,
+    assigned_partition: Option<usize>,
 }
 
 /// Build `EquivalenceProperties` with the specified sort ordering.
@@ -653,6 +676,9 @@ impl DisplayAs for PgSearchScanPlan {
                 write!(f, ", dynamic_filter_pushdown={}", strategy_name(strategy))?;
             }
         }
+        if let Some(range_sample) = &self.range_sample {
+            write!(f, ", partition_by={}", range_sample.partition_by.as_ref())?;
+        }
         write!(f, ", query={}", self.resolved_query.explain_format())
     }
 }
@@ -715,6 +741,20 @@ impl ExecutionPlan for PgSearchScanPlan {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        // TODO: The datafusion-distributed fork currently calls `execute` for ALL partitions in
+        // `run_worker_fragment`, even though this variant was only assigned to process a single
+        // partition. We should triage whether `run_worker_fragment` should be accessing all
+        // partitions, or only assigned partitions for a task. Until then, returning an empty
+        // stream for non-assigned partitions satisfies the fragment execution without crashing.
+        if let Some(assigned) = self.assigned_partition {
+            if partition != assigned {
+                let schema = self.properties.eq_properties.schema().clone();
+                return Ok(Box::pin(unsafe {
+                    UnsafeSendStream::new(futures::stream::empty(), schema)
+                }));
+            }
+        }
+
         let mut state_guard = self.state.lock().map_err(|e| {
             DataFusionError::Internal(format!("Failed to lock PgSearchScanPlan state: {e}"))
         })?;
@@ -727,45 +767,18 @@ impl ExecutionPlan for PgSearchScanPlan {
             )));
         }
 
+        let state = std::mem::replace(&mut *state_guard, ExecutionState::Consumed);
+
         // Handle state transitions for execution.
-        let (scan_state, parallel_state, range_boundaries) = match &mut *state_guard {
+        let (scan_state, parallel_state, range_boundaries) = match state {
             ExecutionState::Shared {
                 parallel_state,
                 scan_state,
-                spent_partitions,
-            } => {
-                if spent_partitions.get(partition).copied().unwrap_or(false) {
-                    return Err(DataFusionError::Internal(format!(
-                        "PgSearchScanPlan partition {partition} executed more than once"
-                    )));
-                }
-                if partition < spent_partitions.len() {
-                    spent_partitions[partition] = true;
-                }
-
-                if let Some(state) = scan_state.take() {
-                    (state.0, parallel_state.as_ref().map(|p| p.0), None)
-                } else {
-                    let schema = self.properties.eq_properties.schema().clone();
-                    return Ok(Box::pin(unsafe {
-                        UnsafeSendStream::new(futures::stream::empty(), schema)
-                    }));
-                }
-            }
+            } => (scan_state.0, parallel_state.map(|p| p.0), None),
             ExecutionState::RangePartitioned {
                 range_boundaries,
                 scan_state,
-                spent_partitions,
             } => {
-                if spent_partitions.get(partition).copied().unwrap_or(false) {
-                    return Err(DataFusionError::Internal(format!(
-                        "PgSearchScanPlan partition {partition} executed more than once"
-                    )));
-                }
-                if partition < spent_partitions.len() {
-                    spent_partitions[partition] = true;
-                }
-
                 // If target_partitions scaled past the available sample boundaries, we
                 // just return empty streams for the extra partitions.
                 if partition > range_boundaries.split_points.len() {
@@ -775,7 +788,12 @@ impl ExecutionPlan for PgSearchScanPlan {
                     }));
                 }
 
-                (scan_state.0.clone(), None, Some(range_boundaries.clone()))
+                (scan_state.0, None, Some(range_boundaries))
+            }
+            ExecutionState::Consumed => {
+                return Err(DataFusionError::Internal(format!(
+                    "PgSearchScanPlan partition {partition} executed more than once"
+                )));
             }
             ExecutionState::Uninitialized => {
                 let schema = self.properties.eq_properties.schema().clone();
@@ -1100,11 +1118,16 @@ impl TaskEstimator for PgSearchScanTaskEstimator {
             Arc::clone(plan)
         };
 
-        // Each worker decodes its own copy, and `execute()` dynamically claims segments from the
-        // parallel state. Variants in the same process share state: see `ExecutionState` for why
-        // this is safe.
+        // Downcast back because repartition returns `Arc<dyn ExecutionPlan>`
+        let final_scan_plan = final_plan.downcast_ref::<PgSearchScanPlan>().unwrap();
+
+        // Assign each task its explicit execution partition to ensure it is the only one executing it.
         let variants = (0..task_count)
-            .map(|_| Arc::clone(&final_plan))
+            .map(|i| {
+                let mut variant = final_scan_plan.clone();
+                variant.assigned_partition = Some(i);
+                Arc::new(variant) as Arc<dyn ExecutionPlan>
+            })
             .collect::<Vec<_>>();
 
         Ok(Some(Arc::new(

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -94,7 +94,7 @@ fn get_deferred_fields(plan: &LogicalPlan) -> Vec<DeferredField> {
 /// Instead of relying on brittle string suffix matching (`ends_with`) or unsafe positional
 /// indices, this function explicitly recursively traces the `Column`'s lineage back down the
 /// plan tree to find its exact root `Column` at the `TableScan` level, allowing robust exact matching.
-fn trace_column(plan: &LogicalPlan, col: &Column) -> Option<Column> {
+pub(crate) fn trace_column(plan: &LogicalPlan, col: &Column) -> Option<Column> {
     match plan {
         LogicalPlan::TableScan(scan) => {
             if scan.projected_schema.has_column(col) {

--- a/pg_search/src/scan/range_partitioning.rs
+++ b/pg_search/src/scan/range_partitioning.rs
@@ -41,6 +41,10 @@ impl RangePartitioning {
     /// - A row whose partition field is NULL will be deterministically routed to partition 0.
     /// - A multi-valued field can fall into multiple partition ranges and duplicate the row. This is statically prevented during index configuration for `partition_by` columns.
     pub fn partition_bounds(&self, partition: usize) -> SearchQueryInput {
+        if self.split_points.is_empty() {
+            return SearchQueryInput::All;
+        }
+
         let lower = if partition > 0 {
             let val = &self.split_points[partition - 1];
             if matches!(val, PdbOwnedValue::Null) {

--- a/pg_search/src/scan/range_partitioning.rs
+++ b/pg_search/src/scan/range_partitioning.rs
@@ -116,7 +116,7 @@ impl RangePartitioning {
 ///
 /// **Precondition**: `sample_points` must be sorted ascending, otherwise the generated
 /// boundaries will produce overlapping or gapped ranges that silently drop or duplicate rows.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RangePartitioningSample {
     /// The index field used to define the boundaries.
     pub partition_by: FieldName,

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -70,8 +70,8 @@ impl VisibilityMode {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PgSearchTableProvider {
-    scan_info: ScanInfo,
-    fields: Vec<WhichFastField>,
+    pub(crate) scan_info: ScanInfo,
+    pub(crate) fields: Vec<WhichFastField>,
     #[serde(skip)]
     schema: OnceLock<SchemaRef>,
     #[serde(skip)]
@@ -145,6 +145,27 @@ mod atomic_bool_serde {
     }
 }
 
+impl Clone for PgSearchTableProvider {
+    fn clone(&self) -> Self {
+        Self {
+            scan_info: self.scan_info.clone(),
+            fields: self.fields.clone(),
+            schema: self.schema.clone(),
+            late_materialization_schema: self.late_materialization_schema.clone(),
+            parallel_state: self.parallel_state,
+            expr_context: self.expr_context,
+            planstate: self.planstate,
+            visibility_mode: self.visibility_mode,
+            late_materialization_active: std::sync::atomic::AtomicBool::new(
+                self.late_materialization_active
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            ),
+            source_idx: self.source_idx,
+            range_sample: self.range_sample.clone(),
+        }
+    }
+}
+
 unsafe impl Send for PgSearchTableProvider {}
 unsafe impl Sync for PgSearchTableProvider {}
 
@@ -174,14 +195,8 @@ impl PgSearchTableProvider {
     /// When a sample is provided, the table provider will produce a plan that is
     /// statically partitioned by range bounds, overriding the default `Shared`
     /// (dynamic segment checkout) partitioning mode.
-    // TODO: Support for declaring range partitioning will be added via https://github.com/paradedb/paradedb/issues/5662
-    #[allow(dead_code)]
-    pub fn with_range_partitioning(
-        mut self,
-        range_sample: Option<RangePartitioningSample>,
-    ) -> Self {
+    pub fn with_range_partitioning(&mut self, range_sample: Option<RangePartitioningSample>) {
         self.range_sample = range_sample;
-        self
     }
 
     /// Transitions the provider from Phase 1 (`Utf8View`) into Phase 2 (`Union`)
@@ -651,15 +666,14 @@ impl PgSearchTableProvider {
         let total_estimated_rows = self.scan_info.estimate.as_planner_estimate();
 
         let segment_count = reader.segment_readers().len();
-        let target_partitions = state.config().target_partitions();
-        // The output partitions of the scan default to min(segments, target_partitions),
-        // or exactly `target_partitions` when range partitioning is enabled.
-        // During distributed planning, the `PgSearchScanTaskEstimator` reads this partition
-        // count to determine how many tasks (e.g. parallel workers) this leaf should scale out into.
+        // Number of target partitions.
         let partition_count = if self.range_sample.is_some() {
-            target_partitions
+            // When using range partitioning, we target the session's target partitions.
+            // The actual number of bounds will be dynamically limited by the sample size
+            // when we create the plan.
+            state.config().target_partitions()
         } else {
-            std::cmp::min(segment_count, target_partitions).max(1)
+            std::cmp::min(segment_count, state.config().target_partitions()).max(1)
         };
 
         self.create_lazy_scan(

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -199,6 +199,10 @@ impl PgSearchTableProvider {
         self.range_sample = range_sample;
     }
 
+    pub fn range_sample(&self) -> Option<&RangePartitioningSample> {
+        self.range_sample.as_ref()
+    }
+
     /// Transitions the provider from Phase 1 (`Utf8View`) into Phase 2 (`Union`)
     pub fn enable_late_materialization_schema(&self) {
         self.late_materialization_active
@@ -666,14 +670,18 @@ impl PgSearchTableProvider {
         let total_estimated_rows = self.scan_info.estimate.as_planner_estimate();
 
         let segment_count = reader.segment_readers().len();
-        // Number of target partitions.
+        let target_partitions = state.config().target_partitions();
+        // The output partitions of the scan default to min(segments, target_partitions),
+        // or exactly `target_partitions` when range partitioning is enabled.
+        // During distributed planning, the `PgSearchScanTaskEstimator` reads this partition
+        // count to determine how many tasks (e.g. parallel workers) this leaf should scale out into.
         let partition_count = if self.range_sample.is_some() {
             // When using range partitioning, we target the session's target partitions.
             // The actual number of bounds will be dynamically limited by the sample size
             // when we create the plan.
-            state.config().target_partitions()
+            target_partitions
         } else {
-            std::cmp::min(segment_count, state.config().target_partitions()).max(1)
+            std::cmp::min(segment_count, target_partitions).max(1)
         };
 
         self.create_lazy_scan(

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -36,12 +36,14 @@ CREATE INDEX mpp_join_files_idx ON mpp_join_files
 USING bm25 (id, title, content)
 WITH (
     key_field='id',
+    partition_by='id',
     text_fields='{"title": {"fast": true}, "content": {}}'
 );
 CREATE INDEX mpp_join_pages_idx ON mpp_join_pages
 USING bm25 (id, file_id, page_text, size_bytes)
 WITH (
     key_field='id',
+    partition_by='file_id',
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
@@ -78,8 +80,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -94,9 +96,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :           PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes
@@ -131,8 +133,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                         QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -145,27 +147,28 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=2, partitions=6
+           :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         CoalescePartitionsExec
-           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
-           :   │           DistributedLeafExec:
-           :   │             t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
-           :   │             t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=3
+           :   │         DistributedLeafExec:
+           :   │           t0: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :   │           t1: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :   │           t2: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=2, partitions=8
-           :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :     ┌───── Stage 1 ── tasks=3, partitions=27
+           :     │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
            :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t0: PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t1: PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t2: PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
-(32 rows)
+(33 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -229,8 +232,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                     QUERY PLAN                                                                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                             QUERY PLAN                                                                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -243,27 +246,28 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=2, partitions=6
+           :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         CoalescePartitionsExec
-           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
-           :   │           DistributedLeafExec:
-           :   │             t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
-           :   │             t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=3
+           :   │         DistributedLeafExec:
+           :   │           t0: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :   │           t1: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :   │           t2: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=2, partitions=8
-           :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :     ┌───── Stage 1 ── tasks=3, partitions=27
+           :     │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
            :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :     │     t1: PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │     t0: PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │     t1: PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │     t2: PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :     └──────────────────────────────────────────────────
-(32 rows)
+(33 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -298,8 +302,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                   QUERY PLAN                                                                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                           QUERY PLAN                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -314,9 +318,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :           PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :           PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -80,8 +80,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                QUERY PLAN                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -96,9 +96,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes
@@ -133,8 +133,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                  QUERY PLAN                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -157,16 +157,16 @@ LIMIT 10;
            :   │         CoalescePartitionsExec
            :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=3
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
-           :   │           t1: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
-           :   │           t2: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :   │           t0: PgSearchScan: segments=2, partition=file_id[-∞..56), dynamic_filters=1, query="all"
+           :   │           t1: PgSearchScan: segments=2, partition=file_id[56..117), dynamic_filters=1, query="all"
+           :   │           t2: PgSearchScan: segments=2, partition=file_id[117..∞), dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=3, partitions=27
            :     │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
            :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t1: PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t2: PgSearchScan: segments=2, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t0: PgSearchScan: segments=2, partition=id[-∞..56), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t1: PgSearchScan: segments=2, partition=id[56..117), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t2: PgSearchScan: segments=2, partition=id[117..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
 (33 rows)
 
@@ -232,8 +232,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                             QUERY PLAN                                                                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                QUERY PLAN                                                                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -256,16 +256,16 @@ LIMIT 10;
            :   │         CoalescePartitionsExec
            :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=3
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
-           :   │           t1: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
-           :   │           t2: PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :   │           t0: PgSearchScan: segments=2, partition=file_id[-∞..56), dynamic_filters=1, query="all"
+           :   │           t1: PgSearchScan: segments=2, partition=file_id[56..117), dynamic_filters=1, query="all"
+           :   │           t2: PgSearchScan: segments=2, partition=file_id[117..∞), dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=3, partitions=27
            :     │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
            :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :     │     t1: PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :     │     t2: PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │     t0: PgSearchScan: segments=2, partition=id[-∞..56), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │     t1: PgSearchScan: segments=2, partition=id[56..117), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │     t2: PgSearchScan: segments=2, partition=id[117..∞), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :     └──────────────────────────────────────────────────
 (33 rows)
 
@@ -302,8 +302,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                           QUERY PLAN                                                                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -318,9 +318,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, partition_by=id, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :           PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=1, partition_by=file_id, query="all"
+           :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -42,6 +42,7 @@ CREATE INDEX mpp_join_files_idx ON mpp_join_files
 USING bm25 (id, title, content)
 WITH (
     key_field='id',
+    partition_by='id',
     text_fields='{"title": {"fast": true}, "content": {}}'
 );
 
@@ -49,6 +50,7 @@ CREATE INDEX mpp_join_pages_idx ON mpp_join_pages
 USING bm25 (id, file_id, page_text, size_bytes)
 WITH (
     key_field='id',
+    partition_by='file_id',
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5662

## What

Add an optimizer rule to enable range partitioning when both sides of a join declare the join key as a `partition_by` column.

## Why

Currently, our `ExecutionPlan` continues to declare `Partitioning::UnknownPartitioning(...)`, but in #5663 it will begin declaring `Partitioning::Range`, which will allow joins to be co-partitioned, and which will change stage boundaries.

## How

Add the logical `RangePartitioningRule` optimizer rule, to adjust the declared partitioning of both sides of a join when possible. Additionally, fix our "glue" to deserialize a task + stage specific copy of our node, to allow a node to have an explicit partition assigned.

There will be further work required around the relationship between `TaskEstimator` + `ExecutionPlan` + `run_worker_fragment`: note the TODO in `PgSearchScanPlan::execute`.

## Tests

Declared range partitioning in `mpp_joinscan`, and confirmed that:
1. plans changed to indicate that partitioning is being applied
2. results are all still correct