### PR TITLE
ci: Use reusable Slack alert action for pg_search alerts

### DIFF
--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -488,5 +488,5 @@ jobs:
         if: failure() && github.event_name == 'push'
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`benchmark-pg_search-queries\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`benchmark-pg_search-queries\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -486,7 +486,8 @@ jobs:
 
       - name: Notify Slack on Failure (push only)
         if: failure() && github.event_name == 'push'
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`benchmark-pg_search-queries\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -335,7 +335,8 @@ jobs:
 
       - name: Notify Slack on Failure (push only)
         if: failure() && github.event_name == 'push'
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`benchmark-pg_search-stressgres\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -337,5 +337,5 @@ jobs:
         if: failure() && github.event_name == 'push'
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`benchmark-pg_search-stressgres\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`benchmark-pg_search-stressgres\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -198,5 +198,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-github-release\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-github-release\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -196,7 +196,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-github-release\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -574,5 +574,5 @@ jobs:
       - name: Notify Slack on Failure
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-paradedb-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-paradedb-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -572,7 +572,8 @@ jobs:
     if: ${{ always() && (needs.set-matrix.result == 'failure' || needs.generate-dockerfiles.result == 'failure' || needs.test-generated-dockerfiles.result == 'failure' || needs.publish-paradedb-docker-image.result == 'failure' || needs.publish-extension-image.result == 'failure' || needs.open-dockerfile-prs.result == 'failure' || needs.notify-orm-repos.result == 'failure') }}
     steps:
       - name: Notify Slack on Failure
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-paradedb-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-paradedb-docs.yml
+++ b/.github/workflows/publish-paradedb-docs.yml
@@ -49,5 +49,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-paradedb-docs\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-paradedb-docs\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-paradedb-docs.yml
+++ b/.github/workflows/publish-paradedb-docs.yml
@@ -47,7 +47,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-paradedb-docs\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -399,7 +399,7 @@ jobs:
         if: ${{ failure() && steps.guard.outputs.build == 'true' }}
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-pg_search-debian\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-debian\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
 
   # Once the Debian packages are published, kick off the ParadeDB Docker publish. The Docker

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -397,10 +397,11 @@ jobs:
 
       - name: Notify Slack on Failure
         if: ${{ failure() && steps.guard.outputs.build == 'true' }}
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-debian\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"
 
   # Once the Debian packages are published, kick off the ParadeDB Docker publish. The Docker
   # image publishing runs after Debian since it installs the Debian packages to avoid needing to build

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -311,5 +311,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-pg_search-macos\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-macos\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -309,7 +309,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-macos\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-pgxn\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -40,5 +40,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-pg_search-pgxn\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-pgxn\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -413,5 +413,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-pg_search-postgresapp\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-postgresapp\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -411,7 +411,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-postgresapp\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -412,5 +412,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-pg_search-rhel\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-rhel\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -410,7 +410,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-rhel\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -111,7 +111,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-schema\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -113,5 +113,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-pg_search-schema\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-schema\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -390,5 +390,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-pg_search-ubuntu\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-ubuntu\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -388,7 +388,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-pg_search-ubuntu\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -108,7 +108,8 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-stressgres-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "${{ github.workflow }} Failed"

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -110,5 +110,5 @@ jobs:
         if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`publish-stressgres-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!subteam^S0BLE20RYPM|@pg_search-maintainers> \`publish-stressgres-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -440,47 +440,10 @@ jobs:
           || needs.build-antithesis-pg_search-deb.result == 'failure'
           || needs.antithesis-trigger-test-run.result == 'failure')
     runs-on: ubuntu-latest
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
     steps:
-      - name: Determine failed jobs
-        id: failed-jobs
-        run: |
-          FAILED_JOBS=""
-          if [ "${{ needs.setup.result }}" == "failure" ]; then
-            FAILED_JOBS="Resolve Workloads, $FAILED_JOBS"
-          fi
-          if [ "${{ needs.build-antithesis-pg_search-deb.result }}" == "failure" ]; then
-            FAILED_JOBS="Build Antithesis pg_search .deb, $FAILED_JOBS"
-          fi
-          if [ "${{ needs.antithesis-trigger-test-run.result }}" == "failure" ]; then
-            FAILED_JOBS="Test pg_search via Antithesis, $FAILED_JOBS"
-          fi
-          FAILED_JOBS="${FAILED_JOBS%, }"
-          echo "failed_jobs=$FAILED_JOBS" >> "$GITHUB_OUTPUT"
-
-      - name: Send Slack notification
-        run: |
-          if [ -n "$SLACK_WEBHOOK_URL" ]; then
-            JSON_DATA="{
-              \"text\": \"🚨 Nightly Antithesis Run Failed - <!subteam^S0BLE20RYPM|@pg_search-maintainers>\",
-              \"attachments\": [
-                {
-                  \"color\": \"danger\",
-                  \"fields\": [
-                    {\"title\": \"Repository\", \"value\": \"${{ github.repository }}\", \"short\": true},
-                    {\"title\": \"Workflow\", \"value\": \"${{ github.workflow }}\", \"short\": true},
-                    {\"title\": \"Run ID\", \"value\": \"${{ github.run_id }}\", \"short\": true},
-                    {\"title\": \"View Logs\", \"value\": \"<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here>\", \"short\": true},
-                    {\"title\": \"Failed Jobs\", \"value\": \"${{ steps.failed-jobs.outputs.failed_jobs }}\", \"short\": false}
-                  ]
-                }
-              ]
-            }"
-
-            curl -X POST -H 'Content-type: application/json' \
-              --data "$JSON_DATA" \
-              "$SLACK_WEBHOOK_URL"
-          else
-            echo "Slack webhook not configured, skipping notification"
-          fi
+      - name: Notify Slack on Failure
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          mention: "<!subteam^S0BLE20RYPM|@pg_search-maintainers>"
+          title: "Nightly Antithesis Run Failed"

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -463,7 +463,7 @@ jobs:
         run: |
           if [ -n "$SLACK_WEBHOOK_URL" ]; then
             JSON_DATA="{
-              \"text\": \"🚨 Nightly Antithesis Run Failed - <!here>\",
+              \"text\": \"🚨 Nightly Antithesis Run Failed - <!subteam^S0BLE20RYPM|@pg_search-maintainers>\",
               \"attachments\": [
                 {
                   \"color\": \"danger\",


### PR DESCRIPTION
## Summary
- Replace duplicated Slack webhook shell snippets with `paradedb/actions/slack-alert@v10`.
- Keep alerts targeted at `<!subteam^S0BLE20RYPM|@pg_search-maintainers>`.
- Use the compact attachment-style Slack rendering from the shared action for publish, benchmark, Docker, docs, release, schema, PGXN, and nightly Antithesis alerts.

## Validation
- `git diff --check`
- `npx --yes prettier --check .github/workflows/benchmark-pg_search-queries.yml .github/workflows/benchmark-pg_search-stressgres.yml .github/workflows/publish-github-release.yml .github/workflows/publish-paradedb-docker.yml .github/workflows/publish-paradedb-docs.yml .github/workflows/publish-pg_search-debian.yml .github/workflows/publish-pg_search-macos.yml .github/workflows/publish-pg_search-pgxn.yml .github/workflows/publish-pg_search-postgresapp.yml .github/workflows/publish-pg_search-rhel.yml .github/workflows/publish-pg_search-schema.yml .github/workflows/publish-pg_search-ubuntu.yml .github/workflows/publish-stressgres-docker.yml .github/workflows/test-pg_search-antithesis.yml`
- Ruby YAML parse for all touched workflows
- `rg -n 'curl -X POST|MESSAGE=|GITHUB_RUN_URL=|SLACK_WEBHOOK_URL|<!here>|@here' ...` returned no matches across touched workflows
- Commit hooks passed, including Prettier and YAML checks

Note: `actionlint` still reports existing baseline workflow findings unrelated to this change, mainly custom runner labels, older `actions/create-github-app-token` input metadata, and existing ShellCheck warnings.