### PR TITLE
fix: validate that key_field is part of the USING clause

### DIFF
--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -141,6 +141,12 @@ unsafe fn validate_index_config(index_relation: &PgSearchRelation) {
     let options = index_relation.options();
     let key_field_name = options.key_field_name();
 
+    // the key_field must be one of the indexed columns, otherwise the index builds fine but every
+    // subsequent INSERT fails when it can't find the key field
+    if options.get_field_type(&key_field_name).is_none() {
+        panic!("the key_field `{key_field_name}` does not exist in the USING clause");
+    }
+
     let options = index_relation.options();
     let text_configs = options.text_config();
     for (field_name, config) in text_configs.iter().flatten() {

--- a/pg_search/tests/pg_regress/expected/index_config_errors.out
+++ b/pg_search/tests/pg_regress/expected/index_config_errors.out
@@ -38,4 +38,10 @@ CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name);
 ERROR:  index should have a `WITH (key_field='...')` option
 CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name) WITH (text_fields ='{"id": {"tokenizer": {"type": "default"}}}');
 ERROR:  index should have a `WITH (key_field='...')` option
+-- the key_field must be part of the USING clause, otherwise the index would be created
+-- successfully and only fail later, on the first INSERT
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
+    USING bm25 (name)
+    WITH (key_field = 'id');
+ERROR:  the key_field `id` does not exist in the USING clause
 DROP TABLE test_index_config_errors CASCADE;

--- a/pg_search/tests/pg_regress/sql/index_config_errors.sql
+++ b/pg_search/tests/pg_regress/sql/index_config_errors.sql
@@ -44,4 +44,11 @@ CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name);
 CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name) WITH (text_fields ='{"id": {"tokenizer": {"type": "default"}}}');
 
 
+-- the key_field must be part of the USING clause, otherwise the index would be created
+-- successfully and only fail later, on the first INSERT
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
+    USING bm25 (name)
+    WITH (key_field = 'id');
+
+
 DROP TABLE test_index_config_errors CASCADE;


### PR DESCRIPTION
Fixes #3777

## Problem

```sql
CREATE TABLE test (id INT, status INT);
CREATE INDEX test_bm25 ON test USING bm25 (status) WITH (key_field = 'id');  -- succeeds
INSERT INTO test (id, status) VALUES (1, 1);
-- ERROR:  No key field defined.
```

`id` is named as the `key_field` but is not in the USING clause, so the index builds fine and only breaks on the first INSERT, where the `.expect("No key field defined.")` in `pg_search/src/postgres/insert.rs` fires. The error points nowhere near the `CREATE INDEX` that caused it.

## Change

`validate_index_config` already validates every *configured* field against the USING clause (via `validate_field_config`), but never validated the key_field itself. This adds that check, so the problem is reported where it originates:

```
ERROR:  the key_field `id` does not exist in the USING clause
```

The wording mirrors the existing `the column \`{field_name}\` does not exist in the USING clause` error in the same file. `validate_index_config` runs from `build_empty`, which is reached from both `ambuild` and `ambuildempty`.

## Tests

Added to the existing `index_config_errors` pg_regress test, which is the file dedicated to exactly this class of error.

Verified locally with `cargo pgrx regress -p pg_search -- pg18 index_config_errors`:

- with the change: `passed=2 failed=0`
- with the change reverted: the test fails, and the diff is the `ERROR` line disappearing — i.e. `CREATE INDEX` silently succeeding, which is the reported bug:

  ```diff
   CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
       USING bm25 (name)
       WITH (key_field = 'id');
  -ERROR:  the key_field `id` does not exist in the USING clause
   DROP TABLE test_index_config_errors CASCADE;
  ```

Also checked by hand against a pgrx-managed PG18 that valid configurations are unaffected — a plain `key_field = 'id'` with `id` indexed, and an index carrying an aliased expression column (`(lower(name)::pdb.simple('alias=name_lower'))`), both build and search normally.

`cargo clippy -p pg_search --all-targets -- -D warnings` and `cargo fmt --check` are clean.