### PR TITLE
ci(benchmarks): publish a cohere baseline from a manual dispatch, and track index build cost

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Whether to fail on query errors. Set to 'false' for backfills against older versions."
     required: false
     default: "true"
+  publish:
+    description: "Whether to push results to the gh-pages baseline that later runs are diffed against. Only a run on main should; every run compares against the baseline regardless."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -73,7 +77,7 @@ runs:
         github-token: ${{ inputs.github_token }}
         gh-repository: github.com/${{ github.repository }}
         gh-pages-branch: gh-pages
-        auto-push: ${{ github.ref == 'refs/heads/main' }}
+        auto-push: ${{ inputs.publish }}
         benchmark-data-dir-path: benchmarks
         alert-threshold: "115%"
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_baseline:
+        description: "Whether to write the results to the gh-pages baseline that later runs are diffed against. Ignored unless this run is on main. Untick for an exploratory run you do not want recorded."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   actions: write
@@ -92,6 +97,9 @@ jobs:
       # chosen index comes from the dispatch input or the label name (no default).
       RUN_STACKOVERFLOW: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'stackoverflow')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmarks", "benchmark-stackoverflow"]'), github.event.label.name)) }}
       RUN_COHERE: ${{ (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'cohere')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)) }}
+      # Only main writes the baseline. Every other run still fetches it and diffs against it,
+      # so a PR gets its comparison without being able to move the reference point.
+      PUBLISH_BASELINE: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.publish_baseline) }}
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:
@@ -278,6 +286,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
+          publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "stackoverflow" Heap Snapshot (1M)
         if: ${{ env.RUN_STACKOVERFLOW == 'true' }}
@@ -309,6 +318,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
+          publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "stackoverflow" Heap Snapshot (20M)
         if: ${{ env.RUN_STACKOVERFLOW == 'true' }}
@@ -340,6 +350,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
+          publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "cohere" Heap Snapshot (1M)
         if: ${{ env.RUN_COHERE == 'true' }}
@@ -386,6 +397,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
+          publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "cohere" Heap Snapshot (10M)
         if: ${{ env.RUN_COHERE == 'true' }}
@@ -428,6 +440,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
+          publish: ${{ env.PUBLISH_BASELINE }}
 
       # Renders the operating points the benchmark selected. The benchmark step measures recall
       # across each query's swept values and keeps the cheapest one reaching each target, writing

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -445,7 +445,7 @@ jobs:
       # Renders the operating points the benchmark selected. The benchmark step measures recall
       # across each query's swept values and keeps the cheapest one reaching each target, writing
       # sweep_summary_{size}.tsv (query, target, param, value, recall, reached, p50, p95, p99).
-      # Latency for those same points is published as `{query}@r90|r95|r99 p50|p95|p99` series.
+      # Latency for those same points is published as `{query}@r90|r95|r99 - p50|p95|p99` series.
       - name: Comment cohere recall
         if: ${{ !cancelled() && env.RUN_COHERE == 'true' }}
         working-directory: benchmarks/

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -335,6 +335,34 @@ impl JSONBenchmarkResult {
             })
             .collect()
     }
+
+    /// Build cost as tracked series, so a regression in how long an index takes to build, or how
+    /// much disk it occupies, is caught the same way a query regression is.
+    ///
+    /// Segment count rides along in `extra` rather than becoming its own series: it is set by the
+    /// index definition, so tracking it would alert on deliberate retuning rather than a regression.
+    fn from_index_creation(result: &IndexCreationResult) -> [Self; 2] {
+        let extra = result
+            .segment_count()
+            .map_or_else(String::new, |c| format!("segments={c}"));
+
+        [
+            Self {
+                name: format!("{} build time", result.index_name()),
+                unit: "min",
+                value: result.duration_min_ms(),
+                range: String::new(),
+                extra: extra.clone(),
+            },
+            Self {
+                name: format!("{} index size", result.index_name()),
+                unit: "MB",
+                value: result.index_size() as f64,
+                range: String::new(),
+                extra,
+            },
+        ]
+    }
 }
 
 /// Nominal row count for a size label like `100k`, `1m`, `20m`.
