### PR TITLE
build: sped up debug builds and shrank target dirs.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,10 @@
 # on macOS, PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
+
+[env]
+# The lindera dictionary build scripts skip the download and rebuild entirely
+# when the built dictionary already exists in this directory, instead of
+# rebuilding into every target dir. Export LINDERA_CACHE to an absolute path
+# in your shell to share one cache across worktrees.
+LINDERA_CACHE = { value = ".lindera-cache", relative = true }

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -207,6 +207,7 @@ jobs:
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           cache-on-failure: true
 
       - name: Extract pgrx Version

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -65,6 +65,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 
@@ -82,7 +83,7 @@ jobs:
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
       - name: Run Rustfmt
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run Rustdoc
         env:

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -67,6 +67,7 @@ jobs:
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
 
       - name: Install & Configure PostgreSQL ${{ env.pg_version }}
         run: |

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -62,6 +62,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -72,6 +72,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -108,6 +108,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -109,6 +109,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           save-if: ${{ github.event_name == 'schedule' && github.ref_name == github.event.repository.default_branch }}
 
       - name: Install required system tools

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Cargo
 target/
+.lindera-cache/
 
 # SSH
 *.pem

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ members = [
   "tests",
   "tokenizers",
 ]
+# A bare `cargo build`/`check`/`clippy`/`test` at the root covers only the
+# extension stack. The other members compile a lot the extension does not need
+# (`benchmarks` builds the bundled DuckDB from C++ source); reach them with
+# `-p <crate>` or `--workspace`.
+default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
 version = "0.25.0"
@@ -17,6 +22,20 @@ license = "AGPL-3.0"
 
 [profile.dev]
 panic = "unwind"
+
+# Backtraces through dependencies keep file:line, but the full DWARF (variable
+# and type info) is dropped; it is most of a debug target dir and is only
+# needed when stepping through a dependency in a debugger. Workspace crates
+# keep full debuginfo. Override locally with a `[profile]` section in
+# `~/.cargo/config.toml` if you need to debug into a dependency.
+[profile.dev.package."*"]
+debug = "line-tables-only"
+
+# `cc` passes `-g` to the bundled DuckDB C++ build based on this. DuckDB is a
+# benchmark comparison engine, not something we debug, and its objects with
+# `-g` cost gigabytes per target dir.
+[profile.dev.package.libduckdb-sys]
+debug = false
 
 [profile.release]
 # Note: We switched from `fat` to `thin` LTO to reduce compile time memory usage, which had been


### PR DESCRIPTION
## What

This PR cuts clean debug build time and debug target size.

Measured with a clean `cargo build -p pg_search` on a 10-core macOS arm64 machine, sccache off:

|        | wall  | CPU   | target dir |
| ------ | ----- | ----- | ---------- |
| before | 5m14s | 1705s | 6.9 GB     |
| after  | 4m18s | 1196s | 5.7 GB     |

## Why

`cargo build --timings` shows `pg_search` itself is only ~40s of a clean build. The rest is the dependency graph:

- The lindera dictionary build scripts download and rebuild their dictionaries into every target dir: 162s of CPU plus ~108 MB per set, and stale copies pile up.
- `benchmarks` compiles the bundled DuckDB from C++ source on workspace-wide builds: 2.8 GB of `-g` objects per copy.
- Full DWARF for every dependency is most of the rest of the target dir.

## How

1. Point `LINDERA_CACHE` at a gitignored `.lindera-cache/` via `.cargo/config.toml`. The lindera build scripts fast-path when the built dictionary already exists there, so the cost is paid once instead of per target dir. The Nix build exports this variable itself and a real environment variable wins over the config entry, so it's unaffected. CI rust-cache steps pick the directory up via `cache-directories`.
2. `default-members = ["pg_search", "tokenizers"]`, so a bare `cargo build`/`check`/`clippy` at the root skips `benchmarks`, `tests` and `stressgres`. CI is unaffected: every invocation is already scoped by `-p`, `--workspace`, or its working directory. `cargo fmt` respects `default-members`, so `lint-rust.yml` now passes `--all` to keep formatting the whole workspace.
3. Dependencies build with `debug = "line-tables-only"`: backtraces keep file and line, workspace crates keep full debuginfo. `libduckdb-sys` gets `debug = false`, which drops `-g` from the DuckDB C++ objects. Please note that `[profile.dst]` inherits these overrides; shout if Antithesis needs full DWARF in dependencies.

Left for follow-ups:
 - release builds still use `codegen-units = 1` (bumping it with thin LTO on is the next lever, but it needs a benchmark run first)
 - our `datafusion-distributed` fork force-enables datafusion's `parquet` and `sql` features (paradedb/datafusion-distributed#50).
 - `cargo llvm-lines` shows no single monomorphization hotspot in `pg_search`: the top 45 symbols are 6% of 3.5M IR lines.
