### PR TITLE
ci: pin bash in the containerised publish workflows

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -42,6 +42,11 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
+    # Container jobs default to `sh -e {0}`, and `/bin/sh` is dash on Debian, which supports
+    # neither `[[` nor some of the control characters the steps below emit.
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         include:
@@ -182,7 +187,6 @@ jobs:
       # PG 18 .deb (both arches) that the PG 18 Docker image installs.
       - name: Determine Whether to Build This Row
         id: guard
-        shell: bash
         run: |
           if [[ "$GITHUB_REF" != *-rc.* || ( "${{ matrix.pg_version }}" == "18" && "${{ matrix.name }}" == "Debian 13 (Trixie)" ) ]]; then
             echo "build=true" >> "$GITHUB_OUTPUT"
@@ -214,12 +218,9 @@ jobs:
           cache: false # Disable cache on publish workflows
           rustflags: "" # Use .cargo/config.toml target-cpu flags
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, since
-      # /bin/sh does not support the `[[` syntax.
       - name: Retrieve OS & GitHub Tag Versions
         if: steps.guard.outputs.build == 'true'
         id: version
-        shell: bash
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
@@ -233,6 +234,13 @@ jobs:
             VERSION=${{ github.event.inputs.version }}
           fi
           echo "GitHub Tag Version: $VERSION"
+
+          # A tag push must never fall through to the 0.0.0 test default, or the assets get built
+          # with the wrong version and uploaded to the v0.0.0 release instead of the real one.
+          if [[ "$VERSION" == "0.0.0" && "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "Refusing to publish 0.0.0 assets for tag $GITHUB_REF"
+            exit 1
+          fi
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
           OS_VERSION="$(lsb_release -cs)"
@@ -349,18 +357,14 @@ jobs:
       # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.
       - name: Sign .deb with Cosign (keyless)
         if: steps.guard.outputs.build == 'true'
-        shell: bash
         env:
           COSIGN_YES: "true"
           DEB: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
         run: cosign sign-blob --yes --bundle "${DEB}.cosign.bundle" "$DEB"
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which
-      # is not capable of parsing certain control characters
       - name: Retrieve GitHub Release Upload URL
         if: steps.guard.outputs.build == 'true'
         id: upload_url
-        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -42,8 +42,6 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
-    # Container jobs default to `sh -e {0}`, and `/bin/sh` is dash on Debian, which supports
-    # neither `[[` nor some of the control characters the steps below emit.
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -40,6 +40,11 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
+    # Container jobs default to `sh -e {0}`. That happens to be bash on UBI, but pin it so the
+    # `[[` tests below cannot silently no-op if the base image ever ships a POSIX `/bin/sh`.
+    defaults:
+      run:
+        shell: bash
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
       matrix:
@@ -250,6 +255,13 @@ jobs:
             VERSION=${{ github.event.inputs.version }}
           fi
           echo "GitHub Tag Version: $VERSION"
+
+          # A tag push must never fall through to the 0.0.0 test default, or the assets get built
+          # with the wrong version and uploaded to the v0.0.0 release instead of the real one.
+          if [[ "$VERSION" == "0.0.0" && "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "Refusing to publish 0.0.0 assets for tag $GITHUB_REF"
+            exit 1
+          fi
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
           OS_VERSION="el$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)"

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -40,8 +40,6 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
-    # Container jobs default to `sh -e {0}`. That happens to be bash on UBI, but pin it so the
-    # `[[` tests below cannot silently no-op if the base image ever ships a POSIX `/bin/sh`.
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -40,6 +40,12 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
+    # Container jobs default to `sh -e {0}`, and `/bin/sh` is dash on Ubuntu, which does not
+    # support `[[`. Without this, every `[[` below silently no-ops (dash reports `[[: not found`
+    # and, because the failure happens in an `if` condition, `-e` does not abort the step).
+    defaults:
+      run:
+        shell: bash
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
       matrix:
@@ -227,6 +233,13 @@ jobs:
             VERSION=${{ github.event.inputs.version }}
           fi
           echo "GitHub Tag Version: $VERSION"
+
+          # A tag push must never fall through to the 0.0.0 test default, or the assets get built
+          # with the wrong version and uploaded to the v0.0.0 release instead of the real one.
+          if [[ "$VERSION" == "0.0.0" && "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "Refusing to publish 0.0.0 assets for tag $GITHUB_REF"
+            exit 1
+          fi
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
           OS_VERSION="$(lsb_release -cs)"

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -40,9 +40,6 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
-    # Container jobs default to `sh -e {0}`, and `/bin/sh` is dash on Ubuntu, which does not
-    # support `[[`. Without this, every `[[` below silently no-ops (dash reports `[[: not found`
-    # and, because the failure happens in an `if` condition, `-e` does not abort the step).
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## What changed

- Add job-level `defaults: run: shell: bash` to `publish-pg_search-ubuntu.yml`, `publish-pg_search-debian.yml` and `publish-pg_search-rhel.yml`.
- Drop the four now-redundant per-step `shell: bash` pins (and their comments) from the Debian workflow.
- Fail the version step if a `refs/tags/*` ref resolves to the `0.0.0` test default.

## Why

v0.25.0's Ubuntu `.deb`s were built as `0.0.0` and uploaded to the v0.0.0 release rather than v0.25.0. From [the run](https://github.com/paradedb/paradedb/actions/runs/30402004178):

```
shell: sh -e {0}
...
/__w/_temp/303bb437-5047-40ce-b919-82be5b8833fb.sh: 3: [[: not found
GitHub Tag Version: 0.0.0
```

`GITHUB_REF` was `refs/tags/v0.25.0`, so the tag push itself was fine. Container jobs default to `sh -e {0}`, `/bin/sh` is dash on Ubuntu, and dash has no `[[`. Because the failure happens inside an `if` condition, `-e` does not abort the step, so `Retrieve OS & GitHub Tag Versions` silently took the else branch and set the "it's a test run" default.

Regressed in #5480, which moved the job into a container. Before that it ran directly on the RunsOn host image, where the default shell is bash — hence v0.24.0 and earlier published their Ubuntu assets correctly.

The `os_codename` assertion added in #5478 to catch exactly this class of mislabelling is also `[[`, so it has been dead since the same commit (`[[: not found` appears twice per job in the log).

Debian was unaffected because it already pinned `shell: bash` on that step. Red Hat was unaffected by luck — its version step also ran under `sh -e {0}`, but UBI9's `/bin/sh` is bash. Pinning it there too so a future base-image change cannot repeat this.

All other v0.25.0 publish targets uploaded correctly (Debian, Red Hat, macOS, Postgres.app, schema — 84 assets); only the 16 Ubuntu `.deb`s and their 16 cosign bundles are missing.

## Validation

- `npx prettier --check` on all three workflows
- YAML parse check on all three
- Guard logic exercised under bash for `(0.0.0, refs/tags/v0.25.0)`, `(0.25.0, refs/tags/v0.25.0)` and `(0.0.0, refs/heads/main)`

## Follow-up

The missing v0.25.0 Ubuntu assets still need a `workflow_dispatch` of `publish-pg_search-ubuntu.yml` at `version=0.25.0` on the `v0.25.0` tag. That path reads the input directly and never evaluates the broken `[[`, so it works with or without this PR.

https://claude.ai/code/session_012GNVAJ4XNKehF6RXJemLmm