### PR TITLE
build: removed the checked-in LINDERA_CACHE override.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,3 @@
 # on macOS, PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
-
-[env]
-# The lindera dictionary build scripts skip the download and rebuild entirely
-# when the built dictionary already exists in this directory, instead of
-# rebuilding into every target dir. Export LINDERA_CACHE to an absolute path
-# in your shell to share one cache across worktrees.
-LINDERA_CACHE = { value = ".lindera-cache", relative = true }

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -207,7 +207,6 @@ jobs:
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          cache-directories: .lindera-cache
           cache-on-failure: true
 
       - name: Extract pgrx Version

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -65,7 +65,6 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -67,7 +67,6 @@ jobs:
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          cache-directories: .lindera-cache
 
       - name: Install & Configure PostgreSQL ${{ env.pg_version }}
         run: |

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -62,7 +62,6 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -72,7 +72,6 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -108,7 +108,6 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          cache-directories: .lindera-cache
           # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
           save-if: false
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -109,7 +109,6 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          cache-directories: .lindera-cache
           save-if: ${{ github.event_name == 'schedule' && github.ref_name == github.event.repository.default_branch }}
 
       - name: Install required system tools

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 
 # Cargo
 target/
-.lindera-cache/
 
 # SSH
 *.pem


### PR DESCRIPTION
# Ticket(s) Closed

- N/A (fixes the `main` benchmark failure after #5739)

## What

This PR removes the `LINDERA_CACHE` entry that #5739 added to `.cargo/config.toml`, plus the matching `cache-directories` lines in the workflows. The `default-members` and profile changes stay.

## Why

The Queries benchmark run on `main` failed compiling `lindera-ipadic`: its `include_bytes!` pointed into `.lindera-cache/`, which did not exist on the runner.

The mechanism: a restored cargo cache can hold fingerprints saying the lindera build scripts are fresh, recorded with `LINDERA_WORKDIR` pointing into `.lindera-cache/`. If that directory is not part of the same cache, the build script does not rerun, the library still recompiles, and the `include_bytes!` path is gone. Any cache setup that persists `target/` without `.lindera-cache/` can hit this, and a failed run restores the same stale fingerprints on retry, so it cannot heal on its own.

## How

Dictionary builds go back into `OUT_DIR`, which lives and dies with `target/` in every cache. Removing the env entry busts the stale fingerprints through `rerun-if-env-changed=LINDERA_CACHE`, so every existing cache self-heals on its next run: the build scripts rerun once and rebuild into `OUT_DIR`.

The local speedup is still available per developer with `export LINDERA_CACHE=~/.cache/lindera` (an absolute path) in your shell, or in `~/.cargo/config.toml` under `[env]`. A real environment variable is also how the Nix build provides its dictionaries.

## Tests

`cargo build -p pg_search` against a target dir previously built with the env set: the build scripts reran and the build passed, which is the same self-heal path CI takes. The real confirmation is this merge's own benchmark run on `main`.
