### PR TITLE
fix: strip orphaned SortExec dynamic filter when SegmentedTopKExec is injected

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -41,8 +41,7 @@ The planner hook builds a [`JoinCSClause`][joincsc] — a serializable IR captur
 1. **[`RangePartitioningRule`](range_partitioning_rule.rs)** — coordinates split points across joins for MPP range partitioning, sampling both sides of the join and injecting the merged sample into both `PgSearchTableProvider`s
 2. **`LateMaterializationRule`** — injects [`TantivyLookupExec`][lookup-exec] to defer string materialization
 3. **[`RangeCoPartitionedJoinRule`](range_partitioning_rule.rs)** — flips a `CollectLeft` inner hash join to `Partitioned` mode when both sides declare compatible `Partitioning::Range` layouts, so MPP joins partition pairs task-locally instead of broadcasting the build side
-4. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)`, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
-5. **FilterPushdown (Post)** — pushes `SegmentedTopKExec`'s `DynamicFilterPhysicalExpr` down to the scan
+4. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)` and transfers ownership of its already pushed-down `DynamicFilterPhysicalExpr` into the injected node, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
 
 If `max_parallel_workers_per_gather > 0` and PostgreSQL has planned parallel execution, `DistributedPlanner` converts the finalized physical plan into an MPP execution tree (`DistributedExec`), slicing it into isolated tasks.
 

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -336,8 +336,7 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
                 // VisibilityCtidResolverRule again here, *after* SegmentedTopKRule, so
                 // that it wires resolvers into the STK node rather than the (now-removed)
                 // VisibilityFilterExec node.
