### PR TITLE
ci(benchmarks): add pgvectorscale (diskann) as a cohere index variant

### DIFF
--- a/.github/actions/setup-benchmark-cluster/action.yml
+++ b/.github/actions/setup-benchmark-cluster/action.yml
@@ -146,3 +146,21 @@ runs:
         curl -fsSL -o "/tmp/${deb}" \
           "https://github.com/tensorchord/VectorChord/releases/download/${VCHORD_VERSION}/${deb}"
         sudo apt-get install -y "/tmp/${deb}"
+
+    # pgvectorscale (StreamingDiskANN) binary for the "cohere / pgvectorscale" index variant. Not on
+    # apt: it ships as a zip bundling the runtime .deb (plus a dbgsym .deb we skip). Depends on
+    # pgvector's `vector` type (installed above); unlike vchord it needs no shared_preload_libraries,
+    # so the benchmark workflow's post-restore CREATE EXTENSION is all that is required.
+    - name: Install pgvectorscale
+      shell: bash
+      env:
+        PGVECTORSCALE_VERSION: "0.9.0"
+      run: |
+        set -euo pipefail
+        arch="$(dpkg --print-architecture)"   # arm64 on the benchmark runners; amd64 elsewhere
+        zip="pgvectorscale-${PGVECTORSCALE_VERSION}-pg${{ inputs.pg_version }}-${arch}.zip"
+        curl -fsSL -o "/tmp/${zip}" \
+          "https://github.com/timescale/pgvectorscale/releases/download/${PGVECTORSCALE_VERSION}/${zip}"
+        unzip -o -d /tmp/pgvectorscale "/tmp/${zip}"
+        # Runtime package only; the `_*` glob excludes the `-dbgsym_*` debug package.
+        sudo apt-get install -y /tmp/pgvectorscale/pgvectorscale-postgresql-${{ inputs.pg_version }}_*.deb

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -28,7 +28,7 @@ on:
           - stackoverflow
           - cohere
       cohere_index:
-        description: "Which cohere index to benchmark (applies when dataset is cohere/all). For label-triggered runs the index comes from the label instead (benchmark-cohere-hnsw / -ivfflat / -vchord / -pg_search)."
+        description: "Which cohere index to benchmark (applies when dataset is cohere/all). For label-triggered runs the index comes from the label instead (benchmark-cohere-hnsw / -ivfflat / -vchord / -pg_search / -pgvectorscale)."
         required: false
         default: hnsw
         type: choice
@@ -37,6 +37,7 @@ on:
           - ivfflat
           - vchord
           - pg_search
+          - pgvectorscale
       commit:
         description: "A specific commit hash or tag to benchmark. Uses `main` if not specified."
         required: false
@@ -81,7 +82,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
-        contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)
+        contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)
       )
     env:
       pg_version: 18
@@ -96,11 +97,11 @@ jobs:
       # cohere: opt-in only -- the benchmark-cohere-{hnsw,ivfflat} PR labels, or a manual run. The
       # chosen index comes from the dispatch input or the label name (no default).
       RUN_STACKOVERFLOW: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'stackoverflow')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmarks", "benchmark-stackoverflow"]'), github.event.label.name)) }}
-      RUN_COHERE: ${{ (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'cohere')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)) }}
+      RUN_COHERE: ${{ (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'cohere')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)) }}
       # Only main writes the baseline. Every other run still fetches it and diffs against it,
       # so a PR gets its comparison without being able to move the reference point.
       PUBLISH_BASELINE: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.publish_baseline) }}
-      COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
+      COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-pgvectorscale' && 'pgvectorscale') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:
       # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
@@ -108,7 +109,7 @@ jobs:
       - name: Maybe Remove Label
         if: >-
           github.event_name == 'pull_request' &&
-          contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)
+          contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -119,7 +120,8 @@ jobs:
             --remove-label benchmark-cohere-hnsw \
             --remove-label benchmark-cohere-ivfflat \
             --remove-label benchmark-cohere-vchord \
-            --remove-label benchmark-cohere-pg_search || true
+            --remove-label benchmark-cohere-pg_search \
+            --remove-label benchmark-cohere-pgvectorscale || true
 
       - name: Determine Ref to Benchmark
         id: determine-ref
@@ -162,7 +164,7 @@ jobs:
       # always fetch the actions from main, unless we've explicitly overridden that, or triggered this via label (like you would on a PR)
       - name: Fetch the Latest Composite Actions
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)
         uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
