### PR TITLE
fix: Cap the number of tasks per table, and account for plan shape changes

### DIFF
--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -170,15 +170,11 @@ fn collect_stages(
                     consumer_task: route_consumer_tasks()?,
                 }
             } else {
-                // Top-level NetworkShuffleExec / NetworkBroadcastExec isn't a shape our customscan plans produce.
-                // They emit partitioned or broadcast output into a parent consumer stage, not directly
-                // into the leader.
-                crate::postgres::customscan::mpp::fail_loud(format!(
-                    "mpp worker_fragments: top-level {} is unsupported \
-                     (stage_id={stage_id}). They emit output into a \
-                     parent consumer stage; a top-level boundary of this type is a planner anomaly.",
-                    plan.name()
-                ))
+                // Top-level NetworkShuffleExec / NetworkBroadcastExec means the entire consumer
+                // pipeline collapsed to a single partition and remained on the leader instead of
+                // becoming a nested consumer stage. In this case, the single leader task is the
+                // only consumer, so it behaves identically to a Coalesce.
+                FragmentRouting::Coalesce { dest_proc: 0 }
             }
         } else {
             // `as_network_boundary()` matched, but the node isn't one of the three concrete

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -287,6 +287,9 @@ impl PgSearchScanPlan {
             .unwrap_or(0);
 
         if range_sample.is_none() {
+            // A partition count exceeding the segment count indicates a bug in
+            // PgSearchScanTaskEstimator::task_estimation, which should cap the tasks
+            // to the segment count when range sampling is disabled.
             assert!(
                 partition_count <= segment_count.max(1),
                 "partition_count {} exceeds segment_count {}",
@@ -1125,7 +1128,12 @@ impl TaskEstimator for PgSearchScanTaskEstimator {
 
         let partition_count = plan.properties().output_partitioning().partition_count();
 
-        Some(TaskEstimation::desired(partition_count))
+        // We use `maximum` rather than `desired` here because `partition_count` is already
+        // clamped to the number of physical index segments (when range sampling is disabled).
+        // Since a single segment cannot be concurrently scanned by multiple workers,
+        // allowing the stage to scale up beyond `partition_count` would just result in
+        // starved tasks doing useless setup work (like building empty hash tables) for zero rows.
+        Some(TaskEstimation::maximum(partition_count))
     }
 
     fn scale_up_leaf_node(

--- a/pg_search/tests/pg_regress/expected/issue_5747.out
+++ b/pg_search/tests/pg_regress/expected/issue_5747.out
@@ -31,8 +31,8 @@ WHERE le.id @@@ paradedb.term('user_id', 'u1')
   AND sv.id @@@ paradedb.term('state', 'merged')
 ORDER BY le.id
 LIMIT 5;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=10.00..11.00 rows=5 width=8)
    ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=5 width=8)
          Relation Tree: sv INNER le
@@ -43,26 +43,22 @@ LIMIT 5;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            : │   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=5
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+           : │     SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
+           : │       VisibilityFilterExec: tables=[sv, le]
+           : │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, series_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+           : │           CoalescePartitionsExec
+           : │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=2, input_tasks=2
+           : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           : │             DistributedLeafExec:
+           : │               t0: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"term":{"field":"user_id","value":"u1"}}}}
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=2, partitions=6
-           :   │ SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-           :   │   VisibilityFilterExec: tables=[sv, le]
-           :   │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, series_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
-           :   │       CoalescePartitionsExec
-           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-           :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
-           :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"term":{"field":"user_id","value":"u1"}}}}
-           :   │           t1: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"term":{"field":"user_id","value":"u1"}}}}
+           :   ┌───── Stage 1 ── tasks=2, partitions=4
+           :   │ BroadcastExec: input_partitions=2, consumer_tasks=1, output_partitions=2
+           :   │   DistributedLeafExec:
+           :   │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}
+           :   │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=2, partitions=8
-           :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
-           :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}
-           :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}
-           :     └──────────────────────────────────────────────────
-(29 rows)
+(25 rows)
 
 SELECT le.id
 FROM pc_small le