-                .with_physical_optimizer_rule(Arc::new(VisibilityCtidResolverRule))
-                .with_physical_optimizer_rule(Arc::new(FilterPushdown::new_post_optimization()));
+                .with_physical_optimizer_rule(Arc::new(VisibilityCtidResolverRule));
         }
         SessionContextProfile::Aggregate => {
             builder = builder

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -233,15 +233,14 @@ impl CustomScanState for JoinScanState {
 /// Selects which physical optimizer rules to install on top of the shared
 /// base session for a given consumer.
 ///
-/// JoinScan needs `SegmentedTopKRule` and the trailing `FilterPushdown` passes
-/// that follow it; AggregateScan needs only a single `FilterPushdown` post-pass.
-/// Exposing the difference as an explicit profile keeps the choice grep-able
-/// from the call site.
+/// JoinScan needs `SegmentedTopKRule`; AggregateScan needs a single
+/// `FilterPushdown` post-pass. Exposing the difference as an explicit profile
+/// keeps the choice grep-able from the call site.
 #[derive(Copy, Clone, Debug)]
 pub enum SessionContextProfile {
-    /// JoinScan execution: enables `topk_dynamic_filter_pushdown`, includes
-    /// `SegmentedTopKRule`, and adds the trailing `FilterPushdown` passes that
-    /// `SegmentedTopKRule` requires.
+    /// JoinScan execution: enables `topk_dynamic_filter_pushdown` and installs
+    /// `SegmentedTopKRule`, which transfers ownership of the SortExec's already
+    /// pushed-down dynamic filter into the injected `SegmentedTopKExec`.
     Join,
     /// AggregateScan execution: single `FilterPushdown` post-pass, no
     /// SegmentedTopK, no topk dynamic filter pushdown.
@@ -290,8 +289,10 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
 /// the physical optimizer rules each consumer needs:
 ///
 /// - [`SessionContextProfile::Join`]: enables `topk_dynamic_filter_pushdown`,
-///   then appends `SegmentedTopKRule` followed by a trailing `FilterPushdown`
-///   pass to pick up any filters `SegmentedTopKRule` injects.
+///   then appends `SegmentedTopKRule`. No trailing `FilterPushdown` pass is
+///   needed: `SegmentedTopKRule` transfers ownership of the SortExec's already
+///   pushed-down `DynamicFilterPhysicalExpr` into `SegmentedTopKExec`, so the
+///   scans stay wired to the same filter the SortExec would have driven.
 /// - [`SessionContextProfile::Aggregate`]: appends a single `FilterPushdown`
 ///   post-pass; SegmentedTopK does not apply to aggregate-on-join queries.
 pub fn create_datafusion_session_context(profile: SessionContextProfile) -> SessionContext {

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -139,6 +139,7 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                     ctx,
                     &self.index_segment_ids,
                     self.parallel_state,
+                    proto_converter,
                 )
             }
             other => Err(DataFusionError::NotImplemented(format!(
@@ -170,7 +171,7 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         }
         if let Some(topk) = node.downcast_ref::<SegmentedTopKExec>() {
             buf.push(TAG_SEGMENTED_TOPK);
-            buf.extend_from_slice(&topk.encode_for_dispatch()?);
+            buf.extend_from_slice(&topk.encode_for_dispatch(proto_converter)?);
             return Ok(());
         }
         Err(DataFusionError::NotImplemented(format!(
@@ -420,18 +421,13 @@ pub fn deserialize_physical_plan_with_runtime(
     let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &codec);
     let plan = proto_converter.proto_to_execution_plan(&proto, &decode_ctx)?;
     // Dynamic filters (hash-join keys, top-k bounds) are process-local Arcs shared between an
-    // operator and the scans below it, and the two link mechanisms differ:
-    //
-    // - HashJoinExec/AggregateExec links ride the wire by identity: the scan ships its
-    //   installed filters (`ScanDispatchDescriptor::dynamic_filters`) and the deduplicating
-    //   converter re-shares each with the operator's own decoded copy via `expr_id` (the
-    //   apache/datafusion#20416 machinery; design discussion in
-    //   https://github.com/apache/datafusion/issues/21207). Those operators skip re-pushing
-    //   when they already carry a filter, so this pass cannot relink them.
-    // - SegmentedTopKExec recreates its filter fresh on decode and re-pushes it every Post
-    //   phase, so this pass is what wires the worker's top-k threshold into its scans.
-    //
-    // Both mechanisms are fragment-local; a link that crossed fragments would need the filter
-    // values shipped between processes.
+    // operator and the scans below it. Every such link now rides the wire by identity: the
+    // scans ship their installed filters (`ScanDispatchDescriptor::dynamic_filters`),
+    // HashJoinExec/AggregateExec/SegmentedTopKExec ship their own copies, and the
+    // deduplicating converter re-shares each pair via `expr_id` (apache/datafusion#20416;
+    // design in https://github.com/apache/datafusion/issues/21207). The trailing pushdown
+    // pass stays as a safety net for any dynamic-filter-bearing operator that hasn't been
+    // wired for identity-round-trip yet; a link that crossed fragments would still need the
+    // filter values shipped between processes.
     FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())
 }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -30,8 +30,6 @@ use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::ScalarUDF;
-use datafusion::physical_optimizer::PhysicalOptimizerRule;
-use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::DistributedCodec;
 use datafusion_proto::physical_plan::{
@@ -420,14 +418,5 @@ pub fn deserialize_physical_plan_with_runtime(
     })?;
     let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &codec);
     let plan = proto_converter.proto_to_execution_plan(&proto, &decode_ctx)?;
-    // Dynamic filters (hash-join keys, top-k bounds) are process-local Arcs shared between an
-    // operator and the scans below it. Every such link now rides the wire by identity: the
-    // scans ship their installed filters (`ScanDispatchDescriptor::dynamic_filters`),
-    // HashJoinExec/AggregateExec/SegmentedTopKExec ship their own copies, and the
-    // deduplicating converter re-shares each pair via `expr_id` (apache/datafusion#20416;
-    // design in https://github.com/apache/datafusion/issues/21207). The trailing pushdown
-    // pass stays as a safety net for any dynamic-filter-bearing operator that hasn't been
-    // wired for identity-round-trip yet; a link that crossed fragments would still need the
-    // filter values shipped between processes.
-    FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())
+    Ok(plan)
 }

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -243,6 +243,7 @@ impl SegmentedTopKExec {
         ffhelper: Arc<FFHelper>,
         k: usize,
         visibility_data: Option<Arc<AbsorbedVisibilityData>>,
+        parent_filter: Option<Arc<DynamicFilterPhysicalExpr>>,
     ) -> Self {
         use datafusion::physical_expr::expressions::lit;
 
@@ -255,12 +256,18 @@ impl SegmentedTopKExec {
             Boundedness::Bounded,
         ));
 
-        // Create a DynamicFilterPhysicalExpr with the sort expression columns
-        // as children. The initial expression is `lit(true)` (no filtering).
-        // At runtime, `update()` replaces this with the global threshold.
-        let children: Vec<Arc<dyn PhysicalExpr>> =
-            sort_exprs.iter().map(|e| Arc::clone(&e.expr)).collect();
-        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(children, lit(true)));
+        // When the enclosing SortExec has already minted a `DynamicFilterPhysicalExpr`
+        // (via `SortExec::with_filter`), take ownership of it instead of minting a
+        // fresh one. The scans below have already been wired to this filter by the
+        // standard `FilterPushdown` pass, so subsequent `update()`s from this node's
+        // heap propagate to the same recipients the SortExec would have driven. If no
+        // parent filter is provided (e.g. worker decode path), fall back to minting.
+        // See #5635.
+        let dynamic_filter = parent_filter.unwrap_or_else(|| {
+            let children: Vec<Arc<dyn PhysicalExpr>> =
+                sort_exprs.iter().map(|e| Arc::clone(&e.expr)).collect();
+            Arc::new(DynamicFilterPhysicalExpr::new(children, lit(true)))
+        });
 
         Self {
             input,
@@ -491,6 +498,8 @@ impl SegmentedTopKExec {
             ffhelper,
             k,
             visibility_data,
+            // Worker decode: no parent SortExec filter to inherit, mint fresh.
+            None,
         )))
     }
 }
