### PR TITLE
feat: wired range partitioning into DataFusion join planning.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-07-27-225116#11008dc16a987ecd95e54ac56330b025ebe462b4"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-07-30-083335#d0310831503abc905b8b312732602676a4a97fb9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2858,7 +2858,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3187,7 +3187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3999,7 +3999,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4365,7 +4365,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5548,7 +5548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6440,7 +6440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7164,7 +7164,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7222,7 +7222,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7651,7 +7651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8294,7 +8294,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9271,7 +9271,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-KrEw9nRh2Kkpc893iDOfk2cCLPQ36kyqBVEYk4q1Zeo=";
+  cargoHash = "sha256-rlcWo2G/wPCOq9Cxa8Bg5EDClFpJFKcQ272KzmoOsyI=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -89,7 +89,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-07-27-225116", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-07-30-083335", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -38,10 +38,11 @@ The planner hook builds a [`JoinCSClause`][joincsc] — a serializable IR captur
 
 [`scan_state.rs`](scan_state.rs) builds a DataFusion logical plan from the `JoinCSClause`, then runs [physical optimization][optimizer-rules]:
 
-1. **[`RangePartitioningRule`](range_partitioning_rule.rs)** — coordinates split points across joins for MPP range partitioning
+1. **[`RangePartitioningRule`](range_partitioning_rule.rs)** — coordinates split points across joins for MPP range partitioning, sampling both sides of the join and injecting the merged sample into both `PgSearchTableProvider`s
 2. **`LateMaterializationRule`** — injects [`TantivyLookupExec`][lookup-exec] to defer string materialization
-3. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)`, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
-4. **FilterPushdown (Post)** — pushes `SegmentedTopKExec`'s `DynamicFilterPhysicalExpr` down to the scan
+3. **[`RangeCoPartitionedJoinRule`](range_partitioning_rule.rs)** — flips a `CollectLeft` inner hash join to `Partitioned` mode when both sides declare compatible `Partitioning::Range` layouts, so MPP joins partition pairs task-locally instead of broadcasting the build side
+4. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)`, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
+5. **FilterPushdown (Post)** — pushes `SegmentedTopKExec`'s `DynamicFilterPhysicalExpr` down to the scan
 
 If `max_parallel_workers_per_gather > 0` and PostgreSQL has planned parallel execution, `DistributedPlanner` converts the finalized physical plan into an MPP execution tree (`DistributedExec`), slicing it into isolated tasks.
 
@@ -67,7 +68,7 @@ JoinScan does not use DataFusion's standard in-process multithreading. Since Pos
 
 Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizing joins. We map PostgreSQL parallel workers to distributed tasks based on segment count:
 
-1. **Partition Output Definition**: Because index segments are checked out atomically from shared memory, [`PgSearchScanPlan`][scan-plan] natively partitions its output by the number of segments. In [`table_provider.rs`](../../scan/table_provider.rs), we formally expose the scan's output partition count as `min(segment_count, target_partitions)`.
+1. **Partition Output Definition**: Because index segments are checked out atomically from shared memory, [`PgSearchScanPlan`][scan-plan] natively partitions its output by the number of segments. In [`table_provider.rs`](../../scan/table_provider.rs), we formally expose the scan's output partition count as `min(segment_count, target_partitions)`. When the `RangePartitioningRule` has injected a range sample, the scan instead declares `Partitioning::Range` with the sample's split points, which lets DataFusion treat the two sides of a join as co-partitioned.
 2. **Task Estimation**: During MPP planning, [`PgSearchScanTaskEstimator`](../../../scan/execution_plan.rs) intercepts the leaf nodes and requests exactly this `partition_count` number of tasks.
 3. **Execution Routing**: This routes large multi-segment tables to scale out across all available PostgreSQL parallel workers, where each parallel worker uses `ParallelScanState` to lazily claim segments. Conversely, tables with a single segment evaluate to exactly 1 task; `datafusion-distributed` detects the absence of parallel work, avoids MPP planning overhead entirely, and falls back to running the query via local serial execution on a single worker.
 
@@ -80,7 +81,7 @@ Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizin
 | [`scan_state.rs`](scan_state.rs)                           | DataFusion plan building, [optimizer registration][optimizer-rules], result streaming |
 | [`planning.rs`](planning.rs)                               | Cost estimation, field validation, ORDER BY extraction                                |
 | [`predicate.rs`](predicate.rs)                             | Postgres expression → `JoinLevelExpr`                                                 |
-| [`range_partitioning_rule.rs`](range_partitioning_rule.rs) | Optimizer rule for synchronizing Join-side MPP partition boundaries                   |
+| [`range_partitioning_rule.rs`](range_partitioning_rule.rs) | Rules that synchronize Join-side MPP partition boundaries and co-partition the join   |
 | [`translator.rs`](translator.rs)                           | Postgres ↔ DataFusion expression mapping                                              |
 | [`explain.rs`](explain.rs)                                 | EXPLAIN output formatting                                                             |
 

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -18,10 +18,15 @@
 use std::sync::Arc;
 
 use datafusion::catalog::default_table_source::DefaultTableSource;
+use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::{Transformed, TreeNode};
-use datafusion::common::{Column, DataFusionError, Result};
+use datafusion::common::{Column, DataFusionError, JoinType, Result};
 use datafusion::logical_expr::{Expr, LogicalPlan, TableScan};
 use datafusion::optimizer::{optimizer::ApplyOrder, OptimizerConfig, OptimizerRule};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties, Partitioning};
 use tantivy::SegmentReader;
 
 use crate::api::FieldName;
@@ -29,6 +34,7 @@ use crate::index::fast_fields_helper::FFType;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::rel::PgSearchRelation;
 use crate::query::SearchQueryInput;
 
@@ -303,7 +309,12 @@ impl OptimizerRule for RangePartitioningRule {
                             }
 
                             if sample.is_none() {
-                                sample = Some(sample_fast_field(l_provider, &l_field_name)?);
+                                sample = merged_sample(
+                                    l_provider,
+                                    &l_field_name,
+                                    r_provider,
+                                    &r_field_name,
+                                )?;
                             }
 
                             if let Some(mut shared_sample) = sample {
@@ -341,6 +352,57 @@ impl OptimizerRule for RangePartitioningRule {
             Ok(Transformed::no(node))
         })
     }