@@ -71,5 +67,5 @@ WHERE le.id @@@ paradedb.term('user_id', 'u1')
   AND sv.id @@@ paradedb.term('state', 'merged')
 ORDER BY le.id
 LIMIT 5;
-ERROR:  DataFusion execution failed: Execution error: transport receiver detached before this channel's EOF; the producer went away
+ERROR:  mpp worker_fragments: top-level NetworkBroadcastExec is unsupported (stage_id=1). They emit output into a parent consumer stage; a top-level boundary of this type is a planner anomaly.
 DROP TABLE pc_big, pc_small CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_5747.out
+++ b/pg_search/tests/pg_regress/expected/issue_5747.out
@@ -1,0 +1,75 @@
+-- Issue 5747: DataFusion partition mismatch error on joins with different segment counts
+--
+-- The trigger is a join between two BM25-indexed tables whose indexes have
+-- DIFFERENT physical segment counts. Equal segment counts do not reproduce it.
+-- It requires MPP to be enabled (max_parallel_workers_per_gather > 0).
+--
+-- To get the asymmetry deterministically without needing much data:
+--   * pc_big   uses mutable_segment_rows='0', so every INSERT lands in its own
+--              immutable segment -> two INSERT statements give 2 segments.
+--   * pc_small omits it, so its rows accumulate in one mutable segment -> 1.
+\pset pager off
+\set ON_ERROR_STOP off
+SET max_parallel_workers_per_gather = 4;
+DROP TABLE IF EXISTS pc_big, pc_small CASCADE;
+CREATE TABLE pc_big   (id bigint PRIMARY KEY, state text);
+CREATE TABLE pc_small (id bigint PRIMARY KEY, series_id bigint, user_id text);
+CREATE INDEX pc_big_idx ON pc_big USING bm25 (id, state)
+  WITH (key_field = 'id', target_segment_count = '3', mutable_segment_rows = '0');
+CREATE INDEX pc_small_idx ON pc_small USING bm25 (id, series_id, user_id)
+  WITH (key_field = 'id', target_segment_count = '3');
+-- Two separate statements, so pc_big ends up with two immutable segments.
+INSERT INTO pc_big SELECT g, 'active' FROM generate_series(1, 50) g;
+INSERT INTO pc_big SELECT g, 'merged' FROM generate_series(51, 80) g;
+-- One statement, so pc_small keeps a single segment.
+INSERT INTO pc_small SELECT g, g, 'u1' FROM generate_series(1, 80) g;
+EXPLAIN
+SELECT le.id
+FROM pc_small le
+JOIN pc_big sv ON sv.id = le.series_id
+WHERE le.id @@@ paradedb.term('user_id', 'u1')
+  AND sv.id @@@ paradedb.term('state', 'merged')
+ORDER BY le.id
+LIMIT 5;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=10.00..11.00 rows=5 width=8)
+   ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=5 width=8)
+         Relation Tree: sv INNER le
+         Join Cond: le.series_id = sv.id
+         Limit: 5
+         Order By: le.id asc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           : │   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=5
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── tasks=2, partitions=6
+           :   │ SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
+           :   │   VisibilityFilterExec: tables=[sv, le]
+           :   │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, series_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+           :   │       CoalescePartitionsExec
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+           :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :   │         DistributedLeafExec:
+           :   │           t0: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"term":{"field":"user_id","value":"u1"}}}}
+           :   │           t1: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"term":{"field":"user_id","value":"u1"}}}}
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── tasks=2, partitions=8
+           :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}
+           :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}
+           :     └──────────────────────────────────────────────────
+(29 rows)
+
+SELECT le.id
+FROM pc_small le
+JOIN pc_big sv ON sv.id = le.series_id
+WHERE le.id @@@ paradedb.term('user_id', 'u1')
+  AND sv.id @@@ paradedb.term('state', 'merged')
+ORDER BY le.id
+LIMIT 5;
+ERROR:  DataFusion execution failed: Execution error: transport receiver detached before this channel's EOF; the producer went away
+DROP TABLE pc_big, pc_small CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_5747.out
+++ b/pg_search/tests/pg_regress/expected/issue_5747.out
@@ -67,5 +67,13 @@ WHERE le.id @@@ paradedb.term('user_id', 'u1')
   AND sv.id @@@ paradedb.term('state', 'merged')
 ORDER BY le.id
 LIMIT 5;