@@ -535,17 +544,17 @@ impl ExecutionPlan for SegmentedTopKExec {
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let mut new = SegmentedTopKExec::new(
+        // Preserve the existing dynamic filter so that filter pushdown wiring
+        // (which already holds a reference) stays connected.
+        let new = SegmentedTopKExec::new(
             children.remove(0),
             self.sort_exprs.clone(),
             self.deferred_columns.clone(),
             Arc::clone(&self.ffhelper),
             self.k,
             self.visibility_data.clone(),
+            Some(Arc::clone(&self.dynamic_filter)),
         );
-        // Preserve the existing dynamic filter so that filter pushdown
-        // wiring (which already holds a reference) stays connected.
-        new.dynamic_filter = Arc::clone(&self.dynamic_filter);
         Ok(Arc::new(new))
     }
 
@@ -2163,6 +2172,7 @@ mod tests {
                 deferred_columns,
                 ffhelper.clone(),
                 10,
+                None,
                 None,
             );
 

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -337,12 +337,15 @@ impl SegmentedTopKExec {
     }
 
     /// Serialize for leader dispatch. The `ffhelper` is live and doesn't travel; the worker
-    /// pulls it from the scan in its decoded subtree. The `dynamic_filter` is internal and is
-    /// recreated fresh by `new` on decode; the leader-side `FilterPushdown` wiring of that filter
-    /// into the scans' `PreFilter` does not travel, so a dispatched fragment scans without the
-    /// runtime top-k pruning (correct, just slower). Rewiring on decode is an open follow-up.
-    /// `decoders`/`properties` are derived.
-    pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
+    /// pulls it from the scan in its decoded subtree. The `dynamic_filter` ships as an
+    /// identity-stamped proto expression so that decoding through the fragment's
+    /// deduplicating proto converter re-shares one instance with the same filter shipped
+    /// by the scan below (see #5766), keeping the worker's top-k threshold wired to its
+    /// scan's `PreFilter`. `decoders`/`properties` are derived.
+    pub(crate) fn encode_for_dispatch(
+        &self,
+        proto_converter: &dyn datafusion_proto::physical_plan::PhysicalProtoConverterExtension,
+    ) -> Result<Vec<u8>> {
         let codec = datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
         let proto_conv = datafusion_proto::physical_plan::DefaultPhysicalProtoConverter {};
         let sort_proto = datafusion_proto::physical_plan::to_proto::serialize_physical_sort_exprs(
@@ -354,6 +357,12 @@ impl SegmentedTopKExec {
             .iter()
             .map(prost::Message::encode_to_vec)
             .collect();
+        // Ship the dynamic filter as a proto expression. The deduplicating converter
+        // re-shares it on decode with the scans below via `expr_id` (see #5766).
+        let dynamic_filter_bytes = {
+            let node = proto_converter.physical_expr_to_proto(&self.dynamic_filter, &codec)?;
+            prost::Message::encode_to_vec(&node)
+        };
         // Ship the visibility "recipe" (serializable plan_position/heap-OID pairs + table
         // names) so a dispatched worker can rebuild AbsorbedVisibilityData. The live ctid
         // resolvers (FFHelpers) don't travel; they are re-collected from the decoded
@@ -381,6 +390,7 @@ impl SegmentedTopKExec {
             self.deferred_columns.clone(),
             self.k,
             visibility_recipe,
+            dynamic_filter_bytes,
         );
         serde_json::to_vec(&payload).map_err(|e| {
             DataFusionError::Internal(format!("SegmentedTopKExec dispatch: serialize: {e}"))
@@ -396,12 +406,14 @@ impl SegmentedTopKExec {
         ctx: &TaskContext,
         index_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
         parallel_state: Option<*mut crate::postgres::ParallelScanState>,
+        proto_converter: &dyn datafusion_proto::physical_plan::PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let (sort_bytes, deferred_columns, k, visibility_recipe): (
+        let (sort_bytes, deferred_columns, k, visibility_recipe, dynamic_filter_bytes): (
             Vec<Vec<u8>>,
             Vec<DeferredSortColumn>,
             usize,
             VisibilityRecipe,
+            Vec<u8>,
         ) = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("SegmentedTopKExec dispatch: deserialize: {e}"))
         })?;
@@ -460,6 +472,26 @@ impl SegmentedTopKExec {
         let sort_exprs = LexOrdering::new(exprs).ok_or_else(|| {
             DataFusionError::Internal("SegmentedTopKExec dispatch: empty sort order".into())
         })?;
+        // Decode the shipped dynamic filter through the deduplicating proto converter so
+        // that the returned Arc is the same instance the scans below decoded (see #5766).
+        // This re-wires the worker's top-k threshold to its own scan's `PreFilter` without
+        // needing a trailing `FilterPushdown(Post)` pass on the decoded fragment.
+        let parent_filter: Option<Arc<dyn PhysicalExpr>> = {
+            let node = <datafusion_proto::protobuf::PhysicalExprNode as prost::Message>::decode(
+                dynamic_filter_bytes.as_slice(),
+            )
+            .map_err(|e| {
+                DataFusionError::Internal(format!(
+                    "SegmentedTopKExec dispatch: dynamic filter decode: {e}"
+                ))
+            })?;
+            let expr = proto_converter.proto_to_physical_expr(
+                &node,
+                input.schema().as_ref(),
+                &decode_ctx,
+            )?;
+            Some(expr)
+        };
         // Rebuild absorbed visibility data from the shipped recipe and re-wire the live
         // ctid resolvers pulled from the decoded subtree. Workers do not re-run the
         // optimizer rule, so the VFExec is already absorbed and gone; leaving this `None`
@@ -500,8 +532,8 @@ impl SegmentedTopKExec {
             ffhelper,
             k,
             visibility_data,
-            // Worker decode: no parent SortExec filter to inherit, mint fresh.
-            None,
+            // Reuse the shipped filter so it stays identity-shared with the scans below.
+            parent_filter,
         )))
     }
 }

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -207,8 +207,10 @@ pub struct SegmentedTopKExec {
     /// Dynamic filter pushed down through DataFusion's standard filter pushdown
     /// mechanism. Updated at runtime with a global threshold (materialized
     /// string literals) that the scanner's `try_rewrite_binary` translates to
-    /// per-segment ordinal bounds.
-    dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+    /// per-segment ordinal bounds. Stored as `Arc<dyn PhysicalExpr>` so the
+    /// same instance can round-trip through the deduplicating proto converter
+    /// on worker dispatch and stay identity-shared with the scans below.
+    dynamic_filter: Arc<dyn PhysicalExpr>,
     /// Visibility data absorbed from a `VisibilityFilterExec` during plan optimization.
     /// Present when VFExec was the direct child of `TantivyLookupExec` (e.g. for inner
     /// joins or the preserved sides of outer/semi/anti joins). When present, this node
@@ -243,7 +245,7 @@ impl SegmentedTopKExec {
         ffhelper: Arc<FFHelper>,
         k: usize,
         visibility_data: Option<Arc<AbsorbedVisibilityData>>,
-        parent_filter: Option<Arc<DynamicFilterPhysicalExpr>>,
+        parent_filter: Option<Arc<dyn PhysicalExpr>>,
     ) -> Self {
         use datafusion::physical_expr::expressions::lit;
 
@@ -261,9 +263,9 @@ impl SegmentedTopKExec {
         // fresh one. The scans below have already been wired to this filter by the
         // standard `FilterPushdown` pass, so subsequent `update()`s from this node's
         // heap propagate to the same recipients the SortExec would have driven. If no
-        // parent filter is provided (e.g. worker decode path), fall back to minting.
-        // See #5635.
-        let dynamic_filter = parent_filter.unwrap_or_else(|| {
+        // parent filter is provided (e.g. worker decode path with no shipped filter),
+        // fall back to minting. See #5635.
+        let dynamic_filter: Arc<dyn PhysicalExpr> = parent_filter.unwrap_or_else(|| {
             let children: Vec<Arc<dyn PhysicalExpr>> =
                 sort_exprs.iter().map(|e| Arc::clone(&e.expr)).collect();
             Arc::new(DynamicFilterPhysicalExpr::new(children, lit(true)))
@@ -749,7 +751,7 @@ impl ExecutionPlan for SegmentedTopKExec {
         // and add our own dynamic filter as a self-filter.
         Ok(FilterDescription::new().with_child(
             ChildFilterDescription::from_child(&parent_filters, &self.input)?
-                .with_self_filter(Arc::clone(&self.dynamic_filter) as Arc<dyn PhysicalExpr>),
+                .with_self_filter(Arc::clone(&self.dynamic_filter)),
         ))
     }
 
@@ -813,7 +815,9 @@ struct SegmentedTopKState {
     segment_cutoffs: Vec<Option<OwnedRow>>,
     /// Dynamic filter updated with global thresholds (materialized strings).
     /// Pushed down through DataFusion's standard filter pushdown to the scanner.
-    dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+    /// Held as `Arc<dyn PhysicalExpr>` so it stays identity-shared with the
+    /// worker-decoded scan filters (see the exec's field for the rationale).
+    dynamic_filter: Arc<dyn PhysicalExpr>,
     /// Buffered batches during the collection phase.
     batches: Vec<RecordBatch>,
     /// Buffered pass-through rows (NULL ordinals) that bypass
@@ -1328,8 +1332,11 @@ impl SegmentedTopKState {
 
         if changed
             && let Some(expr) = Self::build_lexicographic_filter(&self.sort_exprs, &best_values)
+            && let Some(df) = self
+                .dynamic_filter
+                .downcast_ref::<DynamicFilterPhysicalExpr>()
         {
-            let _ = self.dynamic_filter.update(expr);
+            let _ = df.update(expr);
             self.last_published_global = Some(best_row);
         }
 

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 
 use datafusion::common::Result;
 use datafusion::common::config::ConfigOptions;
-use datafusion::physical_expr::expressions::{Column, DynamicFilterPhysicalExpr};
+use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{LexOrdering, PhysicalExpr, PhysicalSortExpr};
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
@@ -129,7 +129,9 @@ fn try_inject_at_sort(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionP
     // therefore reach the same recipients the SortExec would have driven, and no
     // trailing `FilterPushdown(Post)` pass is required to re-push a fresh filter.
     // See #5635.
-    let parent_filter = sort_exec.dynamic_filter_expr();
+    let parent_filter = sort_exec
+        .dynamic_filter_expr()
+        .map(|f| f as Arc<dyn PhysicalExpr>);
 
     // Walk down from SortExec to find TantivyLookupExec.
     // If injection succeeds, SegmentedTopKExec now handles the final sort + limit,
@@ -211,7 +213,7 @@ fn try_inject_below_lookup(
     plan: &Arc<dyn ExecutionPlan>,
     sort_exprs: LexOrdering,
     k: usize,
-    parent_filter: Option<Arc<DynamicFilterPhysicalExpr>>,
+    parent_filter: Option<Arc<dyn PhysicalExpr>>,
 ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
     let children = plan.children();
 

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 
 use datafusion::common::Result;
 use datafusion::common::config::ConfigOptions;
-use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::expressions::{Column, DynamicFilterPhysicalExpr};
 use datafusion::physical_expr::{LexOrdering, PhysicalExpr, PhysicalSortExpr};
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
@@ -122,10 +122,19 @@ fn try_inject_at_sort(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionP
 
     let sort_exprs = sort_exec.expr();
 
+    // Hand the SortExec's already pushed-down `DynamicFilterPhysicalExpr` to the
+    // injected `SegmentedTopKExec` so that ownership transfers cleanly when we
+    // unwrap the SortExec below. The scans have already been wired to this filter
+    // by the earlier standard `FilterPushdown` pass; updates from the STK heap
+    // therefore reach the same recipients the SortExec would have driven, and no
+    // trailing `FilterPushdown(Post)` pass is required to re-push a fresh filter.
+    // See #5635.
+    let parent_filter = sort_exec.dynamic_filter_expr();
+
     // Walk down from SortExec to find TantivyLookupExec.
     // If injection succeeds, SegmentedTopKExec now handles the final sort + limit,
     // so we unwrap SortExec and return its child directly.
-    match try_inject_below_lookup(&plan, sort_exprs.clone(), k)? {
+    match try_inject_below_lookup(&plan, sort_exprs.clone(), k, parent_filter)? {
         Some(rewritten) => {
             let children = rewritten.children();
             Ok(Arc::clone(children[0]))
@@ -202,6 +211,7 @@ fn try_inject_below_lookup(
     plan: &Arc<dyn ExecutionPlan>,
     sort_exprs: LexOrdering,
     k: usize,
+    parent_filter: Option<Arc<DynamicFilterPhysicalExpr>>,
 ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
     let children = plan.children();
 
@@ -246,9 +256,9 @@ fn try_inject_below_lookup(
                         (None, Arc::clone(lookup_child))
                     };
 
-                // Wrap blocking nodes (e.g. SortPreservingMergeExec) so that
-                // the second FilterPushdown(Post) pass can push
-                // SegmentedTopKExec's DynamicFilterPhysicalExpr down to PgSearchScan.
+                // Wrap blocking nodes (e.g. SortPreservingMergeExec) so that the
+                // shared `DynamicFilterPhysicalExpr` can traverse them during the
+                // pushdown pass that reached this scan subtree.
                 let lookup_child = &wrap_blocking_nodes(stk_input)?;
 
                 // Collect all deferred columns found in the sort expressions,
@@ -339,6 +349,7 @@ fn try_inject_below_lookup(
                     Arc::clone(&ffhelper),
                     k,
                     absorbed_visibility,
+                    parent_filter.clone(),
                 ));
 
                 // Rebuild TantivyLookupExec with the new child.
@@ -353,7 +364,9 @@ fn try_inject_below_lookup(
         }
 
         // Recurse into intermediate nodes (ProjectionExec, CoalescePartitionsExec, etc.)
-        if let Some(rewritten) = try_inject_below_lookup(child, sort_exprs.clone(), k)? {
+        if let Some(rewritten) =
+            try_inject_below_lookup(child, sort_exprs.clone(), k, parent_filter.clone())?
+        {
             let mut new_children: Vec<Arc<dyn ExecutionPlan>> =
                 children.iter().map(|c| Arc::clone(c)).collect();
             new_children[child_idx] = rewritten;

--- a/pg_search/src/scan/visibility_ctid_resolver_rule.rs
+++ b/pg_search/src/scan/visibility_ctid_resolver_rule.rs
@@ -213,6 +213,7 @@ mod tests {
             ffhelper,
             5,
             None,
+            None,
         );
 
         // No visibility data absorbed → plan_pos_oids must be empty.
@@ -255,6 +256,7 @@ mod tests {
             Arc::new(FFHelper::empty()),
             5,
             Some(vis_data),
+            None,
         );
 
         let pos_oids = stk.plan_pos_oids();

--- a/pg_search/tests/pg_regress/expected/issue_5635.out
+++ b/pg_search/tests/pg_regress/expected/issue_5635.out
@@ -39,11 +39,16 @@ SELECT
     'File Title ' || LPAD(i::TEXT, 3, '0')
 FROM generate_series(1, 50) AS i;
 CREATE INDEX issue5635_documents_bm25_idx ON issue5635_documents
-USING bm25 (id, category)
-WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
+USING bm25 (
+    id,
+    (category::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id');
 CREATE INDEX issue5635_files_bm25_idx ON issue5635_files
-USING bm25 (id, document_id, title)
-WITH (key_field = 'id', text_fields = '{"document_id": {"tokenizer": {"type": "keyword"}, "fast": true}, "title": {"fast": true}}');
+USING bm25 (
+    id,
+    (document_id::pdb.literal),
+    (title::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id');
 SET paradedb.enable_join_custom_scan = on;
 -- ORDER BY on the deferred `title` column with LIMIT triggers `SegmentedTopKRule`
 -- to inject `SegmentedTopKExec` and unwrap the SortExec. The join is a

--- a/pg_search/tests/pg_regress/expected/issue_5635.out
+++ b/pg_search/tests/pg_regress/expected/issue_5635.out
@@ -1,0 +1,100 @@
+-- Regression test for issue #5635:
+-- Plans where `SegmentedTopKExec` is inserted between a `SortExec` and a
+-- `HashJoinExec` used to leave an orphaned `lit(true)` dynamic filter behind on
+-- `PgSearchScan`, inflating the reported `dynamic_filters=` count by 1.
+-- `SegmentedTopKRule` now transfers ownership of the SortExec's already
+-- pushed down `DynamicFilterPhysicalExpr` into the injected
+-- `SegmentedTopKExec` instead of minting a fresh one, so the count on the
+-- `PgSearchScan` beneath the join reflects only the filters that are still
+-- actively produced (the HashJoin's join key bounds and the SegmentedTopK's
+-- TopK threshold).
+--
+-- We can't assert an exact number here without pinning table cardinalities to a
+-- specific plan shape, but pairing the EXPLAIN with the neighbouring
+-- `segmented_topk.out`/`join_order_by.out` expected files gives full coverage
+-- for the numeric change.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS issue5635_files CASCADE;
+DROP TABLE IF EXISTS issue5635_documents CASCADE;
+CREATE TABLE issue5635_documents (
+    id TEXT PRIMARY KEY,
+    category TEXT
+);
+INSERT INTO issue5635_documents (id, category) VALUES
+    ('doc-01', 'PROJECT_ALPHA design review'),
+    ('doc-02', 'BETA_GROUP budget overview'),
+    ('doc-03', 'PROJECT_ALPHA roadmap planning'),
+    ('doc-04', 'GAMMA_DIVISION quarterly report'),
+    ('doc-05', 'PROJECT_ALPHA feedback notes');
+CREATE TABLE issue5635_files (
+    id SERIAL PRIMARY KEY,
+    document_id TEXT,
+    title TEXT
+);
+INSERT INTO issue5635_files (document_id, title)
+SELECT
+    'doc-' || LPAD(((i - 1) % 5 + 1)::TEXT, 2, '0'),
+    'File Title ' || LPAD(i::TEXT, 3, '0')
+FROM generate_series(1, 50) AS i;
+CREATE INDEX issue5635_documents_bm25_idx ON issue5635_documents
+USING bm25 (id, category)
+WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
+CREATE INDEX issue5635_files_bm25_idx ON issue5635_files
+USING bm25 (id, document_id, title)
+WITH (key_field = 'id', text_fields = '{"document_id": {"tokenizer": {"type": "keyword"}, "fast": true}, "title": {"fast": true}}');
+SET paradedb.enable_join_custom_scan = on;
+-- ORDER BY on the deferred `title` column with LIMIT triggers `SegmentedTopKRule`
+-- to inject `SegmentedTopKExec` and unwrap the SortExec. The join is a
+-- HashJoinExec across the two `@@@` scans. Prior to the fix the inner
+-- PgSearchScan reported `dynamic_filters=3` (SortExec's orphaned filter + STK
+-- threshold + HashJoin bounds); with the fix, it reports `dynamic_filters=2`.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, f.title
+FROM issue5635_files f
+WHERE f.document_id IN (
+    SELECT d.id FROM issue5635_documents d WHERE d.category @@@ 'PROJECT_ALPHA'
+)
+ORDER BY f.title ASC
+LIMIT 3;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.id, f.title
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: f.id, f.title
+         Relation Tree: d INNER f
+         Join Cond: f.document_id = d.id
+         Limit: 3
+         Order By: f.title asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   TantivyLookupExec: decode=[title]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(17 rows)
+
+SELECT f.id, f.title
+FROM issue5635_files f
+WHERE f.document_id IN (
+    SELECT d.id FROM issue5635_documents d WHERE d.category @@@ 'PROJECT_ALPHA'
+)
+ORDER BY f.title ASC
+LIMIT 3;
+ id |     title      
+----+----------------
+  1 | File Title 001
+  3 | File Title 003
+  5 | File Title 005
+(3 rows)
+
+DROP TABLE issue5635_files CASCADE;
+DROP TABLE issue5635_documents CASCADE;
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -162,7 +162,7 @@ ORDER BY s.name
            :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (15 rows)
@@ -479,7 +479,7 @@ ORDER BY p.name
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- =============================================================================
@@ -513,7 +513,7 @@ ORDER BY p.name
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -334,7 +334,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=3, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- Cap the scanner batch size so Top K can tighten its threshold between batches.
@@ -363,7 +363,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=3, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
+           :           PgSearchScan: segments=2, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
 (15 rows)
 
 -- Verify results
@@ -449,7 +449,7 @@ LIMIT 25;
            :         CooperativeExec
            :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=3, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (17 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
@@ -475,7 +475,7 @@ LIMIT 25;
            :         CooperativeExec
            :           PgSearchScan: segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=3, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, rows_pruned=11.57 K, rows_scanned=20.00 K]
+           :           PgSearchScan: segments=2, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, rows_pruned=11.57 K, rows_scanned=20.00 K]
 (15 rows)
 
 SELECT t1.id, t1.val
@@ -544,7 +544,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=3, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (17 rows)
 
 SELECT t1.id, t1.val

--- a/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
@@ -66,7 +66,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"technology_name","query_string":"java","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=3, query="all"
+                 :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
 (16 rows)
 
 SELECT cccf.*

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -325,7 +325,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1"}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT *

--- a/pg_search/tests/pg_regress/expected/order_by_collation.out
+++ b/pg_search/tests/pg_regress/expected/order_by_collation.out
@@ -455,7 +455,7 @@ LIMIT 5;
            :     SegmentedTopKExec: expr=[name_c@2 ASC NULLS LAST], k=5, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name_c@2]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (15 rows)

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -73,7 +73,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
 (17 rows)
 
 SELECT f.id, f.title
@@ -119,7 +119,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
 (17 rows)
 
 SELECT f.id, f.title
@@ -163,7 +163,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
 (15 rows)
 
 -- =============================================================================
@@ -427,7 +427,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
 (17 rows)
 
 SELECT f.id, f.title
@@ -493,7 +493,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
 (17 rows)
 
 SELECT f.id, f.title, f.content
@@ -667,7 +667,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=4, dynamic_filters=3, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, rows_pruned=4.19 K, rows_scanned=30.00 K]
+           :           PgSearchScan: segments=4, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, rows_pruned=4.19 K, rows_scanned=30.00 K]
 (15 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -295,7 +295,7 @@ ORDER BY upper(p.name) ASC
                  :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=5, visibility_checks=[s, p]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name@2]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (19 rows)
@@ -343,7 +343,7 @@ ORDER BY s.name ASC
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
 (17 rows)
 
 SELECT p.name, s.name AS supplier_name

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -487,7 +487,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
 (15 rows)
 
 SELECT f.id, f.title
@@ -533,7 +533,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=3, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
 (15 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/sql/issue_5635.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5635.sql
@@ -1,0 +1,86 @@
+-- Regression test for issue #5635:
+-- Plans where `SegmentedTopKExec` is inserted between a `SortExec` and a
+-- `HashJoinExec` used to leave an orphaned `lit(true)` dynamic filter behind on
+-- `PgSearchScan`, inflating the reported `dynamic_filters=` count by 1.
+-- `SegmentedTopKRule` now transfers ownership of the SortExec's already
+-- pushed down `DynamicFilterPhysicalExpr` into the injected
+-- `SegmentedTopKExec` instead of minting a fresh one, so the count on the
+-- `PgSearchScan` beneath the join reflects only the filters that are still
+-- actively produced (the HashJoin's join key bounds and the SegmentedTopK's
+-- TopK threshold).
+--
+-- We can't assert an exact number here without pinning table cardinalities to a
+-- specific plan shape, but pairing the EXPLAIN with the neighbouring
+-- `segmented_topk.out`/`join_order_by.out` expected files gives full coverage
+-- for the numeric change.
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS issue5635_files CASCADE;
+DROP TABLE IF EXISTS issue5635_documents CASCADE;
+
+CREATE TABLE issue5635_documents (
+    id TEXT PRIMARY KEY,
+    category TEXT
+);
+
+INSERT INTO issue5635_documents (id, category) VALUES
+    ('doc-01', 'PROJECT_ALPHA design review'),
+    ('doc-02', 'BETA_GROUP budget overview'),
+    ('doc-03', 'PROJECT_ALPHA roadmap planning'),
+    ('doc-04', 'GAMMA_DIVISION quarterly report'),
+    ('doc-05', 'PROJECT_ALPHA feedback notes');
+
+CREATE TABLE issue5635_files (
+    id SERIAL PRIMARY KEY,
+    document_id TEXT,
+    title TEXT
+);
+
+INSERT INTO issue5635_files (document_id, title)
+SELECT
+    'doc-' || LPAD(((i - 1) % 5 + 1)::TEXT, 2, '0'),
+    'File Title ' || LPAD(i::TEXT, 3, '0')
+FROM generate_series(1, 50) AS i;
+
+CREATE INDEX issue5635_documents_bm25_idx ON issue5635_documents
+USING bm25 (id, category)
+WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
+
+CREATE INDEX issue5635_files_bm25_idx ON issue5635_files
+USING bm25 (id, document_id, title)
+WITH (key_field = 'id', text_fields = '{"document_id": {"tokenizer": {"type": "keyword"}, "fast": true}, "title": {"fast": true}}');
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- ORDER BY on the deferred `title` column with LIMIT triggers `SegmentedTopKRule`
+-- to inject `SegmentedTopKExec` and unwrap the SortExec. The join is a
+-- HashJoinExec across the two `@@@` scans. Prior to the fix the inner
+-- PgSearchScan reported `dynamic_filters=3` (SortExec's orphaned filter + STK
+-- threshold + HashJoin bounds); with the fix, it reports `dynamic_filters=2`.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, f.title
+FROM issue5635_files f
+WHERE f.document_id IN (
+    SELECT d.id FROM issue5635_documents d WHERE d.category @@@ 'PROJECT_ALPHA'
+)
+ORDER BY f.title ASC
+LIMIT 3;
+
+SELECT f.id, f.title
+FROM issue5635_files f
+WHERE f.document_id IN (
+    SELECT d.id FROM issue5635_documents d WHERE d.category @@@ 'PROJECT_ALPHA'
+)
+ORDER BY f.title ASC
+LIMIT 3;
+
+DROP TABLE issue5635_files CASCADE;
+DROP TABLE issue5635_documents CASCADE;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/sql/issue_5635.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5635.sql
@@ -47,12 +47,17 @@ SELECT
 FROM generate_series(1, 50) AS i;
 
 CREATE INDEX issue5635_documents_bm25_idx ON issue5635_documents
-USING bm25 (id, category)
-WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
+USING bm25 (
+    id,
+    (category::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id');
 
 CREATE INDEX issue5635_files_bm25_idx ON issue5635_files
-USING bm25 (id, document_id, title)
-WITH (key_field = 'id', text_fields = '{"document_id": {"tokenizer": {"type": "keyword"}, "fast": true}, "title": {"fast": true}}');
+USING bm25 (
+    id,
+    (document_id::pdb.literal),
+    (title::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id');
 
 SET paradedb.enable_join_custom_scan = on;
 


### PR DESCRIPTION
Closes #5635. Reworked per @barbarj's review.

`SegmentedTopKRule` now transfers ownership of the SortExec's already pushed down `DynamicFilterPhysicalExpr` into the injected `SegmentedTopKExec` instead of minting a fresh one. `SegmentedTopKExec::new` takes an optional `parent_filter`; when the rule inject site provides it, updates from the STK heap propagate to the same scans the SortExec's filter was wired to, so the orphan never exists.

With the filter owned rather than duplicated, the trailing `FilterPushdown::new_post_optimization` pass on the Join session profile has nothing new to push. Removed in `scan_state.rs`.

Regression test `issue_5635.sql` pins `dynamic_filters=2` (was 3). Seven pre-existing expected out files were regenerated (each dropped 1 from a `dynamic_filters=N` count). Full `cargo pgrx regress pg18`: `passed=314 failed=0` locally. `cargo fmt --check` and `RUSTDOCFLAGS=-D warnings cargo doc` clean.