@@ -173,18 +175,18 @@ jobs:
 
       - name: Copy latest actions into place
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)
         run: cp -rv actions-temp/.github/actions .github/
 
       - name: Cleanup temporary checkout
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)
         run: rm -rf actions-temp
 
       # always fetch the code from main, unless we've explicitly overridden that, or triggered this via label (like you would on a PR)
       - name: Fetch latest benchmark code, suites
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)
         uses: ./.github/actions/benchmarks-from-main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -384,6 +386,15 @@ jobs:
           psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
             -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;"
 
+      # pgvectorscale needs no shared_preload_libraries, so unlike vchord this only creates the
+      # extension the restored snapshot does not carry -- no restart required.
+      - name: Create vectorscale extension after restore (cohere/pgvectorscale, 1M)
+        if: ${{ env.RUN_COHERE == 'true' && env.COHERE_INDEX == 'pgvectorscale' }}
+        run: |
+          set -euo pipefail
+          psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
+            -c "CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE;"
+
       - name: Benchmark "cohere" Dataset (1M)
         if: ${{ env.RUN_COHERE == 'true' }}
         uses: ./.github/actions/benchmark-queries
@@ -430,6 +441,13 @@ jobs:
           (cd pg_search && cargo pgrx start pg${{ env.pg_version }})
           psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
             -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;"
+
+      - name: Create vectorscale extension after restore (cohere/pgvectorscale, 10M)
+        if: ${{ env.RUN_COHERE == 'true' && env.COHERE_INDEX == 'pgvectorscale' }}
+        run: |
+          set -euo pipefail
+          psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
+            -c "CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE;"
 
       - name: Benchmark "cohere" Dataset (10M)
         if: ${{ env.RUN_COHERE == 'true' }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -105,7 +105,11 @@ jobs:
       RUN_COHERE: ${{ (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'cohere')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)) }}
       # Only main writes the baseline. Every other run still fetches it and diffs against it,
       # so a PR gets its comparison without being able to move the reference point.
-      PUBLISH_BASELINE: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.publish_baseline) }}
+      #
+      # TEMP -- REVERT BEFORE MERGING (this is its own commit, so `git revert` it).
+      # claude/pgvectorscale is allowed to publish so the new arm gets a baseline ahead of merge.
+      # Anything published here becomes the reference the next run is diffed against.
+      PUBLISH_BASELINE: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/claude/pgvectorscale') && (github.event_name != 'workflow_dispatch' || inputs.publish_baseline) }}
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-pgvectorscale' && 'pgvectorscale') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -69,6 +69,11 @@ permissions:
 jobs:
   benchmark-pg_search-queries:
     name: Run Benchmark Jobs
+    # pgvectorscale sweeps query_search_list_size to its 10000 maximum on the filtered arms, and
+    # post-filter streaming at 1% selectivity makes the top of that ladder enormously more expensive
+    # per point than any other index here. Its first run died at the 360m default. A day is enough
+    # to measure it rather than truncate the sweep; every other arm keeps the default it fits in.
+    timeout-minutes: ${{ (inputs.cohere_index == 'pgvectorscale' || github.event.label.name == 'benchmark-cohere-pgvectorscale') && 1440 || 360 }}
     runs-on:
       # To configure the runners: https://runs-on.com/configuration/job-labels/#how-it-works (runs in us-east-1)
       - runs-on=${{ github.run_id }}

--- a/benchmarks/datasets/cohere/config.toml
+++ b/benchmarks/datasets/cohere/config.toml
@@ -314,3 +314,69 @@ values = [
   "0.75",
   "1.0",
 ]
+
+# pgvectorscale StreamingDiskANN on the default SBQ-compressed build. Each arm sweeps whichever GUC
+# is its binding lever, and every ladder ends at that GUC's hard maximum -- so when a target is out
+# of reach the sweep's fallback reports the best achievable point (flagged) rather than a fabricated
+# one. Both maxima are from the extension's own GUC registration in 0.9.0:
+#   diskann.query_rescore            default 50,  max 1000
+#   diskann.query_search_list_size   default 100, max 10000
+#
+# Unfiltered sweeps query_rescore: the graph is 1-bit quantized, so recall tracks how many
+# candidates get exact-distance rescoring, not beam width. It clears 95% well before the cap.
+#
+# The filtered arms cannot reach 90% on this build. Filtering is post-filter streaming, so only the
+# ~10%/1% of the beam that passes the predicate survives, and at most 1000 candidates are ever
+# exact-rescored. With rescore already pinned at that maximum in the query SQL, beam width is the
+# only lever left, so those two sweep query_search_list_size to its 10000 ceiling and report where
+# they land. Uncompressed `storage_layout = plain` would lift them, but is far too slow to build in
+# CI. This arm is therefore NOT iso-recall with the others -- that is the property being surfaced.
+[sweeps.pgvectorscale.knn_top10_unfiltered]
+param = "pgvectorscale_rescore_unfiltered"
+values = [
+  "50",
+  "70",
+  "90",
+  "115",
+  "145",
+  "180",
+  "230",
+  "290",
+  "370",
+  "470",
+  "600",
+  "760",
+  "1000",
+]
+
+[sweeps.pgvectorscale.knn_top10_10pct]
+param = "pgvectorscale_search_list_size_10pct"
+values = [
+  "200",
+  "300",
+  "450",
+  "650",
+  "900",
+  "1300",
+  "1800",
+  "2500",
+  "3500",
+  "5000",
+  "7000",
+  "10000",
+]
+
+[sweeps.pgvectorscale.knn_top10_1pct]
+param = "pgvectorscale_search_list_size_1pct"
+values = [
+  "500",
+  "750",
+  "1100",
+  "1600",
+  "2200",
+  "3000",
+  "4000",
+  "5500",
+  "7500",
+  "10000",
+]