+}
+
+/// Returns the arrow type of `field` when the provider exposes it as a named fast field.
+fn named_field_arrow_type(
+    provider: &PgSearchTableProvider,
+    field: &FieldName,
+) -> Option<arrow_schema::DataType> {
+    provider.fields.iter().find_map(|f| match f {
+        WhichFastField::Named(name, sft) if name == field.as_ref() => Some(sft.arrow_data_type()),
+        _ => None,
+    })
+}
+
+/// Sorts points ascending so that `RangePartitioningSample::build` produces
+/// sequential ranges.
+fn sort_sample_points(points: &mut [PdbOwnedValue]) {
+    points.sort_unstable_by(|a, b| {
+        if let (PdbOwnedValue::F64(f1), PdbOwnedValue::F64(f2)) = (a, b) {
+            f1.total_cmp(f2)
+        } else {
+            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+        }
+    });
+}
+
+/// Samples both sides of the join and merges the two distributions, so the split
+/// points reflect the combined key space rather than one side's skew.
+///
+/// Returns `None` when the two key columns expose different arrow types: a shared
+/// sample could not describe both sides faithfully.
+fn merged_sample(
+    l_provider: &PgSearchTableProvider,
+    l_field: &FieldName,
+    r_provider: &PgSearchTableProvider,
+    r_field: &FieldName,
+) -> Result<Option<RangePartitioningSample>> {
+    let (Some(l_type), Some(r_type)) = (
+        named_field_arrow_type(l_provider, l_field),
+        named_field_arrow_type(r_provider, r_field),
+    ) else {
+        return Ok(None);
+    };
+    if l_type != r_type {
+        return Ok(None);
+    }
+
+    let mut sample = sample_fast_field(l_provider, l_field)?;
+    let r_sample = sample_fast_field(r_provider, r_field)?;
+    sample.sample_points.extend(r_sample.sample_points);
+    sort_sample_points(&mut sample.sample_points);
+    Ok(Some(sample))
 }
 
 fn sample_fast_field(
@@ -403,21 +465,98 @@ fn sample_fast_field(
         sample_points.push(val.0);
     }
 
-    // Sort points ascending so that build() produces sequential ranges
-    sample_points.sort_unstable_by(|a, b| {
-        if let (
-            crate::postgres::pdb_owned_value::PdbOwnedValue::F64(f1),
-            crate::postgres::pdb_owned_value::PdbOwnedValue::F64(f2),
-        ) = (a, b)
-        {
-            f1.total_cmp(f2)
-        } else {
-            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-        }
-    });
+    sort_sample_points(&mut sample_points);
 
     Ok(RangePartitioningSample {
         partition_by: partition_by.clone(),
         sample_points,
     })
+}
+
+/// Physical optimizer rule that converts a `CollectLeft` inner hash join to
+/// `Partitioned` mode when both inputs declare compatible `Partitioning::Range`
+/// layouts on the join keys.
+///
+/// A `CollectLeft` join materializes the entire build side in every consumer,
+/// which the distributed planner satisfies by broadcasting it across tasks. When
+/// both sides are range partitioned with identical split points, build-side
+/// partition `i` can only ever match probe-side partition `i`, so `Partitioned`
+/// mode joins each pair task-locally and the broadcast disappears.
+///
+/// Must run after `EnforceDistribution` (which resolves `PartitionMode::Auto`
+/// and inserts the build side's `CoalescePartitionsExec`) and before the
+/// post-optimization `FilterPushdown` pass.
+#[derive(Debug, Default)]
+pub struct RangeCoPartitionedJoinRule;
+
+impl PhysicalOptimizerRule for RangeCoPartitionedJoinRule {
+    fn name(&self) -> &str {
+        "RangeCoPartitionedJoinRule"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        plan.transform_up(|node| {
+            let Some(join) = node.downcast_ref::<HashJoinExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            // DataFusion's range-satisfaction bridge only covers Partitioned inner
+            // joins, so those are the only ones worth flipping.
+            if join.partition_mode() != &PartitionMode::CollectLeft
+                || join.join_type() != &JoinType::Inner
+            {
+                return Ok(Transformed::no(node));
+            }
+
+            // EnforceDistribution collapses the build side to a single partition for
+            // CollectLeft; peel that off to recover the source's declared partitioning.
+            let left = match join.left().downcast_ref::<CoalescePartitionsExec>() {
+                Some(coalesce) if coalesce.fetch().is_none() => Arc::clone(coalesce.input()),
+                _ => Arc::clone(join.left()),
+            };
+            let right = Arc::clone(join.right());
+
+            let range_partitioned = |input: &Arc<dyn ExecutionPlan>| {
+                matches!(input.output_partitioning(), Partitioning::Range(_))
+                    && input.output_partitioning().partition_count() > 1
+            };
+            if !range_partitioned(&left) || !range_partitioned(&right) {
+                return Ok(Transformed::no(node));
+            }
+
+            let candidate = join
+                .builder()
+                .with_new_children(vec![left, right])?
+                .with_partition_mode(PartitionMode::Partitioned)
+                .reset_state()
+                .build_exec()?;
+
+            // Keep the flip only when DataFusion agrees the inputs are co-partitioned:
+            // the join keys match the range keys through equivalences and the split
+            // points are identical on both sides. Anything else keeps the CollectLeft
+            // join (and its broadcast) untouched.
+            let children: Vec<&dyn ExecutionPlan> = candidate
+                .children()
+                .into_iter()
+                .map(|child| child.as_ref())
+                .collect();
+            let co_partitioned = candidate
+                .input_distribution_requirements()
+                .unsatisfied_co_partitioned_children(candidate.name(), &children)?
+                .is_empty();
+            if co_partitioned {
+                Ok(Transformed::yes(candidate))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })
+        .map(|transformed| transformed.data)
+    }
 }

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -474,13 +474,14 @@ fn sample_fast_field(
 /// partition `i` can only ever match probe-side partition `i`, so `Partitioned`
 /// mode joins each pair task-locally and the broadcast disappears.
 ///
-/// A separate rule because `EnforceDistribution` picks `CollectLeft` for a small
-/// build side on size alone and never revisits the mode for range-partitioned
-/// inputs; declaring `Partitioning::Range` on the scans only lets an already
-/// `Partitioned` join skip its repartitions. Must run after `EnforceDistribution`
-/// (which resolves `PartitionMode::Auto` and inserts the build side's
-/// `CoalescePartitionsExec`) and before the post-optimization `FilterPushdown`
-/// pass.
+/// A separate rule because `JoinSelection` picks `CollectLeft` from the build
+/// side's row and byte statistics alone. It never consults `output_partitioning`,
+/// so it can't see that these inputs are already co-partitioned and that the
+/// repartition it's avoiding would cost nothing here. Declaring
+/// `Partitioning::Range` on the scans only helps a join that is already
+/// `Partitioned`, so the mode has to be revisited after the fact. Runs after
+/// `EnsureRequirements` has resolved `PartitionMode::Auto` and inserted the build
+/// side's `CoalescePartitionsExec`.
 #[derive(Debug, Default)]
 pub struct RangeCoPartitionedJoinRule;
 
@@ -527,11 +528,14 @@ impl PhysicalOptimizerRule for RangeCoPartitionedJoinRule {
                 return Ok(Transformed::no(node));
             }
 
+            // Deliberately not `reset_state()`: it would drop the join's handle on the
+            // dynamic filter that `FilterPushdown` already pushed into the probe scan,
+            // leaving the scan holding a filter that nothing ever narrows. Switching the
+            // mode invalidates the cached properties on its own.
             let candidate = join
                 .builder()
                 .with_new_children(vec![left, right])?
                 .with_partition_mode(PartitionMode::Partitioned)
-                .reset_state()
                 .build_exec()?;
 
             // Keep the flip only when DataFusion agrees the inputs are co-partitioned:

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -301,21 +301,12 @@ impl OptimizerRule for RangePartitioningRule {
                             Some((r_provider, r_field_name)),
                         ) = (l_res, r_res)
                         {
-                            let mut sample = None;
-                            if let Some(s) = l_provider.range_sample() {
-                                sample = Some(s.clone());
-                            } else if let Some(s) = r_provider.range_sample() {
-                                sample = Some(s.clone());
-                            }
-
-                            if sample.is_none() {
-                                sample = merged_sample(
-                                    l_provider,
-                                    &l_field_name,
-                                    r_provider,
-                                    &r_field_name,
-                                )?;
-                            }
+                            let sample = merged_sample(
+                                l_provider,
+                                &l_field_name,
+                                r_provider,
+                                &r_field_name,
+                            )?;
 
                             if let Some(mut shared_sample) = sample {
                                 shared_sample.partition_by = l_field_name;

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -474,9 +474,13 @@ fn sample_fast_field(
 /// partition `i` can only ever match probe-side partition `i`, so `Partitioned`
 /// mode joins each pair task-locally and the broadcast disappears.
 ///
-/// Must run after `EnforceDistribution` (which resolves `PartitionMode::Auto`
-/// and inserts the build side's `CoalescePartitionsExec`) and before the
-/// post-optimization `FilterPushdown` pass.
+/// A separate rule because `EnforceDistribution` picks `CollectLeft` for a small
+/// build side on size alone and never revisits the mode for range-partitioned
+/// inputs; declaring `Partitioning::Range` on the scans only lets an already
+/// `Partitioned` join skip its repartitions. Must run after `EnforceDistribution`
+/// (which resolves `PartitionMode::Auto` and inserts the build side's
+/// `CoalescePartitionsExec`) and before the post-optimization `FilterPushdown`
+/// pass.
 #[derive(Debug, Default)]
 pub struct RangeCoPartitionedJoinRule;
 
@@ -498,8 +502,9 @@ impl PhysicalOptimizerRule for RangeCoPartitionedJoinRule {
             let Some(join) = node.downcast_ref::<HashJoinExec>() else {
                 return Ok(Transformed::no(node));
             };
-            // DataFusion's range-satisfaction bridge only covers Partitioned inner
-            // joins, so those are the only ones worth flipping.
+            // `HashJoinExec` enables `allow_range_satisfaction_for_key_partitioning`
+            // only for Partitioned inner joins; flipping any other shape would make
+            // `EnforceDistribution` re-introduce hash repartitions on both sides.
             if join.partition_mode() != &PartitionMode::CollectLeft
                 || join.join_type() != &JoinType::Inner
             {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -282,7 +282,11 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
 
     builder = builder.with_query_planner(Arc::new(PgSearchQueryPlanner));
 
-    builder.with_physical_optimizer_rule(Arc::new(VisibilityCtidResolverRule))
+    builder
+        .with_physical_optimizer_rule(Arc::new(
+            super::range_partitioning_rule::RangeCoPartitionedJoinRule,
+        ))
+        .with_physical_optimizer_rule(Arc::new(VisibilityCtidResolverRule))
 }
 
 /// Creates a DataFusion [`SessionContext`] for either JoinScan or AggregateScan.

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -58,7 +58,9 @@ use crate::postgres::customscan::mpp::interrupt::{check_for_interrupts, HeldInte
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::utils::ExprContextGuard;
 use crate::postgres::ParallelScanState;
-use crate::scan::execution_plan::PgSearchScanTaskEstimator;
+use crate::scan::execution_plan::{
+    pg_search_scan_desired_task_count, pg_search_scan_scale_up_leaf_node,
+};
 use crate::scan::physical_codec::deserialize_physical_plan_with_runtime;
 use datafusion_distributed::shm::SetPlanFrame;
 
@@ -108,7 +110,7 @@ pub(crate) fn build_mpp_session_context(
     // Three knobs that have to be set for the planner to actually emit `NetworkShuffleExec`:
     //   1. target_partitions(N): without it, EnforceDistribution skips every
     //      RepartitionExec so the annotator never sees a Shuffle.
-    //   2. distributed_task_estimator(N): without it, leaves default to Maximum(1) and
+    //   2. desired_task_count(N): without it, leaves default to Maximum(1) and
     //      `_distribute_plan` elides every shuffle.
     //   3. distributed_broadcast_joins(true): otherwise CollectLeft HashJoins cap their
     //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
@@ -156,8 +158,9 @@ pub(crate) fn build_mpp_session_context(
             state_builder.with_distributed_channel_resolver(ShmChannelResolver::new(mesh));
     }
     let state_builder = state_builder
-        .with_distributed_task_estimator(PgSearchScanTaskEstimator)
-        .with_distributed_task_estimator(n_workers)
+        .with_distributed_desired_task_count_handler(pg_search_scan_desired_task_count)
+        .with_distributed_scale_up_leaf_node_handler(pg_search_scan_scale_up_leaf_node)
+        .with_distributed_desired_task_count_handler(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
         .with_distributed_planner();

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -268,11 +268,14 @@ impl PgSearchScanPlan {
         }
         // Output partitioning tells datafusion-distributed how many tasks this leaf can naturally split into.
         // If state is None, execute() will return an EmptyStream for this single partition.
+        let range_boundaries = range_sample.as_ref().map(|s| s.build(partition_count));
+        let partitioning =
+            declared_partitioning(&schema, partition_count, range_boundaries.as_ref());
         let eq_properties = build_equivalence_properties(schema, sort_order);
 
         let properties = Arc::new(PlanProperties::new(
             eq_properties,
-            Partitioning::UnknownPartitioning(partition_count),
+            partitioning,
             EmissionType::Incremental,
             Boundedness::Bounded,
         ));
@@ -303,9 +306,9 @@ impl PgSearchScanPlan {
 
         let exec_state = match state {
             Some(s) => {
-                if let Some(sample) = &range_sample {
+                if let Some(boundaries) = range_boundaries {
                     ExecutionState::RangePartitioned {
-                        range_boundaries: sample.build(partition_count),
+                        range_boundaries: boundaries,
                         scan_state: Box::new(UnsafeSendSync(s)),
                     }
                 } else {
@@ -375,9 +378,20 @@ impl PgSearchScanPlan {
             }
         };
 
+        let range_boundaries = match &new_state {
+            ExecutionState::RangePartitioned {
+                range_boundaries, ..
+            } => Some(range_boundaries),
+            _ => None,
+        };
+        let partitioning = declared_partitioning(
+            self.properties.eq_properties.schema(),
+            target_partitions,
+            range_boundaries,
+        );
         let new_properties = Arc::new(PlanProperties::new(
             self.properties.eq_properties.clone(),
-            Partitioning::UnknownPartitioning(target_partitions),
+            partitioning,
             self.properties.emission_type,
             self.properties.boundedness,
         ));
@@ -657,6 +671,30 @@ struct ScanDispatchDescriptor {
     partition_count: usize,
     range_sample: Option<RangePartitioningSample>,
     assigned_partition: Option<usize>,
+}
+
+/// The output partitioning a scan declares to DataFusion.
+///
+/// `Partitioning::Range` is declared only when the boundaries cover exactly
+/// `partition_count` partitions and translate faithfully to DataFusion's model.
+/// Otherwise `UnknownPartitioning` preserves the requested count, where any
+/// partitions beyond the boundaries execute as empty streams (e.g. when the
+/// sample is smaller than the requested count).
+fn declared_partitioning(
+    schema: &SchemaRef,
+    partition_count: usize,
+    range_boundaries: Option<&RangePartitioning>,
+) -> Partitioning {
+    if partition_count > 1 {
+        if let Some(boundaries) = range_boundaries {
+            if boundaries.split_points.len() + 1 == partition_count {
+                if let Some(partitioning) = boundaries.to_datafusion(schema) {
+                    return partitioning;
+                }
+            }
+        }
+    }
+    Partitioning::UnknownPartitioning(partition_count)
 }
 
 /// Build `EquivalenceProperties` with the specified sort ordering.

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -34,7 +34,6 @@ use arrow_array::RecordBatch;
 use arrow_schema::{SchemaRef, SortOptions};
 use datafusion::common::stats::{ColumnStatistics, Precision};
 use datafusion::common::{DataFusionError, Result, Statistics};
-use datafusion::config::ConfigOptions;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr, PhysicalSortExpr};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
@@ -48,7 +47,10 @@ use datafusion::physical_plan::metrics::{
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
 };
-use datafusion_distributed::{TaskEstimation, TaskEstimator};
+use datafusion_distributed::{
+    DesiredTaskCountEvent, DesiredTaskCountEventResponse, ScaleUpLeafNodeEvent,
+    ScaleUpLeafNodeEventResponse,
+};
 use datafusion_proto::physical_plan::{
     DefaultPhysicalExtensionCodec, PhysicalPlanDecodeContext, PhysicalProtoConverterExtension,
 };
@@ -200,7 +202,7 @@ pub struct PgSearchScanPlan {
     /// When executing in a multi-task distributed or parallel environment, this
     /// indicates the specific execution partition this plan variant is responsible for.
     /// It guarantees that the `ExecutionState` is consumed exactly once by the designated worker.
-    assigned_partition: Option<usize>,
+    pub(crate) assigned_partition: Option<usize>,
 }
 
 impl Clone for PgSearchScanPlan {
@@ -294,7 +296,7 @@ impl PgSearchScanPlan {
 
         if range_sample.is_none() {
             // A partition count exceeding the segment count indicates a bug in
-            // PgSearchScanTaskEstimator::task_estimation, which should cap the tasks
+            // pg_search_scan_desired_task_count, which should cap the tasks
             // to the segment count when range sampling is disabled.
             assert!(
                 partition_count <= segment_count.max(1),
@@ -1199,57 +1201,48 @@ impl<T: Stream<Item = Result<RecordBatch>>> RecordBatchStream for UnsafeSendStre
     }
 }
 
-/// `PgSearchScanTaskEstimator` intercepts `PgSearchScanPlan` during distributed planning
-/// and requests a number of tasks equal to the plan's `partition_count`.
+/// Caps a `PgSearchScanPlan`'s stage at its `partition_count` tasks.
 ///
 /// This correctly maps PostgreSQL parallel workers to tasks, ensuring that tables with 1 segment
 /// do not force MPP planning and fall back to local serial execution (under `Shared` partitioning),
 /// whereas large tables or tables utilizing `Range` partitioning scale out efficiently across
-/// available workers. When scaled up via `scale_up_leaf_node`, the plan internally repartitions
-/// itself to exactly match the requested task count.
-#[derive(Debug)]
-pub(crate) struct PgSearchScanTaskEstimator;
+/// available workers.
+pub(crate) fn pg_search_scan_desired_task_count(
+    ev: DesiredTaskCountEvent,
+) -> Option<DesiredTaskCountEventResponse> {
+    let _ = ev.plan.downcast_ref::<PgSearchScanPlan>()?;
+    let partition_count = ev.plan.properties().output_partitioning().partition_count();
+    // `maximum` rather than `desired`: `partition_count` is already clamped to the number
+    // of physical index segments (when range sampling is disabled). A single segment cannot
+    // be concurrently scanned by multiple workers, so scaling the stage past it would just
+    // starve tasks with useless setup work (like building empty hash tables) for zero rows.
+    Some(DesiredTaskCountEventResponse::maximum(partition_count))
+}
 
-impl TaskEstimator for PgSearchScanTaskEstimator {
-    fn task_estimation(
-        &self,
-        plan: &Arc<dyn ExecutionPlan>,
-        _cfg: &ConfigOptions,
-    ) -> Option<TaskEstimation> {
-        let _ = plan.downcast_ref::<PgSearchScanPlan>()?;
+/// Replaces a `PgSearchScanPlan` leaf with per-task variants once its stage's task
+/// count is final. One partition per task is the distributed contract: the plan is
+/// repartitioned so the counts match, and each variant consumes exactly its own
+/// partition; partitions past a short range sample bound empty ranges rather than
+/// re-chunking tasks.
+pub(crate) fn pg_search_scan_scale_up_leaf_node(
+    ev: ScaleUpLeafNodeEvent,
+) -> Option<datafusion::error::Result<ScaleUpLeafNodeEventResponse>> {
+    let scan_plan = ev.plan.downcast_ref::<PgSearchScanPlan>()?;
 
-        let partition_count = plan.properties().output_partitioning().partition_count();
-
-        // We use `maximum` rather than `desired` here because `partition_count` is already
-        // clamped to the number of physical index segments (when range sampling is disabled).
-        // Since a single segment cannot be concurrently scanned by multiple workers,
-        // allowing the stage to scale up beyond `partition_count` would just result in
-        // starved tasks doing useless setup work (like building empty hash tables) for zero rows.
-        Some(TaskEstimation::maximum(partition_count))
-    }
-
-    fn scale_up_leaf_node(
-        &self,
-        plan: &Arc<dyn ExecutionPlan>,
-        task_count: usize,
-        _cfg: &ConfigOptions,
-    ) -> datafusion::error::Result<Option<Arc<dyn ExecutionPlan>>> {
-        let Some(scan_plan) = plan.downcast_ref::<PgSearchScanPlan>() else {
-            return Ok(None);
-        };
-
-        let current_partitions = plan.properties().output_partitioning().partition_count();
-        let final_plan = if task_count != current_partitions {
-            scan_plan.repartition(task_count)?
+    let scale = || -> datafusion::error::Result<ScaleUpLeafNodeEventResponse> {
+        let current_partitions = ev.plan.properties().output_partitioning().partition_count();
+        let final_plan = if ev.task_count != current_partitions {
+            scan_plan.repartition(ev.task_count)?
         } else {
-            Arc::clone(plan)
+            Arc::clone(ev.plan)
         };
 
         // Downcast back because repartition returns `Arc<dyn ExecutionPlan>`
         let final_scan_plan = final_plan.downcast_ref::<PgSearchScanPlan>().unwrap();
 
-        // Assign each task its explicit execution partition to ensure it is the only one executing it.
-        let variants = (0..task_count)
+        // Assign each task its explicit execution partition to ensure it is the only one
+        // executing it.
+        let variants = (0..ev.task_count)
             .map(|i| {
                 let mut variant = final_scan_plan.clone();
                 variant.assigned_partition = Some(i);
@@ -1257,10 +1250,11 @@ impl TaskEstimator for PgSearchScanTaskEstimator {
             })
             .collect::<Vec<_>>();
 
-        Ok(Some(Arc::new(
+        Ok(ScaleUpLeafNodeEventResponse::new(Arc::new(
             datafusion_distributed::DistributedLeafExec::try_new(final_plan, variants)?,
         )))
-    }
+    };
+    Some(scale())
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/scan/range_partitioning.rs
+++ b/pg_search/src/scan/range_partitioning.rs
@@ -168,6 +168,15 @@ fn scalar_value_for(value: &PdbOwnedValue, data_type: &DataType) -> Option<Scala
     match (data_type, value) {
         (DataType::Int64, PdbOwnedValue::I64(v)) => Some(ScalarValue::Int64(Some(*v))),
         (DataType::UInt64, PdbOwnedValue::U64(v)) => Some(ScalarValue::UInt64(Some(*v))),
+        // The sampler reads through FFType, whose integer classification follows the
+        // physical tantivy column rather than the declared field type; accept the
+        // lossless cross-representations.
+        (DataType::Int64, PdbOwnedValue::U64(v)) if *v <= i64::MAX as u64 => {
+            Some(ScalarValue::Int64(Some(*v as i64)))
+        }
+        (DataType::UInt64, PdbOwnedValue::I64(v)) if *v >= 0 => {
+            Some(ScalarValue::UInt64(Some(*v as u64)))
+        }
         (DataType::Float64, PdbOwnedValue::F64(v)) => Some(ScalarValue::Float64(Some(*v))),
         (DataType::Boolean, PdbOwnedValue::Bool(v)) => Some(ScalarValue::Boolean(Some(*v))),
         (DataType::Utf8View, PdbOwnedValue::Str(v)) => Some(ScalarValue::Utf8View(Some(v.clone()))),

--- a/pg_search/src/scan/range_partitioning.rs
+++ b/pg_search/src/scan/range_partitioning.rs
@@ -15,6 +15,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
+
+use arrow_schema::{DataType, SchemaRef, SortOptions, TimeUnit};
+use datafusion::common::{ScalarValue, SplitPoint};
+use datafusion::physical_expr::{
+    LexOrdering, PhysicalSortExpr, RangePartitioning as DataFusionRangePartitioning,
+};
+use datafusion::physical_plan::expressions::Column;
+use datafusion::physical_plan::Partitioning;
 use serde::{Deserialize, Serialize};
 
 use crate::api::FieldName;
@@ -106,6 +115,67 @@ impl RangePartitioning {
         } else {
             range_query
         }
+    }
+
+    /// Translates these boundaries into a DataFusion [`Partitioning::Range`] declaration
+    /// over `schema`, so the planner can co-partition operators (e.g. joins) without a
+    /// repartition or broadcast.
+    ///
+    /// Returns `None` when the declaration would not be faithful to the execution
+    /// semantics of [`Self::partition_bounds`]:
+    /// - the `partition_by` column is missing from the schema, or
+    /// - a split point is NULL (`partition_bounds` gives NULL split points bespoke
+    ///   empty-range semantics that DataFusion's model does not express), or
+    /// - a split point cannot be represented as a `ScalarValue` of the column's type.
+    pub fn to_datafusion(&self, schema: &SchemaRef) -> Option<Partitioning> {
+        let (col_idx, field) = schema.column_with_name(self.partition_by.as_ref())?;
+
+        let split_points = self
+            .split_points
+            .iter()
+            .map(|value| {
+                scalar_value_for(value, field.data_type()).map(|sv| SplitPoint::new(vec![sv]))
+            })
+            .collect::<Option<Vec<_>>>()?;
+
+        // `partition_bounds` routes NULLs to partition 0 and uses lower-inclusive,
+        // upper-exclusive interior ranges, which is exactly DataFusion's split-point
+        // convention under an ascending NULLS FIRST ordering.
+        let sort_expr = PhysicalSortExpr {
+            expr: Arc::new(Column::new(self.partition_by.as_ref(), col_idx)),
+            options: SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+        };
+        let ordering = LexOrdering::new([sort_expr])?;
+
+        // `new` rather than `try_new`: a down-sampled distribution can legally repeat a
+        // split point, which produces an empty partition in both our execution model and
+        // DataFusion's, but fails `try_new`'s strict-ordering validation.
+        Some(Partitioning::Range(DataFusionRangePartitioning::new(
+            ordering,
+            split_points,
+        )))
+    }
+}
+
+/// Converts a sampled fast-field value into the `ScalarValue` representation of the
+/// column's arrow type. Returns `None` for NULLs and for any value/type combination
+/// that has no exact representation, in which case the caller declines to declare
+/// range partitioning rather than declare it imprecisely.
+fn scalar_value_for(value: &PdbOwnedValue, data_type: &DataType) -> Option<ScalarValue> {
+    match (data_type, value) {
+        (DataType::Int64, PdbOwnedValue::I64(v)) => Some(ScalarValue::Int64(Some(*v))),
+        (DataType::UInt64, PdbOwnedValue::U64(v)) => Some(ScalarValue::UInt64(Some(*v))),
+        (DataType::Float64, PdbOwnedValue::F64(v)) => Some(ScalarValue::Float64(Some(*v))),
+        (DataType::Boolean, PdbOwnedValue::Bool(v)) => Some(ScalarValue::Boolean(Some(*v))),
+        (DataType::Utf8View, PdbOwnedValue::Str(v)) => Some(ScalarValue::Utf8View(Some(v.clone()))),
+        // Datetime fields use v2 storage: i64 microseconds.
+        (DataType::Timestamp(TimeUnit::Microsecond, None), PdbOwnedValue::I64(v)) => {
+            Some(ScalarValue::TimestampMicrosecond(Some(*v), None))
+        }
+        _ => None,
     }
 }
 

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -673,7 +673,7 @@ impl PgSearchTableProvider {
         let target_partitions = state.config().target_partitions();
         // The output partitions of the scan default to min(segments, target_partitions),
         // or exactly `target_partitions` when range partitioning is enabled.
-        // During distributed planning, the `PgSearchScanTaskEstimator` reads this partition
+        // During distributed planning, the `pg_search_scan_desired_task_count` handler reads this partition
         // count to determine how many tasks (e.g. parallel workers) this leaf should scale out into.
         let partition_count = if self.range_sample.is_some() {
             // When using range partitioning, we target the session's target partitions.

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -813,4 +813,108 @@ mod tests {
         };
         assert!(missing.to_datafusion(&schema).is_none());
     }
+
+    #[pg_test]
+    fn test_range_partitioned_assigned_execution() {
+        use datafusion::physical_plan::Partitioning;
+
+        let (heap_oid, index_oid) = get_relation_oids();
+        let heap_rel = PgSearchRelation::open(heap_oid);
+        let index_rel = PgSearchRelation::open(index_oid);
+
+        let reader = SearchIndexReader::open(
+            &index_rel,
+            SearchQueryInput::All,
+            false,
+            MvccSatisfies::Snapshot,
+        )
+        .unwrap();
+
+        let fields = vec![
+            WhichFastField::Ctid,
+            WhichFastField::Named("id".to_string(), SearchFieldType::I64(pg_sys::INT4OID)),
+        ];
+        let ffhelper = FFHelper::with_fields(&reader, &fields);
+
+        unsafe {
+            pg_sys::CommandCounterIncrement();
+            let snap = pg_sys::GetTransactionSnapshot();
+            pg_sys::PushActiveSnapshot(snap);
+        }
+        let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
+        let visibility = HeapVisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
+
+        let scan_state = crate::scan::execution_plan::ScanState {
+            source_idx: None,
+            planner_estimated_rows: 0,
+            scanner_config: crate::scan::execution_plan::ScannerConfig {
+                which_fast_fields: fields.clone(),
+                heap_relid: heap_oid.into(),
+                batch_size_hint: None,
+                score_needed: false,
+            },
+            ffhelper: ffhelper.into(),
+            visibility: Box::new(visibility),
+            reader: reader.clone(),
+        };
+
+        // Table t has ids 1..=100; split points [25, 50, 75] give partitions
+        // (-inf, 25), [25, 50), [50, 75), [75, inf).
+        let sample = crate::scan::range_partitioning::RangePartitioningSample {
+            partition_by: crate::api::FieldName::from("id"),
+            sample_points: vec![
+                crate::postgres::pdb_owned_value::PdbOwnedValue::I64(25),
+                crate::postgres::pdb_owned_value::PdbOwnedValue::I64(50),
+                crate::postgres::pdb_owned_value::PdbOwnedValue::I64(75),
+            ],
+        };
+
+        let mut plan = PgSearchScanPlan::new(
+            Some(scan_state),
+            build_arrow_schema(&fields),
+            SearchQueryInput::All,
+            None,
+            Vec::new(),
+            None,
+            index_oid.into(),
+            None,
+            4,
+            None,
+            Some(sample),
+        );
+        // As one of four task variants: this one owns partition 1 alone.
+        plan.assigned_partition = Some(1);
+
+        assert_eq!(plan.properties().output_partitioning().partition_count(), 4);
+        assert!(matches!(
+            plan.properties().output_partitioning(),
+            Partitioning::Range(_)
+        ));
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let count_rows = |partition: usize| {
+            let mut stream = plan
+                .execute(partition, Arc::new(TaskContext::default()))
+                .unwrap();
+            let mut rows = 0;
+            runtime.block_on(async {
+                while let Some(batch) = stream.next().await {
+                    rows += batch.unwrap().num_rows();
+                }
+            });
+            rows
+        };
+
+        // Non-assigned partitions yield empty streams without touching the state, so
+        // the assigned partition still consumes it afterwards.
+        assert_eq!(count_rows(0), 0);
+        assert_eq!(count_rows(2), 0);
+        assert_eq!(count_rows(3), 0);
+        assert_eq!(count_rows(1), 25); // ids 25..=49
+
+        // The state is consumed exactly once.
+        assert!(plan.execute(1, Arc::new(TaskContext::default())).is_err());
+    }
 }

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -784,6 +784,21 @@ mod tests {
         };
         assert!(with_null.to_datafusion(&schema).is_none());
 
+        // The sampler's FFType-driven integer classification can yield U64 for an
+        // Int64 column; the lossless cross-representation is accepted.
+        let cross_int = RangePartitioning {
+            partition_by: FieldName::from("id"),
+            split_points: vec![PdbOwnedValue::U64(10)],
+        };
+        let cross_partitioning = cross_int.to_datafusion(&schema).unwrap();
+        let Partitioning::Range(cross_range) = &cross_partitioning else {
+            panic!("expected range partitioning, got {cross_partitioning:?}");
+        };
+        assert_eq!(
+            cross_range.split_points()[0].values(),
+            &[ScalarValue::Int64(Some(10))]
+        );
+
         // Value/column type mismatches decline rather than declare imprecisely.
         let mismatched = RangePartitioning {
             partition_by: FieldName::from("id"),

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -704,18 +704,98 @@ mod tests {
             Some(sample),
         );
 
+        use datafusion::physical_plan::Partitioning;
+
+        // The boundaries cover the requested count exactly, so the plan declares
+        // `Partitioning::Range` and DataFusion can co-partition against it.
         assert_eq!(plan.properties().output_partitioning().partition_count(), 5);
+        assert!(matches!(
+            plan.properties().output_partitioning(),
+            Partitioning::Range(_)
+        ));
 
         let plan_2 = plan.repartition(2).unwrap();
         assert_eq!(
             plan_2.properties().output_partitioning().partition_count(),
             2
         );
+        assert!(matches!(
+            plan_2.properties().output_partitioning(),
+            Partitioning::Range(_)
+        ));
 
+        // 10 partitions exceed what the 4-point sample can bound: the plan keeps
+        // the requested count as UnknownPartitioning and the extra partitions
+        // execute as empty streams.
         let plan_10 = plan.repartition(10).unwrap();
         assert_eq!(
             plan_10.properties().output_partitioning().partition_count(),
             10
         );
+        assert!(matches!(
+            plan_10.properties().output_partitioning(),
+            Partitioning::UnknownPartitioning(_)
+        ));
+    }
+
+    #[pg_test]
+    fn test_range_partitioning_to_datafusion() {
+        use crate::api::FieldName;
+        use crate::postgres::pdb_owned_value::PdbOwnedValue;
+        use crate::scan::range_partitioning::RangePartitioning;
+        use arrow_schema::{DataType, Field, Schema};
+        use datafusion::common::ScalarValue;
+        use datafusion::physical_plan::Partitioning;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("ctid", DataType::UInt64, true),
+            Field::new("id", DataType::Int64, true),
+        ]));
+
+        let boundaries = RangePartitioning {
+            partition_by: FieldName::from("id"),
+            split_points: vec![PdbOwnedValue::I64(10), PdbOwnedValue::I64(20)],
+        };
+
+        let partitioning = boundaries.to_datafusion(&schema).unwrap();
+        assert_eq!(partitioning.partition_count(), 3);
+        let Partitioning::Range(range) = &partitioning else {
+            panic!("expected range partitioning, got {partitioning:?}");
+        };
+        assert_eq!(range.split_points().len(), 2);
+        assert_eq!(
+            range.split_points()[0].values(),
+            &[ScalarValue::Int64(Some(10))]
+        );
+        assert_eq!(
+            range.split_points()[1].values(),
+            &[ScalarValue::Int64(Some(20))]
+        );
+        let sort_expr = range.ordering().iter().next().unwrap();
+        assert_eq!(sort_expr.expr.to_string(), "id@1");
+        assert!(!sort_expr.options.descending);
+        assert!(sort_expr.options.nulls_first);
+
+        // NULL split points have bespoke execution semantics that DataFusion's
+        // model does not express; decline to declare.
+        let with_null = RangePartitioning {
+            partition_by: FieldName::from("id"),
+            split_points: vec![PdbOwnedValue::Null],
+        };
+        assert!(with_null.to_datafusion(&schema).is_none());
+
+        // Value/column type mismatches decline rather than declare imprecisely.
+        let mismatched = RangePartitioning {
+            partition_by: FieldName::from("id"),
+            split_points: vec![PdbOwnedValue::F64(1.5)],
+        };
+        assert!(mismatched.to_datafusion(&schema).is_none());
+
+        // Columns missing from the schema decline.
+        let missing = RangePartitioning {
+            partition_by: FieldName::from("missing"),
+            split_points: vec![PdbOwnedValue::I64(10)],
+        };
+        assert!(missing.to_datafusion(&schema).is_none());
     }
 }

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -133,8 +133,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -147,28 +147,23 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │     [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=3, partitions=9
+           :   ┌───── Stage 1 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
-           :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
-           :   │         CoalescePartitionsExec
-           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=3
+           :   │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: segments=2, partition=file_id[-∞..56), dynamic_filters=1, query="all"
-           :   │           t1: PgSearchScan: segments=2, partition=file_id[56..117), dynamic_filters=1, query="all"
-           :   │           t2: PgSearchScan: segments=2, partition=file_id[117..∞), dynamic_filters=1, query="all"
+           :   │           t0: PgSearchScan: segments=2, partition=id[-∞..51), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t1: PgSearchScan: segments=2, partition=id[51..101), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t2: PgSearchScan: segments=2, partition=id[101..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │         DistributedLeafExec:
+           :   │           t0: PgSearchScan: segments=2, partition=file_id[-∞..51), dynamic_filters=1, query="all"
+           :   │           t1: PgSearchScan: segments=2, partition=file_id[51..101), dynamic_filters=1, query="all"
+           :   │           t2: PgSearchScan: segments=2, partition=file_id[101..∞), dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=3, partitions=27
-           :     │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
-           :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=2, partition=id[-∞..56), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t1: PgSearchScan: segments=2, partition=id[56..117), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t2: PgSearchScan: segments=2, partition=id[117..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     └──────────────────────────────────────────────────
-(33 rows)
+(28 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -232,8 +227,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                                QUERY PLAN                                                                                                                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                  QUERY PLAN                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -246,28 +241,23 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │     [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=3, partitions=9
+           :   ┌───── Stage 1 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
-           :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
-           :   │         CoalescePartitionsExec
-           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=3
+           :   │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: segments=2, partition=file_id[-∞..56), dynamic_filters=1, query="all"
-           :   │           t1: PgSearchScan: segments=2, partition=file_id[56..117), dynamic_filters=1, query="all"
-           :   │           t2: PgSearchScan: segments=2, partition=file_id[117..∞), dynamic_filters=1, query="all"
+           :   │           t0: PgSearchScan: segments=2, partition=id[-∞..51), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t1: PgSearchScan: segments=2, partition=id[51..101), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t2: PgSearchScan: segments=2, partition=id[101..∞), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │         DistributedLeafExec:
+           :   │           t0: PgSearchScan: segments=2, partition=file_id[-∞..51), dynamic_filters=1, query="all"
+           :   │           t1: PgSearchScan: segments=2, partition=file_id[51..101), dynamic_filters=1, query="all"
+           :   │           t2: PgSearchScan: segments=2, partition=file_id[101..∞), dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=3, partitions=27
-           :     │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
-           :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=2, partition=id[-∞..56), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :     │     t1: PgSearchScan: segments=2, partition=id[56..117), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :     │     t2: PgSearchScan: segments=2, partition=id[117..∞), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :     └──────────────────────────────────────────────────
-(33 rows)
+(28 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -341,6 +331,99 @@ LIMIT 10;
  file-100 |       1683
  file-100 |       2995
  file-100 |       3691
+(10 rows)
+
+-- =====================================================================
+-- Pass 6: outer joins keep the shuffle path
+--
+-- The co-partitioned range flip applies to inner joins only. A LEFT JOIN
+-- must keep the shuffle-based shape and stay correct under MPP.
+-- =====================================================================
+SET max_parallel_workers_per_gather TO 4;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.title, p.size_bytes
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: f.title, p.size_bytes
+         Relation Tree: p RIGHT f
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: f.title asc, p.size_bytes asc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
+           : │     [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 3 ── tasks=3, partitions=3
+           :   │ LocalLimitExec: fetch=10
+           :   │   TantivyLookupExec: decode=[title]
+           :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[f]
+           :   │       HashJoinExec: mode=Partitioned, join_type=Left, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
+           :   │         [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+           :   │         [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── tasks=3, partitions=9
+           :     │ RepartitionExec: partitioning=Hash([id@1], 9), input_partitions=3
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, partition=id[-∞..51), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t1: PgSearchScan: segments=2, partition=id[51..101), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t2: PgSearchScan: segments=2, partition=id[101..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     └──────────────────────────────────────────────────
+           :     ┌───── Stage 2 ── tasks=3, partitions=9
+           :     │ RepartitionExec: partitioning=Hash([file_id@1], 9), input_partitions=3
+           :     │   VisibilityFilterExec: tables=[p]
+           :     │     DistributedLeafExec:
+           :     │       t0: PgSearchScan: segments=2, partition=file_id[-∞..51), dynamic_filters=1, query="all"
+           :     │       t1: PgSearchScan: segments=2, partition=file_id[51..101), dynamic_filters=1, query="all"
+           :     │       t2: PgSearchScan: segments=2, partition=file_id[101..∞), dynamic_filters=1, query="all"
+           :     └──────────────────────────────────────────────────
+(37 rows)
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+  title  | size_bytes 
+---------+------------
+ file-1  |        616
+ file-1  |       1312
+ file-1  |       2008
+ file-1  |       2704
+ file-1  |       3400
+ file-10 |        153
+ file-10 |       1465
+ file-10 |       2161
+ file-10 |       2857
+ file-10 |       3553
+(10 rows)
+
+SET max_parallel_workers_per_gather TO 0;
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+  title  | size_bytes 
+---------+------------
+ file-1  |        616
+ file-1  |       1312
+ file-1  |       2008
+ file-1  |       2704
+ file-1  |       3400
+ file-10 |        153
+ file-10 |       1465
+ file-10 |       2161
+ file-10 |       2857
+ file-10 |       3553
 (10 rows)
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -202,6 +202,36 @@ ORDER BY f.title, p.size_bytes
 LIMIT 10;
 
 -- =====================================================================
+-- Pass 6: outer joins keep the shuffle path
+--
+-- The co-partitioned range flip applies to inner joins only. A LEFT JOIN
+-- must keep the shuffle-based shape and stay correct under MPP.
+-- =====================================================================
+
+SET max_parallel_workers_per_gather TO 4;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+SET max_parallel_workers_per_gather TO 0;
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+-- =====================================================================
 -- Cleanup
 -- =====================================================================
 


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #5663

## What

This PR reports the sampled range partitioning to DataFusion and uses it to co-partition inner joins.

## Why

#5679 added the `partition_by` syntax and range-bounded execution, and #5720 added the optimizer rule that samples and tags both sides of a join. The scan still declared `UnknownPartitioning`, so DataFusion treated the two sides as unrelated and MPP broadcast the build side to every task.

## How

- `PgSearchScanPlan` now declares `Partitioning::Range` built from its sample. The boundaries own the declared partition count, and tasks no longer need to align one-to-one with partitions: each task owns a balanced contiguous chunk (two partitions each when the boundaries are double the tasks, empty chunks when the sample caps the count below the task count). Range-partitioned execution hands each owned partition a clone of the scan state, guarded against double execution. NULL split points and type mismatches fall back to `UnknownPartitioning`.
- A new physical rule, `RangeCoPartitionedJoinRule`, flips a `CollectLeft` inner hash join to `Partitioned` mode when both children declare compatible ranges. DataFusion's own co-partitioning check (`unsatisfied_co_partitioned_children`) drives the decision, so anything incompatible keeps the broadcast path.
- `RangePartitioningRule` now samples both sides of the join and merges the distributions, and skips join keys whose arrow types differ between the sides.

In `mpp_joinscan`, the inner join collapses from two stages into one, with no network movement between the scans and the join:

```text
before:
  HashJoinExec: mode=CollectLeft
    CoalescePartitionsExec
      [Stage 1] => NetworkBroadcastExec
    DistributedLeafExec (probe side)

after:
  HashJoinExec: mode=Partitioned
    DistributedLeafExec (build side, partition=id[..))
    DistributedLeafExec (probe side, partition=file_id[..))
```

## Tests

- Unit tests for the `Partitioning::Range` translation and the declared-partitioning fallbacks.
- `mpp_joinscan` regress: the inner-join MPP plans are now single-stage `mode=Partitioned`, a new LEFT JOIN pass shows outer joins keep the shuffle path, and all results still match the serial baselines.