-ERROR:  mpp worker_fragments: top-level NetworkBroadcastExec is unsupported (stage_id=1). They emit output into a parent consumer stage; a top-level boundary of this type is a planner anomaly.
+ id 
+----
+ 51
+ 52
+ 53
+ 54
+ 55
+(5 rows)
+
 DROP TABLE pc_big, pc_small CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_5747.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5747.sql
@@ -1,0 +1,42 @@
+-- Issue 5747: DataFusion partition mismatch error on joins with different segment counts
+--
+-- The trigger is a join between two BM25-indexed tables whose indexes have
+-- DIFFERENT physical segment counts. Equal segment counts do not reproduce it.
+-- It requires MPP to be enabled (max_parallel_workers_per_gather > 0).
+--
+-- To get the asymmetry deterministically without needing much data:
+--   * pc_big   uses mutable_segment_rows='0', so every INSERT lands in its own
+--              immutable segment -> two INSERT statements give 2 segments.
+--   * pc_small omits it, so its rows accumulate in one mutable segment -> 1.
+\pset pager off
+\set ON_ERROR_STOP off
+SET max_parallel_workers_per_gather = 4;
+DROP TABLE IF EXISTS pc_big, pc_small CASCADE;
+CREATE TABLE pc_big   (id bigint PRIMARY KEY, state text);
+CREATE TABLE pc_small (id bigint PRIMARY KEY, series_id bigint, user_id text);
+CREATE INDEX pc_big_idx ON pc_big USING bm25 (id, state)
+  WITH (key_field = 'id', target_segment_count = '3', mutable_segment_rows = '0');
+CREATE INDEX pc_small_idx ON pc_small USING bm25 (id, series_id, user_id)
+  WITH (key_field = 'id', target_segment_count = '3');
+-- Two separate statements, so pc_big ends up with two immutable segments.
+INSERT INTO pc_big SELECT g, 'active' FROM generate_series(1, 50) g;
+INSERT INTO pc_big SELECT g, 'merged' FROM generate_series(51, 80) g;
+-- One statement, so pc_small keeps a single segment.
+INSERT INTO pc_small SELECT g, g, 'u1' FROM generate_series(1, 80) g;
+EXPLAIN
+SELECT le.id
+FROM pc_small le
+JOIN pc_big sv ON sv.id = le.series_id
+WHERE le.id @@@ paradedb.term('user_id', 'u1')
+  AND sv.id @@@ paradedb.term('state', 'merged')
+ORDER BY le.id
+LIMIT 5;
+
+SELECT le.id
+FROM pc_small le
+JOIN pc_big sv ON sv.id = le.series_id
+WHERE le.id @@@ paradedb.term('user_id', 'u1')
+  AND sv.id @@@ paradedb.term('state', 'merged')
+ORDER BY le.id
+LIMIT 5;
+DROP TABLE pc_big, pc_small CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5747

## What

* Adjust our `TaskEstimator` to use a hard cap on tasks for a `PgSearchScanPlan`.
* Allow plans which have collapsed into broadcast hash joins running on the leader.

## Why

Our `TaskEstimator` was declaring a `desired` task count, rather than a `max` task count, which meant that we would sometimes get more than we requested, which tripped an assertion in the `ExecutionPlan`. AFAICT, we don't ever want to run with more tasks than is necessary for a particular table (or at least, we haven't seen an example yet: #5756 or #5734 may affect this).

After fixing that, this particular repro resulted in a plan shape that we had never seen before, where the leader actually executes the collect side of a broadcast hash join. We adjust our constraints to allow that plan to be created.

## Tests

See the new regress test.