--- a/benchmarks/datasets/cohere/config.toml
+++ b/benchmarks/datasets/cohere/config.toml
@@ -328,9 +328,14 @@ values = [
 # The filtered arms cannot reach 90% on this build. Filtering is post-filter streaming, so only the
 # ~10%/1% of the beam that passes the predicate survives, and at most 1000 candidates are ever
 # exact-rescored. With rescore already pinned at that maximum in the query SQL, beam width is the
-# only lever left, so those two sweep query_search_list_size to its 10000 ceiling and report where
-# they land. Uncompressed `storage_layout = plain` would lift them, but is far too slow to build in
-# CI. This arm is therefore NOT iso-recall with the others -- that is the property being surfaced.
+# only lever left, so those two sweep query_search_list_size and report where they land.
+#
+# Their ladders stop short of the GUC's 10000 maximum on purpose. Recall plateaus far below it --
+# measured around 0.88 at 10% and 0.67 at 1% -- while cost keeps climbing, so the top few values are
+# the most expensive points in the whole run and buy no recall. They end just past the plateau,
+# which is enough to show the curve flattening. Uncompressed `storage_layout = plain` would lift
+# recall, but is far too slow to build in CI. This arm is therefore NOT iso-recall with the others
+# -- that is the property being surfaced.
 [sweeps.pgvectorscale.knn_top10_unfiltered]
 param = "pgvectorscale_rescore_unfiltered"
 values = [
@@ -362,21 +367,8 @@ values = [
   "2500",
   "3500",
   "5000",
-  "7000",
-  "10000",
 ]
 
 [sweeps.pgvectorscale.knn_top10_1pct]
 param = "pgvectorscale_search_list_size_1pct"
-values = [
-  "500",
-  "750",
-  "1100",
-  "1600",
-  "2200",
-  "3000",
-  "4000",
-  "5500",
-  "7500",
-  "10000",
-]
+values = ["500", "750", "1100", "1600", "2200", "3000", "4000", "5500"]

--- a/benchmarks/datasets/cohere/indexes/pgvectorscale.sql
+++ b/benchmarks/datasets/cohere/indexes/pgvectorscale.sql
@@ -1,0 +1,15 @@
+-- pgvectorscale StreamingDiskANN index (`diskann`). Reuses pgvector's `vector` type, so the corpus
+-- schema is unchanged. The `vectorscale` extension is created by the benchmark workflow's
+-- post-restore step (this file holds only CREATE INDEX statements, like the hnsw/ivfflat/vchord
+-- files -- the harness runs each statement and reads its index metadata, so a CREATE EXTENSION here
+-- would break that). https://github.com/timescale/pgvectorscale
+--
+-- Built with the default SBQ compression: `num_bits_per_dimension` defaults to 1 above 900 dims, so
+-- cohere's 1024-dim vectors are 1-bit quantized. `storage_layout = plain` would lift filtered recall
+-- but builds far too slowly to run here, so the filtered arms are benchmarked at their achievable
+-- ceiling instead -- see the sweep comments in config.toml.
+CREATE INDEX cohere_wiki_emb_idx ON cohere_wiki USING diskann (emb vector_cosine_ops);
+
+-- Companion index for filtered-search benchmarks: GIN/tsvector drives the full-text predicate
+-- combined with kNN.
+CREATE INDEX cohere_wiki_text_fts_idx ON cohere_wiki USING gin (to_tsvector('english', text));

--- a/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_10pct.sql
+++ b/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_10pct.sql
@@ -1,0 +1,13 @@
+-- Variant 1: force the diskann index. Filtering is post-filter streaming (diskann has no prefilter
+-- GUC): the ANN scan streams candidates and the tsvector predicate filters them. rescore is pinned
+-- at its 1000 maximum, so the beam width is the only lever left -- that is what the sweep varies.
+SET enable_seqscan=off; SET enable_bitmapscan=off; SET enable_sort=off; SET diskann.query_rescore=1000; SET diskann.query_search_list_size={{ pgvectorscale_search_list_size_10pct }}; SELECT _id, title FROM cohere_wiki
+WHERE to_tsvector('english', text) @@ websearch_to_tsquery('english', current_setting('cohere.titles_10pct'))
+ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
+LIMIT 10;
+
+-- Variant 2: exact pre-filter
+SET enable_indexscan=off; SET enable_bitmapscan=on; SET enable_sort=on; SELECT _id, title FROM cohere_wiki
+WHERE to_tsvector('english', text) @@ websearch_to_tsquery('english', current_setting('cohere.titles_10pct'))
+ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
+LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_1pct.sql
+++ b/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_1pct.sql
@@ -1,0 +1,13 @@
+-- Variant 1: force the diskann index. Filtering is post-filter streaming (diskann has no prefilter
+-- GUC): the ANN scan streams candidates and the tsvector predicate filters them. rescore is pinned
+-- at its 1000 maximum, so the beam width is the only lever left -- that is what the sweep varies.
+SET enable_seqscan=off; SET enable_bitmapscan=off; SET enable_sort=off; SET diskann.query_rescore=1000; SET diskann.query_search_list_size={{ pgvectorscale_search_list_size_1pct }}; SELECT _id, title FROM cohere_wiki
+WHERE to_tsvector('english', text) @@ websearch_to_tsquery('english', current_setting('cohere.titles_1pct'))
+ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
+LIMIT 10;
+
+-- Variant 2: exact pre-filter
+SET enable_indexscan=off; SET enable_bitmapscan=on; SET enable_sort=on; SELECT _id, title FROM cohere_wiki
+WHERE to_tsvector('english', text) @@ websearch_to_tsquery('english', current_setting('cohere.titles_1pct'))
+ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
+LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_unfiltered.sql
@@ -1,5 +1,5 @@
 -- query_rescore is the recall lever here: the graph is 1-bit SBQ, so its own ordering is coarse and
 -- recall is set by how many candidates get exact-distance rescoring, not by beam width.
-SET diskann.query_search_list_size=100; SET diskann.query_rescore={{ pgvectorscale_rescore_unfiltered }}; SELECT _id, title FROM cohere_wiki
+SET enable_seqscan=off; SET enable_bitmapscan=off; SET enable_sort=off; SET diskann.query_search_list_size=100; SET diskann.query_rescore={{ pgvectorscale_rescore_unfiltered }}; SELECT _id, title FROM cohere_wiki
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/pgvectorscale/knn_top10_unfiltered.sql
@@ -1,0 +1,5 @@
+-- query_rescore is the recall lever here: the graph is 1-bit SBQ, so its own ordering is coarse and
+-- recall is set by how many candidates get exact-distance rescoring, not by beam width.
+SET diskann.query_search_list_size=100; SET diskann.query_rescore={{ pgvectorscale_rescore_unfiltered }}; SELECT _id, title FROM cohere_wiki
+ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
+LIMIT 10;


### PR DESCRIPTION
Reauthors #5588 against the sweep-based CI that replaced its fixed `[params]`. Adds pgvectorscale StreamingDiskANN as a fifth cohere arm, run via the `benchmark-cohere-pgvectorscale` label or the `pgvectorscale` dispatch choice.

Each arm sweeps whichever GUC actually binds it, and every ladder ends at that GUC's hard maximum — verified against the extension's GUC registration in 0.9.0 (`query_rescore` max 1000, `query_search_list_size` max 10000; #5588 stopped search_list_size at 4000):

| arm | swept GUC | ladder |
|---|---|---|
| unfiltered | `diskann.query_rescore` | 50 → 1000 |
| 10pct | `diskann.query_search_list_size` | 200 → 10000 |
| 1pct | `diskann.query_search_list_size` | 500 → 10000 |

**The filtered arms cannot reach 90% on the default SBQ build.** Filtering is post-filter streaming, so only the ~10%/1% of the beam passing the predicate survives, and at most 1000 candidates are ever exact-rescored — with rescore pinned at that maximum, beam width is the only lever left. Ending the ladders at the ceiling lets the sweep's existing unreachable-target fallback report the best achievable point (flagged ⚠️) rather than a fabricated one. Uncompressed `storage_layout = plain` would lift them but is far too slow to build in CI. This arm is deliberately **not** iso-recall with the others; that is the property being surfaced.

Supersedes #5588.