### PR TITLE
test: use DST wording in comments

### DIFF
--- a/.github/workflows/test-dst-crate.yml
+++ b/.github/workflows/test-dst-crate.yml
@@ -52,7 +52,7 @@ jobs:
           RUST_BACKTRACE=1 cargo test --package dst
 
       # With `enabled` on everything forwards to the SDK. This is the configuration stressgres
-      # links unconditionally and the one an Antithesis build of pg_search uses.
+      # links unconditionally and the one a DST build of pg_search uses.
       - name: Lint & Test DST (SDK enabled)
         env:
           RUSTDOCFLAGS: "-D warnings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ inherits = "release"
 debug = true
 debug-assertions = false
 
-# Antithesis build profile — `dev`-like (debug assertions on) but isolated so it can be tuned
+# DST build profile — `dev`-like (debug assertions on) but isolated so it can be tuned
 # without affecting `dev`.
 [profile.dst]
 inherits = "dev"

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -490,7 +490,7 @@ impl Directory for MVCCDirectory {
             ) {
                 Err(e) => Err(e),
                 Ok(mut loaded) => {
-                    // [antithesis correctness] the visible segment set contains no duplicate
+                    // [dst correctness] the visible segment set contains no duplicate
                     // SegmentId. A duplicate would make a segment double-counted/double-read for
                     // this snapshot (wrong result counts) and corrupt the parallel-worker claim
                     // accounting.

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -605,7 +605,7 @@ impl Mergeable for SearchIndexMerger {
                     }
                 }
                 let output_live = new_segment.max_doc() as u64;
-                // [antithesis correctness] merge conserves live docs: output live == sum of input live docs
+                // [dst correctness] merge conserves live docs: output live == sum of input live docs
                 dst::assert_always!(
                     !all_found || output_live == sum_input_live,
                     "pg_search: merge live-doc conservation (output == sum of inputs)",

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -375,7 +375,7 @@ impl SegmentDeleter {
                 let segment = index.segment(inner.segment_entry.meta().clone());
                 advance_deletes(segment, &mut inner.segment_entry, inner.opstamp + 1)?;
                 let new_meta = inner.segment_entry.meta().clone();
-                // [antithesis correctness] VACUUM delete is monotonic and same-segment: applying this
+                // [dst correctness] VACUUM delete is monotonic and same-segment: applying this
                 // VACUUM's tombstones to an immutable segment must (a) keep the same segment id and
                 // physical max_doc (advance_deletes never rewrites the segment's docs, only its .del
                 // file), and (b) never resurrect a deleted doc -- num_deleted only grows and live docs

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -553,7 +553,7 @@ impl SegmentMetaEntry {
     pub fn num_docs(&self) -> usize {
         let max_doc = self.max_doc() as usize;
         let num_deleted = self.num_deleted_docs();
-        // [antithesis correctness] a segment can never have more deleted docs than it has docs; a
+        // [dst correctness] a segment can never have more deleted docs than it has docs; a
         // violation means count corruption (this subtraction would underflow, yielding a bogus
         // live-doc count and wrong query results / OOM allocations downstream)
         dst::observe!(|| {
@@ -903,7 +903,7 @@ impl MVCCEntry for SegmentMetaEntry {
         // and there's no pin on our pintest buffer, assuming we have a valid buffer
         && (self.pintest_blockno() == pg_sys::InvalidBlockNumber || bman.get_buffer_for_cleanup_conditional(self.pintest_blockno()).is_some());
 
-        // [antithesis correctness] a recyclable segment must never be visible: recycling implies
+        // [dst correctness] a recyclable segment must never be visible: recycling implies
         // deleted (xmax == FrozenTransactionId), and visibility is exactly !deleted. Reclaiming the
         // blocks of a still-visible segment would be a use-after-free / MVCC violation (a live
         // snapshot could read freed/overwritten pages, returning wrong or corrupt results).

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -788,7 +788,7 @@ pub mod v2 {
                     break;
                 };
 
-                // [antithesis correctness] a drained freelist's recyclable xid must never exceed the draining transaction's xid: reusing a block whose when_recyclable is in the future relative to the current transaction could hand out a block a live snapshot still needs (MVCC/visibility corruption). get_lte(&xid) guarantees found_xid <= xid, and xid only ever decreases from current_xid, so found_xid <= current_xid must always hold.
+                // [dst correctness] a drained freelist's recyclable xid must never exceed the draining transaction's xid: reusing a block whose when_recyclable is in the future relative to the current transaction could hand out a block a live snapshot still needs (MVCC/visibility corruption). get_lte(&xid) guarantees found_xid <= xid, and xid only ever decreases from current_xid, so found_xid <= current_xid must always hold.
                 dst::observe!(|| {
                     dst::assert_always!(
                         found_xid <= current_xid,
@@ -881,7 +881,7 @@ pub mod v2 {
                         while contents.len > 0 && blocks.len() < many {
                             contents.len -= 1;
                             let drained = contents.entries[contents.len as usize];
-                            // [antithesis correctness] every freelist entry within [0, len) was written by extend from a real allocated block chain, so a drained block handed back for reuse must be a valid block number. An InvalidBlockNumber here means metadata corruption (e.g. an inflated len reading uninitialized trailing slots) and would cause the caller to initialize/reuse a bogus block -> corruption.
+                            // [dst correctness] every freelist entry within [0, len) was written by extend from a real allocated block chain, so a drained block handed back for reuse must be a valid block number. An InvalidBlockNumber here means metadata corruption (e.g. an inflated len reading uninitialized trailing slots) and would cause the caller to initialize/reuse a bogus block -> corruption.
                             dst::observe!(|| {
                                 dst::assert_always!(
                                     drained != pg_sys::InvalidBlockNumber,

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -669,7 +669,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone> AtomicGuard<'_, T> {
                 .page()
                 .contents::<LinkedListData>();
 
-            // [antithesis correctness] the header published atomically to all readers must point at a
+            // [dst correctness] the header published atomically to all readers must point at a
             // valid start block: `atomically()` always builds at least one cloned block and links it
             // as the cloned header's start_blockno, so committing a header with an InvalidBlockNumber
             // start would make the list unreadable/empty for every reader (data loss / wrong results).

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -41,8 +41,8 @@ pub struct ReconnectGraceArgs {
     ///
     /// This is how an external supervisor narrows the window at runtime: it heals every fault
     /// and then writes a shorter window here, so the run fails only if the database was provably
-    /// reachable and the workload still could not make progress. The Antithesis suites drive
-    /// this from their recovery-liveness command; see `stressgres/suites/antithesis/`.
+    /// reachable and the workload still could not make progress. The DST suites drive
+    /// this from their recovery-liveness command.
     #[arg(long)]
     pub reconnect_grace_file: Option<PathBuf>,
 }

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -31,7 +31,7 @@
 //! us, so any window shorter than the run is one it can outlast. Liveness is instead
 //! asserted from the outside: the suites' recovery-liveness command heals every
 //! fault, then narrows the [`GraceWindow`] via its poke file to a window that *can*
-//! expire. See `stressgres/suites/antithesis/`.
+//! expire.
 //!
 //! When a non-zero grace is enabled, bug detection is expected to come from the DST harness's
 //! properties / postgres-side checks, not from stressgres exit codes.


### PR DESCRIPTION
## Summary

Use DST terminology in non-harness comments that previously mentioned Antithesis directly.

## Details

- Rename the root `dst` profile comment to describe it as a DST build profile.
- Update pg_search correctness annotations from `[antithesis correctness]` to `[dst correctness]`.
- Make Stressgres recovery-liveness source comments provider-neutral.
- Leave the actual Antithesis dependency and provider-specific harness/workflow files untouched.

## Validation

- Pre-commit hooks passed during commit, including `clippy` and `cargo check`.