@@ -1192,7 +1220,7 @@ async fn generate_json_output(args: &BenchmarkArgs) -> anyhow::Result<()> {
             process_index_creation(args)
                 .await?
                 .iter()
-                .flat_map(index_creation_series),
+                .flat_map(JSONBenchmarkResult::from_index_creation),
         );
         process_after_create_index_sql(args).await?;
     }
@@ -1638,34 +1666,6 @@ fn write_benchmark_results_md(
     result_line.push_str(&format!("| {num_results} | `{md_query}` |"));
     writeln!(file, "{result_line}")?;
     Ok(())
-}
-
-/// Build cost as tracked series, so a regression in how long an index takes to build or how much
-/// disk it occupies is caught the same way a query regression is.
-///
-/// Segment count rides along in `extra` rather than becoming its own series: it is set by the index
-/// definition, so tracking it would alert on deliberate retuning rather than on a regression.
-fn index_creation_series(result: &IndexCreationResult) -> [JSONBenchmarkResult; 2] {
-    let extra = result
-        .segment_count()
-        .map_or_else(String::new, |c| format!("segments={c}"));
-
-    [
-        JSONBenchmarkResult {
-            name: format!("{} build time", result.index_name()),
-            unit: "min",
-            value: result.duration_min_ms(),
-            range: String::new(),
-            extra: extra.clone(),
-        },
-        JSONBenchmarkResult {
-            name: format!("{} index size", result.index_name()),
-            unit: "MB",
-            value: result.index_size() as f64,
-            range: String::new(),
-            extra,
-        },
-    ]
 }
 
 ///
