### PR TITLE
build: bumped release codegen-units to the default 16.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,10 @@
 # on macOS, PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
+
+[env]
+# The lindera dictionary build scripts skip the download and rebuild entirely
+# when the built dictionary already exists in this directory, instead of
+# rebuilding into every target dir. Export LINDERA_CACHE to an absolute path
+# in your shell to share one cache across worktrees.
+LINDERA_CACHE = { value = ".lindera-cache", relative = true }

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -207,6 +207,7 @@ jobs:
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           cache-on-failure: true
 
       - name: Extract pgrx Version

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -65,6 +65,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 
@@ -82,7 +83,7 @@ jobs:
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
       - name: Run Rustfmt
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run Rustdoc
         env:

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -67,6 +67,7 @@ jobs:
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
 
       - name: Install & Configure PostgreSQL ${{ env.pg_version }}
         run: |

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -62,6 +62,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -72,6 +72,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -108,6 +108,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -109,6 +109,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
+          cache-directories: .lindera-cache
           save-if: ${{ github.event_name == 'schedule' && github.ref_name == github.event.repository.default_branch }}
 
       - name: Install required system tools

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Cargo
 target/
+.lindera-cache/
 
 # SSH
 *.pem

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,9 @@ debug = false
 lto = "thin"
 panic = "unwind"
 opt-level = 3
-codegen-units = 1
+# The release default of 16 lets codegen and optimization run in parallel;
+# thin LTO recovers the cross-unit inlining a single codegen unit provides.
+codegen-units = 16
 
 # Optimized + debug symbols, for profiling; debug-assertions off keeps dst asserts compiled out.
 [profile.release-with-debug]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ members = [
   "tests",
   "tokenizers",
 ]
+# A bare `cargo build`/`check`/`clippy`/`test` at the root covers only the
+# extension stack. The other members compile a lot the extension does not need
+# (`benchmarks` builds the bundled DuckDB from C++ source); reach them with
+# `-p <crate>` or `--workspace`.
+default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
 version = "0.25.0"
@@ -17,6 +22,20 @@ license = "AGPL-3.0"
 
 [profile.dev]
 panic = "unwind"
+
+# Backtraces through dependencies keep file:line, but the full DWARF (variable
+# and type info) is dropped; it is most of a debug target dir and is only
+# needed when stepping through a dependency in a debugger. Workspace crates
+# keep full debuginfo. Override locally with a `[profile]` section in
+# `~/.cargo/config.toml` if you need to debug into a dependency.
+[profile.dev.package."*"]
+debug = "line-tables-only"
+
+# `cc` passes `-g` to the bundled DuckDB C++ build based on this. DuckDB is a
+# benchmark comparison engine, not something we debug, and its objects with
+# `-g` cost gigabytes per target dir.
+[profile.dev.package.libduckdb-sys]
+debug = false
 
 [profile.release]
 # Note: We switched from `fat` to `thin` LTO to reduce compile time memory usage, which had been


### PR DESCRIPTION
# Ticket(s) Closed

- N/A (follow-up to #5739, from the Slack thread on build times)

## What

This PR sets release `codegen-units` to 16, the cargo default, stacked on #5739.

Draft: compile-time numbers are in, runtime benchmarks are not.

## Why

With thin LTO on, a single codegen unit serializes codegen of every big crate. On a clean `cargo build --release -p pg_search` (10-core macOS arm64, sccache off), `pg_search` alone spends 245s in its one unit.

## How

One-line change to `[profile.release]`. Measured on the same machine:

|                      | wall  | CPU   | `libpg_search.dylib` |
| -------------------- | ----- | ----- | -------------------- |
| `codegen-units = 1`  | 7m36s | 1859s | 154 MB               |
| `codegen-units = 16` | 6m25s | 1381s | 215 MB               |

The 26% CPU cut is what CI runners feel. The binary grows 40%, which is a real distribution cost. Whether runtime moves is the open question; thin LTO should recover the cross-unit inlining, but that is what the benchmark run is for.

## Tests

No functional change. The `benchmarks` label triggers the stackoverflow run on this PR; if it regresses, we close this.