@@ -2161,7 +2161,7 @@ mod tests {
 
     #[test]
     fn bm25_index_publishes_build_time_and_size_with_segments_in_extra() {
-        let series = index_creation_series(&IndexCreationResult::Bm25 {
+        let series = JSONBenchmarkResult::from_index_creation(&IndexCreationResult::Bm25 {
             duration_min_ms: 4.25,
             index_name: "search_idx".to_owned(),
             index_size: 1234,
@@ -2180,7 +2180,7 @@ mod tests {
     /// pgvector access methods have no segments, so `extra` has nothing to carry.
     #[test]
     fn non_bm25_index_publishes_the_same_series_without_segments() {
-        let series = index_creation_series(&IndexCreationResult::Other {
+        let series = JSONBenchmarkResult::from_index_creation(&IndexCreationResult::Other {
             duration_min_ms: 12.5,
             index_name: "cohere_hnsw_idx".to_owned(),
             index_size: 40960,
@@ -2198,7 +2198,7 @@ mod tests {
     #[test]
     fn results_json_uses_the_field_names_the_publish_action_expects() {
         let json = serde_json::to_string(
-            &index_creation_series(&IndexCreationResult::Other {
+            &JSONBenchmarkResult::from_index_creation(&IndexCreationResult::Other {
                 duration_min_ms: 1.0,
                 index_name: "i".to_owned(),
                 index_size: 2,

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1188,7 +1188,12 @@ async fn generate_json_output(args: &BenchmarkArgs) -> anyhow::Result<()> {
     // Index and query metrics share one results.json, so the publish step reports them as one set.
     let mut results = Vec::new();
     if !args.skip_index {
-        results.extend(index_creation_json(args).await?);
+        results.extend(
+            process_index_creation(args)
+                .await?
+                .iter()
+                .flat_map(index_creation_series),
+        );
         process_after_create_index_sql(args).await?;
     }
     results.extend(
@@ -1661,14 +1666,6 @@ fn index_creation_series(result: &IndexCreationResult) -> [JSONBenchmarkResult; 
             extra,
         },
     ]
-}
-
-async fn index_creation_json(args: &BenchmarkArgs) -> anyhow::Result<Vec<JSONBenchmarkResult>> {
-    Ok(process_index_creation(args)
-        .await?
-        .iter()
-        .flat_map(index_creation_series)
-        .collect())
 }
 
 ///

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -326,7 +326,9 @@ impl JSONBenchmarkResult {
             .map(|(label, p)| {
                 let (lo, hi) = percentile_confidence_interval(&res.results.samples, *p, 0.95);
                 Self {
-                    name: format!("{} {label}", res.query_type),
+                    // " - " is the dashboard's chart-grouping separator, so an operating point's
+                    // three percentiles share one chart instead of getting one each.
+                    name: format!("{} - {label}", res.query_type),
                     unit: "ms",
                     value: percentile(&res.results.samples, *p),
                     range: format!("95% CI [{lo:.3}, {hi:.3}]"),
@@ -2131,9 +2133,9 @@ mod tests {
         assert_eq!(
             out.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
             [
-                "knn_top10_1pct@r95 p50",
-                "knn_top10_1pct@r95 p95",
-                "knn_top10_1pct@r95 p99"
+                "knn_top10_1pct@r95 - p50",
+                "knn_top10_1pct@r95 - p95",
+                "knn_top10_1pct@r95 - p99"
             ]
         );
         assert!(out

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1185,11 +1185,24 @@ async fn generate_csv_output(args: &BenchmarkArgs) -> anyhow::Result<()> {
 }
 
 async fn generate_json_output(args: &BenchmarkArgs) -> anyhow::Result<()> {
+    // Index and query metrics share one results.json, so the publish step reports them as one set.
+    let mut results = Vec::new();
     if !args.skip_index {
-        process_index_creation_json(args).await?;
+        results.extend(index_creation_json(args).await?);
         process_after_create_index_sql(args).await?;
     }
-    run_benchmarks_json(args).await?;
+    results.extend(
+        run_benchmarks(args)
+            .await?
+            .into_iter()
+            .flat_map(JSONBenchmarkResult::from_query_result),
+    );
+
+    let mut file = File::create("results.json").with_context(|| "Failed to create output file")?;
+    let results_json =
+        serde_json::to_string(&results).with_context(|| "Failed to serialize results")?;
+    file.write_all(results_json.as_bytes())
+        .with_context(|| "Failed to write results")?;
     Ok(())
 }
 
@@ -1622,25 +1635,40 @@ fn write_benchmark_results_md(
     Ok(())
 }
 
-async fn process_index_creation_json(args: &BenchmarkArgs) -> anyhow::Result<()> {
-    for _result in process_index_creation(args).await? {
-        // TODO: Record index creation results as JSON.
-    }
-    Ok(())
+/// Build cost as tracked series, so a regression in how long an index takes to build or how much
+/// disk it occupies is caught the same way a query regression is.
+///
+/// Segment count rides along in `extra` rather than becoming its own series: it is set by the index
+/// definition, so tracking it would alert on deliberate retuning rather than on a regression.
+fn index_creation_series(result: &IndexCreationResult) -> [JSONBenchmarkResult; 2] {
+    let extra = result
+        .segment_count()
+        .map_or_else(String::new, |c| format!("segments={c}"));
+
+    [
+        JSONBenchmarkResult {
+            name: format!("{} build time", result.index_name()),
+            unit: "min",
+            value: result.duration_min_ms(),
+            range: String::new(),
+            extra: extra.clone(),
+        },
+        JSONBenchmarkResult {
+            name: format!("{} index size", result.index_name()),
+            unit: "MB",
+            value: result.index_size() as f64,
+            range: String::new(),
+            extra,
+        },
+    ]
 }
 
-async fn run_benchmarks_json(args: &BenchmarkArgs) -> anyhow::Result<()> {
-    let mut file = File::create("results.json").with_context(|| "Failed to create output file")?;
-    let results = run_benchmarks(args)
+async fn index_creation_json(args: &BenchmarkArgs) -> anyhow::Result<Vec<JSONBenchmarkResult>> {
+    Ok(process_index_creation(args)
         .await?
-        .into_iter()
-        .flat_map(JSONBenchmarkResult::from_query_result)
-        .collect::<Vec<_>>();
-    let results_json =
-        serde_json::to_string(&results).with_context(|| "Failed to serialize results")?;
-    file.write_all(results_json.as_bytes())
-        .with_context(|| "Failed to write results")?;
-    Ok(())
+        .iter()
+        .flat_map(index_creation_series)
+        .collect())
 }
 
 ///
@@ -2132,5 +2160,58 @@ mod tests {
         assert_eq!(out[0].unit, "mean ms");
         assert_eq!(out[0].value, 12.0);
         assert!(out[0].extra.contains("p50=12.000"), "{}", out[0].extra);
+    }
+
+    #[test]
+    fn bm25_index_publishes_build_time_and_size_with_segments_in_extra() {
+        let series = index_creation_series(&IndexCreationResult::Bm25 {
+            duration_min_ms: 4.25,
+            index_name: "search_idx".to_owned(),
+            index_size: 1234,
+            segment_count: 8,
+        });
+
+        assert_eq!(series[0].name, "search_idx build time");
+        assert_eq!(series[0].unit, "min");
+        assert_eq!(series[0].value, 4.25);
+        assert_eq!(series[1].name, "search_idx index size");
+        assert_eq!(series[1].unit, "MB");
+        assert_eq!(series[1].value, 1234.0);
+        assert!(series.iter().all(|s| s.extra == "segments=8"));
+    }
+
+    /// pgvector access methods have no segments, so `extra` has nothing to carry.
+    #[test]
+    fn non_bm25_index_publishes_the_same_series_without_segments() {
+        let series = index_creation_series(&IndexCreationResult::Other {
+            duration_min_ms: 12.5,
+            index_name: "cohere_hnsw_idx".to_owned(),
+            index_size: 40960,
+        });
+
+        assert_eq!(
+            series.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+            ["cohere_hnsw_idx build time", "cohere_hnsw_idx index size"]
+        );
+        assert!(series.iter().all(|s| s.extra.is_empty()));
+    }
+
+    /// github-action-benchmark's customSmallerIsBetter parser keys off these exact field names; a
+    /// rename would publish entries it silently drops.
+    #[test]
+    fn results_json_uses_the_field_names_the_publish_action_expects() {
+        let json = serde_json::to_string(
+            &index_creation_series(&IndexCreationResult::Other {
+                duration_min_ms: 1.0,
+                index_name: "i".to_owned(),
+                index_size: 2,
+            })[0],
+        )
+        .unwrap();
+
+        assert_eq!(
+            json,
+            r#"{"name":"i build time","unit":"min","value":1.0,"range":"","extra":""}"#
+        );
     }
 }


### PR DESCRIPTION
Cohere has no gh-pages baseline today — 0 series, against stackoverflow's 110 — so a labelled PR run has nothing to diff against. Two reasons: `RUN_COHERE` excludes `push`, and publishing was gated on `github.ref` inside the composite action, where it was invisible from the dispatch UI and had no opt-out.

**Publishing.** Hoisted into a `PUBLISH_BASELINE` job env passed to the action. Push-to-main and PR-label behaviour is unchanged; a dispatch on main publishes by default and can be unticked for an exploratory run. Runs off main still fetch the baseline and comment their comparison — they just cannot move it.

**Index build cost.** `process_index_creation_json` was a TODO stub, so build time and index size only ever reached the markdown/CSV outputs. Now published as `{index} build time` (min) and `{index} index size` (MB). Segment count rides in `extra` rather than becoming its own series, since it is pinned by the index definition and would alert on deliberate retuning.

Seeding is then a dispatch on main per index arm.

Per an earlier discussion: no fixed-param work here — the swept `@rNN` operating points stay as they are.