### PR TITLE
POC: hybrid search via built-in Reciprocal Rank Fusion (pdb.rrf + ~~~ operator)

### DIFF
--- a/pg_search/pg_search.control
+++ b/pg_search/pg_search.control
@@ -1,5 +1,5 @@
 comment = 'pg_search: Full text search for PostgreSQL using BM25'
-default_version = '0.25.0.4'
+default_version = '0.25.0.5'
 module_pathname = '$libdir/pg_search'
 relocatable = false
 superuser = false

--- a/pg_search/pg_search.control
+++ b/pg_search/pg_search.control
@@ -1,5 +1,5 @@
 comment = 'pg_search: Full text search for PostgreSQL using BM25'
-default_version = '0.25.0.3'
+default_version = '0.25.0.4'
 module_pathname = '$libdir/pg_search'
 relocatable = false
 superuser = false

--- a/pg_search/pg_search.control
+++ b/pg_search/pg_search.control
@@ -1,5 +1,5 @@
 comment = 'pg_search: Full text search for PostgreSQL using BM25'
-default_version = '0.25.0.2'
+default_version = '0.25.0.3'
 module_pathname = '$libdir/pg_search'
 relocatable = false
 superuser = false

--- a/pg_search/pg_search.control
+++ b/pg_search/pg_search.control
@@ -1,5 +1,5 @@
 comment = 'pg_search: Full text search for PostgreSQL using BM25'
-default_version = '@CARGO_VERSION@'
+default_version = '0.25.0.2'
 module_pathname = '$libdir/pg_search'
 relocatable = false
 superuser = false

--- a/pg_search/sql/pg_search--0.25.0--0.25.0.1.sql
+++ b/pg_search/sql/pg_search--0.25.0--0.25.0.1.sql
@@ -1,0 +1,75 @@
+-- pg_search 0.25.0 -> 0.25.0.1 (dev): hybrid search via built-in
+-- Reciprocal Rank Fusion.
+--
+--   * pdb.score(relation, "type") — typed score projection
+--     ('bm25' | 'vector' | 'hybrid' | 'rank')
+--   * pdb.rrf(bm25_score, vector_distance, k, window_size) — rank-fusion
+--     ORDER BY expression
+--   * ~~~ (vector, vector) — knn candidacy predicate for union-style hybrid
+--
+-- The DROPs are defensive: dev databases may have created these functions
+-- manually before this upgrade path existed.
+
+DROP FUNCTION IF EXISTS pdb.score(anyelement, text);
+CREATE FUNCTION pdb."score"(
+    "relation_reference" anyelement,
+    "type" text
+) RETURNS real
+STRICT STABLE PARALLEL SAFE COST 1
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'score_from_relation_typed_wrapper';
+ALTER FUNCTION pdb.score(anyelement, text) SUPPORT paradedb.placeholder_support;
+
+DROP FUNCTION IF EXISTS pdb.rrf(real, double precision, integer);
+DROP FUNCTION IF EXISTS pdb.rrf(double precision, double precision, integer);
+DROP FUNCTION IF EXISTS pdb.rrf(double precision, double precision, integer, integer);
+-- deliberately NOT STRICT so NULL legs still reach the placeholder body and
+-- error loudly when the query is not executed by a rank-fusion scan.
+CREATE FUNCTION pdb."rrf"(
+    "bm25_score" double precision,
+    "vector_distance" double precision,
+    "k" integer DEFAULT 60,
+    "window_size" integer DEFAULT 0
+) RETURNS double precision
+STABLE PARALLEL SAFE COST 1
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'rrf_placeholder_wrapper';
+
+-- the fully-implied relation form: both legs come from the WHERE clause
+-- (text query + ~~~ knn predicate) of the relation the reference points at
+DROP FUNCTION IF EXISTS pdb.rrf(anyelement, integer, integer);
+CREATE FUNCTION pdb."rrf"(
+    "relation_reference" anyelement,
+    "k" integer DEFAULT 60,
+    "window_size" integer DEFAULT 0
+) RETURNS double precision
+STRICT STABLE PARALLEL SAFE COST 1
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'rrf_from_relation_wrapper';
+
+DROP OPERATOR IF EXISTS pg_catalog.~~~ (anyelement, anyelement);
+DROP FUNCTION IF EXISTS paradedb.search_with_knn(anyelement, anyelement);
+DROP FUNCTION IF EXISTS paradedb.search_with_knn_support(internal);
+
+CREATE FUNCTION paradedb."search_with_knn"(
+    "_field" anyelement,
+    "_vector" anyelement
+) RETURNS bool
+IMMUTABLE STRICT PARALLEL SAFE COST 1000000000
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'search_with_knn_wrapper';
+
+CREATE OPERATOR pg_catalog.~~~ (
+    PROCEDURE = paradedb."search_with_knn",
+    LEFTARG = anyelement,
+    RIGHTARG = anyelement
+);
+
+CREATE FUNCTION paradedb."search_with_knn_support"(
+    "arg" internal
+) RETURNS internal
+IMMUTABLE PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'search_with_knn_support_wrapper';
+
+ALTER FUNCTION paradedb.search_with_knn SUPPORT paradedb.search_with_knn_support;

--- a/pg_search/sql/pg_search--0.25.0.1--0.25.0.2.sql
+++ b/pg_search/sql/pg_search--0.25.0.1--0.25.0.2.sql
@@ -1,0 +1,30 @@
+-- pg_search 0.25.0.1 -> 0.25.0.2 (dev): pdb.rrf ergonomics.
+--
+--   * new fully-implied relation form `pdb.rrf(relation, k, window_size)`:
+--     the BM25 leg is the relation's WHERE text query and the vector leg its
+--     `~~~` knn predicate, so `ORDER BY pdb.rrf(id)` says everything once
+--   * the explicit-legs form loses its DEFAULT NULL distance (it would make
+--     one-argument calls ambiguous against the relation form)
+
+DROP FUNCTION IF EXISTS pdb.rrf(double precision, double precision, integer, integer);
+-- deliberately NOT STRICT so NULL legs still reach the placeholder body and
+-- error loudly when the query is not executed by a rank-fusion scan.
+CREATE FUNCTION pdb."rrf"(
+    "bm25_score" double precision,
+    "vector_distance" double precision,
+    "k" integer DEFAULT 60,
+    "window_size" integer DEFAULT 0
+) RETURNS double precision
+STABLE PARALLEL SAFE COST 1
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'rrf_placeholder_wrapper';
+
+DROP FUNCTION IF EXISTS pdb.rrf(anyelement, integer, integer);
+CREATE FUNCTION pdb."rrf"(
+    "relation_reference" anyelement,
+    "k" integer DEFAULT 60,
+    "window_size" integer DEFAULT 0
+) RETURNS double precision
+STRICT STABLE PARALLEL SAFE COST 1
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'rrf_from_relation_wrapper';

--- a/pg_search/sql/pg_search--0.25.0.2--0.25.0.3.sql
+++ b/pg_search/sql/pg_search--0.25.0.2--0.25.0.3.sql
@@ -1,0 +1,29 @@
+-- pg_search 0.25.0.2 -> 0.25.0.3 (dev): per-arm rrf candidate windows.
+--
+-- Both pdb.rrf overloads gain bm25_window_size / vector_window_size named
+-- arguments (0 = inherit window_size = auto).
+
+DROP FUNCTION IF EXISTS pdb.rrf(double precision, double precision, integer, integer);
+CREATE FUNCTION pdb."rrf"(
+    "bm25_score" double precision,
+    "vector_distance" double precision,
+    "k" integer DEFAULT 60,
+    "window_size" integer DEFAULT 0,
+    "bm25_window_size" integer DEFAULT 0,
+    "vector_window_size" integer DEFAULT 0
+) RETURNS double precision
+STABLE PARALLEL SAFE COST 1
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'rrf_placeholder_wrapper';
+
+DROP FUNCTION IF EXISTS pdb.rrf(anyelement, integer, integer);
+CREATE FUNCTION pdb."rrf"(
+    "relation_reference" anyelement,
+    "k" integer DEFAULT 60,
+    "window_size" integer DEFAULT 0,
+    "bm25_window_size" integer DEFAULT 0,
+    "vector_window_size" integer DEFAULT 0
+) RETURNS double precision
+STRICT STABLE PARALLEL SAFE COST 1
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'rrf_from_relation_wrapper';

--- a/pg_search/sql/pg_search--0.25.0.3--0.25.0.4.sql
+++ b/pg_search/sql/pg_search--0.25.0.3--0.25.0.4.sql
@@ -1,38 +1,9 @@
--- pg_search 0.25.0.3 -> 0.25.0.4 (dev): ::pdb.top(n) fusion-arm annotations.
+-- pg_search 0.25.0.3 -> 0.25.0.4 (dev): intentionally empty.
 --
--- Casting a boolean search-predicate subtree to pdb.top(n) marks it as a
--- rank-fusion arm bounded to its top n candidates:
---
---   WHERE (description ||| 'shoes' OR category === 'footwear')::pdb.top(100)
---      OR (embedding ~~~ '[...]')::pdb.top(200)
---   ORDER BY pdb.rrf(id) LIMIT 10;
-
-CREATE TYPE pdb.top;
-
-CREATE FUNCTION top_in(cstring, oid, integer) RETURNS pdb.top
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_in_wrapper';
-CREATE FUNCTION top_out(pdb.top) RETURNS cstring
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_out_wrapper';
-CREATE FUNCTION top_typmod_in(cstring[]) RETURNS integer
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_typmod_in_wrapper';
-CREATE FUNCTION top_typmod_out(integer) RETURNS cstring
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_typmod_out_wrapper';
-
-CREATE TYPE pdb.top (
-    INPUT = top_in,
-    OUTPUT = top_out,
-    LIKE = bool,
-    TYPMOD_IN = top_typmod_in,
-    TYPMOD_OUT = top_typmod_out
-);
-
-CREATE FUNCTION bool_to_top(boolean, integer, boolean) RETURNS pdb.top
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'bool_to_top_wrapper';
-CREATE FUNCTION top_to_top(pdb.top, integer, boolean) RETURNS pdb.top
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_to_top_wrapper';
-CREATE FUNCTION top_to_bool(pdb.top) RETURNS boolean
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_to_bool_wrapper';
-
-CREATE CAST (boolean AS pdb.top) WITH FUNCTION bool_to_top(boolean, integer, boolean) AS ASSIGNMENT;
-CREATE CAST (pdb.top AS pdb.top) WITH FUNCTION top_to_top(pdb.top, integer, boolean) AS IMPLICIT;
-CREATE CAST (pdb.top AS boolean) WITH FUNCTION top_to_bool(pdb.top) AS IMPLICIT;
+-- This step originally created the measure-less pdb.top(n) fusion-arm
+-- annotation type, whose C symbols no longer exist: 0.25.0.5 replaced it
+-- with the measure-named pdb.top_bm25(n)/pdb.top_knn(n). Databases that
+-- were at 0.25.0.4 when those symbols existed are handled by the 0.25.0.4
+-- -> 0.25.0.5 script (its DROP ... IF EXISTS tolerates both states), so
+-- upgrade chains passing through here create nothing.
+SELECT 1;

--- a/pg_search/sql/pg_search--0.25.0.3--0.25.0.4.sql
+++ b/pg_search/sql/pg_search--0.25.0.3--0.25.0.4.sql
@@ -1,0 +1,38 @@
+-- pg_search 0.25.0.3 -> 0.25.0.4 (dev): ::pdb.top(n) fusion-arm annotations.
+--
+-- Casting a boolean search-predicate subtree to pdb.top(n) marks it as a
+-- rank-fusion arm bounded to its top n candidates:
+--
+--   WHERE (description ||| 'shoes' OR category === 'footwear')::pdb.top(100)
+--      OR (embedding ~~~ '[...]')::pdb.top(200)
+--   ORDER BY pdb.rrf(id) LIMIT 10;
+
+CREATE TYPE pdb.top;
+
+CREATE FUNCTION top_in(cstring, oid, integer) RETURNS pdb.top
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_in_wrapper';
+CREATE FUNCTION top_out(pdb.top) RETURNS cstring
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_out_wrapper';
+CREATE FUNCTION top_typmod_in(cstring[]) RETURNS integer
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_typmod_in_wrapper';
+CREATE FUNCTION top_typmod_out(integer) RETURNS cstring
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_typmod_out_wrapper';
+
+CREATE TYPE pdb.top (
+    INPUT = top_in,
+    OUTPUT = top_out,
+    LIKE = bool,
+    TYPMOD_IN = top_typmod_in,
+    TYPMOD_OUT = top_typmod_out
+);
+
+CREATE FUNCTION bool_to_top(boolean, integer, boolean) RETURNS pdb.top
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'bool_to_top_wrapper';
+CREATE FUNCTION top_to_top(pdb.top, integer, boolean) RETURNS pdb.top
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_to_top_wrapper';
+CREATE FUNCTION top_to_bool(pdb.top) RETURNS boolean
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_to_bool_wrapper';
+
+CREATE CAST (boolean AS pdb.top) WITH FUNCTION bool_to_top(boolean, integer, boolean) AS ASSIGNMENT;
+CREATE CAST (pdb.top AS pdb.top) WITH FUNCTION top_to_top(pdb.top, integer, boolean) AS IMPLICIT;
+CREATE CAST (pdb.top AS boolean) WITH FUNCTION top_to_bool(pdb.top) AS IMPLICIT;

--- a/pg_search/sql/pg_search--0.25.0.4--0.25.0.5.sql
+++ b/pg_search/sql/pg_search--0.25.0.4--0.25.0.5.sql
@@ -1,0 +1,68 @@
+-- pg_search 0.25.0.4 -> 0.25.0.5 (dev): measure-named fusion-arm
+-- annotations.
+--
+-- The measure-less pdb.top(n) is replaced by pdb.top_bm25(n) and
+-- pdb.top_knn(n): the type name declares what ranks the arm, so every other
+-- predicate inside the arm is a filter:
+--
+--   WHERE (category === 'shoes' AND description ||| 'running shoes')::pdb.top_bm25(100)
+--      OR (category === 'shoes' AND embedding ~~~ '[...]')::pdb.top_knn(200)
+--   ORDER BY pdb.rrf(id) LIMIT 10;
+
+-- Drop the measure-less pdb.top; CASCADE takes its casts and the functions
+-- whose signatures mention the type (top_in/top_out and the cast functions).
+-- On chains that skipped 0.25.0.4's creation (its symbols are gone) this is
+-- a no-op, which is why the typmod functions below are CREATE OR REPLACE.
+DROP TYPE IF EXISTS pdb.top CASCADE;
+
+CREATE TYPE pdb.top_bm25;
+CREATE TYPE pdb.top_knn;
+
+CREATE OR REPLACE FUNCTION top_typmod_in(cstring[]) RETURNS integer
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_typmod_in_wrapper';
+CREATE OR REPLACE FUNCTION top_typmod_out(integer) RETURNS cstring
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_typmod_out_wrapper';
+
+CREATE FUNCTION top_bm25_in(cstring, oid, integer) RETURNS pdb.top_bm25
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_bm25_in_wrapper';
+CREATE FUNCTION top_bm25_out(pdb.top_bm25) RETURNS cstring
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_bm25_out_wrapper';
+CREATE FUNCTION top_knn_in(cstring, oid, integer) RETURNS pdb.top_knn
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_knn_in_wrapper';
+CREATE FUNCTION top_knn_out(pdb.top_knn) RETURNS cstring
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_knn_out_wrapper';
+
+CREATE TYPE pdb.top_bm25 (
+    INPUT = top_bm25_in,
+    OUTPUT = top_bm25_out,
+    LIKE = bool,
+    TYPMOD_IN = top_typmod_in,
+    TYPMOD_OUT = top_typmod_out
+);
+CREATE TYPE pdb.top_knn (
+    INPUT = top_knn_in,
+    OUTPUT = top_knn_out,
+    LIKE = bool,
+    TYPMOD_IN = top_typmod_in,
+    TYPMOD_OUT = top_typmod_out
+);
+
+CREATE FUNCTION bool_to_top_bm25(boolean, integer, boolean) RETURNS pdb.top_bm25
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'bool_to_top_bm25_wrapper';
+CREATE FUNCTION top_bm25_to_top_bm25(pdb.top_bm25, integer, boolean) RETURNS pdb.top_bm25
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_bm25_to_top_bm25_wrapper';
+CREATE FUNCTION top_bm25_to_bool(pdb.top_bm25) RETURNS boolean
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_bm25_to_bool_wrapper';
+CREATE FUNCTION bool_to_top_knn(boolean, integer, boolean) RETURNS pdb.top_knn
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'bool_to_top_knn_wrapper';
+CREATE FUNCTION top_knn_to_top_knn(pdb.top_knn, integer, boolean) RETURNS pdb.top_knn
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_knn_to_top_knn_wrapper';
+CREATE FUNCTION top_knn_to_bool(pdb.top_knn) RETURNS boolean
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'top_knn_to_bool_wrapper';
+
+CREATE CAST (boolean AS pdb.top_bm25) WITH FUNCTION bool_to_top_bm25(boolean, integer, boolean) AS ASSIGNMENT;
+CREATE CAST (pdb.top_bm25 AS pdb.top_bm25) WITH FUNCTION top_bm25_to_top_bm25(pdb.top_bm25, integer, boolean) AS IMPLICIT;
+CREATE CAST (pdb.top_bm25 AS boolean) WITH FUNCTION top_bm25_to_bool(pdb.top_bm25) AS IMPLICIT;
+CREATE CAST (boolean AS pdb.top_knn) WITH FUNCTION bool_to_top_knn(boolean, integer, boolean) AS ASSIGNMENT;
+CREATE CAST (pdb.top_knn AS pdb.top_knn) WITH FUNCTION top_knn_to_top_knn(pdb.top_knn, integer, boolean) AS IMPLICIT;
+CREATE CAST (pdb.top_knn AS boolean) WITH FUNCTION top_knn_to_bool(pdb.top_knn) AS IMPLICIT;

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -524,6 +524,11 @@ pub enum OrderByFeature {
         /// Per-leg candidate pool (the overfetch); 0 = auto-size from the
         /// LIMIT.
         window: i32,
+        /// Per-arm overrides; 0 = inherit `window`.
+        #[serde(default)]
+        bm25_window: i32,
+        #[serde(default)]
+        vector_window: i32,
     },
 }
 
@@ -557,6 +562,8 @@ impl std::fmt::Display for OrderByFeature {
                 metric,
                 k,
                 window,
+                bm25_window,
+                vector_window,
                 ..
             } => {
                 match (name, metric) {
@@ -569,6 +576,12 @@ impl std::fmt::Display for OrderByFeature {
                 }
                 if *window > 0 {
                     write!(f, ", window_size={window}")?;
+                }
+                if *bm25_window > 0 {
+                    write!(f, ", bm25_window_size={bm25_window}")?;
+                }
+                if *vector_window > 0 {
+                    write!(f, ", vector_window_size={vector_window}")?;
                 }
                 write!(f, ")")
             }

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -505,6 +505,26 @@ pub enum OrderByFeature {
         /// L2-normalized for cosine/L2 ordering.
         metric: VectorMetric,
     },
+    /// `ORDER BY pdb.rrf(pdb.score(key), vector_col <op> query_vector [, k])`:
+    /// Reciprocal Rank Fusion of the query's BM25 ranking and a
+    /// vector-distance ranking. Produces rows in fused-rank order (ascending
+    /// rank = best first).
+    Rrf {
+        /// The vector field of the distance leg. `None` when the distance
+        /// leg was omitted from `pdb.rrf(...)`; filled in at execution time
+        /// from the WHERE clause's `~~~` knn predicate.
+        name: Option<FieldName>,
+        rti: u32,
+        /// See [`OrderByFeature::VectorDistance::query_vector`].
+        query_vector: Option<QueryVector>,
+        /// See [`OrderByFeature::VectorDistance::metric`].
+        metric: Option<VectorMetric>,
+        /// The RRF constant: each leg contributes `1 / (k + rank)`.
+        k: i32,
+        /// Per-leg candidate pool (the overfetch); 0 = auto-size from the
+        /// LIMIT.
+        window: i32,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -532,6 +552,26 @@ impl std::fmt::Display for OrderByFeature {
             Self::VectorDistance { name, metric, .. } => {
                 write!(f, "{name} {} vector", metric.operator())
             }
+            Self::Rrf {
+                name,
+                metric,
+                k,
+                window,
+                ..
+            } => {
+                match (name, metric) {
+                    (Some(name), Some(metric)) => write!(
+                        f,
+                        "pdb.rrf(pdb.score(), {name} {} vector, k={k}",
+                        metric.operator()
+                    )?,
+                    _ => write!(f, "pdb.rrf(pdb.score(), ~~~ knn, k={k}")?,
+                }
+                if *window > 0 {
+                    write!(f, ", window_size={window}")?;
+                }
+                write!(f, ")")
+            }
         }
     }
 }
@@ -550,6 +590,10 @@ impl OrderByInfo {
 
     pub fn is_vector_distance(&self) -> bool {
         matches!(self.feature, OrderByFeature::VectorDistance { .. })
+    }
+
+    pub fn is_rrf(&self) -> bool {
+        matches!(self.feature, OrderByFeature::Rrf { .. })
     }
 
     /// If the ORDER BY is a vector distance, return
@@ -581,8 +625,17 @@ impl OrderByInfo {
         estate: *mut pgrx::pg_sys::EState,
         planstate: *mut pgrx::pg_sys::PlanState,
     ) {
-        if let OrderByFeature::VectorDistance { query_vector, .. } = &mut self.feature {
-            query_vector.resolve(estate, planstate);
+        match &mut self.feature {
+            OrderByFeature::VectorDistance { query_vector, .. } => {
+                query_vector.resolve(estate, planstate);
+            }
+            OrderByFeature::Rrf {
+                query_vector: Some(query_vector),
+                ..
+            } => {
+                query_vector.resolve(estate, planstate);
+            }
+            _ => {}
         }
     }
 }

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -28,6 +28,7 @@ mod proximity;
 mod searchqueryinput;
 pub(crate) mod slop;
 mod tildetildetilde;
+pub(crate) mod top;
 
 use crate::api::operator::boost::{boost_to_boost, BoostType};
 use crate::api::operator::fuzzy::{fuzzy_to_fuzzy, FuzzyType};

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -27,6 +27,7 @@ mod ororor;
 mod proximity;
 mod searchqueryinput;
 pub(crate) mod slop;
+mod tildetildetilde;
 
 use crate::api::operator::boost::{boost_to_boost, BoostType};
 use crate::api::operator::fuzzy::{fuzzy_to_fuzzy, FuzzyType};
@@ -71,6 +72,8 @@ enum RHSValue {
     TextArray(Vec<String>),
     PdbQuery(pdb::Query),
     ProximityClause(ProximityClause),
+    /// A pgvector value, used by the `~~~(vector, vector)` knn operator.
+    Vector(Vec<f32>),
 }
 
 #[derive(Debug)]
@@ -182,7 +185,7 @@ pub fn is_paradedb_search_operator(opno: pg_sys::Oid) -> bool {
         let is_ours = match opername {
             // These have anyelement as the left type.
             // The left-type check excludes built-in @@ @/tsvector and geometric collisions.
-            "@@@" | "|||" | "&&&" | "===" | "###" => oprleft == pg_sys::ANYELEMENTOID,
+            "@@@" | "|||" | "&&&" | "===" | "###" | "~~~" => oprleft == pg_sys::ANYELEMENTOID,
 
             // Proximity operators use proximityclause (a ParadeDB type) on the left.
             // No built-in collision risk, but we still verify it's not a geometric ##
@@ -358,7 +361,10 @@ pub(crate) fn estimate_selectivity_and_cost(
     indexrel: &PgSearchRelation,
     search_query_input: SearchQueryInput,
 ) -> (Option<f64>, Option<u64>) {
-    if estimate_heuristically(&search_query_input) {
+    // A knn (`~~~`) leaf can never be converted to a tantivy query (it is
+    // resolved by the rank-fusion TopK path instead), so queries containing
+    // one must always take the heuristic path rather than opening the index.
+    if estimate_heuristically(&search_query_input) || search_query_input.contains_knn() {
         // #4172 skips opening the index, so derive the work estimate from the same
         // heuristic: these shapes drive far more docset work than they match, so scale the
         // heuristic match estimate (selectivity x rows) by EXPENSIVE_QUERY_COST_FACTOR.
@@ -950,6 +956,13 @@ where
                     .expect("rhs fielded proximity clause must not be NULL");
                 RHSValue::ProximityClause(prox)
             }
+
+            // pgvector values, used by the `~~~(vector, vector)` knn operator
+            other if crate::postgres::catalog::is_pgvector_oid(other) => RHSValue::Vector(
+                crate::vector::PgVector::from_datum((*const_).constvalue, (*const_).constisnull)
+                    .expect("rhs vector value must not be NULL")
+                    .0,
+            ),
 
             other => panic!("operator does not support rhs type {other}"),
         };

--- a/pg_search/src/api/operator/tildetildetilde.rs
+++ b/pg_search/src/api/operator/tildetildetilde.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! The `~~~(vector, vector)` knn search operator: "this row is among the
+//! top-`window_size` nearest neighbors of the query vector".
+//!
+//! Unlike pgvector's distance operators the metric is not encoded in the
+//! operator: it comes from the vector column's opclass in the bm25 index.
+//!
+//! `~~~` only defines *candidacy* (which rows can match); ranking still comes
+//! from `ORDER BY pdb.rrf(...)`, which is required for queries using this
+//! operator. Predicate scoping follows boolean position: predicates ANDed
+//! around the `OR` of a text matcher and a `~~~` matcher apply to both legs,
+//! predicates grouped inside a branch apply to that leg only.
+
+use crate::api::operator::{request_simplify, RHSValue, ReturnedNodePointer};
+use crate::query::SearchQueryInput;
+use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
+
+#[pg_operator(immutable, parallel_safe, cost = 1000000000)]
+#[opname(pg_catalog.~~~)]
+fn search_with_knn(_field: AnyElement, _vector: AnyElement) -> bool {
+    panic!("query is incompatible with pg_search's `~~~(vector, vector)` operator: the left-hand side must be a bm25-indexed vector column and the query must be executed by a ParadeDB scan ordered by `pdb.rrf(...)`")
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn search_with_knn_support(arg: Internal) -> ReturnedNodePointer {
+    unsafe {
+        request_simplify(
+            arg.unwrap().unwrap().cast_mut_ptr::<pg_sys::Node>(),
+            |_lhs, field, value| {
+                let field = field.expect(
+                    "the left-hand side of the `~~~(vector, vector)` operator must be a bm25-indexed vector column",
+                );
+                match value {
+                    RHSValue::Vector(query_vector) => SearchQueryInput::Knn {
+                        field,
+                        query_vector,
+                    },
+                    _ => panic!(
+                        "the right-hand side of the `~~~(vector, vector)` operator must be a vector value"
+                    ),
+                }
+            },
+            |_field, _lhs, _rhs| {
+                panic!(
+                    "the right-hand side of the `~~~(vector, vector)` operator must be a constant vector: parameters and runtime expressions are not yet supported"
+                )
+            },
+        )
+        .unwrap_or(ReturnedNodePointer(None))
+    }
+}
+
+extension_sql!(
+    r#"
+        ALTER FUNCTION paradedb.search_with_knn SUPPORT paradedb.search_with_knn_support;
+    "#,
+    name = "search_with_knn_support_fn",
+    requires = [search_with_knn, search_with_knn_support]
+);

--- a/pg_search/src/api/operator/top.rs
+++ b/pg_search/src/api/operator/top.rs
@@ -1,0 +1,259 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! The `::pdb.top(n)` arm annotation for rank fusion.
+//!
+//! Casting a boolean search-predicate subtree to `pdb.top(n)` turns it into
+//! a fusion *arm*: "this row is among the top `n` rows ranked by this
+//! subtree's own measure" (BM25 for text predicates, proximity for a `~~~`
+//! knn predicate). The typmod carries `n`, following the same pattern as
+//! `'term'::pdb.boost(2)`.
+//!
+//! ```sql
+//! WHERE (description ||| 'shoes' OR category === 'footwear')::pdb.top(100)
+//!    OR (embedding ~~~ '[...]')::pdb.top(200)
+//! ORDER BY pdb.rrf(id)
+//! LIMIT 10;
+//! ```
+//!
+//! The type itself is inert: every executable path errors, because the
+//! annotation only has meaning inside a ParadeDB rank-fusion scan, which
+//! consumes it at plan time (see `qual_inspect`) and never evaluates it.
+
+use pgrx::{extension_sql, pg_extern, pg_sys};
+use std::ffi::{CStr, CString};
+use std::str::FromStr;
+
+const TOP_NOT_EXECUTABLE: &str = "::pdb.top(n) can only annotate a search predicate in a query executed by a ParadeDB rank-fusion scan: use `WHERE (<predicate>)::pdb.top(<n>) ... ORDER BY pdb.rrf(<key>) LIMIT <k>`";
+
+/// The `pdb.top` SQL type. Its runtime value is never legitimately
+/// constructed (the annotation is consumed at plan time), so the payload is
+/// a placeholder `bool`.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct TopType(#[allow(dead_code)] bool);
+
+// pgrx boilerplate to let `TopType` cross the SQL/Rust boundary.
+mod sql_datum_support {
+    use super::TopType;
+    use pgrx::callconv::{Arg, ArgAbi, BoxRet, FcInfo};
+    use pgrx::nullable::Nullable;
+    use pgrx::pgrx_sql_entity_graph::metadata::{
+        ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
+    };
+    use pgrx::{pg_sys, FromDatum, IntoDatum};
+
+    impl IntoDatum for TopType {
+        fn into_datum(self) -> Option<pg_sys::Datum> {
+            self.0.into_datum()
+        }
+
+        fn type_oid() -> pg_sys::Oid {
+            pg_sys::BOOLOID
+        }
+    }
+
+    impl FromDatum for TopType {
+        unsafe fn from_polymorphic_datum(
+            datum: pg_sys::Datum,
+            is_null: bool,
+            typoid: pg_sys::Oid,
+        ) -> Option<Self> {
+            bool::from_polymorphic_datum(datum, is_null, typoid).map(TopType)
+        }
+    }
+
+    unsafe impl SqlTranslatable for TopType {
+        const TYPE_IDENT: &'static str = pgrx::pgrx_resolved_type!(TopType);
+        const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
+        const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
+            Ok(SqlMappingRef::literal("pdb.top"));
+        const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
+            Ok(ReturnsRef::One(SqlMappingRef::literal("pdb.top")));
+    }
+
+    unsafe impl BoxRet for TopType {
+        unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> pgrx::datum::Datum<'fcx> {
+            match self.into_datum() {
+                Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
+                None => fcinfo.return_null(),
+            }
+        }
+    }
+
+    unsafe impl<'fcx> ArgAbi<'fcx> for TopType {
+        unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> Self {
+            let index = arg.index();
+            unsafe {
+                arg.unbox_arg_using_from_datum()
+                    .unwrap_or_else(|| panic!("argument {index} must not be null"))
+            }
+        }
+
+        unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
+            unsafe { arg.unbox_arg_using_from_datum().into() }
+        }
+    }
+}
+
+extension_sql!(
+    r#"
+        CREATE SCHEMA IF NOT EXISTS pdb;
+        CREATE TYPE pdb.top;
+    "#,
+    name = "TopType_shell",
+    creates = [Type(TopType)]
+);
+
+#[pg_extern(immutable, parallel_safe)]
+fn top_in(_input: &CStr, _typoid: pg_sys::Oid, _typmod: i32) -> TopType {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn top_out(_input: TopType) -> CString {
+    CString::from_str("pdb.top").unwrap()
+}
+
+/// Parse the `(n)` of `::pdb.top(n)`: a single positive candidate-window
+/// size, stored directly as the typmod.
+#[pg_extern(immutable, parallel_safe)]
+fn top_typmod_in(typmod_parts: pgrx::Array<&CStr>) -> i32 {
+    assert!(
+        typmod_parts.len() == 1,
+        "pdb.top takes exactly one modifier"
+    );
+    let n_str = typmod_parts
+        .get(0)
+        .unwrap()
+        .expect("typmod cstring must not be NULL")
+        .to_str()
+        .unwrap();
+    let n = i32::from_str(n_str).unwrap_or_else(|_| panic!("invalid pdb.top window: {n_str}"));
+    if n < 1 {
+        panic!("pdb.top window must be >= 1, got {n}");
+    }
+    n
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn top_typmod_out(typmod: i32) -> CString {
+    CString::from_str(&format!("({typmod})")).unwrap()
+}
+
+extension_sql!(
+    r#"
+        CREATE TYPE pdb.top (
+            INPUT = top_in,
+            OUTPUT = top_out,
+            LIKE = bool,
+            TYPMOD_IN = top_typmod_in,
+            TYPMOD_OUT = top_typmod_out
+        );
+    "#,
+    name = "TopType_final",
+    requires = [
+        "TopType_shell",
+        top_in,
+        top_out,
+        top_typmod_in,
+        top_typmod_out
+    ]
+);
+
+/// `(bool_expr)::pdb.top(n)`: the cast that creates an arm. Consumed at plan
+/// time by qual inspection; never legitimately executed.
+#[pg_extern(immutable, parallel_safe)]
+fn bool_to_top(_input: bool, _typmod: i32, _is_explicit: bool) -> TopType {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+/// Re-annotation (`x::pdb.top(3)::pdb.top(5)`); the outermost typmod wins.
+#[pg_extern(immutable, parallel_safe)]
+fn top_to_top(_input: TopType, _typmod: i32, _is_explicit: bool) -> TopType {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+/// Lets the annotated expression stand where SQL requires a boolean (the
+/// WHERE clause). Also consumed at plan time.
+#[pg_extern(immutable, parallel_safe)]
+fn top_to_bool(_input: TopType) -> bool {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+extension_sql!(
+    r#"
+        CREATE CAST (boolean AS pdb.top) WITH FUNCTION bool_to_top(boolean, integer, boolean) AS ASSIGNMENT;
+        CREATE CAST (pdb.top AS pdb.top) WITH FUNCTION top_to_top(pdb.top, integer, boolean) AS IMPLICIT;
+        CREATE CAST (pdb.top AS boolean) WITH FUNCTION top_to_bool(pdb.top) AS IMPLICIT;
+    "#,
+    name = "cast_top",
+    requires = [bool_to_top, top_to_top, top_to_bool, "TopType_final"]
+);
+
+/// Look up a function in the `paradedb` schema, returning `InvalidOid` when
+/// it does not exist yet (upgrade safety).
+fn lookup_paradedb_function(func_name: &str, arg_types: &[pg_sys::Oid]) -> pg_sys::Oid {
+    unsafe {
+        let schema = pg_sys::get_namespace_oid(c"paradedb".as_ptr(), true);
+        if schema == pg_sys::InvalidOid {
+            return pg_sys::InvalidOid;
+        }
+        let mut name_list = pgrx::PgList::<pg_sys::Node>::new();
+        name_list.push(pg_sys::makeString(c"paradedb".as_ptr() as *mut std::ffi::c_char) as *mut _);
+        let func_name_cstr = std::ffi::CString::new(func_name).unwrap();
+        name_list
+            .push(pg_sys::makeString(func_name_cstr.as_ptr() as *mut std::ffi::c_char) as *mut _);
+        pg_sys::LookupFuncName(
+            name_list.as_ptr(),
+            arg_types.len() as i32,
+            arg_types.as_ptr(),
+            true,
+        )
+    }
+}
+
+pub fn top_typoid() -> pg_sys::Oid {
+    crate::postgres::catalog::lookup_typoid(c"pdb", c"top").unwrap_or(pg_sys::InvalidOid)
+}
+
+/// Oid of `paradedb.top_to_bool(pdb.top)`, the outer layer of the cast
+/// sandwich qual inspection unwraps.
+pub fn top_to_bool_procoid() -> pg_sys::Oid {
+    let top = top_typoid();
+    if top == pg_sys::InvalidOid {
+        return pg_sys::InvalidOid;
+    }
+    lookup_paradedb_function("top_to_bool", &[top])
+}
+
+/// Oid of `paradedb.bool_to_top(boolean, integer, boolean)`.
+pub fn bool_to_top_procoid() -> pg_sys::Oid {
+    lookup_paradedb_function(
+        "bool_to_top",
+        &[pg_sys::BOOLOID, pg_sys::INT4OID, pg_sys::BOOLOID],
+    )
+}
+
+/// Oid of `paradedb.top_to_top(pdb.top, integer, boolean)`.
+pub fn top_to_top_procoid() -> pg_sys::Oid {
+    let top = top_typoid();
+    if top == pg_sys::InvalidOid {
+        return pg_sys::InvalidOid;
+    }
+    lookup_paradedb_function("top_to_top", &[top, pg_sys::INT4OID, pg_sys::BOOLOID])
+}

--- a/pg_search/src/api/operator/top.rs
+++ b/pg_search/src/api/operator/top.rs
@@ -15,22 +15,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! The `::pdb.top(n)` arm annotation for rank fusion.
+//! The `::pdb.top_bm25(n)` / `::pdb.top_knn(n)` arm annotations for rank
+//! fusion.
 //!
-//! Casting a boolean search-predicate subtree to `pdb.top(n)` turns it into
-//! a fusion *arm*: "this row is among the top `n` rows ranked by this
-//! subtree's own measure" (BM25 for text predicates, proximity for a `~~~`
-//! knn predicate). The typmod carries `n`, following the same pattern as
-//! `'term'::pdb.boost(2)`.
+//! Casting a boolean search-predicate subtree to one of these types turns it
+//! into a fusion *arm*: "this row is among the top `n` rows ranked by the
+//! named measure". The type name declares what ranks the arm (BM25 relevance
+//! or knn proximity); every other predicate inside the arm is a filter. The
+//! typmod carries `n`, following the same pattern as `'term'::pdb.boost(2)`.
 //!
 //! ```sql
-//! WHERE (description ||| 'shoes' OR category === 'footwear')::pdb.top(100)
-//!    OR (embedding ~~~ '[...]')::pdb.top(200)
+//! WHERE (category === 'footwear' AND description ||| 'running shoes')::pdb.top_bm25(100)
+//!    OR (category === 'footwear' AND embedding ~~~ '[...]')::pdb.top_knn(200)
 //! ORDER BY pdb.rrf(id)
 //! LIMIT 10;
 //! ```
 //!
-//! The type itself is inert: every executable path errors, because the
+//! The types themselves are inert: every executable path errors, because the
 //! annotation only has meaning inside a ParadeDB rank-fusion scan, which
 //! consumes it at plan time (see `qual_inspect`) and never evaluates it.
 
@@ -38,18 +39,25 @@ use pgrx::{extension_sql, pg_extern, pg_sys};
 use std::ffi::{CStr, CString};
 use std::str::FromStr;
 
-const TOP_NOT_EXECUTABLE: &str = "::pdb.top(n) can only annotate a search predicate in a query executed by a ParadeDB rank-fusion scan: use `WHERE (<predicate>)::pdb.top(<n>) ... ORDER BY pdb.rrf(<key>) LIMIT <k>`";
+const TOP_NOT_EXECUTABLE: &str = "::pdb.top_bm25(n)/::pdb.top_knn(n) can only annotate a search predicate in a query executed by a ParadeDB rank-fusion scan: use `WHERE (<predicate>)::pdb.top_bm25(<n>) ... ORDER BY pdb.rrf(<key>) LIMIT <k>`";
 
-/// The `pdb.top` SQL type. Its runtime value is never legitimately
-/// constructed (the annotation is consumed at plan time), so the payload is
-/// a placeholder `bool`.
+/// The `pdb.top_bm25` SQL type: the annotated arm is ranked by BM25
+/// relevance. Its runtime value is never legitimately constructed (the
+/// annotation is consumed at plan time), so the payload is a placeholder
+/// `bool`.
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct TopType(#[allow(dead_code)] bool);
+pub struct TopBm25Type(#[allow(dead_code)] bool);
 
-// pgrx boilerplate to let `TopType` cross the SQL/Rust boundary.
+/// The `pdb.top_knn` SQL type: the annotated arm is ranked by the proximity
+/// of its single `~~~` knn predicate. See [`TopBm25Type`].
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct TopKnnType(#[allow(dead_code)] bool);
+
+// pgrx boilerplate to let the annotation types cross the SQL/Rust boundary.
 mod sql_datum_support {
-    use super::TopType;
+    use super::{TopBm25Type, TopKnnType};
     use pgrx::callconv::{Arg, ArgAbi, BoxRet, FcInfo};
     use pgrx::nullable::Nullable;
     use pgrx::pgrx_sql_entity_graph::metadata::{
@@ -57,85 +65,87 @@ mod sql_datum_support {
     };
     use pgrx::{pg_sys, FromDatum, IntoDatum};
 
-    impl IntoDatum for TopType {
-        fn into_datum(self) -> Option<pg_sys::Datum> {
-            self.0.into_datum()
-        }
+    macro_rules! top_type_boilerplate {
+        ($ty:ident, $sql_name:literal) => {
+            impl IntoDatum for $ty {
+                fn into_datum(self) -> Option<pg_sys::Datum> {
+                    self.0.into_datum()
+                }
 
-        fn type_oid() -> pg_sys::Oid {
-            pg_sys::BOOLOID
-        }
-    }
-
-    impl FromDatum for TopType {
-        unsafe fn from_polymorphic_datum(
-            datum: pg_sys::Datum,
-            is_null: bool,
-            typoid: pg_sys::Oid,
-        ) -> Option<Self> {
-            bool::from_polymorphic_datum(datum, is_null, typoid).map(TopType)
-        }
-    }
-
-    unsafe impl SqlTranslatable for TopType {
-        const TYPE_IDENT: &'static str = pgrx::pgrx_resolved_type!(TopType);
-        const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
-        const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-            Ok(SqlMappingRef::literal("pdb.top"));
-        const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-            Ok(ReturnsRef::One(SqlMappingRef::literal("pdb.top")));
-    }
-
-    unsafe impl BoxRet for TopType {
-        unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> pgrx::datum::Datum<'fcx> {
-            match self.into_datum() {
-                Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-                None => fcinfo.return_null(),
+                fn type_oid() -> pg_sys::Oid {
+                    pg_sys::BOOLOID
+                }
             }
-        }
-    }
 
-    unsafe impl<'fcx> ArgAbi<'fcx> for TopType {
-        unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> Self {
-            let index = arg.index();
-            unsafe {
-                arg.unbox_arg_using_from_datum()
-                    .unwrap_or_else(|| panic!("argument {index} must not be null"))
+            impl FromDatum for $ty {
+                unsafe fn from_polymorphic_datum(
+                    datum: pg_sys::Datum,
+                    is_null: bool,
+                    typoid: pg_sys::Oid,
+                ) -> Option<Self> {
+                    bool::from_polymorphic_datum(datum, is_null, typoid).map($ty)
+                }
             }
-        }
 
-        unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
-            unsafe { arg.unbox_arg_using_from_datum().into() }
-        }
+            unsafe impl SqlTranslatable for $ty {
+                const TYPE_IDENT: &'static str = pgrx::pgrx_resolved_type!($ty);
+                const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
+                const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
+                    Ok(SqlMappingRef::literal($sql_name));
+                const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
+                    Ok(ReturnsRef::One(SqlMappingRef::literal($sql_name)));
+            }
+
+            unsafe impl BoxRet for $ty {
+                unsafe fn box_into<'fcx>(
+                    self,
+                    fcinfo: &mut FcInfo<'fcx>,
+                ) -> pgrx::datum::Datum<'fcx> {
+                    match self.into_datum() {
+                        Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
+                        None => fcinfo.return_null(),
+                    }
+                }
+            }
+
+            unsafe impl<'fcx> ArgAbi<'fcx> for $ty {
+                unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> Self {
+                    let index = arg.index();
+                    unsafe {
+                        arg.unbox_arg_using_from_datum()
+                            .unwrap_or_else(|| panic!("argument {index} must not be null"))
+                    }
+                }
+
+                unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
+                    unsafe { arg.unbox_arg_using_from_datum().into() }
+                }
+            }
+        };
     }
+
+    top_type_boilerplate!(TopBm25Type, "pdb.top_bm25");
+    top_type_boilerplate!(TopKnnType, "pdb.top_knn");
 }
 
 extension_sql!(
     r#"
         CREATE SCHEMA IF NOT EXISTS pdb;
-        CREATE TYPE pdb.top;
+        CREATE TYPE pdb.top_bm25;
+        CREATE TYPE pdb.top_knn;
     "#,
     name = "TopType_shell",
-    creates = [Type(TopType)]
+    creates = [Type(TopBm25Type), Type(TopKnnType)]
 );
 
-#[pg_extern(immutable, parallel_safe)]
-fn top_in(_input: &CStr, _typoid: pg_sys::Oid, _typmod: i32) -> TopType {
-    panic!("{TOP_NOT_EXECUTABLE}");
-}
-
-#[pg_extern(immutable, parallel_safe)]
-fn top_out(_input: TopType) -> CString {
-    CString::from_str("pdb.top").unwrap()
-}
-
-/// Parse the `(n)` of `::pdb.top(n)`: a single positive candidate-window
-/// size, stored directly as the typmod.
+/// Parse the `(n)` of a `::pdb.top_bm25(n)` / `::pdb.top_knn(n)` annotation:
+/// a single positive candidate-window size, stored directly as the typmod.
+/// Shared by both annotation types.
 #[pg_extern(immutable, parallel_safe)]
 fn top_typmod_in(typmod_parts: pgrx::Array<&CStr>) -> i32 {
     assert!(
         typmod_parts.len() == 1,
-        "pdb.top takes exactly one modifier"
+        "fusion-arm annotations take exactly one modifier"
     );
     let n_str = typmod_parts
         .get(0)
@@ -143,9 +153,9 @@ fn top_typmod_in(typmod_parts: pgrx::Array<&CStr>) -> i32 {
         .expect("typmod cstring must not be NULL")
         .to_str()
         .unwrap();
-    let n = i32::from_str(n_str).unwrap_or_else(|_| panic!("invalid pdb.top window: {n_str}"));
+    let n = i32::from_str(n_str).unwrap_or_else(|_| panic!("invalid arm window: {n_str}"));
     if n < 1 {
-        panic!("pdb.top window must be >= 1, got {n}");
+        panic!("the arm window must be >= 1, got {n}");
     }
     n
 }
@@ -155,11 +165,38 @@ fn top_typmod_out(typmod: i32) -> CString {
     CString::from_str(&format!("({typmod})")).unwrap()
 }
 
+#[pg_extern(immutable, parallel_safe)]
+fn top_bm25_in(_input: &CStr, _typoid: pg_sys::Oid, _typmod: i32) -> TopBm25Type {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn top_bm25_out(_input: TopBm25Type) -> CString {
+    CString::from_str("pdb.top_bm25").unwrap()
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn top_knn_in(_input: &CStr, _typoid: pg_sys::Oid, _typmod: i32) -> TopKnnType {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn top_knn_out(_input: TopKnnType) -> CString {
+    CString::from_str("pdb.top_knn").unwrap()
+}
+
 extension_sql!(
     r#"
-        CREATE TYPE pdb.top (
-            INPUT = top_in,
-            OUTPUT = top_out,
+        CREATE TYPE pdb.top_bm25 (
+            INPUT = top_bm25_in,
+            OUTPUT = top_bm25_out,
+            LIKE = bool,
+            TYPMOD_IN = top_typmod_in,
+            TYPMOD_OUT = top_typmod_out
+        );
+        CREATE TYPE pdb.top_knn (
+            INPUT = top_knn_in,
+            OUTPUT = top_knn_out,
             LIKE = bool,
             TYPMOD_IN = top_typmod_in,
             TYPMOD_OUT = top_typmod_out
@@ -168,41 +205,73 @@ extension_sql!(
     name = "TopType_final",
     requires = [
         "TopType_shell",
-        top_in,
-        top_out,
+        top_bm25_in,
+        top_bm25_out,
+        top_knn_in,
+        top_knn_out,
         top_typmod_in,
         top_typmod_out
     ]
 );
 
-/// `(bool_expr)::pdb.top(n)`: the cast that creates an arm. Consumed at plan
-/// time by qual inspection; never legitimately executed.
+/// `(bool_expr)::pdb.top_bm25(n)`: the cast that creates a BM25-ranked arm.
+/// Consumed at plan time by qual inspection; never legitimately executed.
 #[pg_extern(immutable, parallel_safe)]
-fn bool_to_top(_input: bool, _typmod: i32, _is_explicit: bool) -> TopType {
+fn bool_to_top_bm25(_input: bool, _typmod: i32, _is_explicit: bool) -> TopBm25Type {
     panic!("{TOP_NOT_EXECUTABLE}");
 }
 
-/// Re-annotation (`x::pdb.top(3)::pdb.top(5)`); the outermost typmod wins.
+/// Re-annotation (`x::pdb.top_bm25(3)::pdb.top_bm25(5)`); the outermost
+/// typmod wins.
 #[pg_extern(immutable, parallel_safe)]
-fn top_to_top(_input: TopType, _typmod: i32, _is_explicit: bool) -> TopType {
+fn top_bm25_to_top_bm25(_input: TopBm25Type, _typmod: i32, _is_explicit: bool) -> TopBm25Type {
     panic!("{TOP_NOT_EXECUTABLE}");
 }
 
 /// Lets the annotated expression stand where SQL requires a boolean (the
 /// WHERE clause). Also consumed at plan time.
 #[pg_extern(immutable, parallel_safe)]
-fn top_to_bool(_input: TopType) -> bool {
+fn top_bm25_to_bool(_input: TopBm25Type) -> bool {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+/// `(bool_expr)::pdb.top_knn(n)`: the cast that creates a knn-ranked arm.
+#[pg_extern(immutable, parallel_safe)]
+fn bool_to_top_knn(_input: bool, _typmod: i32, _is_explicit: bool) -> TopKnnType {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+/// Re-annotation (`x::pdb.top_knn(3)::pdb.top_knn(5)`); the outermost typmod
+/// wins.
+#[pg_extern(immutable, parallel_safe)]
+fn top_knn_to_top_knn(_input: TopKnnType, _typmod: i32, _is_explicit: bool) -> TopKnnType {
+    panic!("{TOP_NOT_EXECUTABLE}");
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn top_knn_to_bool(_input: TopKnnType) -> bool {
     panic!("{TOP_NOT_EXECUTABLE}");
 }
 
 extension_sql!(
     r#"
-        CREATE CAST (boolean AS pdb.top) WITH FUNCTION bool_to_top(boolean, integer, boolean) AS ASSIGNMENT;
-        CREATE CAST (pdb.top AS pdb.top) WITH FUNCTION top_to_top(pdb.top, integer, boolean) AS IMPLICIT;
-        CREATE CAST (pdb.top AS boolean) WITH FUNCTION top_to_bool(pdb.top) AS IMPLICIT;
+        CREATE CAST (boolean AS pdb.top_bm25) WITH FUNCTION bool_to_top_bm25(boolean, integer, boolean) AS ASSIGNMENT;
+        CREATE CAST (pdb.top_bm25 AS pdb.top_bm25) WITH FUNCTION top_bm25_to_top_bm25(pdb.top_bm25, integer, boolean) AS IMPLICIT;
+        CREATE CAST (pdb.top_bm25 AS boolean) WITH FUNCTION top_bm25_to_bool(pdb.top_bm25) AS IMPLICIT;
+        CREATE CAST (boolean AS pdb.top_knn) WITH FUNCTION bool_to_top_knn(boolean, integer, boolean) AS ASSIGNMENT;
+        CREATE CAST (pdb.top_knn AS pdb.top_knn) WITH FUNCTION top_knn_to_top_knn(pdb.top_knn, integer, boolean) AS IMPLICIT;
+        CREATE CAST (pdb.top_knn AS boolean) WITH FUNCTION top_knn_to_bool(pdb.top_knn) AS IMPLICIT;
     "#,
     name = "cast_top",
-    requires = [bool_to_top, top_to_top, top_to_bool, "TopType_final"]
+    requires = [
+        bool_to_top_bm25,
+        top_bm25_to_top_bm25,
+        top_bm25_to_bool,
+        bool_to_top_knn,
+        top_knn_to_top_knn,
+        top_knn_to_bool,
+        "TopType_final"
+    ]
 );
 
 /// Look up a function in the `paradedb` schema, returning `InvalidOid` when
@@ -227,33 +296,37 @@ fn lookup_paradedb_function(func_name: &str, arg_types: &[pg_sys::Oid]) -> pg_sy
     }
 }
 
-pub fn top_typoid() -> pg_sys::Oid {
-    crate::postgres::catalog::lookup_typoid(c"pdb", c"top").unwrap_or(pg_sys::InvalidOid)
+/// The cast-function oids that make up one annotation type's cast sandwich
+/// `<to_bool>(<retypmod>*(<creator>(subtree, typmod, _)))`; see
+/// `qual_inspect::top_arm`.
+pub struct TopCastProcs {
+    pub to_bool: pg_sys::Oid,
+    pub creator: pg_sys::Oid,
+    pub retypmod: pg_sys::Oid,
 }
 
-/// Oid of `paradedb.top_to_bool(pdb.top)`, the outer layer of the cast
-/// sandwich qual inspection unwraps.
-pub fn top_to_bool_procoid() -> pg_sys::Oid {
-    let top = top_typoid();
-    if top == pg_sys::InvalidOid {
-        return pg_sys::InvalidOid;
-    }
-    lookup_paradedb_function("top_to_bool", &[top])
+fn cast_procs(type_name: &CStr, base: &str) -> Option<TopCastProcs> {
+    let typoid = crate::postgres::catalog::lookup_typoid(c"pdb", type_name)?;
+    Some(TopCastProcs {
+        to_bool: lookup_paradedb_function(&format!("{base}_to_bool"), &[typoid]),
+        creator: lookup_paradedb_function(
+            &format!("bool_to_{base}"),
+            &[pg_sys::BOOLOID, pg_sys::INT4OID, pg_sys::BOOLOID],
+        ),
+        retypmod: lookup_paradedb_function(
+            &format!("{base}_to_{base}"),
+            &[typoid, pg_sys::INT4OID, pg_sys::BOOLOID],
+        ),
+    })
 }
 
-/// Oid of `paradedb.bool_to_top(boolean, integer, boolean)`.
-pub fn bool_to_top_procoid() -> pg_sys::Oid {
-    lookup_paradedb_function(
-        "bool_to_top",
-        &[pg_sys::BOOLOID, pg_sys::INT4OID, pg_sys::BOOLOID],
-    )
+/// Cast-sandwich oids for `pdb.top_bm25`, or `None` before the type exists
+/// (upgrade safety).
+pub fn top_bm25_procs() -> Option<TopCastProcs> {
+    cast_procs(c"top_bm25", "top_bm25")
 }
 
-/// Oid of `paradedb.top_to_top(pdb.top, integer, boolean)`.
-pub fn top_to_top_procoid() -> pg_sys::Oid {
-    let top = top_typoid();
-    if top == pg_sys::InvalidOid {
-        return pg_sys::InvalidOid;
-    }
-    lookup_paradedb_function("top_to_top", &[top, pg_sys::INT4OID, pg_sys::BOOLOID])
+/// Cast-sandwich oids for `pdb.top_knn`.
+pub fn top_knn_procs() -> Option<TopCastProcs> {
+    cast_procs(c"top_knn", "top_knn")
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -120,6 +120,44 @@ pub struct HybridDocScores {
     pub rank: usize,
 }
 
+/// The candidate-window sizes for a `pdb.rrf()` fused search: a shared
+/// `window_size` plus optional per-arm overrides, all `0 = inherit/auto`.
+#[derive(Debug, Clone, Copy)]
+struct RrfWindows {
+    shared: i32,
+    bm25: i32,
+    vector: i32,
+}
+
+impl RrfWindows {
+    /// Auto-sizing for a per-arm candidate window: a multiple of the
+    /// requested page so fusion sees meaningfully more than K docs.
+    const RRF_WINDOW_MULTIPLIER: usize = 4;
+    const RRF_MIN_WINDOW: usize = 100;
+
+    /// Effective window for one arm: the per-arm override if set, else the
+    /// shared `window_size`, else auto. Explicit values are respected
+    /// literally (an arm window smaller than the page bounds that arm's
+    /// contribution; the page still fills from the union of arms, though a
+    /// single-arm query with a too-small window can return fewer rows).
+    fn effective(per_arm: i32, shared: i32, n: usize, offset: usize) -> usize {
+        let explicit = if per_arm > 0 { per_arm } else { shared };
+        if explicit > 0 {
+            explicit as usize
+        } else {
+            (Self::RRF_WINDOW_MULTIPLIER * (n + offset)).max(Self::RRF_MIN_WINDOW)
+        }
+    }
+
+    fn bm25_window(&self, n: usize, offset: usize) -> usize {
+        Self::effective(self.bm25, self.shared, n, offset)
+    }
+
+    fn vector_window(&self, n: usize, offset: usize) -> usize {
+        Self::effective(self.vector, self.shared, n, offset)
+    }
+}
+
 /// A known-size iterator of results for Top K.
 pub struct TopKSearchResults {
     results_original_len: usize,
@@ -1089,6 +1127,8 @@ impl SearchIndexReader {
                         query_vector,
                         k,
                         window,
+                        bm25_window,
+                        vector_window,
                         ..
                     },
                 direction,
@@ -1111,7 +1151,11 @@ impl SearchIndexReader {
                     name,
                     query_vector,
                     *k,
-                    *window,
+                    RrfWindows {
+                        shared: *window,
+                        bm25: *bm25_window,
+                        vector: *vector_window,
+                    },
                     *direction,
                     n,
                     offset,
@@ -1145,18 +1189,13 @@ impl SearchIndexReader {
         field_name: &FieldName,
         query_vector: &QueryVector,
         k: i32,
-        window: i32,
+        windows: RrfWindows,
         direction: SortDirection,
         n: usize,
         offset: usize,
         aux_collector: Option<TopKAuxiliaryCollector>,
         rrf_bm25_leg: Option<(&SearchQueryInput, &SearchQueryInput)>,
     ) -> TopKSearchResults {
-        /// Auto-sizing for the per-leg candidate window: a multiple of the
-        /// requested page so fusion sees meaningfully more than K docs.
-        const RRF_WINDOW_MULTIPLIER: usize = 4;
-        const RRF_MIN_WINDOW: usize = 100;
-
         #[derive(Default)]
         struct Candidate {
             bm25: Option<f32>,
@@ -1165,13 +1204,8 @@ impl SearchIndexReader {
         }
 
         let segment_ids: Vec<SegmentId> = segment_ids.collect();
-        // An explicit window is floored at the page size so it cannot
-        // truncate the requested LIMIT; 0 auto-sizes from the page.
-        let window = if window > 0 {
-            (window as usize).max(n + offset)
-        } else {
-            (RRF_WINDOW_MULTIPLIER * (n + offset)).max(RRF_MIN_WINDOW)
-        };
+        let bm25_window = windows.bm25_window(n, offset);
+        let vector_window = windows.vector_window(n, offset);
 
         // Vector leg: top-`window` nearest matching docs. The auxiliary
         // (aggregation) collector piggybacks on this pass, mirroring the
@@ -1185,7 +1219,7 @@ impl SearchIndexReader {
             .expect("pdb.rrf query vector was never resolved")
             .to_vec();
         self.validate_query_vector_dims(field_name, &query_vector);
-        let collector = TopDocs::with_limit(window)
+        let collector = TopDocs::with_limit(vector_window)
             .order_by_similarity(field.field(), query_vector)
             .with_adaptive_params(AdaptiveProbeParams {
                 epsilon: crate::gucs::vector_cluster_probe_epsilon(),
@@ -1220,7 +1254,7 @@ impl SearchIndexReader {
             .top_by_score_in_segments(
                 segment_ids.iter().copied(),
                 SortDirection::DescNullsLast,
-                window,
+                bm25_window,
                 0,
                 None,
                 None,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use crate::aggregate::mvcc_collector::MVCCFilterCollector;
 use crate::api::operator::keyset::KeySet;
 use crate::api::version::Version;
-use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, SortDirection};
+use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, QueryVector, SortDirection};
 use crate::index::fast_fields_helper::FFHelper;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::scorer::{DeferredScorer, LazyWeight, ScorerIter};
@@ -37,7 +37,7 @@ use crate::postgres::storage::metadata::MetaPage;
 use crate::query::estimate_tree::QueryWithEstimates;
 use crate::query::SearchQueryInput;
 use crate::scan::info::RowEstimate;
-use crate::schema::SearchIndexSchema;
+use crate::schema::{SearchFieldType, SearchIndexSchema};
 
 use anyhow::Result;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
@@ -101,11 +101,33 @@ type TopKWithAggregate<T> = (
     Option<IntermediateAggregationResults>,
 );
 
+/// Per-document score components computed by the `pdb.rrf()` rank-fusion
+/// TopK path, consumed by `pdb.rrf()` / `pdb.score(relation, type)`
+/// projection.
+#[derive(Debug, Clone, Copy)]
+pub struct HybridDocScores {
+    /// BM25 score of the document against the text leg's query. `None` when
+    /// the document does not match the text leg (surfaced only by a `~~~`
+    /// knn predicate).
+    pub bm25: Option<f32>,
+    /// Vector similarity of the document against the query vector. `None`
+    /// when the document was outside the vector leg's candidate window.
+    pub similarity: Option<f32>,
+    /// The positive RRF score: `1/(k + bm25_rank) [+ 1/(k + vector_rank)]`.
+    pub fused: f32,
+    /// 1-based rank of the document in the fused ordering. This is the value
+    /// `pdb.rrf()` projects and sorts by (ascending = best first).
+    pub rank: usize,
+}
+
 /// A known-size iterator of results for Top K.
 pub struct TopKSearchResults {
     results_original_len: usize,
     results: std::vec::IntoIter<(SearchIndexScore, DocAddress)>,
     aggregation_results: Option<IntermediateAggregationResults>,
+    /// Per-document score components, present only for `pdb.rrf()` fused
+    /// searches.
+    hybrid_components: Option<HashMap<DocAddress, HybridDocScores>>,
 }
 
 impl TopKSearchResults {
@@ -121,6 +143,7 @@ impl TopKSearchResults {
             results_original_len: results.len(),
             results: results.into_iter(),
             aggregation_results,
+            hybrid_components: None,
         }
     }
 
@@ -157,6 +180,17 @@ impl TopKSearchResults {
 
     pub fn original_len(&self) -> usize {
         self.results_original_len
+    }
+
+    /// The not-yet-consumed results, in emit order.
+    pub fn remaining(&self) -> &[(SearchIndexScore, DocAddress)] {
+        self.results.as_slice()
+    }
+
+    /// Take the per-document score components produced by a `pdb.rrf()`
+    /// fused search, if any.
+    pub fn take_hybrid_components(&mut self) -> Option<HashMap<DocAddress, HybridDocScores>> {
+        self.hybrid_components.take()
     }
 
     pub fn take_aggregation_results(&mut self) -> Option<IntermediateAggregationResults> {
@@ -509,6 +543,16 @@ impl SearchIndexReader {
         self.and_query(tantivy_query)
     }
 
+    /// A copy of this reader whose driving query is `query`, sharing the
+    /// underlying searcher and segment state. Used by the `pdb.rrf()`
+    /// rank-fusion path to score the text leg against a different query than
+    /// the vector leg when a `~~~` knn predicate splits them.
+    pub fn with_query_input(&self, query: &SearchQueryInput) -> Self {
+        let mut clone = self.clone();
+        clone.query = self.make_query(query, None);
+        clone
+    }
+
     pub fn weight(&self) -> Box<dyn Weight> {
         self.query
             .weight(if self.need_scores {
@@ -523,6 +567,59 @@ impl SearchIndexReader {
                 }
             })
             .expect("weight should be constructable")
+    }
+
+    /// Compute the BM25 score of each of `docs` against this reader's query.
+    ///
+    /// Used by `pdb.rrf()` fused searches and by `pdb.score(relation, 'bm25')`
+    /// under a vector-distance TopK ordering, where the collector produces
+    /// similarity scores and the BM25 scores of the top-K documents must be
+    /// recovered separately. Creates one scorer per segment
+    /// and seeks it through that segment's docs in ascending order, so the
+    /// cost is proportional to the number of distinct segments plus docs.
+    ///
+    /// Documents that do not match the query are absent from the returned
+    /// map (this happens for docs surfaced only by a `~~~` knn predicate,
+    /// which need not match the text leg).
+    pub fn bm25_scores_for_docs(
+        &self,
+        docs: impl IntoIterator<Item = DocAddress>,
+    ) -> HashMap<DocAddress, Score> {
+        let mut docs_by_segment: HashMap<SegmentOrdinal, Vec<DocId>> = HashMap::default();
+        for doc in docs {
+            docs_by_segment
+                .entry(doc.segment_ord)
+                .or_default()
+                .push(doc.doc_id);
+        }
+
+        let weight = self
+            .query
+            .weight(EnableScoring::Enabled {
+                searcher: &self.searcher,
+                statistics_provider: &self.searcher,
+            })
+            .expect("weight should be constructable");
+
+        let mut scores = HashMap::default();
+        for (segment_ord, mut doc_ids) in docs_by_segment {
+            doc_ids.sort_unstable();
+            doc_ids.dedup();
+
+            let segment_reader = self.searcher.segment_reader(segment_ord);
+            let mut scorer = weight
+                .scorer(segment_reader, 1.0)
+                .expect("scorer should be constructable");
+            for doc_id in doc_ids {
+                if scorer.doc() < doc_id {
+                    scorer.seek(doc_id);
+                }
+                if scorer.doc() == doc_id {
+                    scores.insert(DocAddress::new(segment_ord, doc_id), scorer.score());
+                }
+            }
+        }
+        scores
     }
 
     fn make_query(
@@ -820,6 +917,7 @@ impl SearchIndexReader {
     /// results for MVCC visibility, and re-query if necessary.
     ///
     /// `parallel_state_holding_shared_threshold` should only be passed if we intend to query with a shared_threshold
+    #[allow(clippy::too_many_arguments)]
     pub fn search_top_k_in_segments(
         &self,
         segment_ids: impl Iterator<Item = SegmentId>,
@@ -828,6 +926,7 @@ impl SearchIndexReader {
         offset: usize,
         aux_collector: Option<TopKAuxiliaryCollector>,
         parallel_state_holding_shared_threshold: Option<*mut crate::postgres::ParallelScanState>,
+        rrf_bm25_leg: Option<(&SearchQueryInput, &SearchQueryInput)>,
     ) -> TopKSearchResults {
         let (first_orderby_info, erased_features) = self.prepare_features(orderby_info);
         match first_orderby_info {
@@ -968,6 +1067,7 @@ impl SearchIndexReader {
                     .resolved()
                     .expect("vector ORDER BY query vector was never resolved")
                     .to_vec();
+                self.validate_query_vector_dims(name, &query_vector);
                 let collector = TopDocs::with_limit(n)
                     .and_offset(offset)
                     .order_by_similarity(tantivy_field, query_vector)
@@ -982,7 +1082,240 @@ impl SearchIndexReader {
                     self.collect_maybe_auxiliary(segment_ids, collector, aux_collector);
                 TopKSearchResults::new_for_score(fruit.results, aggregation_results)
             }
+            OrderByInfo {
+                feature:
+                    OrderByFeature::Rrf {
+                        name,
+                        query_vector,
+                        k,
+                        window,
+                        ..
+                    },
+                direction,
+            } => {
+                let only_score_feature =
+                    erased_features.len() == 1 && erased_features.score_index() == Some(0);
+                if !(erased_features.is_empty() || only_score_feature) {
+                    panic!("secondary ORDER BY fields are not supported for pdb.rrf()");
+                }
+                // An omitted distance leg is filled in from the `~~~` knn
+                // predicate before execution (see the TopK exec method init).
+                let name = name
+                    .as_ref()
+                    .expect("pdb.rrf distance leg should have been resolved before execution");
+                let query_vector = query_vector
+                    .as_ref()
+                    .expect("pdb.rrf distance leg should have been resolved before execution");
+                self.rrf_top_k_in_segments(
+                    segment_ids,
+                    name,
+                    query_vector,
+                    *k,
+                    *window,
+                    *direction,
+                    n,
+                    offset,
+                    aux_collector,
+                    rrf_bm25_leg,
+                )
+            }
         }
+    }
+
+    /// `ORDER BY pdb.rrf(pdb.score(key), vector_col <op> query_vector, k)`:
+    /// run the query's BM25 ranking and a vector-similarity ranking as two
+    /// top-`window` legs over the matching documents, fuse them with
+    /// Reciprocal Rank Fusion, and return the requested page in fused-rank
+    /// order along with the per-document components for score projection.
+    ///
+    /// Ranking details:
+    ///   * When a `~~~` knn predicate split the query, `rrf_bm25_leg` is the
+    ///     text leg's query `W[knn := false]` and this reader's own query is
+    ///     the vector leg's driving query `W[knn := true]`; without a knn
+    ///     predicate both legs share this reader's query.
+    ///   * Candidates are the union of both windows. Documents get a BM25
+    ///     rank only when they match the text leg (backfilled via
+    ///     [`Self::bm25_scores_for_docs`] for vector-window docs), and a
+    ///     vector rank only inside the vector window; each present rank
+    ///     contributes `1/(k + rank)` to the fused score.
+    #[allow(clippy::too_many_arguments)]
+    fn rrf_top_k_in_segments(
+        &self,
+        segment_ids: impl Iterator<Item = SegmentId>,
+        field_name: &FieldName,
+        query_vector: &QueryVector,
+        k: i32,
+        window: i32,
+        direction: SortDirection,
+        n: usize,
+        offset: usize,
+        aux_collector: Option<TopKAuxiliaryCollector>,
+        rrf_bm25_leg: Option<(&SearchQueryInput, &SearchQueryInput)>,
+    ) -> TopKSearchResults {
+        /// Auto-sizing for the per-leg candidate window: a multiple of the
+        /// requested page so fusion sees meaningfully more than K docs.
+        const RRF_WINDOW_MULTIPLIER: usize = 4;
+        const RRF_MIN_WINDOW: usize = 100;
+
+        #[derive(Default)]
+        struct Candidate {
+            bm25: Option<f32>,
+            similarity: Option<f32>,
+            vector_rank: Option<usize>,
+        }
+
+        let segment_ids: Vec<SegmentId> = segment_ids.collect();
+        // An explicit window is floored at the page size so it cannot
+        // truncate the requested LIMIT; 0 auto-sizes from the page.
+        let window = if window > 0 {
+            (window as usize).max(n + offset)
+        } else {
+            (RRF_WINDOW_MULTIPLIER * (n + offset)).max(RRF_MIN_WINDOW)
+        };
+
+        // Vector leg: top-`window` nearest matching docs. The auxiliary
+        // (aggregation) collector piggybacks on this pass, mirroring the
+        // vector-distance arm above.
+        let field = self
+            .schema
+            .search_field(field_name)
+            .expect("pdb.rrf vector field should exist in index schema");
+        let query_vector = query_vector
+            .resolved()
+            .expect("pdb.rrf query vector was never resolved")
+            .to_vec();
+        self.validate_query_vector_dims(field_name, &query_vector);
+        let collector = TopDocs::with_limit(window)
+            .order_by_similarity(field.field(), query_vector)
+            .with_adaptive_params(AdaptiveProbeParams {
+                epsilon: crate::gucs::vector_cluster_probe_epsilon(),
+                max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
+                ..Default::default()
+            });
+        let (fruit, aggregation_results) =
+            self.collect_maybe_auxiliary(segment_ids.iter().copied(), collector, aux_collector);
+
+        let mut candidates: HashMap<DocAddress, Candidate> = HashMap::default();
+        for (index, (similarity, doc_address)) in fruit.results.into_iter().enumerate() {
+            let candidate = candidates.entry(doc_address).or_default();
+            candidate.similarity = Some(similarity);
+            candidate.vector_rank = Some(index + 1);
+        }
+
+        // BM25 leg: top-`window` matching docs by score. With a `~~~` knn
+        // split the text leg has its own candidate-source query
+        // (`W[knn := false]`) and text-relevance scoring query (`W` with the
+        // knn leaf deleted); otherwise both legs share this reader's query.
+        // The two leg queries only differ when the knn predicate is ANDed
+        // with the text query, where the candidate source is empty (no row
+        // matches independently of the knn set) but candidates surfaced by
+        // the vector window are still scored for text relevance.
+        let candidate_reader =
+            rrf_bm25_leg.map(|(match_query, _)| self.with_query_input(match_query));
+        let candidate_reader = candidate_reader.as_ref().unwrap_or(self);
+        let scoring_reader =
+            rrf_bm25_leg.map(|(_, scoring_query)| self.with_query_input(scoring_query));
+        let scoring_reader = scoring_reader.as_ref().unwrap_or(self);
+        for (scored, doc_address) in candidate_reader
+            .top_by_score_in_segments(
+                segment_ids.iter().copied(),
+                SortDirection::DescNullsLast,
+                window,
+                0,
+                None,
+                None,
+            )
+            .remaining()
+        {
+            candidates.entry(*doc_address).or_default().bm25 = Some(scored.bm25);
+        }
+
+        // Backfill BM25 scores for docs surfaced only by the vector leg;
+        // docs that don't match the text leg stay `None`.
+        let missing: Vec<DocAddress> = candidates
+            .iter()
+            .filter(|(_, candidate)| candidate.bm25.is_none())
+            .map(|(doc_address, _)| *doc_address)
+            .collect();
+        if !missing.is_empty() {
+            let backfilled = scoring_reader.bm25_scores_for_docs(missing);
+            for (doc_address, score) in backfilled {
+                candidates.entry(doc_address).or_default().bm25 = Some(score);
+            }
+        }
+
+        // BM25 ranks over the text-leg-matching candidates, then fuse: each
+        // present rank contributes its reciprocal.
+        let mut by_bm25: Vec<(DocAddress, f32)> = candidates
+            .iter()
+            .filter_map(|(doc_address, candidate)| candidate.bm25.map(|bm25| (*doc_address, bm25)))
+            .collect();
+        by_bm25.sort_unstable_by(|a, b| {
+            b.1.total_cmp(&a.1)
+                .then_with(|| (a.0.segment_ord, a.0.doc_id).cmp(&(b.0.segment_ord, b.0.doc_id)))
+        });
+        let bm25_ranks: HashMap<DocAddress, usize> = by_bm25
+            .into_iter()
+            .enumerate()
+            .map(|(index, (doc_address, _))| (doc_address, index + 1))
+            .collect();
+
+        let k = k as f32;
+        let mut fused: Vec<(DocAddress, HybridDocScores)> = candidates
+            .iter()
+            .map(|(doc_address, candidate)| {
+                let fused_score = bm25_ranks
+                    .get(doc_address)
+                    .map(|rank| 1.0 / (k + *rank as f32))
+                    .unwrap_or(0.0)
+                    + candidate
+                        .vector_rank
+                        .map(|rank| 1.0 / (k + rank as f32))
+                        .unwrap_or(0.0);
+                (
+                    *doc_address,
+                    HybridDocScores {
+                        bm25: candidate.bm25,
+                        similarity: candidate.similarity,
+                        fused: fused_score,
+                        rank: 0, // assigned below, once sorted
+                    },
+                )
+            })
+            .collect();
+
+        fused.sort_unstable_by(|a, b| {
+            b.1.fused
+                .total_cmp(&a.1.fused)
+                .then_with(|| (a.0.segment_ord, a.0.doc_id).cmp(&(b.0.segment_ord, b.0.doc_id)))
+        });
+        for (index, (_, scores)) in fused.iter_mut().enumerate() {
+            scores.rank = index + 1;
+        }
+
+        // Ascending rank is the natural direction (rank 1 = best first); a
+        // DESC ORDER BY honestly reverses it.
+        if !direction.is_asc() {
+            fused.reverse();
+        }
+
+        let results: Vec<(SearchIndexScore, DocAddress)> = fused
+            .iter()
+            .skip(offset)
+            .take(n)
+            .map(|(doc_address, scores)| {
+                (
+                    SearchIndexScore {
+                        bm25: scores.bm25.unwrap_or(0.0),
+                    },
+                    *doc_address,
+                )
+            })
+            .collect();
+
+        let mut top_k = TopKSearchResults::new(results, aggregation_results);
+        top_k.hybrid_components = Some(fused.into_iter().collect());
+        top_k
     }
 
     /// Called by `search_top_k_in_segments`.
@@ -1493,6 +1826,13 @@ impl SearchIndexReader {
                     // Vector distance cannot be a secondary sort key
                     unimplemented!("Vector distance ORDER BY can only be the primary sort key")
                 }
+                OrderByInfo {
+                    feature: OrderByFeature::Rrf { .. },
+                    ..
+                } => {
+                    // Rank fusion cannot be a secondary sort key
+                    unimplemented!("pdb.rrf() ORDER BY can only be the primary sort key")
+                }
             }
         }
 
@@ -1510,6 +1850,24 @@ impl SearchIndexReader {
 
     fn segment_ordinal_by_id(&self, segment_id: &SegmentId) -> Option<SegmentOrdinal> {
         self.segment_ordinal_by_id.get(segment_id).copied()
+    }
+
+    /// Validate that a resolved query vector's dimensionality matches the
+    /// indexed vector field, erroring with an actionable message instead of
+    /// letting the similarity kernel fail an internal assertion.
+    fn validate_query_vector_dims(&self, field_name: &FieldName, query_vector: &[f32]) {
+        if let Some(SearchFieldType::Vector(_, dims, _)) =
+            self.schema.get_field_type(field_name.root())
+        {
+            if dims != query_vector.len() {
+                pgrx::error!(
+                    "query vector has {} dimensions but field \"{}\" is indexed with {}",
+                    query_vector.len(),
+                    field_name,
+                    dims
+                );
+            }
+        }
     }
 
     /// NOTE: It is very important that this method consumes the input SegmentIds lazily, because

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -376,7 +376,8 @@ impl AggregateCSClause {
                 OrderByFeature::Score { .. }
                 | OrderByFeature::Var { .. }
                 | OrderByFeature::NullTest { .. }
-                | OrderByFeature::VectorDistance { .. } => None,
+                | OrderByFeature::VectorDistance { .. }
+                | OrderByFeature::Rrf { .. } => None,
             })
             .collect()
     }

--- a/pg_search/src/postgres/customscan/basescan/cost.rs
+++ b/pg_search/src/postgres/customscan/basescan/cost.rs
@@ -76,6 +76,10 @@ pub(super) enum WorkerDecisionReason {
     /// The row-count heuristic (`compute_nworkers`): no ANALYZE stats, or an unsorted scan with no
     /// usable cost estimate. Caps workers so each gets at least `min_rows_per_worker` rows.
     RowHeuristic,
+    /// A `pdb.rrf()` rank-fusion ordering: ranks are computed over the full
+    /// candidate set, so per-worker segment splits would fuse per-worker
+    /// ranks and produce wrong results. Always serial.
+    RankFusion,
 }
 
 impl WorkerDecisionReason {
@@ -87,6 +91,7 @@ impl WorkerDecisionReason {
             Self::CostModelLimited => "Cost model (LIMIT)",
             Self::SortedPerSegment => "Per-segment",
             Self::RowHeuristic => "Row-capped",
+            Self::RankFusion => "Rank fusion (serial)",
         }
     }
 }

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -415,9 +415,9 @@ impl ExecMethod for TopKScanExecState {
             }
         }
 
-        // Inject per-arm candidate windows harvested from `::pdb.top(n)`
-        // annotations, erroring if the same arm's window was also given via
-        // pdb.rrf() arguments.
+        // Inject per-arm candidate windows harvested from `::pdb.top_bm25(n)`
+        // / `::pdb.top_knn(n)` annotations, erroring if the same arm's window
+        // was also given via pdb.rrf() arguments.
         {
             let arm_bm25 = state.arm_bm25_window;
             let arm_vector = state.arm_vector_window;
@@ -433,7 +433,7 @@ impl ExecMethod for TopKScanExecState {
                             if let Some(window) = arm_bm25 {
                                 if *bm25_window != 0 && *bm25_window != window {
                                     pgrx::error!(
-                                        "the text arm's window is specified both via ::pdb.top and pdb.rrf(bm25_window_size => ..); use one"
+                                        "the text arm's window is specified both via ::pdb.top_bm25 and pdb.rrf(bm25_window_size => ..); use one"
                                     );
                                 }
                                 *bm25_window = window;
@@ -441,7 +441,7 @@ impl ExecMethod for TopKScanExecState {
                             if let Some(window) = arm_vector {
                                 if *vector_window != 0 && *vector_window != window {
                                     pgrx::error!(
-                                        "the vector arm's window is specified both via ::pdb.top and pdb.rrf(vector_window_size => ..); use one"
+                                        "the vector arm's window is specified both via ::pdb.top_knn and pdb.rrf(vector_window_size => ..); use one"
                                     );
                                 }
                                 *vector_window = window;

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -415,6 +415,53 @@ impl ExecMethod for TopKScanExecState {
             }
         }
 
+        // Inject per-arm candidate windows harvested from `::pdb.top(n)`
+        // annotations, erroring if the same arm's window was also given via
+        // pdb.rrf() arguments.
+        {
+            let arm_bm25 = state.arm_bm25_window;
+            let arm_vector = state.arm_vector_window;
+            if arm_bm25.is_some() || arm_vector.is_some() {
+                let fill = |infos: &mut [OrderByInfo]| {
+                    for info in infos.iter_mut() {
+                        if let OrderByFeature::Rrf {
+                            bm25_window,
+                            vector_window,
+                            ..
+                        } = &mut info.feature
+                        {
+                            if let Some(window) = arm_bm25 {
+                                if *bm25_window != 0 && *bm25_window != window {
+                                    pgrx::error!(
+                                        "the text arm's window is specified both via ::pdb.top and pdb.rrf(bm25_window_size => ..); use one"
+                                    );
+                                }
+                                *bm25_window = window;
+                            }
+                            if let Some(window) = arm_vector {
+                                if *vector_window != 0 && *vector_window != window {
+                                    pgrx::error!(
+                                        "the vector arm's window is specified both via ::pdb.top and pdb.rrf(vector_window_size => ..); use one"
+                                    );
+                                }
+                                *vector_window = window;
+                            }
+                        }
+                    }
+                };
+                if let ExecMethodType::TopK {
+                    orderby_info: Some(infos),
+                    ..
+                } = &mut state.exec_method_type
+                {
+                    fill(infos);
+                }
+                if let Some(infos) = self.orderby_info.as_mut() {
+                    fill(infos);
+                }
+            }
+        }
+
         // Call the default init behavior first
         self.reset(state);
 

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -18,10 +18,11 @@
 use std::cell::RefCell;
 
 use crate::api::version::VersionInfo;
-use crate::api::{HashMap, OrderByInfo};
+use crate::api::{HashMap, OrderByFeature, OrderByInfo};
 use crate::gucs;
 use crate::gucs::WorkMem;
 use crate::index::fast_fields_helper::{resolve_ctid, FFType};
+use crate::index::reader::index::HybridDocScores;
 use crate::index::reader::index::{
     SearchIndexReader, TopKAuxiliaryCollector, TopKSearchResults, MAX_TOPK_FEATURES,
 };
@@ -256,6 +257,33 @@ impl TopKScanExecState {
         })
     }
 
+    /// Populate `state.hybrid_doc_scores` with the BM25 score of each
+    /// document in the batch just fetched by `query`, for
+    /// `pdb.score(relation, 'bm25')` projection under a plain vector-distance
+    /// ordering (where the scan's own score is the similarity).
+    fn compute_vector_order_bm25_scores(&self, state: &mut BaseScanState) {
+        let batch = self.search_results.remaining();
+        if batch.is_empty() {
+            return;
+        }
+
+        let search_reader = self.search_reader.as_ref().unwrap();
+        let bm25_scores = search_reader.bm25_scores_for_docs(batch.iter().map(|(_, doc)| *doc));
+
+        let doc_scores = state.hybrid_doc_scores.get_or_insert_with(Default::default);
+        for (similarity, doc_address) in batch {
+            doc_scores.insert(
+                *doc_address,
+                HybridDocScores {
+                    bm25: bm25_scores.get(doc_address).copied(),
+                    similarity: Some(similarity.bm25),
+                    fused: 0.0,
+                    rank: 0,
+                },
+            );
+        }
+    }
+
     fn finalize_aggregates(
         &self,
         aggregations: PreparedAggregations,
@@ -332,6 +360,58 @@ impl ExecMethod for TopKScanExecState {
                 if let Some(infos) = self.orderby_info.as_mut() {
                     resolve(infos);
                 }
+            }
+        }
+
+        // Fill an omitted pdb.rrf() distance leg from the WHERE clause's
+        // `~~~` knn predicate, so the query vector only has to be written
+        // once.
+        {
+            let knn_fill = state.knn_leaf.clone().map(|(field, vector)| {
+                let schema = state
+                    .search_reader
+                    .as_ref()
+                    .expect("search reader should be initialized before the exec method")
+                    .schema();
+                let Some(crate::schema::SearchFieldType::Vector(_, _, metric)) =
+                    schema.get_field_type(field.root())
+                else {
+                    pgrx::error!("\"{field}\" is not a vector field of the bm25 index");
+                };
+                (field, vector, metric)
+            });
+
+            let fill = |infos: &mut [OrderByInfo]| {
+                for info in infos.iter_mut() {
+                    if let OrderByFeature::Rrf {
+                        name,
+                        query_vector,
+                        metric,
+                        ..
+                    } = &mut info.feature
+                    {
+                        if query_vector.is_none() {
+                            let Some((field, vector, field_metric)) = knn_fill.as_ref() else {
+                                pgrx::error!(
+                                    "pdb.rrf() without a distance leg requires a `~~~(vector, vector)` predicate in the WHERE clause"
+                                );
+                            };
+                            *name = Some(field.clone());
+                            *query_vector = Some(crate::api::QueryVector::Resolved(vector.clone()));
+                            *metric = Some(*field_metric);
+                        }
+                    }
+                }
+            };
+            if let ExecMethodType::TopK {
+                orderby_info: Some(infos),
+                ..
+            } = &mut state.exec_method_type
+            {
+                fill(infos);
+            }
+            if let Some(infos) = self.orderby_info.as_mut() {
+                fill(infos);
             }
         }
 
@@ -420,6 +500,36 @@ impl ExecMethod for TopKScanExecState {
             } else {
                 None
             };
+            // A `~~~` knn predicate must rank by the same vector as
+            // pdb.rrf()'s distance leg — its candidates are collected by
+            // that leg's ordering.
+            if let Some((knn_field, knn_vector)) = &state.knn_leaf {
+                let rrf_feature = orderby_info.first().map(|info| &info.feature);
+                let Some(OrderByFeature::Rrf {
+                    name, query_vector, ..
+                }) = rrf_feature
+                else {
+                    unreachable!(
+                        "a `~~~` predicate requires an rrf ordering (validated at scan init)"
+                    )
+                };
+                if name.as_ref() != Some(knn_field) {
+                    let name = name
+                        .as_ref()
+                        .map(|name| name.to_string())
+                        .unwrap_or_else(|| "<unresolved>".to_string());
+                    pgrx::error!(
+                        "the `~~~` operator's vector column (\"{knn_field}\") must match pdb.rrf()'s distance leg (\"{name}\")"
+                    );
+                }
+                if query_vector.as_ref().and_then(|qv| qv.resolved()) != Some(knn_vector.as_slice())
+                {
+                    pgrx::error!(
+                        "the `~~~` operator's query vector must match pdb.rrf()'s distance leg query vector"
+                    );
+                }
+            }
+
             self.search_reader
                 .as_ref()
                 .unwrap()
@@ -433,6 +543,10 @@ impl ExecMethod for TopKScanExecState {
                     self.offset,
                     maybe_aux_collector,
                     maybe_parallel_state,
+                    state
+                        .knn_bm25_leg_query
+                        .as_ref()
+                        .zip(state.knn_scoring_query.as_ref()),
                 )
         } else {
             self.search_reader
@@ -502,6 +616,23 @@ impl ExecMethod for TopKScanExecState {
             );
 
             state.window_aggregate_results = Some(window_aggregate_results);
+        }
+
+        // A `pdb.rrf()` fused search hands back per-document score components
+        // for `pdb.rrf()` / `pdb.score(relation, type)` projection.
+        if let Some(components) = self.search_results.take_hybrid_components() {
+            state
+                .hybrid_doc_scores
+                .get_or_insert_with(Default::default)
+                .extend(components);
+        }
+
+        // Under a plain vector-distance ordering the collector only produced
+        // similarity scores; recover per-document BM25 scores whenever score
+        // projection is in play — `pdb.score(relation)` always means the BM25
+        // score, regardless of what ranking drove the scan.
+        if state.orderby_is_vector_distance() && state.need_scores() {
+            self.compute_vector_order_bm25_scores(state);
         }
 
         // Record the offset to start from for the next query.

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -136,13 +136,48 @@ impl BaseScan {
         let needs_tokenizer_manager =
             search_query_input.needs_tokenizer() || state.custom_state().need_snippets();
 
+        // `::pdb.top(n)` arm annotations carry per-arm candidate windows;
+        // harvest them and strip the inert wrappers before execution.
+        let (search_query_input, top_arms) = search_query_input.strip_top_arms();
+        if !top_arms.is_empty() {
+            if !state.custom_state().orderby_is_rrf() {
+                pgrx::error!(
+                    "::pdb.top(n) annotations require a rank-fusion ordering: `ORDER BY pdb.rrf(<key>) LIMIT <n>`"
+                );
+            }
+            let mut text_window: Option<i32> = None;
+            let mut vector_window: Option<i32> = None;
+            for arm in &top_arms {
+                if arm.nested {
+                    pgrx::error!("::pdb.top(n) annotations cannot be nested");
+                }
+                if arm.contains_knn {
+                    if !arm.knn_only {
+                        pgrx::error!(
+                            "a ::pdb.top arm may contain either text predicates or a single `~~~` knn predicate, not both: the two are ranked by incomparable measures"
+                        );
+                    }
+                    if vector_window.replace(arm.window).is_some() {
+                        pgrx::error!("only one `~~~` knn arm is supported per query");
+                    }
+                } else if text_window.replace(arm.window).is_some() {
+                    pgrx::error!("multiple text arms (N-ary rank fusion) are not supported yet");
+                }
+            }
+            state.custom_state_mut().arm_bm25_window = text_window;
+            state.custom_state_mut().arm_vector_window = vector_window;
+            state
+                .custom_state_mut()
+                .replace_search_query_input(search_query_input.clone());
+        }
+
         // A `~~~` knn predicate splits the query into per-leg queries for the
         // rank-fusion TopK: the reader is opened with the vector leg's
         // driving query `W[knn := true]`; the text leg `W[knn := false]` is
         // stashed for the bm25 side of the fusion.
         let knn_leaves = search_query_input.knn_leaves();
         let search_query_input = if knn_leaves.is_empty() {
-            search_query_input.clone()
+            search_query_input
         } else {
             if !state.custom_state().orderby_is_rrf() {
                 pgrx::error!(
@@ -2819,6 +2854,11 @@ fn base_query_has_search_predicates(
 
         // A knn candidate predicate is a search predicate
         SearchQueryInput::Knn { .. } => true,
+
+        // A ::pdb.top arm is a search predicate when its subtree is
+        SearchQueryInput::TopN { query, .. } => {
+            base_query_has_search_predicates(query, current_index_oid)
+        }
 
         // HeapFilter contains search predicates
         SearchQueryInput::HeapFilter { indexed_query, .. } => {

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -90,7 +90,7 @@ use crate::postgres::utils::{
     filter_implied_predicates, is_unnest_func, missing_partial_index_predicate,
 };
 use crate::query::pdb_query::pdb;
-use crate::query::SearchQueryInput;
+use crate::query::{SearchQueryInput, TopMeasure};
 use crate::schema::SearchIndexSchema;
 use crate::{nodecast, DEFAULT_STARTUP_COST, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
 use crate::{FULL_RELATION_SELECTIVITY, UNASSIGNED_SELECTIVITY};
@@ -136,40 +136,70 @@ impl BaseScan {
         let needs_tokenizer_manager =
             search_query_input.needs_tokenizer() || state.custom_state().need_snippets();
 
-        // `::pdb.top(n)` arm annotations carry per-arm candidate windows;
-        // harvest them and strip the inert wrappers before execution.
-        let (search_query_input, top_arms) = search_query_input.strip_top_arms();
+        // `::pdb.top_bm25(n)` / `::pdb.top_knn(n)` arm annotations declare
+        // each arm's ranking measure and candidate window; harvest them and
+        // strip the inert wrappers before execution. A `::pdb.top_knn` arm
+        // also scopes the vector leg: its candidates are gathered among rows
+        // matching the arm's own filters (plus the shared context), not the
+        // whole boolean, so we derive those two leg queries from the
+        // pre-strip tree here.
+        let (stripped_query_input, top_arms) = search_query_input.strip_top_arms();
+        let mut arm_vector_leg: Option<SearchQueryInput> = None;
+        let mut arm_scoring_query: Option<SearchQueryInput> = None;
         if !top_arms.is_empty() {
             if !state.custom_state().orderby_is_rrf() {
                 pgrx::error!(
-                    "::pdb.top(n) annotations require a rank-fusion ordering: `ORDER BY pdb.rrf(<key>) LIMIT <n>`"
+                    "::pdb.top_bm25(n)/::pdb.top_knn(n) annotations require a rank-fusion ordering: `ORDER BY pdb.rrf(<key>) LIMIT <n>`"
                 );
             }
             let mut text_window: Option<i32> = None;
             let mut vector_window: Option<i32> = None;
             for arm in &top_arms {
                 if arm.nested {
-                    pgrx::error!("::pdb.top(n) annotations cannot be nested");
+                    pgrx::error!("fusion-arm annotations cannot be nested");
                 }
-                if arm.contains_knn {
-                    if !arm.knn_only {
-                        pgrx::error!(
-                            "a ::pdb.top arm may contain either text predicates or a single `~~~` knn predicate, not both: the two are ranked by incomparable measures"
-                        );
+                match arm.measure {
+                    TopMeasure::Bm25 => {
+                        if arm.contains_knn {
+                            pgrx::error!(
+                                "a ::pdb.top_bm25 arm ranks by BM25 and cannot contain a `~~~` knn predicate; annotate that group with ::pdb.top_knn instead"
+                            );
+                        }
+                        if text_window.replace(arm.window).is_some() {
+                            pgrx::error!(
+                                "multiple ::pdb.top_bm25 arms (N-ary rank fusion) are not supported yet"
+                            );
+                        }
                     }
-                    if vector_window.replace(arm.window).is_some() {
-                        pgrx::error!("only one `~~~` knn arm is supported per query");
+                    TopMeasure::Knn => {
+                        if !arm.contains_knn {
+                            pgrx::error!(
+                                "a ::pdb.top_knn arm must contain a `~~~` knn predicate: that is the measure it ranks by"
+                            );
+                        }
+                        if vector_window.replace(arm.window).is_some() {
+                            pgrx::error!("only one ::pdb.top_knn arm is supported per query");
+                        }
+                        arm_vector_leg = Some(SearchQueryInput::Boolean {
+                            must: vec![
+                                arm.inner.substitute_knn(true),
+                                search_query_input.knn_arm_context(),
+                            ],
+                            should: vec![],
+                            must_not: vec![],
+                            minimum_should_match: None,
+                        });
+                        arm_scoring_query = Some(search_query_input.without_knn_arm());
                     }
-                } else if text_window.replace(arm.window).is_some() {
-                    pgrx::error!("multiple text arms (N-ary rank fusion) are not supported yet");
                 }
             }
             state.custom_state_mut().arm_bm25_window = text_window;
             state.custom_state_mut().arm_vector_window = vector_window;
             state
                 .custom_state_mut()
-                .replace_search_query_input(search_query_input.clone());
+                .replace_search_query_input(stripped_query_input.clone());
         }
+        let search_query_input = stripped_query_input;
 
         // A `~~~` knn predicate splits the query into per-leg queries for the
         // rank-fusion TopK: the reader is opened with the vector leg's
@@ -194,9 +224,10 @@ impl BaseScan {
                 );
             }
 
-            let vector_leg = search_query_input.substitute_knn(true);
+            let vector_leg =
+                arm_vector_leg.unwrap_or_else(|| search_query_input.substitute_knn(true));
             let bm25_leg = search_query_input.substitute_knn(false);
-            let scoring = search_query_input.without_knn();
+            let scoring = arm_scoring_query.unwrap_or_else(|| search_query_input.without_knn());
             state.custom_state_mut().knn_bm25_leg_query = Some(bm25_leg);
             state.custom_state_mut().knn_scoring_query = Some(scoring);
             state.custom_state_mut().knn_leaf = Some((field, query_vector));
@@ -2855,7 +2886,7 @@ fn base_query_has_search_predicates(
         // A knn candidate predicate is a search predicate
         SearchQueryInput::Knn { .. } => true,
 
-        // A ::pdb.top arm is a search predicate when its subtree is
+        // A fusion-arm annotation is a search predicate when its subtree is
         SearchQueryInput::TopN { query, .. } => {
             base_query_has_search_predicates(query, current_index_oid)
         }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -45,7 +45,9 @@ use crate::postgres::customscan::basescan::exec_methods::{
     fast_fields, normal::NormalScanExecState, ExecState,
 };
 use crate::postgres::customscan::basescan::privdat::PrivateData;
-use crate::postgres::customscan::basescan::projections::score::uses_scores;
+use crate::postgres::customscan::basescan::projections::score::{
+    collect_typed_score_kinds, rrf_funcoids, typed_score_funcoid, uses_rrf, uses_scores, ScoreKind,
+};
 use crate::postgres::customscan::basescan::projections::snippet::{
     snippet_funcoids, snippet_positions_funcoids, snippets_funcoids, uses_snippets, SnippetType,
 };
@@ -121,11 +123,50 @@ impl BaseScan {
     ///    In this case, every worker executes the full scan independently using its own
     ///    transaction snapshot (`MvccSatisfies::Snapshot`).
     pub(crate) fn init_search_reader(state: &mut CustomScanStateWrapper<Self>) {
+        Self::validate_hybrid_usage(state.custom_state());
+
         let planstate = state.planstate();
         let expr_context = state.runtime_context;
         state
             .custom_state_mut()
             .prepare_query_for_execution(planstate, expr_context);
+
+        let search_query_input = state.custom_state().search_query_input();
+        let need_scores = state.custom_state().need_scores();
+        let needs_tokenizer_manager =
+            search_query_input.needs_tokenizer() || state.custom_state().need_snippets();
+
+        // A `~~~` knn predicate splits the query into per-leg queries for the
+        // rank-fusion TopK: the reader is opened with the vector leg's
+        // driving query `W[knn := true]`; the text leg `W[knn := false]` is
+        // stashed for the bm25 side of the fusion.
+        let knn_leaves = search_query_input.knn_leaves();
+        let search_query_input = if knn_leaves.is_empty() {
+            search_query_input.clone()
+        } else {
+            if !state.custom_state().orderby_is_rrf() {
+                pgrx::error!(
+                    "the `~~~(vector, vector)` operator requires a rank-fusion ordering: `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`"
+                );
+            }
+            if knn_leaves.len() > 1 {
+                pgrx::error!("only one `~~~(vector, vector)` predicate is supported per query");
+            }
+            let (field, query_vector, negated) = knn_leaves.into_iter().next().unwrap();
+            if negated {
+                pgrx::error!(
+                    "the `~~~(vector, vector)` operator cannot be used in a negated (NOT) position"
+                );
+            }
+
+            let vector_leg = search_query_input.substitute_knn(true);
+            let bm25_leg = search_query_input.substitute_knn(false);
+            let scoring = search_query_input.without_knn();
+            state.custom_state_mut().knn_bm25_leg_query = Some(bm25_leg);
+            state.custom_state_mut().knn_scoring_query = Some(scoring);
+            state.custom_state_mut().knn_leaf = Some((field, query_vector));
+            vector_leg
+        };
 
         // Open the index
         let indexrel = state
@@ -134,14 +175,9 @@ impl BaseScan {
             .as_ref()
             .expect("custom_state.indexrel should already be open");
 
-        let search_query_input = state.custom_state().search_query_input();
-        let need_scores = state.custom_state().need_scores();
-        let needs_tokenizer_manager =
-            search_query_input.needs_tokenizer() || state.custom_state().need_snippets();
-
         let search_reader = SearchIndexReader::open_with_context(
             indexrel,
-            search_query_input.clone(),
+            search_query_input,
             need_scores,
             unsafe {
                 if pg_sys::ParallelWorkerNumber == -1 {
@@ -193,9 +229,12 @@ impl BaseScan {
                 };
 
             for (snippet_type, generator) in &mut snippet_generators {
-                // Use enhanced query if available, otherwise use base query
+                // Use enhanced query if available, otherwise use base query.
+                // A `~~~` knn leaf has no text terms to highlight, so the
+                // text leg substitute stands in for it.
                 let query_to_use = enhanced_query_for_snippets
                     .as_ref()
+                    .or(state.custom_state().knn_scoring_query.as_ref())
                     .unwrap_or_else(|| state.custom_state().search_query_input());
 
                 let mut new_generator = state
@@ -222,6 +261,60 @@ impl BaseScan {
 
         unsafe {
             inject_pdb_placeholders(state);
+        }
+    }
+
+    /// Validate that the `pdb.rrf()` / `pdb.score(relation, type)` usages in
+    /// the query are computable by this scan's shape, erroring with
+    /// actionable messages when they are not.
+    fn validate_hybrid_usage(custom_state: &BaseScanState) {
+        let kinds = custom_state.typed_score_kinds;
+        if !kinds.has_any() && !custom_state.uses_rrf {
+            return;
+        }
+
+        let rrf_mode = custom_state.orderby_is_rrf();
+        let vector_mode = custom_state.orderby_is_vector_distance();
+
+        if custom_state.uses_rrf && !rrf_mode {
+            pgrx::error!(
+                "pdb.rrf() must drive the scan's ordering: use `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`"
+            );
+        }
+
+        for kind in [ScoreKind::Hybrid, ScoreKind::Rank] {
+            if kinds.contains(kind) && !rrf_mode {
+                pgrx::error!(
+                    "pdb.score(relation, '{}') requires a rank-fusion ordering: `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`",
+                    kind.type_name()
+                );
+            }
+        }
+
+        if kinds.contains(ScoreKind::Vector) && !rrf_mode && !vector_mode {
+            pgrx::error!(
+                "pdb.score(relation, 'vector') requires a vector ranking: order by `pdb.rrf(...)` or by a vector distance operator with a LIMIT"
+            );
+        }
+
+        if (custom_state.uses_rrf || kinds.contains(ScoreKind::Hybrid))
+            && custom_state.parallel_state.is_some()
+        {
+            pgrx::error!(
+                "pdb.rrf() is not supported under parallel query; try `SET max_parallel_workers_per_gather = 0`"
+            );
+        }
+
+        // Rank fusion over one partition of a partitioned table computes
+        // per-partition ranks that a Merge Append then interleaves, which is
+        // not the global fusion the query asks for (ranks, unlike scores,
+        // are not comparable across partitions).
+        if (custom_state.uses_rrf || rrf_mode)
+            && unsafe { (*custom_state.heaprel().rd_rel).relispartition }
+        {
+            pgrx::error!(
+                "pdb.rrf() is not supported on partitioned tables: per-partition fused ranks cannot be merged into a global ranking; query one partition directly or fuse per-partition results in SQL"
+            );
         }
     }
 
@@ -950,23 +1043,41 @@ impl CustomScan for BaseScan {
                 let consider_parallel_local = (*builder.args().rel).consider_parallel;
                 let prunability = topk_can_prune_for_method(&method, builder.args().root, &quals);
 
+                // A rank-fusion (`pdb.rrf()`) ordering computes ranks over the
+                // full candidate set: per-worker segment splits would fuse
+                // per-worker ranks and produce wrong results, so it is always
+                // serial.
+                let is_rrf_ordering = matches!(
+                    &method,
+                    ExecMethodType::TopK {
+                        orderby_info: Some(infos),
+                        ..
+                    } if infos.iter().any(|info| info.is_rrf())
+                );
+
                 // Decide the policy first: its reason gates the path cost below.
-                let policy = decide_scan_parallelism(ScanParallelismInputs {
-                    prunability,
-                    query: &query,
-                    drive_cost,
-                    row_estimate,
-                    is_sorted,
-                    limit: float_limit,
-                    base_result_rows,
-                    segment_count,
-                    consider_parallel: consider_parallel_local,
-                    quals: &quals,
-                    root: builder.args().root,
-                    parallel_leader_participates,
-                    is_join_context,
-                    has_grouping,
-                });
+                let policy = if is_rrf_ordering {
+                    WorkerPathPolicy::SerialOnly {
+                        reason: WorkerDecisionReason::RankFusion,
+                    }
+                } else {
+                    decide_scan_parallelism(ScanParallelismInputs {
+                        prunability,
+                        query: &query,
+                        drive_cost,
+                        row_estimate,
+                        is_sorted,
+                        limit: float_limit,
+                        base_result_rows,
+                        segment_count,
+                        consider_parallel: consider_parallel_local,
+                        quals: &quals,
+                        root: builder.args().root,
+                        parallel_leader_participates,
+                        is_join_context,
+                        has_grouping,
+                    })
+                };
                 let reason = policy.reason();
 
                 // Path cost. A prunable TopK excludes `drive_cost`: Block-WAND prunes it sublinear, so
@@ -978,7 +1089,8 @@ impl CustomScan for BaseScan {
                     WorkerDecisionReason::CostModel
                     | WorkerDecisionReason::CostModelLimited
                     | WorkerDecisionReason::SortedPerSegment
-                    | WorkerDecisionReason::RowHeuristic => drive_cost,
+                    | WorkerDecisionReason::RowHeuristic
+                    | WorkerDecisionReason::RankFusion => drive_cost,
                 };
                 let drive = match (path_drive_cost, row_estimate.known_rows()) {
                     (Some(cost), Some(matches)) => Some(DriveCost { cost, matches }),
@@ -1293,11 +1405,25 @@ impl CustomScan for BaseScan {
             builder.custom_state().snippet_funcoids = snippet_funcoids;
             builder.custom_state().snippets_funcoids = snippets_funcoids;
             builder.custom_state().snippet_positions_funcoids = snippet_positions_funcoids;
-            builder.custom_state().need_scores = uses_scores(
+            builder.custom_state().typed_score_kinds = collect_typed_score_kinds(
                 builder.target_list().as_ptr().cast(),
-                score_funcoids,
+                typed_score_funcoid(),
                 builder.custom_state().execution_rti,
             );
+            builder.custom_state().uses_rrf = uses_rrf(
+                builder.target_list().as_ptr().cast(),
+                rrf_funcoids(),
+                builder.custom_state().execution_rti,
+            );
+            // typed score projection and rank fusion need tantivy scoring
+            // enabled just like pdb.score does
+            builder.custom_state().need_scores =
+                uses_scores(
+                    builder.target_list().as_ptr().cast(),
+                    score_funcoids,
+                    builder.custom_state().execution_rti,
+                ) || builder.custom_state().typed_score_kinds.has_any()
+                    || builder.custom_state().uses_rrf;
 
             // Store join snippet predicates in the scan state
             builder.custom_state().join_predicates =
@@ -1622,7 +1748,7 @@ impl CustomScan for BaseScan {
                 ExecState::FromHeap {
                     ctid,
                     score,
-                    doc_address: _,
+                    doc_address,
                 } => {
                     unsafe {
                         let slot = match check_visibility(state, ctid, state.scanslot().cast()) {
@@ -1672,12 +1798,45 @@ impl CustomScan for BaseScan {
                             per_tuple_context.reset();
 
                             if state.custom_state().need_scores() {
+                                // `pdb.score(relation)` always means the BM25
+                                // score. Under a plain vector-distance
+                                // ordering the exec method's `score` is the
+                                // similarity, and under a `pdb.rrf()` union a
+                                // row may not match the text leg at all, so
+                                // in both cases the BM25 value comes from the
+                                // per-document component map.
+                                let bm25 = if state.custom_state().orderby_is_vector_distance()
+                                    || state.custom_state().orderby_is_rrf()
+                                {
+                                    state
+                                        .custom_state()
+                                        .hybrid_doc_scores
+                                        .as_ref()
+                                        .and_then(|scores| scores.get(&doc_address))
+                                        .and_then(|doc_scores| doc_scores.bm25)
+                                } else {
+                                    Some(score)
+                                };
                                 let const_score_node = state
                                     .custom_state()
                                     .const_score_node
                                     .expect("const_score_node should be set");
-                                (*const_score_node).constvalue = score.into_datum().unwrap();
-                                (*const_score_node).constisnull = false;
+                                match bm25 {
+                                    Some(bm25) => {
+                                        (*const_score_node).constvalue = bm25.into_datum().unwrap();
+                                        (*const_score_node).constisnull = false;
+                                    }
+                                    None => {
+                                        (*const_score_node).constvalue = pg_sys::Datum::null();
+                                        (*const_score_node).constisnull = true;
+                                    }
+                                }
+                            }
+
+                            if state.custom_state().has_typed_scores()
+                                || state.custom_state().uses_rrf
+                            {
+                                inject_hybrid_consts(state.custom_state(), score, doc_address);
                             }
 
                             // Update window aggregate values
@@ -2193,10 +2352,18 @@ unsafe fn inject_pdb_placeholders(state: &mut CustomScanStateWrapper<BaseScan>) 
     // forced projection we must do later.
     let planstate = state.planstate();
 
-    let (targetlist, const_score_node, const_snippet_nodes) = inject_placeholders(
+    let (
+        targetlist,
+        const_score_node,
+        const_typed_score_nodes,
+        const_rrf_node,
+        const_snippet_nodes,
+    ) = inject_placeholders(
         (*(*planstate).plan).targetlist,
         state.custom_state().planning_rti,
         state.custom_state().score_funcoids,
+        typed_score_funcoid(),
+        rrf_funcoids(),
         state.custom_state().snippet_funcoids,
         state.custom_state().snippets_funcoids,
         state.custom_state().snippet_positions_funcoids,
@@ -2223,9 +2390,83 @@ unsafe fn inject_pdb_placeholders(state: &mut CustomScanStateWrapper<BaseScan>) 
 
     state.custom_state_mut().placeholder_targetlist = Some(targetlist);
     state.custom_state_mut().const_score_node = Some(const_score_node);
+    state.custom_state_mut().const_typed_score_nodes = const_typed_score_nodes;
+    state.custom_state_mut().const_rrf_node = const_rrf_node;
     state.custom_state_mut().const_snippet_nodes = const_snippet_nodes;
     state.custom_state_mut().const_window_agg_nodes = const_window_agg_nodes;
     state.custom_state_mut().vector_distance_placeholder = vector_distance_placeholder;
+}
+
+/// Fill the `pdb.rrf()` and per-kind `pdb.score(relation, type)` placeholder
+/// `Const` nodes for the current row.
+///
+/// `score` is the row's score as produced by the exec method: the BM25 score
+/// in an ordinary search scan (including `pdb.rrf()` fused scans, which emit
+/// the BM25 leg score as the row score), or the vector similarity when the
+/// scan's TopK ordering is a plain vector distance. Everything else comes
+/// from the per-document `hybrid_doc_scores` component map.
+unsafe fn inject_hybrid_consts(
+    custom_state: &BaseScanState,
+    score: f32,
+    doc_address: tantivy::DocAddress,
+) {
+    let rrf_mode = custom_state.orderby_is_rrf();
+    let vector_mode = custom_state.orderby_is_vector_distance();
+    let components = custom_state
+        .hybrid_doc_scores
+        .as_ref()
+        .and_then(|scores| scores.get(&doc_address));
+
+    if let Some(const_rrf_node) = custom_state.const_rrf_node {
+        match components {
+            // validated: rrf consts only exist under an rrf ordering
+            Some(doc_scores) if rrf_mode => {
+                (*const_rrf_node).constvalue = (doc_scores.rank as f64).into_datum().unwrap();
+                (*const_rrf_node).constisnull = false;
+            }
+            _ => {
+                (*const_rrf_node).constvalue = pg_sys::Datum::null();
+                (*const_rrf_node).constisnull = true;
+            }
+        }
+    }
+
+    for kind in ScoreKind::ALL {
+        let Some(const_node) = custom_state.const_typed_score_nodes[kind as usize] else {
+            continue;
+        };
+
+        let value = match kind {
+            // the exec-method score IS the BM25 score except under a
+            // vector-distance or rank-fusion ordering, where the component
+            // map carries it (None for union rows outside the text leg)
+            ScoreKind::Bm25 if !vector_mode && !rrf_mode => Some(score),
+            ScoreKind::Bm25 => components.and_then(|doc_scores| doc_scores.bm25),
+            // under a plain vector-distance ordering the exec-method score IS
+            // the similarity; under rrf it comes from the vector leg (None
+            // for docs outside the vector window)
+            ScoreKind::Vector if vector_mode => Some(score),
+            ScoreKind::Vector => components.and_then(|doc_scores| doc_scores.similarity),
+            // validated: only computable under an rrf ordering
+            ScoreKind::Hybrid => components
+                .filter(|_| rrf_mode)
+                .map(|doc_scores| doc_scores.fused),
+            ScoreKind::Rank => components
+                .filter(|_| rrf_mode)
+                .map(|doc_scores| doc_scores.rank as f32),
+        };
+
+        match value {
+            Some(value) => {
+                (*const_node).constvalue = value.into_datum().unwrap();
+                (*const_node).constisnull = false;
+            }
+            None => {
+                (*const_node).constvalue = pg_sys::Datum::null();
+                (*const_node).constisnull = true;
+            }
+        }
+    }
 }
 
 /// Replace every *junk* top-level pgvector distance `OpExpr`
@@ -2575,6 +2816,9 @@ fn base_query_has_search_predicates(
 
         // Postgres expressions are unknown, assume they could be search predicates
         SearchQueryInput::PostgresExpression { .. } => true,
+
+        // A knn candidate predicate is a search predicate
+        SearchQueryInput::Knn { .. } => true,
 
         // HeapFilter contains search predicates
         SearchQueryInput::HeapFilter { indexed_query, .. } => {

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -18,12 +18,12 @@
 use crate::nodecast;
 use crate::postgres::customscan::score_funcoids;
 use pgrx::pg_sys::expression_tree_walker;
-use pgrx::{extension_sql, pg_extern, pg_guard, pg_sys, AnyElement, PgList};
+use pgrx::{extension_sql, pg_extern, pg_guard, pg_sys, AnyElement, FromDatum, PgList};
 use std::ptr::addr_of_mut;
 
 #[pgrx::pg_schema]
 mod pdb {
-    use pgrx::{extension_sql, pg_extern, AnyElement};
+    use pgrx::{default, extension_sql, pg_extern, AnyElement};
 
     #[allow(unused_variables)]
     #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
@@ -31,13 +31,354 @@ mod pdb {
         panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 
+    // `pdb.score` is overloaded (see `score_from_relation_typed`), so the
+    // ALTER must name the exact signature.
     extension_sql!(
         r#"
-    ALTER FUNCTION pdb.score SUPPORT paradedb.placeholder_support;
+    ALTER FUNCTION pdb.score(anyelement) SUPPORT paradedb.placeholder_support;
     "#,
         name = "score_placeholder",
         requires = [score_from_relation, placeholder_support]
     );
+
+    /// `pdb.score(relation, type)` — typed score projection. The score type is
+    /// one of `'bm25'`, `'vector'`, or `'hybrid'`; see
+    /// [`super::ScoreKind`]. Deliberately has NO DEFAULT on the second
+    /// argument: a defaulted overload would make plain `pdb.score(id)` calls
+    /// ambiguous against the single-argument function.
+    #[allow(unused_variables)]
+    #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
+    fn score_from_relation_typed(relation_reference: AnyElement, score_type: String) -> f32 {
+        panic!("pdb.score(relation, type) is only supported on queries executed by a ParadeDB custom scan. Please report unexpected cases at https://github.com/paradedb/paradedb/issues/new/choose");
+    }
+
+    // Rename the second parameter to `type` so callers can write
+    // `pdb.score(id, type => 'hybrid')`. `type` is a Rust keyword and pgrx
+    // renders `r#type` verbatim into SQL, so the pgrx-generated function is
+    // dropped and recreated with the desired parameter name (Postgres
+    // forbids renaming a named input parameter via CREATE OR REPLACE).
+    extension_sql!(
+        r#"
+    DROP FUNCTION pdb."score"(anyelement, text);
+    CREATE FUNCTION pdb."score"(
+        "relation_reference" anyelement,
+        "type" text
+    ) RETURNS real
+    STRICT STABLE PARALLEL SAFE COST 1
+    LANGUAGE c
+    AS 'MODULE_PATHNAME', 'score_from_relation_typed_wrapper';
+    ALTER FUNCTION pdb.score(anyelement, text) SUPPORT paradedb.placeholder_support;
+    "#,
+        name = "score_typed_placeholder",
+        requires = [score_from_relation_typed, placeholder_support]
+    );
+
+    /// `pdb.rrf(bm25_score, vector_distance, k, window_size)` — Reciprocal
+    /// Rank Fusion of a BM25 ranking and a vector-distance ranking. Only
+    /// meaningful as a TopK ORDER BY expression, e.g.
+    /// `ORDER BY pdb.rrf(pdb.score(id), embedding <=> '[...]') LIMIT 10`.
+    /// Returns the fused rank (1 = best), so ascending ORDER BY — the
+    /// pgvector convention — puts the best match first.
+    ///
+    /// See also the fully-implied relation form `pdb.rrf(relation, k,
+    /// window_size)` below, where both legs come from the WHERE clause.
+    /// The distance leg here must NOT have a DEFAULT: a defaulted overload
+    /// would make one-argument calls ambiguous against the relation form.
+    /// (The function is deliberately NOT STRICT so a literal NULL leg still
+    /// reaches the placeholder body and errors loudly when the query is not
+    /// executed by a rank-fusion scan, instead of silently sorting by NULL.)
+    ///
+    /// `window_size` is the per-leg candidate pool (the overfetch): each leg
+    /// contributes its top-`window_size` documents to the fusion. `0` (the
+    /// default) auto-sizes it to `max(4 * (LIMIT + OFFSET), 100)`; explicit
+    /// values are floored at `LIMIT + OFFSET` so the page cannot be
+    /// truncated. (Named `window_size` rather than `window` because WINDOW
+    /// is a reserved keyword and could not be used in `=>` notation.)
+    ///
+    /// Both ranking legs are `float8` so the legs can be written in either
+    /// order: `pdb.score(...)` is `real` and casts up implicitly, while a
+    /// `float8` distance could never cast down to a `real` parameter.
+    ///
+    /// No `placeholder_support` here: the call contains Vars for both the key
+    /// column and the vector column, which the support function's
+    /// single-`Var` PlaceHolderVar wrapping cannot represent.
+    #[allow(unused_variables)]
+    #[pg_extern(name = "rrf", stable, parallel_safe, cost = 1)]
+    fn rrf_placeholder(
+        bm25_score: Option<f64>,
+        vector_distance: Option<f64>,
+        k: default!(i32, 60),
+        window_size: default!(i32, 0),
+    ) -> f64 {
+        panic!("pdb.rrf() requires a ParadeDB TopK scan: use `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>` on a table with a bm25-indexed vector column");
+    }
+
+    /// `pdb.rrf(relation, k, window_size)` — the fully-implied form of rank
+    /// fusion: the BM25 leg is the WHERE clause's text query and the vector
+    /// leg is its `~~~` knn predicate, e.g.
+    ///
+    /// ```sql
+    /// WHERE description ||| 'shoes' OR embedding ~~~ '[...]'
+    /// ORDER BY pdb.rrf(id)
+    /// LIMIT 10;
+    /// ```
+    ///
+    /// The relation reference plays the same role as in `pdb.score(id)`.
+    #[allow(unused_variables)]
+    #[pg_extern(name = "rrf", stable, parallel_safe, cost = 1)]
+    fn rrf_from_relation(
+        relation_reference: AnyElement,
+        k: default!(i32, 60),
+        window_size: default!(i32, 0),
+    ) -> f64 {
+        panic!("pdb.rrf() requires a ParadeDB TopK scan: use `ORDER BY pdb.rrf(<key>) LIMIT <n>` with a `~~~` predicate in the WHERE clause");
+    }
+}
+
+/// The score type requested by a `pdb.score(relation, type)` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(usize)]
+pub enum ScoreKind {
+    /// The BM25 score of the row against the query's search predicate.
+    Bm25 = 0,
+    /// The vector similarity of the row against the query's vector ranking
+    /// (the `pdb.rrf()` distance leg, or a vector-distance ORDER BY).
+    Vector = 1,
+    /// The Reciprocal Rank Fusion score of the BM25 and vector rankings —
+    /// the positive fused score whose rank `pdb.rrf()` sorts by.
+    Hybrid = 2,
+    /// The 1-based fused rank — the same value `pdb.rrf()` projects.
+    Rank = 3,
+}
+
+impl ScoreKind {
+    pub const ALL: [ScoreKind; 4] = [
+        ScoreKind::Bm25,
+        ScoreKind::Vector,
+        ScoreKind::Hybrid,
+        ScoreKind::Rank,
+    ];
+
+    pub fn from_type_name(name: &str) -> Option<Self> {
+        match name {
+            "bm25" => Some(ScoreKind::Bm25),
+            "vector" => Some(ScoreKind::Vector),
+            "hybrid" => Some(ScoreKind::Hybrid),
+            "rank" => Some(ScoreKind::Rank),
+            _ => None,
+        }
+    }
+
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            ScoreKind::Bm25 => "bm25",
+            ScoreKind::Vector => "vector",
+            ScoreKind::Hybrid => "hybrid",
+            ScoreKind::Rank => "rank",
+        }
+    }
+}
+
+/// The set of `pdb.score(relation, type)` score types appearing in a query's
+/// target list.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ScoreKindSet([bool; 4]);
+
+impl ScoreKindSet {
+    pub fn insert(&mut self, kind: ScoreKind) {
+        self.0[kind as usize] = true;
+    }
+
+    pub fn contains(&self, kind: ScoreKind) -> bool {
+        self.0[kind as usize]
+    }
+
+    pub fn has_any(&self) -> bool {
+        self.0.iter().any(|b| *b)
+    }
+}
+
+/// Oid of the `pdb.score(anyelement, text)` typed-projection overload.
+pub fn typed_score_funcoid() -> pg_sys::Oid {
+    crate::postgres::utils::lookup_pdb_function("score", &[pg_sys::ANYELEMENTOID, pg_sys::TEXTOID])
+}
+
+/// Oids of the two `pdb.rrf` overloads: the explicit-legs form
+/// `pdb.rrf(float8, float8, int, int)` and the fully-implied relation form
+/// `pdb.rrf(anyelement, int, int)`.
+pub fn rrf_funcoids() -> [pg_sys::Oid; 2] {
+    [
+        crate::postgres::utils::lookup_pdb_function(
+            "rrf",
+            &[
+                pg_sys::FLOAT8OID,
+                pg_sys::FLOAT8OID,
+                pg_sys::INT4OID,
+                pg_sys::INT4OID,
+            ],
+        ),
+        crate::postgres::utils::lookup_pdb_function(
+            "rrf",
+            &[pg_sys::ANYELEMENTOID, pg_sys::INT4OID, pg_sys::INT4OID],
+        ),
+    ]
+}
+
+/// True when `funcid` is one of the (existing) `pdb.rrf` overloads.
+pub fn is_rrf_funcoid(funcid: pg_sys::Oid) -> bool {
+    funcid != pg_sys::Oid::INVALID && rrf_funcoids().contains(&funcid)
+}
+
+/// Extract the score type argument from a `pdb.score(relation, type)` call.
+///
+/// Returns `None` when the second argument is not a constant (e.g. a Var or
+/// arbitrary expression). Raises an ERROR when the constant is NULL or not a
+/// recognized score type.
+pub unsafe fn typed_score_kind_from_funcexpr(funcexpr: *mut pg_sys::FuncExpr) -> Option<ScoreKind> {
+    let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+    if args.len() != 2 {
+        return None;
+    }
+    let const_ = nodecast!(Const, T_Const, args.get_ptr(1)?)?;
+    if (*const_).constisnull {
+        panic!("pdb.score: the score type must not be NULL");
+    }
+    let type_name = String::from_datum((*const_).constvalue, false)
+        .expect("pdb.score: should be able to read the score type argument");
+    match ScoreKind::from_type_name(&type_name) {
+        Some(kind) => Some(kind),
+        None => panic!(
+            "pdb.score: unrecognized score type '{type_name}'; expected 'bm25', 'vector', 'hybrid', or 'rank'"
+        ),
+    }
+}
+
+/// Walk `node` collecting the score types of all `pdb.score(<var>, <type>)`
+/// calls whose relation reference belongs to `rti`.
+///
+/// Raises an ERROR if a matching call's score type argument is not a constant.
+pub unsafe fn collect_typed_score_kinds(
+    node: *mut pg_sys::Node,
+    typed_score_funcoid: pg_sys::Oid,
+    rti: pg_sys::Index,
+) -> ScoreKindSet {
+    if typed_score_funcoid == pg_sys::Oid::INVALID {
+        return ScoreKindSet::default();
+    }
+
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        data: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+
+        if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, node) {
+            let data_ref = &mut *data.cast::<Data>();
+            if (*funcexpr).funcid == data_ref.typed_score_funcoid {
+                let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+                if let Some(var) = args.get_ptr(0).and_then(|arg| nodecast!(Var, T_Var, arg)) {
+                    if (*var).varno as i32 == data_ref.rti as i32 {
+                        match typed_score_kind_from_funcexpr(funcexpr) {
+                            Some(kind) => data_ref.kinds.insert(kind),
+                            None => panic!("pdb.score: the score type must be a constant"),
+                        }
+                    }
+                }
+            }
+        }
+
+        expression_tree_walker(node, Some(walker), data)
+    }
+
+    struct Data {
+        typed_score_funcoid: pg_sys::Oid,
+        rti: pg_sys::Index,
+        kinds: ScoreKindSet,
+    }
+
+    let mut data = Data {
+        typed_score_funcoid,
+        rti,
+        kinds: ScoreKindSet::default(),
+    };
+
+    walker(node, addr_of_mut!(data).cast());
+    data.kinds
+}
+
+/// Walk `node` looking for a `pdb.rrf(...)` call containing any `Var`
+/// belonging to `rti` (the relation reference, score leg, and distance leg
+/// all qualify).
+///
+/// Raises an ERROR when two structurally different `pdb.rrf(...)` calls
+/// appear: all calls share one per-row placeholder value (the ORDER BY's
+/// fused rank), so distinct calls would silently project the wrong value.
+pub unsafe fn uses_rrf(
+    node: *mut pg_sys::Node,
+    rrf_funcoids: [pg_sys::Oid; 2],
+    rti: pg_sys::Index,
+) -> bool {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn contains_rti_var(
+        node: *mut pg_sys::Node,
+        data: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+        if let Some(var) = nodecast!(Var, T_Var, node) {
+            let rti = *data.cast::<pg_sys::Index>();
+            if (*var).varno as i32 == rti as i32 {
+                return true;
+            }
+        }
+        expression_tree_walker(node, Some(contains_rti_var), data)
+    }
+
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        data: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+
+        if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, node) {
+            let data_ref = &mut *data.cast::<Data>();
+            if (*funcexpr).funcid != pg_sys::Oid::INVALID
+                && data_ref.rrf_funcoids.contains(&(*funcexpr).funcid)
+                && contains_rti_var(node, addr_of_mut!(data_ref.rti).cast())
+            {
+                if data_ref.first.is_null() {
+                    data_ref.first = node;
+                } else if !pg_sys::equal(data_ref.first.cast(), node.cast()) {
+                    panic!("pdb.rrf: all pdb.rrf() calls in a query must be identical (same legs and k); project the fused rank once and reuse it");
+                }
+                // don't descend: a pdb.rrf() call cannot contain another
+                return false;
+            }
+        }
+
+        expression_tree_walker(node, Some(walker), data)
+    }
+
+    struct Data {
+        rrf_funcoids: [pg_sys::Oid; 2],
+        rti: pg_sys::Index,
+        first: *mut pg_sys::Node,
+    }
+
+    let mut data = Data {
+        rrf_funcoids,
+        rti,
+        first: std::ptr::null_mut(),
+    };
+    walker(node, addr_of_mut!(data).cast());
+    !data.first.is_null()
 }
 
 // In `0.19.0`, we renamed the schema from `paradedb` to `pdb`.

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -91,9 +91,13 @@ mod pdb {
     /// `window_size` is the per-leg candidate pool (the overfetch): each leg
     /// contributes its top-`window_size` documents to the fusion. `0` (the
     /// default) auto-sizes it to `max(4 * (LIMIT + OFFSET), 100)`; explicit
-    /// values are floored at `LIMIT + OFFSET` so the page cannot be
-    /// truncated. (Named `window_size` rather than `window` because WINDOW
-    /// is a reserved keyword and could not be used in `=>` notation.)
+    /// values are respected literally, so an arm window smaller than the
+    /// page bounds that arm's contribution (and a single-arm query with a
+    /// too-small window can return fewer rows than the LIMIT).
+    /// `bm25_window_size` / `vector_window_size` override it per arm
+    /// (0 = inherit `window_size`). (Named `window_size` rather than
+    /// `window` because WINDOW is a reserved keyword and could not be used
+    /// in `=>` notation.)
     ///
     /// Both ranking legs are `float8` so the legs can be written in either
     /// order: `pdb.score(...)` is `real` and casts up implicitly, while a
@@ -109,6 +113,8 @@ mod pdb {
         vector_distance: Option<f64>,
         k: default!(i32, 60),
         window_size: default!(i32, 0),
+        bm25_window_size: default!(i32, 0),
+        vector_window_size: default!(i32, 0),
     ) -> f64 {
         panic!("pdb.rrf() requires a ParadeDB TopK scan: use `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>` on a table with a bm25-indexed vector column");
     }
@@ -130,6 +136,8 @@ mod pdb {
         relation_reference: AnyElement,
         k: default!(i32, 60),
         window_size: default!(i32, 0),
+        bm25_window_size: default!(i32, 0),
+        vector_window_size: default!(i32, 0),
     ) -> f64 {
         panic!("pdb.rrf() requires a ParadeDB TopK scan: use `ORDER BY pdb.rrf(<key>) LIMIT <n>` with a `~~~` predicate in the WHERE clause");
     }
@@ -215,11 +223,19 @@ pub fn rrf_funcoids() -> [pg_sys::Oid; 2] {
                 pg_sys::FLOAT8OID,
                 pg_sys::INT4OID,
                 pg_sys::INT4OID,
+                pg_sys::INT4OID,
+                pg_sys::INT4OID,
             ],
         ),
         crate::postgres::utils::lookup_pdb_function(
             "rrf",
-            &[pg_sys::ANYELEMENTOID, pg_sys::INT4OID, pg_sys::INT4OID],
+            &[
+                pg_sys::ANYELEMENTOID,
+                pg_sys::INT4OID,
+                pg_sys::INT4OID,
+                pg_sys::INT4OID,
+                pg_sys::INT4OID,
+            ],
         ),
     ]
 }

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -109,6 +109,11 @@ pub struct BaseScanState {
     /// The `(vector field, query vector)` of the `~~~` knn predicate, for
     /// validating that it matches `pdb.rrf()`'s distance leg.
     pub knn_leaf: Option<(FieldName, Vec<f32>)>,
+    /// Per-arm candidate windows harvested from `::pdb.top(n)` annotations
+    /// in the WHERE clause (text arm, vector arm). Injected into the Rrf
+    /// ordering feature at exec-method init.
+    pub arm_bm25_window: Option<i32>,
+    pub arm_vector_window: Option<i32>,
 
     /// True when a junk ORDER-BY `embedding <-> query` `OpExpr` in the scan's
     /// targetlist was replaced with a NULL placeholder `Const` (see
@@ -178,6 +183,13 @@ impl BaseScanState {
 
     pub fn set_base_search_query_input(&mut self, input: SearchQueryInput) {
         self.base_search_query_input = input;
+    }
+
+    /// Replace the executable query (used after `::pdb.top` arm annotations
+    /// are stripped, so downstream consumers like snippet generation never
+    /// see the inert wrappers).
+    pub fn replace_search_query_input(&mut self, input: SearchQueryInput) {
+        self.search_query_input = input;
     }
 
     pub fn search_query_input(&self) -> &SearchQueryInput {

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -109,9 +109,9 @@ pub struct BaseScanState {
     /// The `(vector field, query vector)` of the `~~~` knn predicate, for
     /// validating that it matches `pdb.rrf()`'s distance leg.
     pub knn_leaf: Option<(FieldName, Vec<f32>)>,
-    /// Per-arm candidate windows harvested from `::pdb.top(n)` annotations
-    /// in the WHERE clause (text arm, vector arm). Injected into the Rrf
-    /// ordering feature at exec-method init.
+    /// Per-arm candidate windows harvested from `::pdb.top_bm25(n)` /
+    /// `::pdb.top_knn(n)` annotations in the WHERE clause (text arm, vector
+    /// arm). Injected into the Rrf ordering feature at exec-method init.
     pub arm_bm25_window: Option<i32>,
     pub arm_vector_window: Option<i32>,
 
@@ -185,9 +185,9 @@ impl BaseScanState {
         self.base_search_query_input = input;
     }
 
-    /// Replace the executable query (used after `::pdb.top` arm annotations
-    /// are stripped, so downstream consumers like snippet generation never
-    /// see the inert wrappers).
+    /// Replace the executable query (used after fusion-arm annotations are
+    /// stripped, so downstream consumers like snippet generation never see
+    /// the inert wrappers).
     pub fn replace_search_query_input(&mut self, input: SearchQueryInput) {
         self.search_query_input = input;
     }

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -17,11 +17,13 @@
 
 use std::cell::UnsafeCell;
 
-use crate::api::{FieldName, HashMap, OrderByInfo, Varno};
+use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, Varno};
 use crate::customscan::CustomScanState;
+use crate::index::reader::index::HybridDocScores;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::customscan::basescan::cost::WorkerDecisionReason;
 use crate::postgres::customscan::basescan::exec_methods::ExecMethod;
+use crate::postgres::customscan::basescan::projections::score::ScoreKindSet;
 use crate::postgres::customscan::basescan::projections::snippet::pdb::IntArray2D;
 use crate::postgres::customscan::basescan::projections::snippet::SnippetType;
 use crate::postgres::customscan::basescan::projections::window_agg::WindowAggregateInfo;
@@ -37,6 +39,7 @@ use crate::query::SearchQueryInput;
 use pgrx::heap_tuple::PgHeapTuple;
 use pgrx::{pg_sys, PgTupleDesc};
 use tantivy::snippet::SnippetGenerator;
+use tantivy::DocAddress;
 
 #[derive(Default)]
 pub struct BaseScanState {
@@ -74,6 +77,38 @@ pub struct BaseScanState {
     pub need_scores: bool,
     pub const_score_node: Option<*mut pg_sys::Const>,
     pub score_funcoids: [pg_sys::Oid; 2],
+
+    /// Which `pdb.score(relation, type)` score types appear in the target
+    /// list (empty when the typed overload is not used).
+    pub typed_score_kinds: ScoreKindSet,
+    /// True when the target list contains a `pdb.rrf(...)` call for this
+    /// relation.
+    pub uses_rrf: bool,
+    /// Placeholder `Const` nodes for `pdb.score(relation, type)` calls, one
+    /// slot per
+    /// [`crate::postgres::customscan::basescan::projections::score::ScoreKind`],
+    /// mutated per row during projection.
+    pub const_typed_score_nodes: [Option<*mut pg_sys::Const>; 4],
+    /// Placeholder `Const` node (float8) for `pdb.rrf(...)` calls, mutated
+    /// per row with the document's fused rank.
+    pub const_rrf_node: Option<*mut pg_sys::Const>,
+    /// Per-document score components (BM25, similarity, fused RRF score and
+    /// rank) computed by the exec method for `pdb.rrf()` orderings and for
+    /// typed score projection under a vector-distance ordering.
+    pub hybrid_doc_scores: Option<HashMap<DocAddress, HybridDocScores>>,
+
+    /// When the WHERE clause contains a `~~~` knn predicate, the text leg's
+    /// candidate-source query `W[knn := false]` (the search reader itself is
+    /// opened with the vector leg's driving query `W[knn := true]`).
+    pub knn_bm25_leg_query: Option<SearchQueryInput>,
+    /// The text-relevance scoring query: `W` with the knn leaf deleted from
+    /// its boolean context. Identical to the candidate-source query for OR
+    /// shapes; under `text AND ~~~` it preserves the text query where the
+    /// `false` substitution would collapse to `Empty`.
+    pub knn_scoring_query: Option<SearchQueryInput>,
+    /// The `(vector field, query vector)` of the `~~~` knn predicate, for
+    /// validating that it matches `pdb.rrf()`'s distance leg.
+    pub knn_leaf: Option<(FieldName, Vec<f32>)>,
 
     /// True when a junk ORDER-BY `embedding <-> query` `OpExpr` in the scan's
     /// targetlist was replaced with a NULL placeholder `Const` (see
@@ -229,6 +264,37 @@ impl BaseScanState {
     #[inline(always)]
     pub fn need_snippets(&self) -> bool {
         !self.snippet_generators.is_empty()
+    }
+
+    #[inline(always)]
+    pub fn has_typed_scores(&self) -> bool {
+        self.typed_score_kinds.has_any()
+    }
+
+    /// True when this scan's TopK ordering is a vector-distance feature, i.e.
+    /// the per-row score produced by the exec method is a vector similarity
+    /// rather than a BM25 score.
+    pub fn orderby_is_vector_distance(&self) -> bool {
+        self.orderby_info()
+            .as_ref()
+            .map(|infos| {
+                infos
+                    .iter()
+                    .any(|info| matches!(info.feature, OrderByFeature::VectorDistance { .. }))
+            })
+            .unwrap_or(false)
+    }
+
+    /// True when this scan's TopK ordering is a `pdb.rrf(...)` rank fusion.
+    pub fn orderby_is_rrf(&self) -> bool {
+        self.orderby_info()
+            .as_ref()
+            .map(|infos| {
+                infos
+                    .iter()
+                    .any(|info| matches!(info.feature, OrderByFeature::Rrf { .. }))
+            })
+            .unwrap_or(false)
     }
 
     #[track_caller]
@@ -396,6 +462,7 @@ impl BaseScanState {
             self.doc_from_heap_state = Some(HeapFetchState::new(self.heaprel()));
         }
         self.window_aggregate_results = None;
+        self.hybrid_doc_scores = None;
         self.exec_method_mut().reset(self);
     }
 

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -43,6 +43,18 @@ pub enum OrderByStyle {
         /// See `OrderByFeature::VectorDistance::metric`.
         metric: crate::vector::metric::VectorMetric,
     },
+    /// See `OrderByFeature::Rrf`.
+    Rrf {
+        pathkey: *mut pg_sys::PathKey,
+        /// The vector field of the distance leg; `None` when the vector leg
+        /// is deferred to the WHERE clause's `~~~` predicate.
+        name: Option<FieldName>,
+        rti: u32,
+        query_vector: Option<crate::api::QueryVector>,
+        metric: Option<crate::vector::metric::VectorMetric>,
+        k: i32,
+        window: i32,
+    },
 }
 
 impl OrderByStyle {
@@ -51,6 +63,7 @@ impl OrderByStyle {
             OrderByStyle::Score { pathkey, .. } => *pathkey,
             OrderByStyle::Field { pathkey, .. } => *pathkey,
             OrderByStyle::VectorDistance { pathkey, .. } => *pathkey,
+            OrderByStyle::Rrf { pathkey, .. } => *pathkey,
         }
     }
 
@@ -112,6 +125,22 @@ impl From<&OrderByStyle> for OrderByInfo {
                 rti: *rti,
                 query_vector: query_vector.clone(),
                 metric: *metric,
+            },
+            OrderByStyle::Rrf {
+                name,
+                rti,
+                query_vector,
+                metric,
+                k,
+                window,
+                ..
+            } => OrderByFeature::Rrf {
+                name: name.clone(),
+                rti: *rti,
+                query_vector: query_vector.clone(),
+                metric: *metric,
+                k: *k,
+                window: *window,
             },
         };
         OrderByInfo {

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -54,6 +54,8 @@ pub enum OrderByStyle {
         metric: Option<crate::vector::metric::VectorMetric>,
         k: i32,
         window: i32,
+        bm25_window: i32,
+        vector_window: i32,
     },
 }
 
@@ -133,6 +135,8 @@ impl From<&OrderByStyle> for OrderByInfo {
                 metric,
                 k,
                 window,
+                bm25_window,
+                vector_window,
                 ..
             } => OrderByFeature::Rrf {
                 name: name.clone(),
@@ -141,6 +145,8 @@ impl From<&OrderByStyle> for OrderByInfo {
                 metric: *metric,
                 k: *k,
                 window: *window,
+                bm25_window: *bm25_window,
+                vector_window: *vector_window,
             },
         };
         OrderByInfo {

--- a/pg_search/src/postgres/customscan/explain.rs
+++ b/pg_search/src/postgres/customscan/explain.rs
@@ -241,6 +241,7 @@ fn inject_estimates_into_json(
         | SearchQueryInput::PostgresExpression { .. }
         | SearchQueryInput::FieldedQuery { .. }
         | SearchQueryInput::Knn { .. }
+        | SearchQueryInput::TopN { .. }
         | SearchQueryInput::Uninitialized => {
             // These are leaf nodes, no children to process
         }

--- a/pg_search/src/postgres/customscan/explain.rs
+++ b/pg_search/src/postgres/customscan/explain.rs
@@ -240,6 +240,7 @@ fn inject_estimates_into_json(
         | SearchQueryInput::TermSet { .. }
         | SearchQueryInput::PostgresExpression { .. }
         | SearchQueryInput::FieldedQuery { .. }
+        | SearchQueryInput::Knn { .. }
         | SearchQueryInput::Uninitialized => {
             // These are leaf nodes, no children to process
         }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -767,6 +767,9 @@ fn resolve_orderby_feature(
         OrderByFeature::VectorDistance { .. } => {
             unimplemented!("Vector distance ORDER BY is not supported in JoinScan")
         }
+        OrderByFeature::Rrf { .. } => {
+            unimplemented!("pdb.rrf() ORDER BY is not supported in JoinScan")
+        }
     }
 }
 
@@ -1006,7 +1009,9 @@ fn build_source_df<'a>(
                             }
                         }
                     }
-                    OrderByFeature::Score { .. } | OrderByFeature::VectorDistance { .. } => {}
+                    OrderByFeature::Score { .. }
+                    | OrderByFeature::VectorDistance { .. }
+                    | OrderByFeature::Rrf { .. } => {}
                     OrderByFeature::NullTest { inner, .. } => match inner.as_ref() {
                         OrderByFeature::Field { name, rti } if source.contains_rti(*rti) => {
                             insert_field_name_required_early(

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -31,6 +31,9 @@ use crate::postgres::catalog::{
     lookup_collation_locale, lookup_database_collation_locale, CollationLocale, CollationProvider,
 };
 use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_matching_fast_field;
+use crate::postgres::customscan::basescan::projections::score::{
+    is_rrf_funcoid, rrf_funcoids, typed_score_funcoid, typed_score_kind_from_funcexpr, ScoreKind,
+};
 use crate::postgres::customscan::builders::custom_path::OrderByStyle;
 use crate::postgres::customscan::score_funcoids;
 use crate::postgres::rel_get_bm25_index;
@@ -73,6 +76,21 @@ pub enum SortExpressionType {
     VectorMetricMismatch {
         field_metric: VectorMetric,
         op_metric: VectorMetric,
+    },
+    /// Sorting by Reciprocal Rank Fusion:
+    /// `ORDER BY pdb.rrf(pdb.score(key) [, vector_col <op> query_vector] [, k, window])`.
+    /// Fuses the query's BM25 ranking with a vector-distance ranking; rows
+    /// come out in fused-rank order (ascending = best first).
+    ///
+    /// `query_vector`/`metric` are `None` when the distance leg was omitted;
+    /// they are filled in at execution time from the WHERE clause's `~~~`
+    /// knn predicate.
+    Rrf {
+        query_vector: Option<QueryVector>,
+        metric: Option<VectorMetric>,
+        k: i32,
+        /// Per-leg candidate pool; 0 = auto-size from the LIMIT.
+        window: i32,
     },
 }
 
@@ -145,8 +163,173 @@ unsafe fn extract_score_var(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var>
                 return nodecast!(Var, T_Var, args.get_ptr(0).unwrap());
             }
         }
+
+        // `pdb.score(relation, 'bm25')` sorts by score too; the other score
+        // types cannot drive a score-ordered TopK.
+        let typed = typed_score_funcoid();
+        if typed != pg_sys::Oid::INVALID
+            && (*funcexpr).funcid == typed
+            && typed_score_kind_from_funcexpr(funcexpr) == Some(ScoreKind::Bm25)
+        {
+            let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+            return nodecast!(Var, T_Var, args.get_ptr(0)?);
+        }
     }
     None
+}
+
+/// Unwrap a single-argument cast `FuncExpr` (e.g. the `real -> double
+/// precision` coercion Postgres inserts around `pdb.score(...)` to match
+/// `pdb.rrf`'s float8 parameters), returning the cast's argument.
+unsafe fn strip_cast_funcexpr(node: *mut pg_sys::Node) -> *mut pg_sys::Node {
+    if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, node) {
+        if (*funcexpr).funcformat == pg_sys::CoercionForm::COERCE_IMPLICIT_CAST
+            || (*funcexpr).funcformat == pg_sys::CoercionForm::COERCE_EXPLICIT_CAST
+        {
+            let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+            if args.len() == 1 {
+                return args.get_ptr(0).unwrap();
+            }
+        }
+    }
+    node
+}
+
+/// Detect `pdb.rrf(...)` in either form:
+///
+///   * explicit legs — `pdb.rrf(pdb.score(key), vector_col <op> query_vector
+///     [, k, window_size])`, legs in either order;
+///   * relation form — `pdb.rrf(relation [, k, window_size])`, where the BM25
+///     leg is the WHERE clause's text query and the vector leg its `~~~` knn
+///     predicate (filled in at execution time).
+///
+/// Returns a `Var` of the target relation (for pathkey validation and, when
+/// an explicit distance leg is present, field-name resolution) and the sort
+/// descriptor. A metric/opclass mismatch on an explicit distance leg is
+/// propagated as `SortExpressionType::VectorMetricMismatch` so the planner
+/// surfaces the specific warning instead of silently falling back.
+unsafe fn extract_rrf(
+    node: *mut pg_sys::Node,
+    context: VarContext,
+    schema: &SearchIndexSchema,
+) -> Option<(*mut pg_sys::Var, SortExpressionType)> {
+    let funcexpr = nodecast!(FuncExpr, T_FuncExpr, node)?;
+    if !is_rrf_funcoid((*funcexpr).funcid) {
+        return None;
+    }
+    let [_, relation_form_funcoid] = rrf_funcoids();
+
+    let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+
+    // The fully-implied relation form: pdb.rrf(relation, k, window_size).
+    // Both legs come from the target relation's own predicates. The relation
+    // reference may also be written as pdb.score(relation).
+    if (*funcexpr).funcid == relation_form_funcoid {
+        if args.len() != 3 {
+            return None;
+        }
+        let relation_arg = strip_cast_funcexpr(args.get_ptr(0)?);
+        let relation_var =
+            nodecast!(Var, T_Var, relation_arg).or_else(|| extract_score_var(relation_arg))?;
+
+        let (k, window) = extract_rrf_knobs(&args, 1)?;
+        return Some((
+            relation_var,
+            SortExpressionType::Rrf {
+                query_vector: None,
+                metric: None,
+                k,
+                window,
+            },
+        ));
+    }
+
+    if args.len() != 4 {
+        return None;
+    }
+
+    // `pdb.rrf`'s ranking parameters are float8, so Postgres wraps the `real`
+    // `pdb.score(...)` leg in an implicit cast; unwrap before classifying.
+    let (first, second) = (
+        strip_cast_funcexpr(args.get_ptr(0)?),
+        strip_cast_funcexpr(args.get_ptr(1)?),
+    );
+    let (score_leg, distance_leg) = if extract_score_var(first).is_some() {
+        (first, second)
+    } else if extract_score_var(second).is_some() {
+        (second, first)
+    } else {
+        return None;
+    };
+    let score_var = extract_score_var(score_leg)?;
+
+    let distance_leg = strip_identity_wrappers(distance_leg);
+
+    // The distance leg is optional (a NULL Const when defaulted): the vector
+    // leg then comes from the WHERE clause's `~~~` knn predicate, resolved
+    // at execution time. The relation Var for pathkey validation is the
+    // vector column's when present, else the score leg's relation reference.
+    let (leg_var, query_vector, metric) =
+        if let Some(const_) = nodecast!(Const, T_Const, distance_leg) {
+            if !(*const_).constisnull {
+                return None;
+            }
+            (score_var, None, None)
+        } else {
+            let (vector_var, vector_sort) = extract_vector_distance(distance_leg, context, schema)?;
+
+            // Both legs must reference the same relation.
+            if (*score_var).varno != (*vector_var).varno {
+                return None;
+            }
+
+            match vector_sort {
+                SortExpressionType::VectorDistance {
+                    query_vector,
+                    metric,
+                } => (vector_var, Some(query_vector), Some(metric)),
+                mismatch @ SortExpressionType::VectorMetricMismatch { .. } => {
+                    return Some((vector_var, mismatch));
+                }
+                _ => return None,
+            }
+        };
+
+    let (k, window) = extract_rrf_knobs(&args, 2)?;
+
+    Some((
+        leg_var,
+        SortExpressionType::Rrf {
+            query_vector,
+            metric,
+            k,
+            window,
+        },
+    ))
+}
+
+/// Extract the constant `k` and `window_size` arguments of a `pdb.rrf(...)`
+/// call, starting at `start` in its argument list.
+unsafe fn extract_rrf_knobs(args: &PgList<pg_sys::Node>, start: usize) -> Option<(i32, i32)> {
+    let k_const = nodecast!(Const, T_Const, args.get_ptr(start)?)?;
+    if (*k_const).constisnull {
+        return None;
+    }
+    let k = i32::from_datum((*k_const).constvalue, false)?;
+    if k < 0 {
+        panic!("pdb.rrf: k must be >= 0, got {k}");
+    }
+
+    let window_const = nodecast!(Const, T_Const, args.get_ptr(start + 1)?)?;
+    if (*window_const).constisnull {
+        return None;
+    }
+    let window = i32::from_datum((*window_const).constvalue, false)?;
+    if window < 0 {
+        panic!("pdb.rrf: window_size must be >= 0 (0 = auto-size from the LIMIT), got {window}");
+    }
+
+    Some((k, window))
 }
 
 unsafe fn extract_lower_var(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var> {
@@ -255,6 +438,12 @@ pub unsafe fn analyze_sort_expression(
     }
 
     if let Some(info) = index_info {
+        if let Some((var, rrf_sort)) = extract_rrf(node, context, info.schema) {
+            let (relid, attno) = context.var_relation(var);
+            let field_name = fieldname_from_var(relid, var, attno);
+            return Some((rrf_sort, var, field_name));
+        }
+
         if let Some((var, vector_sort)) = extract_vector_distance(node, context, info.schema) {
             let (relid, attno) = context.var_relation(var);
             let field_name = fieldname_from_var(relid, var, attno);
@@ -631,6 +820,35 @@ where
                             break;
                         }
                     }
+                    SortExpressionType::Rrf {
+                        ref query_vector,
+                        metric,
+                        k,
+                        window,
+                    } => {
+                        // With an explicit distance leg the vector field name
+                        // is required; without one (vector leg deferred to
+                        // the WHERE clause's `~~~` predicate) there is none.
+                        let name = if query_vector.is_some() {
+                            match field_name_opt {
+                                Some(field_name) => Some(field_name),
+                                None => continue,
+                            }
+                        } else {
+                            None
+                        };
+                        pathkey_styles.push(OrderByStyle::Rrf {
+                            pathkey,
+                            name,
+                            rti,
+                            query_vector: query_vector.clone(),
+                            metric,
+                            k,
+                            window,
+                        });
+                        found_valid_member = true;
+                        break;
+                    }
                     SortExpressionType::VectorMetricMismatch {
                         field_metric,
                         op_metric,
@@ -803,6 +1021,10 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
             }
             SortExpressionType::VectorDistance { .. } => {
                 // Vector distance is always valid if the field exists in the index
+                continue;
+            }
+            SortExpressionType::Rrf { .. } => {
+                // Rank fusion is always valid if the vector field exists in the index
                 continue;
             }
             SortExpressionType::VectorMetricMismatch { .. } => {

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -91,6 +91,9 @@ pub enum SortExpressionType {
         k: i32,
         /// Per-leg candidate pool; 0 = auto-size from the LIMIT.
         window: i32,
+        /// Per-arm overrides; 0 = inherit `window`.
+        bm25_window: i32,
+        vector_window: i32,
     },
 }
 
@@ -225,14 +228,14 @@ unsafe fn extract_rrf(
     // Both legs come from the target relation's own predicates. The relation
     // reference may also be written as pdb.score(relation).
     if (*funcexpr).funcid == relation_form_funcoid {
-        if args.len() != 3 {
+        if args.len() != 5 {
             return None;
         }
         let relation_arg = strip_cast_funcexpr(args.get_ptr(0)?);
         let relation_var =
             nodecast!(Var, T_Var, relation_arg).or_else(|| extract_score_var(relation_arg))?;
 
-        let (k, window) = extract_rrf_knobs(&args, 1)?;
+        let (k, window, bm25_window, vector_window) = extract_rrf_knobs(&args, 1)?;
         return Some((
             relation_var,
             SortExpressionType::Rrf {
@@ -240,11 +243,13 @@ unsafe fn extract_rrf(
                 metric: None,
                 k,
                 window,
+                bm25_window,
+                vector_window,
             },
         ));
     }
 
-    if args.len() != 4 {
+    if args.len() != 6 {
         return None;
     }
 
@@ -295,7 +300,7 @@ unsafe fn extract_rrf(
             }
         };
 
-    let (k, window) = extract_rrf_knobs(&args, 2)?;
+    let (k, window, bm25_window, vector_window) = extract_rrf_knobs(&args, 2)?;
 
     Some((
         leg_var,
@@ -304,32 +309,34 @@ unsafe fn extract_rrf(
             metric,
             k,
             window,
+            bm25_window,
+            vector_window,
         },
     ))
 }
 
-/// Extract the constant `k` and `window_size` arguments of a `pdb.rrf(...)`
-/// call, starting at `start` in its argument list.
-unsafe fn extract_rrf_knobs(args: &PgList<pg_sys::Node>, start: usize) -> Option<(i32, i32)> {
-    let k_const = nodecast!(Const, T_Const, args.get_ptr(start)?)?;
-    if (*k_const).constisnull {
-        return None;
-    }
-    let k = i32::from_datum((*k_const).constvalue, false)?;
-    if k < 0 {
-        panic!("pdb.rrf: k must be >= 0, got {k}");
+/// Extract the constant `k`, `window_size`, `bm25_window_size`, and
+/// `vector_window_size` arguments of a `pdb.rrf(...)` call, starting at
+/// `start` in its argument list.
+unsafe fn extract_rrf_knobs(
+    args: &PgList<pg_sys::Node>,
+    start: usize,
+) -> Option<(i32, i32, i32, i32)> {
+    let mut knobs = [0i32; 4];
+    let names = ["k", "window_size", "bm25_window_size", "vector_window_size"];
+    for (i, name) in names.into_iter().enumerate() {
+        let const_ = nodecast!(Const, T_Const, args.get_ptr(start + i)?)?;
+        if (*const_).constisnull {
+            return None;
+        }
+        let value = i32::from_datum((*const_).constvalue, false)?;
+        if value < 0 {
+            panic!("pdb.rrf: {name} must be >= 0, got {value}");
+        }
+        knobs[i] = value;
     }
 
-    let window_const = nodecast!(Const, T_Const, args.get_ptr(start + 1)?)?;
-    if (*window_const).constisnull {
-        return None;
-    }
-    let window = i32::from_datum((*window_const).constvalue, false)?;
-    if window < 0 {
-        panic!("pdb.rrf: window_size must be >= 0 (0 = auto-size from the LIMIT), got {window}");
-    }
-
-    Some((k, window))
+    Some((knobs[0], knobs[1], knobs[2], knobs[3]))
 }
 
 unsafe fn extract_lower_var(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var> {
@@ -825,6 +832,8 @@ where
                         metric,
                         k,
                         window,
+                        bm25_window,
+                        vector_window,
                     } => {
                         // With an explicit distance leg the vector field name
                         // is required; without one (vector leg deferred to
@@ -845,6 +854,8 @@ where
                             metric,
                             k,
                             window,
+                            bm25_window,
+                            vector_window,
                         });
                         found_valid_member = true;
                         break;

--- a/pg_search/src/postgres/customscan/projections.rs
+++ b/pg_search/src/postgres/customscan/projections.rs
@@ -28,6 +28,9 @@ use crate::api::FieldName;
 use crate::api::HashMap;
 use crate::api::Varno;
 use crate::nodecast;
+use crate::postgres::customscan::basescan::projections::score::{
+    rrf_funcoids, typed_score_funcoid, typed_score_kind_from_funcexpr,
+};
 use crate::postgres::customscan::basescan::projections::snippet::{
     extract_snippet, extract_snippet_positions, extract_snippets, snippet_funcoids,
     snippet_positions_funcoids, SnippetType,
@@ -393,6 +396,10 @@ pub unsafe fn maybe_needs_const_projections(node: *mut pg_sys::Node) -> bool {
         if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, node) {
             let data = &*data.cast::<Data>();
             if data.score_funcoids.contains(&(*funcexpr).funcid)
+                || (data.typed_score_funcoid != pg_sys::Oid::INVALID
+                    && (*funcexpr).funcid == data.typed_score_funcoid)
+                || ((*funcexpr).funcid != pg_sys::Oid::INVALID
+                    && data.rrf_funcoids.contains(&(*funcexpr).funcid))
                 || data.snippet_funcoids.contains(&(*funcexpr).funcid)
                 || data
                     .snippet_positions_funcoids
@@ -407,12 +414,16 @@ pub unsafe fn maybe_needs_const_projections(node: *mut pg_sys::Node) -> bool {
 
     struct Data {
         score_funcoids: [pg_sys::Oid; 2],
+        typed_score_funcoid: pg_sys::Oid,
+        rrf_funcoids: [pg_sys::Oid; 2],
         snippet_funcoids: [pg_sys::Oid; 2],
         snippet_positions_funcoids: [pg_sys::Oid; 2],
     }
 
     let mut data = Data {
         score_funcoids: score_funcoids(),
+        typed_score_funcoid: typed_score_funcoid(),
+        rrf_funcoids: rrf_funcoids(),
         snippet_funcoids: snippet_funcoids(),
         snippet_positions_funcoids: snippet_positions_funcoids(),
     };
@@ -494,6 +505,8 @@ pub unsafe fn inject_placeholders(
     targetlist: *mut pg_sys::List,
     rti: pg_sys::Index,
     score_funcoids: [pg_sys::Oid; 2],
+    typed_score_funcoid: pg_sys::Oid,
+    rrf_funcoids: [pg_sys::Oid; 2],
     snippet_funcoids: [pg_sys::Oid; 2],
     snippets_funcoids: [pg_sys::Oid; 2],
     snippet_positions_funcoids: [pg_sys::Oid; 2],
@@ -502,6 +515,8 @@ pub unsafe fn inject_placeholders(
 ) -> (
     *mut pg_sys::List,
     *mut pg_sys::Const,
+    [Option<*mut pg_sys::Const>; 4],
+    Option<*mut pg_sys::Const>,
     HashMap<SnippetType, Vec<*mut pg_sys::Const>>,
 ) {
     #[pg_guard]
@@ -519,6 +534,45 @@ pub unsafe fn inject_placeholders(
 
             if data.score_funcoids.contains(&(*funcexpr).funcid) {
                 return Some(data.const_score_node.cast());
+            }
+
+            if data.typed_score_funcoid != pg_sys::Oid::INVALID
+                && (*funcexpr).funcid == data.typed_score_funcoid
+            {
+                // one shared Const per score type, created lazily on first use
+                let kind = typed_score_kind_from_funcexpr(funcexpr)?;
+                let slot = &mut data.const_typed_score_nodes[kind as usize];
+                if slot.is_none() {
+                    *slot = Some(pg_sys::makeConst(
+                        pg_sys::FLOAT4OID,
+                        -1,
+                        pg_sys::Oid::INVALID,
+                        size_of::<f32>() as _,
+                        pg_sys::Datum::null(),
+                        true,
+                        true,
+                    ));
+                }
+                return Some(slot.unwrap().cast());
+            }
+
+            if (*funcexpr).funcid != pg_sys::Oid::INVALID
+                && data.rrf_funcoids.contains(&(*funcexpr).funcid)
+            {
+                // one shared float8 Const for all pdb.rrf() calls, created
+                // lazily on first use
+                if data.const_rrf_node.is_none() {
+                    data.const_rrf_node = Some(pg_sys::makeConst(
+                        pg_sys::FLOAT8OID,
+                        -1,
+                        pg_sys::Oid::INVALID,
+                        size_of::<f64>() as _,
+                        pg_sys::Datum::null(),
+                        true,
+                        true,
+                    ));
+                }
+                return Some(data.const_rrf_node.unwrap().cast());
             }
 
             let mut this_snippet_type = None;
@@ -601,6 +655,12 @@ pub unsafe fn inject_placeholders(
         score_funcoids: [pg_sys::Oid; 2],
         const_score_node: *mut pg_sys::Const,
 
+        typed_score_funcoid: pg_sys::Oid,
+        const_typed_score_nodes: [Option<*mut pg_sys::Const>; 4],
+
+        rrf_funcoids: [pg_sys::Oid; 2],
+        const_rrf_node: Option<*mut pg_sys::Const>,
+
         snippet_funcoids: [pg_sys::Oid; 2],
         snippets_funcoids: [pg_sys::Oid; 2],
         snippet_positions_funcoids: [pg_sys::Oid; 2],
@@ -624,6 +684,12 @@ pub unsafe fn inject_placeholders(
             true,
         ),
 
+        typed_score_funcoid,
+        const_typed_score_nodes: [None; 4],
+
+        rrf_funcoids,
+        const_rrf_node: None,
+
         snippet_funcoids,
         snippets_funcoids,
         snippet_positions_funcoids,
@@ -635,6 +701,8 @@ pub unsafe fn inject_placeholders(
     (
         targetlist.cast(),
         data.const_score_node,
+        data.const_typed_score_nodes,
+        data.const_rrf_node,
         data.const_snippet_nodes,
     )
 }

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -28,7 +28,7 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::var::VarContext;
 use crate::query::heap_field_filter::HeapFieldFilter;
 use crate::query::pdb_query::pdb;
-use crate::query::SearchQueryInput;
+use crate::query::{SearchQueryInput, TopMeasure};
 use pg_sys::BoolExprType;
 use pgrx::{pg_guard, pg_sys, FromDatum, IntoDatum, PgList};
 use std::ops::Bound;
@@ -36,12 +36,14 @@ use std::ops::Bound;
 #[derive(Debug, Clone)]
 pub enum Qual {
     All,
-    /// A `(subtree)::pdb.top(n)` fusion-arm annotation: the row is among the
-    /// top `n` rows ranked by the subtree's own measure. Consumed by the
-    /// rank-fusion scan; see `SearchQueryInput::TopN`.
+    /// A `(subtree)::pdb.top_bm25(n)` / `(subtree)::pdb.top_knn(n)`
+    /// fusion-arm annotation: the row is among the top `n` rows ranked by
+    /// the named measure. Consumed by the rank-fusion scan; see
+    /// `SearchQueryInput::TopN`.
     TopArm {
         inner: Box<Qual>,
         window: i32,
+        measure: TopMeasure,
     },
     ExternalVar,
     ExternalExpr,
@@ -499,9 +501,14 @@ impl From<&Qual> for SearchQueryInput {
             Qual::All => SearchQueryInput::All,
             Qual::ExternalVar => SearchQueryInput::All,
             Qual::ExternalExpr => SearchQueryInput::All,
-            Qual::TopArm { inner, window } => SearchQueryInput::TopN {
+            Qual::TopArm {
+                inner,
+                window,
+                measure,
+            } => SearchQueryInput::TopN {
                 query: Box::new(SearchQueryInput::from(inner.as_ref())),
                 window: *window,
+                measure: *measure,
             },
             // Handle ScalarArrayOpExpr: PostgreSQL 18+ rewrites OR clauses like
             // `field @@@ 'a' OR field @@@ 'b'` into `field @@@ ANY(ARRAY['a','b'])`.
@@ -846,10 +853,12 @@ pub unsafe fn is_subplan(node: *mut pg_sys::Node, root: *mut pg_sys::PlannerInfo
     walker(node, std::ptr::null_mut())
 }
 
-/// Recognize the `(subtree)::pdb.top(n)` cast sandwich:
-/// `top_to_bool(top_to_top*(bool_to_top(subtree, typmod, _), typmod, _))`,
-/// where re-annotation layers may repeat and the outermost typmod wins.
-/// Returns a [`Qual::TopArm`] wrapping the recursively-extracted subtree.
+/// Recognize a `(subtree)::pdb.top_bm25(n)` / `(subtree)::pdb.top_knn(n)`
+/// cast sandwich: `<to_bool>(<retypmod>*(<creator>(subtree, typmod, _),
+/// typmod, _))`, where re-annotation layers may repeat and the outermost
+/// typmod wins. The type name of the cast declares the arm's ranking
+/// measure. Returns a [`Qual::TopArm`] wrapping the recursively-extracted
+/// subtree.
 #[allow(clippy::too_many_arguments)]
 unsafe fn top_arm(
     context: &PlannerContext,
@@ -861,13 +870,19 @@ unsafe fn top_arm(
     state: &mut QualExtractState,
     attempt_pushdown: bool,
 ) -> Option<Qual> {
-    use crate::api::operator::top::{bool_to_top_procoid, top_to_bool_procoid, top_to_top_procoid};
+    use crate::api::operator::top::{top_bm25_procs, top_knn_procs};
 
     let outer = nodecast!(FuncExpr, T_FuncExpr, node)?;
-    let top_to_bool = top_to_bool_procoid();
-    if top_to_bool == pg_sys::Oid::INVALID || (*outer).funcid != top_to_bool {
-        return None;
-    }
+    let (measure, type_name, procs) = [
+        (TopMeasure::Bm25, "pdb.top_bm25", top_bm25_procs()),
+        (TopMeasure::Knn, "pdb.top_knn", top_knn_procs()),
+    ]
+    .into_iter()
+    .find_map(|(measure, type_name, procs)| {
+        let procs = procs?;
+        (procs.to_bool != pg_sys::Oid::INVALID && (*outer).funcid == procs.to_bool)
+            .then_some((measure, type_name, procs))
+    })?;
 
     // Descend through re-annotation layers; the outermost typmod wins.
     let mut window: Option<i32> = None;
@@ -875,8 +890,8 @@ unsafe fn top_arm(
     loop {
         let funcexpr = nodecast!(FuncExpr, T_FuncExpr, current)?;
         let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
-        let is_creator = (*funcexpr).funcid == bool_to_top_procoid();
-        let is_retypmod = (*funcexpr).funcid == top_to_top_procoid();
+        let is_creator = (*funcexpr).funcid == procs.creator;
+        let is_retypmod = (*funcexpr).funcid == procs.retypmod;
         if !is_creator && !is_retypmod {
             return None;
         }
@@ -894,7 +909,9 @@ unsafe fn top_arm(
         let inner = args.get_ptr(0)?;
         if is_creator {
             let Some(window) = window else {
-                pgrx::error!("::pdb.top requires a window, e.g. `(<predicate>)::pdb.top(100)`");
+                pgrx::error!(
+                    "::{type_name} requires a window, e.g. `(<predicate>)::{type_name}(100)`"
+                );
             };
             let inner_qual = extract_quals(
                 context,
@@ -909,6 +926,7 @@ unsafe fn top_arm(
             return Some(Qual::TopArm {
                 inner: Box::new(inner_qual),
                 window,
+                measure,
             });
         }
         current = inner;
@@ -932,8 +950,9 @@ pub unsafe fn extract_quals(
 
     match (*node).type_ {
         pg_sys::NodeTag::T_FuncExpr => {
-            // `(subtree)::pdb.top(n)` fusion-arm annotations arrive as a cast
-            // sandwich: top_to_bool(bool_to_top(subtree, typmod, ..)).
+            // `(subtree)::pdb.top_bm25(n)` / `::pdb.top_knn(n)` fusion-arm
+            // annotations arrive as a cast sandwich:
+            // <to_bool>(<creator>(subtree, typmod, ..)).
             if let Some(qual) = top_arm(
                 context,
                 rti,

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -36,6 +36,13 @@ use std::ops::Bound;
 #[derive(Debug, Clone)]
 pub enum Qual {
     All,
+    /// A `(subtree)::pdb.top(n)` fusion-arm annotation: the row is among the
+    /// top `n` rows ranked by the subtree's own measure. Consumed by the
+    /// rank-fusion scan; see `SearchQueryInput::TopN`.
+    TopArm {
+        inner: Box<Qual>,
+        window: i32,
+    },
     ExternalVar,
     ExternalExpr,
     OpExpr {
@@ -153,6 +160,7 @@ impl Qual {
             Qual::And(quals) => quals.iter().any(|q| q.contains_all()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_all()),
             Qual::Not(qual) => qual.contains_all(),
+            Qual::TopArm { inner, .. } => inner.contains_all(),
         }
     }
 
@@ -175,6 +183,7 @@ impl Qual {
             Qual::And(quals) => quals.iter().any(|q| q.contains_external_var()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_external_var()),
             Qual::Not(qual) => qual.contains_external_var(),
+            Qual::TopArm { inner, .. } => inner.contains_external_var(),
         }
     }
 
@@ -197,6 +206,7 @@ impl Qual {
             Qual::And(quals) => quals.iter().any(|q| q.contains_correlated_param(root)),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_correlated_param(root)),
             Qual::Not(qual) => qual.contains_correlated_param(root),
+            Qual::TopArm { inner, .. } => inner.contains_correlated_param(root),
         }
     }
 
@@ -219,6 +229,7 @@ impl Qual {
             Qual::And(quals) => quals.iter().any(|q| q.contains_exprs()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_exprs()),
             Qual::Not(qual) => qual.contains_exprs(),
+            Qual::TopArm { inner, .. } => inner.contains_exprs(),
         }
     }
 
@@ -241,6 +252,7 @@ impl Qual {
             Qual::And(quals) => quals.iter().any(|q| q.contains_score_exprs()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_score_exprs()),
             Qual::Not(qual) => qual.contains_score_exprs(),
+            Qual::TopArm { inner, .. } => inner.contains_score_exprs(),
         }
     }
 
@@ -487,6 +499,10 @@ impl From<&Qual> for SearchQueryInput {
             Qual::All => SearchQueryInput::All,
             Qual::ExternalVar => SearchQueryInput::All,
             Qual::ExternalExpr => SearchQueryInput::All,
+            Qual::TopArm { inner, window } => SearchQueryInput::TopN {
+                query: Box::new(SearchQueryInput::from(inner.as_ref())),
+                window: *window,
+            },
             // Handle ScalarArrayOpExpr: PostgreSQL 18+ rewrites OR clauses like
             // `field @@@ 'a' OR field @@@ 'b'` into `field @@@ ANY(ARRAY['a','b'])`.
             // We decode the array and convert it to a Boolean query (should/must).
@@ -830,6 +846,75 @@ pub unsafe fn is_subplan(node: *mut pg_sys::Node, root: *mut pg_sys::PlannerInfo
     walker(node, std::ptr::null_mut())
 }
 
+/// Recognize the `(subtree)::pdb.top(n)` cast sandwich:
+/// `top_to_bool(top_to_top*(bool_to_top(subtree, typmod, _), typmod, _))`,
+/// where re-annotation layers may repeat and the outermost typmod wins.
+/// Returns a [`Qual::TopArm`] wrapping the recursively-extracted subtree.
+#[allow(clippy::too_many_arguments)]
+unsafe fn top_arm(
+    context: &PlannerContext,
+    rti: pg_sys::Index,
+    node: *mut pg_sys::Node,
+    ri_type: RestrictInfoType,
+    indexrel: &PgSearchRelation,
+    convert_external_to_special_qual: bool,
+    state: &mut QualExtractState,
+    attempt_pushdown: bool,
+) -> Option<Qual> {
+    use crate::api::operator::top::{bool_to_top_procoid, top_to_bool_procoid, top_to_top_procoid};
+
+    let outer = nodecast!(FuncExpr, T_FuncExpr, node)?;
+    let top_to_bool = top_to_bool_procoid();
+    if top_to_bool == pg_sys::Oid::INVALID || (*outer).funcid != top_to_bool {
+        return None;
+    }
+
+    // Descend through re-annotation layers; the outermost typmod wins.
+    let mut window: Option<i32> = None;
+    let mut current = PgList::<pg_sys::Node>::from_pg((*outer).args).get_ptr(0)?;
+    loop {
+        let funcexpr = nodecast!(FuncExpr, T_FuncExpr, current)?;
+        let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+        let is_creator = (*funcexpr).funcid == bool_to_top_procoid();
+        let is_retypmod = (*funcexpr).funcid == top_to_top_procoid();
+        if !is_creator && !is_retypmod {
+            return None;
+        }
+
+        if window.is_none() {
+            let typmod_const = nodecast!(Const, T_Const, args.get_ptr(1)?)?;
+            if !(*typmod_const).constisnull {
+                let typmod = i32::from_datum((*typmod_const).constvalue, false)?;
+                if typmod >= 0 {
+                    window = Some(typmod);
+                }
+            }
+        }
+
+        let inner = args.get_ptr(0)?;
+        if is_creator {
+            let Some(window) = window else {
+                pgrx::error!("::pdb.top requires a window, e.g. `(<predicate>)::pdb.top(100)`");
+            };
+            let inner_qual = extract_quals(
+                context,
+                rti,
+                inner,
+                ri_type,
+                indexrel,
+                convert_external_to_special_qual,
+                state,
+                attempt_pushdown,
+            )?;
+            return Some(Qual::TopArm {
+                inner: Box::new(inner_qual),
+                window,
+            });
+        }
+        current = inner;
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn extract_quals(
     context: &PlannerContext,
@@ -847,6 +932,21 @@ pub unsafe fn extract_quals(
 
     match (*node).type_ {
         pg_sys::NodeTag::T_FuncExpr => {
+            // `(subtree)::pdb.top(n)` fusion-arm annotations arrive as a cast
+            // sandwich: top_to_bool(bool_to_top(subtree, typmod, ..)).
+            if let Some(qual) = top_arm(
+                context,
+                rti,
+                node.cast(),
+                ri_type,
+                indexrel,
+                convert_external_to_special_qual,
+                state,
+                attempt_pushdown,
+            ) {
+                return Some(qual);
+            }
+
             // Standalone FuncExprs in a WHERE clause must return boolean (e.g. ST_DWithin).
             // This is distinct from FuncExprs used inside comparisons (e.g. pdb.score(id) > 0.5),
             // which are handled within opexpr().

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -125,6 +125,14 @@ pub enum SearchQueryInput {
         oid: pg_sys::Oid,
         query: Box<SearchQueryInput>,
     },
+    /// A `(subtree)::pdb.top(n)` fusion-arm annotation: "this row is among
+    /// the top `window` rows ranked by `query`'s own measure". Like `Knn`,
+    /// never converted to a tantivy query — the rank-fusion path harvests
+    /// the window and strips the wrapper before execution.
+    TopN {
+        query: Box<SearchQueryInput>,
+        window: i32,
+    },
     /// The `~~~(vector, vector)` knn operator: "this row is among the
     /// top-`window_size` nearest neighbors of `query_vector`". Not a
     /// standalone tantivy query — a query containing a `Knn` leaf must be
@@ -151,6 +159,20 @@ pub enum SearchQueryInput {
         field: FieldName,
         query: pdb::Query,
     },
+}
+
+/// One harvested `::pdb.top(n)` arm annotation; see
+/// [`SearchQueryInput::strip_top_arms`].
+#[derive(Debug, Clone, Copy)]
+pub struct TopArmInfo {
+    /// The arm's candidate window (the typmod `n`).
+    pub window: i32,
+    /// The annotated subtree contains a `~~~` knn predicate.
+    pub contains_knn: bool,
+    /// The annotated subtree is exactly a knn predicate.
+    pub knn_only: bool,
+    /// The annotated subtree itself contains another `::pdb.top` annotation.
+    pub nested: bool,
 }
 
 fn serialize_fielded_query<S>(
@@ -405,6 +427,8 @@ impl SearchQueryInput {
             | SearchQueryInput::Knn { .. }
             | SearchQueryInput::PostgresExpression { .. } => false,
 
+            SearchQueryInput::TopN { query, .. } => query.needs_tokenizer(),
+
             SearchQueryInput::Parse { .. } | SearchQueryInput::MoreLikeThis { .. } => true,
 
             SearchQueryInput::FieldedQuery { query, .. } => query.needs_tokenizer(),
@@ -439,8 +463,9 @@ impl SearchQueryInput {
     /// Used by `estimate_selectivity` to short-circuit and return a heuristic instead.
     pub fn is_expensive_to_estimate(&self) -> bool {
         match self {
-            // not estimable at all: a knn leaf cannot become a tantivy query
-            SearchQueryInput::Knn { .. } => true,
+            // not estimable at all: knn leaves and ::pdb.top arms cannot
+            // become tantivy queries
+            SearchQueryInput::Knn { .. } | SearchQueryInput::TopN { .. } => true,
             SearchQueryInput::Boolean {
                 must,
                 should,
@@ -480,6 +505,7 @@ impl SearchQueryInput {
             // knn candidacy is bounded by the rank-fusion window, which is
             // tiny relative to the table
             SearchQueryInput::Knn { .. } => 0.01,
+            SearchQueryInput::TopN { query, .. } => query.selectivity_heuristic(),
             SearchQueryInput::Boolean { must, should, .. } => {
                 // AND: product of children selectivities; OR: max of children selectivities.
                 let must_sel = must
@@ -694,6 +720,9 @@ impl SearchQueryInput {
             SearchQueryInput::HeapFilter { indexed_query, .. } => {
                 indexed_query.visit(visitor);
             }
+            SearchQueryInput::TopN { query, .. } => {
+                query.visit(visitor);
+            }
 
             SearchQueryInput::Uninitialized
             | SearchQueryInput::All
@@ -756,6 +785,7 @@ impl SearchQueryInput {
                 SearchQueryInput::HeapFilter { indexed_query, .. } => {
                     walk(indexed_query, negated, leaves)
                 }
+                SearchQueryInput::TopN { query, .. } => walk(query, negated, leaves),
                 SearchQueryInput::DisjunctionMax { disjuncts, .. } => {
                     for q in disjuncts {
                         walk(q, negated, leaves);
@@ -795,7 +825,7 @@ impl SearchQueryInput {
 
     /// True when this query (possibly through score-transparent wrappers) is
     /// nothing but a [`SearchQueryInput::Knn`] leaf.
-    fn is_knn_only(&self) -> bool {
+    pub(crate) fn is_knn_only(&self) -> bool {
         match self {
             SearchQueryInput::Knn { .. } => true,
             SearchQueryInput::WithIndex { query, .. }
@@ -806,6 +836,76 @@ impl SearchQueryInput {
             } => query.is_knn_only(),
             _ => false,
         }
+    }
+
+    /// Return a copy of this tree with every [`SearchQueryInput::TopN`] arm
+    /// annotation removed, harvesting each arm's classification and window.
+    ///
+    /// The annotations only carry plan-level information (per-arm candidate
+    /// windows); execution runs over the stripped tree.
+    pub fn strip_top_arms(&self) -> (SearchQueryInput, Vec<TopArmInfo>) {
+        fn walk(query: &SearchQueryInput, arms: &mut Vec<TopArmInfo>) -> SearchQueryInput {
+            match query {
+                SearchQueryInput::TopN { query, window } => {
+                    let mut inner_arms = Vec::new();
+                    let stripped = walk(query, &mut inner_arms);
+                    arms.push(TopArmInfo {
+                        window: *window,
+                        contains_knn: query.contains_knn(),
+                        knn_only: query.is_knn_only(),
+                        nested: !inner_arms.is_empty(),
+                    });
+                    arms.extend(inner_arms);
+                    stripped
+                }
+                SearchQueryInput::Boolean {
+                    must,
+                    should,
+                    must_not,
+                    minimum_should_match,
+                } => SearchQueryInput::Boolean {
+                    must: must.iter().map(|q| walk(q, arms)).collect(),
+                    should: should.iter().map(|q| walk(q, arms)).collect(),
+                    must_not: must_not.iter().map(|q| walk(q, arms)).collect(),
+                    minimum_should_match: *minimum_should_match,
+                },
+                SearchQueryInput::WithIndex { oid, query } => SearchQueryInput::WithIndex {
+                    oid: *oid,
+                    query: Box::new(walk(query, arms)),
+                },
+                SearchQueryInput::Boost { query, factor } => SearchQueryInput::Boost {
+                    query: Box::new(walk(query, arms)),
+                    factor: *factor,
+                },
+                SearchQueryInput::ConstScore { query, score } => SearchQueryInput::ConstScore {
+                    query: Box::new(walk(query, arms)),
+                    score: *score,
+                },
+                SearchQueryInput::ScoreFilter { bounds, query } => SearchQueryInput::ScoreFilter {
+                    bounds: bounds.clone(),
+                    query: query.as_ref().map(|q| Box::new(walk(q, arms))),
+                },
+                SearchQueryInput::HeapFilter {
+                    indexed_query,
+                    field_filters,
+                } => SearchQueryInput::HeapFilter {
+                    indexed_query: Box::new(walk(indexed_query, arms)),
+                    field_filters: field_filters.clone(),
+                },
+                SearchQueryInput::DisjunctionMax {
+                    disjuncts,
+                    tie_breaker,
+                } => SearchQueryInput::DisjunctionMax {
+                    disjuncts: disjuncts.iter().map(|q| walk(q, arms)).collect(),
+                    tie_breaker: *tie_breaker,
+                },
+                other => other.clone(),
+            }
+        }
+
+        let mut arms = Vec::new();
+        let stripped = walk(self, &mut arms);
+        (stripped, arms)
     }
 
     /// Return a copy of this tree with every [`SearchQueryInput::Knn`] leaf
@@ -868,6 +968,10 @@ impl SearchQueryInput {
             } => SearchQueryInput::HeapFilter {
                 indexed_query: Box::new(indexed_query.without_knn()),
                 field_filters: field_filters.clone(),
+            },
+            SearchQueryInput::TopN { query, window } => SearchQueryInput::TopN {
+                query: Box::new(query.without_knn()),
+                window: *window,
             },
             SearchQueryInput::DisjunctionMax {
                 disjuncts,
@@ -1311,6 +1415,9 @@ impl SearchQueryInput {
             }
             SearchQueryInput::Knn { .. } => {
                 panic!("the `~~~(vector, vector)` operator requires a ParadeDB TopK rank-fusion scan: use `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`")
+            }
+            SearchQueryInput::TopN { .. } => {
+                panic!("::pdb.top(n) annotations require a ParadeDB TopK rank-fusion scan: use `ORDER BY pdb.rrf(<key>) LIMIT <k>`")
             }
             SearchQueryInput::Boolean {
                 must,

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -125,13 +125,16 @@ pub enum SearchQueryInput {
         oid: pg_sys::Oid,
         query: Box<SearchQueryInput>,
     },
-    /// A `(subtree)::pdb.top(n)` fusion-arm annotation: "this row is among
-    /// the top `window` rows ranked by `query`'s own measure". Like `Knn`,
-    /// never converted to a tantivy query — the rank-fusion path harvests
-    /// the window and strips the wrapper before execution.
+    /// A `(subtree)::pdb.top_bm25(n)` / `(subtree)::pdb.top_knn(n)`
+    /// fusion-arm annotation: "this row is among the top `window` rows
+    /// ranked by `measure`"; every other predicate in the subtree is a
+    /// filter. Like `Knn`, never converted to a tantivy query — the
+    /// rank-fusion path harvests the measure and window and strips the
+    /// wrapper before execution.
     TopN {
         query: Box<SearchQueryInput>,
         window: i32,
+        measure: TopMeasure,
     },
     /// The `~~~(vector, vector)` knn operator: "this row is among the
     /// top-`window_size` nearest neighbors of `query_vector`". Not a
@@ -161,18 +164,29 @@ pub enum SearchQueryInput {
     },
 }
 
-/// One harvested `::pdb.top(n)` arm annotation; see
+/// The ranking measure a fusion-arm annotation declares: the type name of
+/// the cast (`::pdb.top_bm25(n)` or `::pdb.top_knn(n)`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TopMeasure {
+    Bm25,
+    Knn,
+}
+
+/// One harvested fusion-arm annotation; see
 /// [`SearchQueryInput::strip_top_arms`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct TopArmInfo {
     /// The arm's candidate window (the typmod `n`).
     pub window: i32,
+    /// The measure the annotation's type name declares.
+    pub measure: TopMeasure,
     /// The annotated subtree contains a `~~~` knn predicate.
     pub contains_knn: bool,
-    /// The annotated subtree is exactly a knn predicate.
-    pub knn_only: bool,
-    /// The annotated subtree itself contains another `::pdb.top` annotation.
+    /// The annotated subtree itself contains another arm annotation.
     pub nested: bool,
+    /// The arm's subtree, with any nested annotations stripped.
+    pub inner: SearchQueryInput,
 }
 
 fn serialize_fielded_query<S>(
@@ -463,7 +477,7 @@ impl SearchQueryInput {
     /// Used by `estimate_selectivity` to short-circuit and return a heuristic instead.
     pub fn is_expensive_to_estimate(&self) -> bool {
         match self {
-            // not estimable at all: knn leaves and ::pdb.top arms cannot
+            // not estimable at all: knn leaves and fusion arms cannot
             // become tantivy queries
             SearchQueryInput::Knn { .. } | SearchQueryInput::TopN { .. } => true,
             SearchQueryInput::Boolean {
@@ -846,14 +860,19 @@ impl SearchQueryInput {
     pub fn strip_top_arms(&self) -> (SearchQueryInput, Vec<TopArmInfo>) {
         fn walk(query: &SearchQueryInput, arms: &mut Vec<TopArmInfo>) -> SearchQueryInput {
             match query {
-                SearchQueryInput::TopN { query, window } => {
+                SearchQueryInput::TopN {
+                    query,
+                    window,
+                    measure,
+                } => {
                     let mut inner_arms = Vec::new();
                     let stripped = walk(query, &mut inner_arms);
                     arms.push(TopArmInfo {
                         window: *window,
+                        measure: *measure,
                         contains_knn: query.contains_knn(),
-                        knn_only: query.is_knn_only(),
                         nested: !inner_arms.is_empty(),
+                        inner: stripped.clone(),
                     });
                     arms.extend(inner_arms);
                     stripped
@@ -906,6 +925,126 @@ impl SearchQueryInput {
         let mut arms = Vec::new();
         let stripped = walk(self, &mut arms);
         (stripped, arms)
+    }
+
+    /// The boolean context a `::pdb.top_knn` arm's candidates must satisfy
+    /// beyond the arm's own predicates: this (pre-strip) tree with the knn
+    /// arm assumed true (replaced by `All`) and every other annotation
+    /// unwrapped.
+    ///
+    /// Under `bm25_arm OR knn_arm` the OR is absorbed and only shared
+    /// predicates remain; under `bm25_arm AND knn_arm` the bm25 arm survives
+    /// as a gate (the intersection shape). ANDing this context with the knn
+    /// arm's own `inner[knn := true]` yields the vector leg's driving query,
+    /// so a text-arm row that fails the knn arm's filters can never occupy a
+    /// slot in its candidate window.
+    pub fn knn_arm_context(&self) -> SearchQueryInput {
+        match self {
+            SearchQueryInput::TopN { query, measure, .. } => match measure {
+                TopMeasure::Knn => SearchQueryInput::All,
+                TopMeasure::Bm25 => query.knn_arm_context(),
+            },
+            SearchQueryInput::Boolean {
+                must,
+                should,
+                must_not,
+                minimum_should_match,
+            } => SearchQueryInput::Boolean {
+                must: must.iter().map(|q| q.knn_arm_context()).collect(),
+                should: should.iter().map(|q| q.knn_arm_context()).collect(),
+                must_not: must_not.iter().map(|q| q.knn_arm_context()).collect(),
+                minimum_should_match: *minimum_should_match,
+            },
+            SearchQueryInput::WithIndex { oid, query } => SearchQueryInput::WithIndex {
+                oid: *oid,
+                query: Box::new(query.knn_arm_context()),
+            },
+            SearchQueryInput::HeapFilter {
+                indexed_query,
+                field_filters,
+            } => SearchQueryInput::HeapFilter {
+                indexed_query: Box::new(indexed_query.knn_arm_context()),
+                field_filters: field_filters.clone(),
+            },
+            other => other.clone(),
+        }
+    }
+
+    /// Like [`Self::without_knn`], but at the granularity of a whole
+    /// `::pdb.top_knn` arm: the arm's entire subtree (its `~~~` predicate
+    /// *and* its filters) is deleted from its boolean context, and every
+    /// other annotation is unwrapped.
+    ///
+    /// This is the text-relevance scoring query when arms are annotated:
+    /// under `bm25_arm OR knn_arm` it is the bm25 arm alone, so a document
+    /// matching the knn arm's filters gets no BM25 credit for them. A tree
+    /// that consists solely of the knn arm becomes `Empty` (there is no text
+    /// relevance).
+    pub fn without_knn_arm(&self) -> SearchQueryInput {
+        fn is_knn_arm(query: &SearchQueryInput) -> bool {
+            matches!(
+                query,
+                SearchQueryInput::TopN {
+                    measure: TopMeasure::Knn,
+                    ..
+                }
+            )
+        }
+
+        match self {
+            SearchQueryInput::TopN { query, measure, .. } => match measure {
+                TopMeasure::Knn => SearchQueryInput::Empty,
+                TopMeasure::Bm25 => query.without_knn_arm(),
+            },
+            SearchQueryInput::Boolean {
+                must,
+                should,
+                must_not,
+                minimum_should_match,
+            } => {
+                let strip = |clauses: &[SearchQueryInput]| {
+                    clauses
+                        .iter()
+                        .filter(|clause| !is_knn_arm(clause))
+                        .map(|clause| clause.without_knn_arm())
+                        .collect::<Vec<_>>()
+                };
+                let (must, should, must_not) = (strip(must), strip(should), strip(must_not));
+                if must.is_empty() && should.is_empty() && must_not.is_empty() {
+                    SearchQueryInput::Empty
+                } else {
+                    SearchQueryInput::Boolean {
+                        must,
+                        should,
+                        must_not,
+                        minimum_should_match: *minimum_should_match,
+                    }
+                }
+            }
+            SearchQueryInput::WithIndex { oid, query } => SearchQueryInput::WithIndex {
+                oid: *oid,
+                query: Box::new(query.without_knn_arm()),
+            },
+            SearchQueryInput::HeapFilter {
+                indexed_query,
+                field_filters,
+            } => SearchQueryInput::HeapFilter {
+                indexed_query: Box::new(indexed_query.without_knn_arm()),
+                field_filters: field_filters.clone(),
+            },
+            SearchQueryInput::DisjunctionMax {
+                disjuncts,
+                tie_breaker,
+            } => SearchQueryInput::DisjunctionMax {
+                disjuncts: disjuncts
+                    .iter()
+                    .filter(|disjunct| !is_knn_arm(disjunct))
+                    .map(|disjunct| disjunct.without_knn_arm())
+                    .collect(),
+                tie_breaker: *tie_breaker,
+            },
+            other => other.clone(),
+        }
     }
 
     /// Return a copy of this tree with every [`SearchQueryInput::Knn`] leaf
@@ -969,9 +1108,14 @@ impl SearchQueryInput {
                 indexed_query: Box::new(indexed_query.without_knn()),
                 field_filters: field_filters.clone(),
             },
-            SearchQueryInput::TopN { query, window } => SearchQueryInput::TopN {
+            SearchQueryInput::TopN {
+                query,
+                window,
+                measure,
+            } => SearchQueryInput::TopN {
                 query: Box::new(query.without_knn()),
                 window: *window,
+                measure: *measure,
             },
             SearchQueryInput::DisjunctionMax {
                 disjuncts,
@@ -1417,7 +1561,7 @@ impl SearchQueryInput {
                 panic!("the `~~~(vector, vector)` operator requires a ParadeDB TopK rank-fusion scan: use `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`")
             }
             SearchQueryInput::TopN { .. } => {
-                panic!("::pdb.top(n) annotations require a ParadeDB TopK rank-fusion scan: use `ORDER BY pdb.rrf(<key>) LIMIT <k>`")
+                panic!("::pdb.top_bm25(n)/::pdb.top_knn(n) annotations require a ParadeDB TopK rank-fusion scan: use `ORDER BY pdb.rrf(<key>) LIMIT <k>`")
             }
             SearchQueryInput::Boolean {
                 must,

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -125,6 +125,16 @@ pub enum SearchQueryInput {
         oid: pg_sys::Oid,
         query: Box<SearchQueryInput>,
     },
+    /// The `~~~(vector, vector)` knn operator: "this row is among the
+    /// top-`window_size` nearest neighbors of `query_vector`". Not a
+    /// standalone tantivy query — a query containing a `Knn` leaf must be
+    /// executed by the `pdb.rrf()` rank-fusion TopK path, which splits the
+    /// tree into per-leg queries (substituting the leaf with `All`/`Empty`)
+    /// before any tantivy conversion.
+    Knn {
+        field: FieldName,
+        query_vector: Vec<f32>,
+    },
     PostgresExpression {
         expr: PostgresExpression,
     },
@@ -392,6 +402,7 @@ impl SearchQueryInput {
             | SearchQueryInput::All
             | SearchQueryInput::Empty
             | SearchQueryInput::TermSet { .. }
+            | SearchQueryInput::Knn { .. }
             | SearchQueryInput::PostgresExpression { .. } => false,
 
             SearchQueryInput::Parse { .. } | SearchQueryInput::MoreLikeThis { .. } => true,
@@ -428,6 +439,8 @@ impl SearchQueryInput {
     /// Used by `estimate_selectivity` to short-circuit and return a heuristic instead.
     pub fn is_expensive_to_estimate(&self) -> bool {
         match self {
+            // not estimable at all: a knn leaf cannot become a tantivy query
+            SearchQueryInput::Knn { .. } => true,
             SearchQueryInput::Boolean {
                 must,
                 should,
@@ -464,6 +477,9 @@ impl SearchQueryInput {
         use crate::MORE_LIKE_THIS_SELECTIVITY;
 
         match self {
+            // knn candidacy is bounded by the rank-fusion window, which is
+            // tiny relative to the table
+            SearchQueryInput::Knn { .. } => 0.01,
             SearchQueryInput::Boolean { must, should, .. } => {
                 // AND: product of children selectivities; OR: max of children selectivities.
                 let must_sel = must
@@ -686,7 +702,185 @@ impl SearchQueryInput {
             | SearchQueryInput::Parse { .. }
             | SearchQueryInput::TermSet { .. }
             | SearchQueryInput::PostgresExpression { .. }
+            | SearchQueryInput::Knn { .. }
             | SearchQueryInput::FieldedQuery { .. } => {}
+        }
+    }
+
+    /// True when this query tree contains a [`SearchQueryInput::Knn`] leaf
+    /// (the `~~~` operator).
+    pub fn contains_knn(&self) -> bool {
+        let mut this = self.clone();
+        let mut found = false;
+        this.visit(&mut |query| {
+            if matches!(query, SearchQueryInput::Knn { .. }) {
+                found = true;
+            }
+        });
+        found
+    }
+
+    /// The `(field, query_vector)` of every [`SearchQueryInput::Knn`] leaf in
+    /// this tree, paired with whether the leaf sits in a negated position (a
+    /// `must_not` clause at any level).
+    pub fn knn_leaves(&self) -> Vec<(FieldName, Vec<f32>, bool)> {
+        fn walk(
+            query: &SearchQueryInput,
+            negated: bool,
+            leaves: &mut Vec<(FieldName, Vec<f32>, bool)>,
+        ) {
+            match query {
+                SearchQueryInput::Knn {
+                    field,
+                    query_vector,
+                } => leaves.push((field.clone(), query_vector.clone(), negated)),
+                SearchQueryInput::Boolean {
+                    must,
+                    should,
+                    must_not,
+                    ..
+                } => {
+                    for q in must.iter().chain(should.iter()) {
+                        walk(q, negated, leaves);
+                    }
+                    for q in must_not {
+                        walk(q, true, leaves);
+                    }
+                }
+                SearchQueryInput::Boost { query, .. }
+                | SearchQueryInput::ConstScore { query, .. }
+                | SearchQueryInput::WithIndex { query, .. } => walk(query, negated, leaves),
+                SearchQueryInput::ScoreFilter {
+                    query: Some(query), ..
+                } => walk(query, negated, leaves),
+                SearchQueryInput::HeapFilter { indexed_query, .. } => {
+                    walk(indexed_query, negated, leaves)
+                }
+                SearchQueryInput::DisjunctionMax { disjuncts, .. } => {
+                    for q in disjuncts {
+                        walk(q, negated, leaves);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut leaves = Vec::new();
+        walk(self, false, &mut leaves);
+        leaves
+    }
+
+    /// Return a copy of this tree with every [`SearchQueryInput::Knn`] leaf
+    /// replaced by [`SearchQueryInput::All`] (`assume_matches = true`) or
+    /// [`SearchQueryInput::Empty`] (`assume_matches = false`).
+    ///
+    /// This is how the `pdb.rrf()` rank-fusion path splits a query `W`
+    /// containing a knn predicate into its two legs: the text leg's
+    /// candidate source is `W[knn := false]` and the vector leg's driving
+    /// query is `W[knn := true]` (the knn candidates are then the top-window
+    /// nearest among that leg's matches).
+    pub fn substitute_knn(&self, assume_matches: bool) -> SearchQueryInput {
+        let mut this = self.clone();
+        this.visit(&mut |query| {
+            if matches!(query, SearchQueryInput::Knn { .. }) {
+                *query = if assume_matches {
+                    SearchQueryInput::All
+                } else {
+                    SearchQueryInput::Empty
+                };
+            }
+        });
+        this
+    }
+
+    /// True when this query (possibly through score-transparent wrappers) is
+    /// nothing but a [`SearchQueryInput::Knn`] leaf.
+    fn is_knn_only(&self) -> bool {
+        match self {
+            SearchQueryInput::Knn { .. } => true,
+            SearchQueryInput::WithIndex { query, .. }
+            | SearchQueryInput::Boost { query, .. }
+            | SearchQueryInput::ConstScore { query, .. } => query.is_knn_only(),
+            SearchQueryInput::ScoreFilter {
+                query: Some(query), ..
+            } => query.is_knn_only(),
+            _ => false,
+        }
+    }
+
+    /// Return a copy of this tree with every [`SearchQueryInput::Knn`] leaf
+    /// *deleted from its boolean context* (removed from the `must`/`should`
+    /// list that contains it), rather than substituted with a constant.
+    ///
+    /// This is the text-RELEVANCE query for the `pdb.rrf()` text leg: under
+    /// `text OR knn` it equals `text` (same as `W[knn := false]`), but under
+    /// `text AND knn` it also equals `text` — where the `false` substitution
+    /// would collapse the whole conjunction to `Empty` and erase the text
+    /// leg's contribution to the fusion. A tree that consists solely of the
+    /// knn predicate becomes `Empty` (there is no text relevance).
+    pub fn without_knn(&self) -> SearchQueryInput {
+        match self {
+            SearchQueryInput::Knn { .. } => SearchQueryInput::Empty,
+            SearchQueryInput::Boolean {
+                must,
+                should,
+                must_not,
+                minimum_should_match,
+            } => {
+                let strip = |clauses: &[SearchQueryInput]| {
+                    clauses
+                        .iter()
+                        .filter(|clause| !clause.is_knn_only())
+                        .map(|clause| clause.without_knn())
+                        .collect::<Vec<_>>()
+                };
+                let (must, should, must_not) = (strip(must), strip(should), strip(must_not));
+                if must.is_empty() && should.is_empty() && must_not.is_empty() {
+                    SearchQueryInput::Empty
+                } else {
+                    SearchQueryInput::Boolean {
+                        must,
+                        should,
+                        must_not,
+                        minimum_should_match: *minimum_should_match,
+                    }
+                }
+            }
+            SearchQueryInput::WithIndex { oid, query } => SearchQueryInput::WithIndex {
+                oid: *oid,
+                query: Box::new(query.without_knn()),
+            },
+            SearchQueryInput::Boost { query, factor } => SearchQueryInput::Boost {
+                query: Box::new(query.without_knn()),
+                factor: *factor,
+            },
+            SearchQueryInput::ConstScore { query, score } => SearchQueryInput::ConstScore {
+                query: Box::new(query.without_knn()),
+                score: *score,
+            },
+            SearchQueryInput::ScoreFilter { bounds, query } => SearchQueryInput::ScoreFilter {
+                bounds: bounds.clone(),
+                query: query.as_ref().map(|query| Box::new(query.without_knn())),
+            },
+            SearchQueryInput::HeapFilter {
+                indexed_query,
+                field_filters,
+            } => SearchQueryInput::HeapFilter {
+                indexed_query: Box::new(indexed_query.without_knn()),
+                field_filters: field_filters.clone(),
+            },
+            SearchQueryInput::DisjunctionMax {
+                disjuncts,
+                tie_breaker,
+            } => SearchQueryInput::DisjunctionMax {
+                disjuncts: disjuncts
+                    .iter()
+                    .filter(|disjunct| !disjunct.is_knn_only())
+                    .map(|disjunct| disjunct.without_knn())
+                    .collect(),
+                tie_breaker: *tie_breaker,
+            },
+            other => other.clone(),
         }
     }
 
@@ -1114,6 +1308,9 @@ impl SearchQueryInput {
             SearchQueryInput::All => {
                 let query = Box::new(ConstScoreQuery::new(Box::new(AllQuery), 0.0));
                 Ok(builder.build_leaf(query, || "All Query".to_string(), cloned_for_estimate))
+            }
+            SearchQueryInput::Knn { .. } => {
+                panic!("the `~~~(vector, vector)` operator requires a ParadeDB TopK rank-fusion scan: use `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`")
             }
             SearchQueryInput::Boolean {
                 must,

--- a/pg_search/tests/pg_regress/expected/rrf_hybrid.out
+++ b/pg_search/tests/pg_regress/expected/rrf_hybrid.out
@@ -199,6 +199,63 @@ LIMIT 3;
   4 |          3
 (3 rows)
 
+-- ::pdb.top(n) arm annotations: per-arm windows written on the arms
+-- themselves. Equivalent to the vector_window_size => 3 query above (2,1,4),
+-- and the windows are visible in the Tantivy Query.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on hyb
+         Table: hyb
+         Index: hyb_idx
+         Exec Method: TopKScanExecState
+         Scores: true
+            TopK Order By: pdb.rrf(pdb.score(), ~~~ knn, k=60) asc
+            TopK Limit: 3
+         Tantivy Query: {"boolean":{"should":[{"top_n":{"query":{"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}},"window":100}},{"top_n":{"query":{"with_index":{"query":{"knn":{"field":"vec","query_vector":[0.05000000074505806,0.10000000149011612,0.9900000095367432]}}}},"window":3}}]}}
+(9 rows)
+
+SELECT id, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+ id | fused_rank 
+----+------------
+  2 |          1
+  1 |          2
+  4 |          3
+(3 rows)
+
+-- a ::pdb.top arm cannot mix text and knn predicates
+SELECT id FROM hyb
+WHERE (label ||| 'east wind' AND vec ~~~ '[1,0,0]')::pdb.top(5)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+ERROR:  a ::pdb.top arm may contain either text predicates or a single `~~~` knn predicate, not both: the two are ranked by incomparable measures
+-- multiple text arms are not supported yet
+SELECT id FROM hyb
+WHERE (label ||| 'east')::pdb.top(5) OR (label ||| 'wind')::pdb.top(5) OR vec ~~~ '[1,0,0]'
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+ERROR:  multiple text arms (N-ary rank fusion) are not supported yet
+-- a window given both on the arm and on pdb.rrf() is a conflict
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+ORDER BY pdb.rrf(id, vector_window_size => 5)
+LIMIT 3;
+ERROR:  the vector arm's window is specified both via ::pdb.top and pdb.rrf(vector_window_size => ..); use one
+-- ::pdb.top requires the rank-fusion ordering
+SELECT id FROM hyb
+WHERE (label ||| 'east wind')::pdb.top(5)
+ORDER BY id
+LIMIT 3;
+ERROR:  ::pdb.top(n) annotations require a rank-fusion ordering: `ORDER BY pdb.rrf(<key>) LIMIT <n>`
 -- ============================================================
 -- filtered semantics: WHERE defines the candidate set
 -- ============================================================

--- a/pg_search/tests/pg_regress/expected/rrf_hybrid.out
+++ b/pg_search/tests/pg_regress/expected/rrf_hybrid.out
@@ -199,16 +199,18 @@ LIMIT 3;
   4 |          3
 (3 rows)
 
--- ::pdb.top(n) arm annotations: per-arm windows written on the arms
--- themselves. Equivalent to the vector_window_size => 3 query above (2,1,4),
--- and the windows are visible in the Tantivy Query.
+-- ::pdb.top_bm25(n) / ::pdb.top_knn(n) arm annotations: the cast's type
+-- name declares what ranks the arm, the typmod its candidate window, both
+-- written on the arm itself. Equivalent to the vector_window_size => 3 query
+-- above (2,1,4), and the measures and windows are visible in the Tantivy
+-- Query.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM hyb
-WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+WHERE (label ||| 'east wind')::pdb.top_bm25(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(3)
 ORDER BY pdb.rrf(id)
 LIMIT 3;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Base Scan) on hyb
          Table: hyb
@@ -217,12 +219,12 @@ LIMIT 3;
          Scores: true
             TopK Order By: pdb.rrf(pdb.score(), ~~~ knn, k=60) asc
             TopK Limit: 3
-         Tantivy Query: {"boolean":{"should":[{"top_n":{"query":{"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}},"window":100}},{"top_n":{"query":{"with_index":{"query":{"knn":{"field":"vec","query_vector":[0.05000000074505806,0.10000000149011612,0.9900000095367432]}}}},"window":3}}]}}
+         Tantivy Query: {"boolean":{"should":[{"top_n":{"query":{"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}},"window":100,"measure":"bm25"}},{"top_n":{"query":{"with_index":{"query":{"knn":{"field":"vec","query_vector":[0.05000000074505806,0.10000000149011612,0.9900000095367432]}}}},"window":3,"measure":"knn"}}]}}
 (9 rows)
 
 SELECT id, pdb.score(id, type => 'rank') AS fused_rank
 FROM hyb
-WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+WHERE (label ||| 'east wind')::pdb.top_bm25(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(3)
 ORDER BY pdb.rrf(id)
 LIMIT 3;
  id | fused_rank 
@@ -232,30 +234,68 @@ LIMIT 3;
   4 |          3
 (3 rows)
 
--- a ::pdb.top arm cannot mix text and knn predicates
-SELECT id FROM hyb
-WHERE (label ||| 'east wind' AND vec ~~~ '[1,0,0]')::pdb.top(5)
+-- predicates inside a ::pdb.top_knn arm are filters: the arm ranks by
+-- proximity among the rows that pass them. The knn arm is gated to id < 3
+-- (docs 1, 2; doc 2 the nearer) and truncated to a window of 1, so only
+-- doc 2 gets vector credit: 1/62 + 1/61 beats doc 1's 1/61 and doc 3's 1/63.
+SELECT id, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind')::pdb.top_bm25(100)
+   OR (id < 3 AND vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(1)
 ORDER BY pdb.rrf(id)
 LIMIT 3;
-ERROR:  a ::pdb.top arm may contain either text predicates or a single `~~~` knn predicate, not both: the two are ranked by incomparable measures
--- multiple text arms are not supported yet
+ id | fused_rank 
+----+------------
+  2 |          1
+  1 |          2
+  3 |          3
+(3 rows)
+
+-- a lone ::pdb.top_knn arm with a text filter is a filtered knn search:
+-- candidates must match the filter (docs 1, 2, 3), ranked purely by
+-- proximity (2, 3, 1); there is no text arm, so bm25 is NULL
+SELECT id, round(pdb.score(id)::numeric, 6) AS bm25, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind' AND vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(5)
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+ id | bm25 | fused_rank 
+----+------+------------
+  2 |      |          1
+  3 |      |          2
+  1 |      |          3
+(3 rows)
+
+-- a ::pdb.top_bm25 arm ranks by BM25, so a ~~~ inside it has no meaning
 SELECT id FROM hyb
-WHERE (label ||| 'east')::pdb.top(5) OR (label ||| 'wind')::pdb.top(5) OR vec ~~~ '[1,0,0]'
+WHERE (label ||| 'east wind' AND vec ~~~ '[1,0,0]')::pdb.top_bm25(5)
 ORDER BY pdb.rrf(id)
 LIMIT 3;
-ERROR:  multiple text arms (N-ary rank fusion) are not supported yet
+ERROR:  a ::pdb.top_bm25 arm ranks by BM25 and cannot contain a `~~~` knn predicate; annotate that group with ::pdb.top_knn instead
+-- a ::pdb.top_knn arm must have a ~~~ to rank by
+SELECT id FROM hyb
+WHERE (label ||| 'east wind')::pdb.top_knn(5)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+ERROR:  a ::pdb.top_knn arm must contain a `~~~` knn predicate: that is the measure it ranks by
+-- multiple bm25 arms are not supported yet
+SELECT id FROM hyb
+WHERE (label ||| 'east')::pdb.top_bm25(5) OR (label ||| 'wind')::pdb.top_bm25(5) OR vec ~~~ '[1,0,0]'
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+ERROR:  multiple ::pdb.top_bm25 arms (N-ary rank fusion) are not supported yet
 -- a window given both on the arm and on pdb.rrf() is a conflict
 SELECT id FROM hyb
-WHERE label ||| 'east wind' OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+WHERE label ||| 'east wind' OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(3)
 ORDER BY pdb.rrf(id, vector_window_size => 5)
 LIMIT 3;
-ERROR:  the vector arm's window is specified both via ::pdb.top and pdb.rrf(vector_window_size => ..); use one
--- ::pdb.top requires the rank-fusion ordering
+ERROR:  the vector arm's window is specified both via ::pdb.top_knn and pdb.rrf(vector_window_size => ..); use one
+-- the annotations require the rank-fusion ordering
 SELECT id FROM hyb
-WHERE (label ||| 'east wind')::pdb.top(5)
+WHERE (label ||| 'east wind')::pdb.top_bm25(5)
 ORDER BY id
 LIMIT 3;
-ERROR:  ::pdb.top(n) annotations require a rank-fusion ordering: `ORDER BY pdb.rrf(<key>) LIMIT <n>`
+ERROR:  ::pdb.top_bm25(n)/::pdb.top_knn(n) annotations require a rank-fusion ordering: `ORDER BY pdb.rrf(<key>) LIMIT <n>`
 -- ============================================================
 -- filtered semantics: WHERE defines the candidate set
 -- ============================================================

--- a/pg_search/tests/pg_regress/expected/rrf_hybrid.out
+++ b/pg_search/tests/pg_regress/expected/rrf_hybrid.out
@@ -165,6 +165,40 @@ LIMIT 3;
   2 |          3
 (3 rows)
 
+-- per-arm windows: shrinking the vector arm's window to the page size
+-- truncates its contribution. Vector top-3 for [0.05,0.1,0.99] is docs
+-- 4, 2, 5, so doc 3 (vector rank 4 with the default window) loses its
+-- vector contribution and doc 4 overtakes it: 2, 1, 4 instead of 2, 1, 3.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id, vector_window_size => 3)
+LIMIT 3;
+                                                                                                                                                                         QUERY PLAN                                                                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on hyb
+         Table: hyb
+         Index: hyb_idx
+         Exec Method: TopKScanExecState
+         Scores: true
+            TopK Order By: pdb.rrf(pdb.score(), ~~~ knn, k=60, vector_window_size=3) asc
+            TopK Limit: 3
+         Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}},{"with_index":{"query":{"knn":{"field":"vec","query_vector":[0.05000000074505806,0.10000000149011612,0.9900000095367432]}}}}]}}
+(9 rows)
+
+SELECT id, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id, vector_window_size => 3)
+LIMIT 3;
+ id | fused_rank 
+----+------------
+  2 |          1
+  1 |          2
+  4 |          3
+(3 rows)
+
 -- ============================================================
 -- filtered semantics: WHERE defines the candidate set
 -- ============================================================

--- a/pg_search/tests/pg_regress/expected/rrf_hybrid.out
+++ b/pg_search/tests/pg_regress/expected/rrf_hybrid.out
@@ -1,0 +1,430 @@
+-- Hybrid search via Reciprocal Rank Fusion:
+--
+--   SELECT ...
+--   FROM t
+--   WHERE <text predicate>                                  -- candidate set
+--   ORDER BY pdb.rrf(pdb.score(id), vec <op> '[...]' [, k]) -- fused ranking
+--   LIMIT n;
+--
+-- pdb.rrf() fuses the query's BM25 ranking with a vector-distance ranking
+-- and returns the fused rank (1 = best), so plain ascending ORDER BY puts
+-- the best match first (pgvector convention, no DESC needed).
+--
+-- pdb.score(relation, type) projects the components:
+--   * 'bm25'   — the text predicate's BM25 score (what pdb.score(relation)
+--                means in every scan shape)
+--   * 'vector' — the vector leg's similarity
+--   * 'hybrid' — the positive fused RRF score pdb.rrf() ranks by
+--   * 'rank'   — the 1-based fused rank, identical to pdb.rrf()'s value
+--
+-- The corpus is built so BM25 scores and vector similarities are distinct
+-- (no rank ties) in the flagship queries. Scores are rounded to 6 decimals.
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE TABLE hyb (
+    id    int PRIMARY KEY,
+    label text,
+    vec   vector(3)
+);
+INSERT INTO hyb VALUES
+    (1, 'east wind',        '[1,   0,   0]'),
+    (2, 'east gate',        '[0.9, 0,   0.1]'),
+    (3, 'north wind blows', '[0,   1,   0]'),
+    (4, 'up draft',         '[0,   0,   1]'),
+    (5, 'mid point',        '[0.7, 0.7, 0]');
+CREATE INDEX hyb_idx ON hyb
+    USING bm25 (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+-- ============================================================
+-- flagship: fused ordering + all score components
+-- ============================================================
+-- Matches docs 1, 2, 3. BM25 ranks: 1, 2, 3. Vector ranks for [0.6,0.8,0]:
+-- doc3=1, doc1=2, doc2=3. RRF (k=60): doc1 = 1/61+1/62, doc3 = 1/63+1/61,
+-- doc2 = 1/62+1/63, so the fused order (1, 3, 2) differs from both legs.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]')
+LIMIT 3;
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on hyb
+         Table: hyb
+         Index: hyb_idx
+         Exec Method: TopKScanExecState
+         Scores: true
+            TopK Order By: pdb.rrf(pdb.score(), vec <=> vector, k=60) asc
+            TopK Limit: 3
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
+
+SELECT id,
+       pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]')          AS fused_rank,
+       round(pdb.score(id)::numeric, 6)                       AS bm25,
+       round(pdb.score(id, type => 'bm25')::numeric, 6)       AS bm25_typed,
+       round(pdb.score(id, type => 'vector')::numeric, 6)     AS similarity,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6)     AS hybrid,
+       pdb.score(id, type => 'rank')                          AS rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]')
+LIMIT 3;
+ id | fused_rank |   bm25   | bm25_typed | similarity |  hybrid  | rank 
+----+------------+----------+------------+------------+----------+------
+  1 |          1 | 1.818570 |   1.818570 |   0.600000 | 0.032523 |    1
+  3 |          2 | 0.762099 |   0.762099 |   0.800000 | 0.032267 |    2
+  2 |          3 | 0.909285 |   0.909285 |   0.596330 | 0.032002 |    3
+(3 rows)
+
+-- ordering by the output alias works too
+SELECT id, r AS fused_rank
+FROM (
+    SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]') AS r
+    FROM hyb
+    WHERE label ||| 'east wind'
+    ORDER BY r
+    LIMIT 3
+) fused;
+ id | fused_rank 
+----+------------
+  1 |          1
+  3 |          2
+  2 |          3
+(3 rows)
+
+-- the legs may be written in either order
+SELECT id, pdb.rrf(vec <=> '[0.6,0.8,0]', pdb.score(id)) AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(vec <=> '[0.6,0.8,0]', pdb.score(id))
+LIMIT 3;
+ id | fused_rank 
+----+------------
+  1 |          1
+  3 |          2
+  2 |          3
+(3 rows)
+
+-- DESC honestly reverses the fused ranking (worst first)
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]') AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]') DESC
+LIMIT 3;
+ id | fused_rank 
+----+------------
+  2 |          3
+  3 |          2
+  1 |          1
+(3 rows)
+
+-- k is tunable via named argument
+SELECT id,
+       pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', k => 1)      AS fused_rank,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6)         AS hybrid
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', k => 1)
+LIMIT 3;
+ id | fused_rank |  hybrid  
+----+------------+----------
+  1 |          1 | 0.833333
+  3 |          2 | 0.750000
+  2 |          3 | 0.583333
+(3 rows)
+
+-- so is the per-leg candidate window (the overfetch); it shows in EXPLAIN
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', window_size => 200)
+LIMIT 3;
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on hyb
+         Table: hyb
+         Index: hyb_idx
+         Exec Method: TopKScanExecState
+         Scores: true
+            TopK Order By: pdb.rrf(pdb.score(), vec <=> vector, k=60, window_size=200) asc
+            TopK Limit: 3
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
+
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', window_size => 200) AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', window_size => 200)
+LIMIT 3;
+ id | fused_rank 
+----+------------
+  1 |          1
+  3 |          2
+  2 |          3
+(3 rows)
+
+-- ============================================================
+-- filtered semantics: WHERE defines the candidate set
+-- ============================================================
+-- doc4 is the nearest neighbor of [0.2,0.1,0.97] but does not match the text
+-- predicate, so it never surfaces. (docs 1 and 2 tie on the fused score by
+-- symmetric rank swap; the tie breaks deterministically by document order.)
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.2,0.1,0.97]') AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.2,0.1,0.97]')
+LIMIT 4;
+ id | fused_rank 
+----+------------
+  1 |          1
+  2 |          2
+  3 |          3
+(3 rows)
+
+-- ============================================================
+-- union hybrid via the ~~~ knn predicate
+-- ============================================================
+-- Predicate scoping follows boolean position: predicates ANDed outside the
+-- OR apply to both legs; predicates grouped inside a branch apply to that
+-- leg only. With a ~~~ predicate the fully-implied form `pdb.rrf(id)`
+-- suffices: the BM25 leg is the relation's text query and the vector leg its
+-- knn predicate, so the query vector is written once. (The explicit two-leg
+-- form is still allowed and validated against the predicate.)
+-- doc4 'up draft' is the nearest neighbor of [0.05,0.1,0.99] but matches no
+-- text; with `OR vec ~~~ ...` it surfaces (union semantics), with a NULL
+-- bm25 score. Vector ranks over all docs: 4, 2, 5, 3, 1; bm25 ranks: 1, 2, 3.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+                                                                                                                                                                         QUERY PLAN                                                                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on hyb
+         Table: hyb
+         Index: hyb_idx
+         Exec Method: TopKScanExecState
+         Scores: true
+            TopK Order By: pdb.rrf(pdb.score(), ~~~ knn, k=60) asc
+            TopK Limit: 5
+         Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"match":{"field":"label","value":"east wind","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}},{"with_index":{"query":{"knn":{"field":"vec","query_vector":[0.05000000074505806,0.10000000149011612,0.9900000095367432]}}}}]}}
+(9 rows)
+
+SELECT id,
+       round(pdb.score(id)::numeric, 6)                   AS bm25,
+       round(pdb.score(id, type => 'vector')::numeric, 6) AS similarity,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6) AS hybrid
+FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+ id |   bm25   | similarity |  hybrid  
+----+----------+------------+----------
+  2 | 0.909285 |   0.159613 | 0.032258
+  1 | 1.818570 |   0.050186 | 0.031778
+  3 | 0.762099 |   0.100372 | 0.031498
+  4 |          |   0.993683 | 0.016393
+  5 |          |   0.106461 | 0.015873
+(5 rows)
+
+-- a shared filter (ANDed outside the OR) constrains BOTH legs: doc5 is gone
+-- from the vector leg entirely
+SELECT id,
+       round(pdb.score(id)::numeric, 6) AS bm25,
+       pdb.score(id, type => 'rank')    AS fused_rank
+FROM hyb
+WHERE id < 5 AND (label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]')
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.05,0.1,0.99]')
+LIMIT 5;
+ id |   bm25   | fused_rank 
+----+----------+------------
+  2 | 1.909290 |          1
+  1 | 2.818570 |          2
+  3 | 1.762100 |          3
+  4 |          |          4
+(4 rows)
+
+-- a predicate grouped with the text matcher applies to the bm25 leg only:
+-- doc3 matches the text but is excluded from the bm25 leg by id < 3, so it
+-- only surfaces (and ranks) via the vector leg
+SELECT id,
+       round(pdb.score(id)::numeric, 6) AS bm25,
+       pdb.score(id, type => 'rank')    AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind' AND id < 3) OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+ id |   bm25   | fused_rank 
+----+----------+------------
+  2 | 1.909290 |          1
+  1 | 2.818570 |          2
+  4 |          |          3
+  5 |          |          4
+  3 |          |          5
+(5 rows)
+
+-- intersection: text AND ~~~ — candidates must match BOTH legs, and the
+-- fusion still ranks by text relevance and proximity: bm25 ranks 1,2,3
+-- (docs 1,2,3) fuse with vector ranks 2,1,3 giving the order 2, 1, 3
+SELECT id,
+       round(pdb.score(id)::numeric, 6)                   AS bm25,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6) AS hybrid,
+       pdb.score(id, type => 'rank')                      AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind' AND vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+ id |   bm25   |  hybrid  | fused_rank 
+----+----------+----------+------------
+  2 | 0.909285 | 0.032523 |          1
+  1 | 1.818570 | 0.032267 |          2
+  3 | 0.762099 | 0.032002 |          3
+(3 rows)
+
+-- knn-only WHERE: every row surfaces via the vector leg, text scores NULL
+SELECT id, round(pdb.score(id)::numeric, 6) AS bm25, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(pdb.score(id))  -- relation reference may also be spelled pdb.score(id)
+LIMIT 3;
+ id | bm25 | fused_rank 
+----+------+------------
+  4 |      |          1
+  2 |      |          2
+  5 |      |          3
+(3 rows)
+
+-- ============================================================
+-- parameterized query vector (`<=> $1`) inside pdb.rrf()
+-- ============================================================
+SET plan_cache_mode = force_generic_plan;
+PREPARE hyb_p(vector) AS
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> $1)
+LIMIT 3;
+EXECUTE hyb_p('[0.6,0.8,0]');
+ id 
+----
+  1
+  3
+  2
+(3 rows)
+
+EXECUTE hyb_p('[0.2,0.1,0.97]');
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+DEALLOCATE hyb_p;
+RESET plan_cache_mode;
+-- ============================================================
+-- typed score projection under a plain vector-distance ordering
+-- ============================================================
+-- pdb.score(relation) means the BM25 score in every scan shape, including
+-- here where the scan itself is ordered by similarity; 'vector' projects
+-- that similarity.
+SELECT id,
+       round(pdb.score(id)::numeric, 6)                   AS bm25,
+       round(pdb.score(id, type => 'vector')::numeric, 6) AS similarity,
+       pdb.score(id) = pdb.score(id, type => 'bm25')      AS score_is_bm25
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY vec <=> '[0.6,0.8,0]' LIMIT 3;
+ id |   bm25   | similarity | score_is_bm25 
+----+----------+------------+---------------
+  3 | 0.762099 |   0.800000 | t
+  1 | 1.818570 |   0.600000 | t
+  2 | 0.909285 |   0.596330 | t
+(3 rows)
+
+-- plain pdb.score(id) on a text query is unchanged
+SELECT id, pdb.score(id) = pdb.score(id, type => 'bm25') AS typed_matches_untyped
+FROM hyb
+WHERE label @@@ 'wind'
+ORDER BY id;
+ id | typed_matches_untyped 
+----+-----------------------
+  1 | t
+  3 | t
+(2 rows)
+
+-- ============================================================
+-- error cases
+-- ============================================================
+-- pdb.rrf() must drive the ordering
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[1,0,0]') FROM hyb WHERE label @@@ 'wind';
+ERROR:  pdb.rrf() must drive the scan's ordering: use `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`
+-- 'hybrid' requires a rank-fusion ordering
+SELECT id, pdb.score(id, type => 'hybrid') FROM hyb WHERE label @@@ 'wind';
+ERROR:  pdb.score(relation, 'hybrid') requires a rank-fusion ordering: `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`
+-- 'vector' requires a vector ranking
+SELECT id, pdb.score(id, type => 'vector') FROM hyb WHERE label @@@ 'wind';
+ERROR:  pdb.score(relation, 'vector') requires a vector ranking: order by `pdb.rrf(...)` or by a vector distance operator with a LIMIT
+-- 'rank' requires a rank-fusion ordering
+SELECT id, pdb.score(id, type => 'rank') FROM hyb WHERE label @@@ 'wind';
+ERROR:  pdb.score(relation, 'rank') requires a rank-fusion ordering: `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`
+-- unrecognized score type
+SELECT id, pdb.score(id, type => 'nope') FROM hyb WHERE label @@@ 'wind';
+ERROR:  pdb.score: unrecognized score type 'nope'; expected 'bm25', 'vector', 'hybrid', or 'rank'
+-- the score type must be a constant
+SELECT id, pdb.score(id, label) FROM hyb WHERE label @@@ 'wind';
+ERROR:  pdb.score: the score type must be a constant
+-- query vector dimensionality must match the indexed field
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[1,2]')
+LIMIT 3;
+ERROR:  query vector has 2 dimensions but field "vec" is indexed with 3
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY vec <=> '[1,2]'
+LIMIT 3;
+ERROR:  query vector has 2 dimensions but field "vec" is indexed with 3
+-- pdb.rrf() without a distance leg requires a ~~~ predicate
+SELECT id FROM hyb
+WHERE label @@@ 'wind'
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+ERROR:  pdb.rrf() without a distance leg requires a `~~~(vector, vector)` predicate in the WHERE clause
+-- ~~~ requires the rank-fusion ordering
+SELECT id FROM hyb WHERE label ||| 'east wind' OR vec ~~~ '[1,0,0]';
+ERROR:  the `~~~(vector, vector)` operator requires a rank-fusion ordering: `ORDER BY pdb.rrf(pdb.score(<key>), <vector_column> <op> <query_vector>) LIMIT <n>`
+-- ~~~ cannot be negated
+SELECT id FROM hyb
+WHERE label @@@ 'wind' AND NOT (vec ~~~ '[1,0,0]')
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[1,0,0]')
+LIMIT 3;
+ERROR:  the `~~~(vector, vector)` operator cannot be used in a negated (NOT) position
+-- only one ~~~ predicate per query
+SELECT id FROM hyb
+WHERE vec ~~~ '[1,0,0]' OR vec ~~~ '[0,1,0]'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[1,0,0]')
+LIMIT 3;
+ERROR:  only one `~~~(vector, vector)` predicate is supported per query
+-- the ~~~ query vector must match pdb.rrf()'s distance leg
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[1,0,0]'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0,1,0]')
+LIMIT 3;
+ERROR:  the `~~~` operator's query vector must match pdb.rrf()'s distance leg query vector
+-- partitioned tables are rejected: per-partition fused ranks cannot be
+-- merged into a global ranking
+CREATE TABLE hyb_part (id int, label text, vec vector(3), PRIMARY KEY (id)) PARTITION BY RANGE (id);
+CREATE TABLE hyb_part_1 PARTITION OF hyb_part FOR VALUES FROM (0) TO (100);
+CREATE TABLE hyb_part_2 PARTITION OF hyb_part FOR VALUES FROM (100) TO (200);
+INSERT INTO hyb_part VALUES (1, 'east wind', '[1,0,0]'), (101, 'east gate', '[0.9,0,0.1]');
+CREATE INDEX hyb_part_idx ON hyb_part USING bm25 (id, label, vec vector_cosine_ops) WITH (key_field = id);
+SELECT id FROM hyb_part
+WHERE label ||| 'east wind' OR vec ~~~ '[1,0,0]'
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+ERROR:  pdb.rrf() is not supported on partitioned tables: per-partition fused ranks cannot be merged into a global ranking; query one partition directly or fuse per-partition results in SQL
+DROP TABLE hyb_part;
+DROP TABLE hyb;

--- a/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
+++ b/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
@@ -127,6 +127,45 @@ ORDER BY pdb.rrf(id, vector_window_size => 3)
 LIMIT 3;
 
 
+-- ::pdb.top(n) arm annotations: per-arm windows written on the arms
+-- themselves. Equivalent to the vector_window_size => 3 query above (2,1,4),
+-- and the windows are visible in the Tantivy Query.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+SELECT id, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+
+-- a ::pdb.top arm cannot mix text and knn predicates
+SELECT id FROM hyb
+WHERE (label ||| 'east wind' AND vec ~~~ '[1,0,0]')::pdb.top(5)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+
+-- multiple text arms are not supported yet
+SELECT id FROM hyb
+WHERE (label ||| 'east')::pdb.top(5) OR (label ||| 'wind')::pdb.top(5) OR vec ~~~ '[1,0,0]'
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+
+-- a window given both on the arm and on pdb.rrf() is a conflict
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+ORDER BY pdb.rrf(id, vector_window_size => 5)
+LIMIT 3;
+
+-- ::pdb.top requires the rank-fusion ordering
+SELECT id FROM hyb
+WHERE (label ||| 'east wind')::pdb.top(5)
+ORDER BY id
+LIMIT 3;
+
+
 -- ============================================================
 -- filtered semantics: WHERE defines the candidate set
 -- ============================================================

--- a/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
+++ b/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
@@ -127,41 +127,69 @@ ORDER BY pdb.rrf(id, vector_window_size => 3)
 LIMIT 3;
 
 
--- ::pdb.top(n) arm annotations: per-arm windows written on the arms
--- themselves. Equivalent to the vector_window_size => 3 query above (2,1,4),
--- and the windows are visible in the Tantivy Query.
+-- ::pdb.top_bm25(n) / ::pdb.top_knn(n) arm annotations: the cast's type
+-- name declares what ranks the arm, the typmod its candidate window, both
+-- written on the arm itself. Equivalent to the vector_window_size => 3 query
+-- above (2,1,4), and the measures and windows are visible in the Tantivy
+-- Query.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM hyb
-WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+WHERE (label ||| 'east wind')::pdb.top_bm25(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(3)
 ORDER BY pdb.rrf(id)
 LIMIT 3;
 SELECT id, pdb.score(id, type => 'rank') AS fused_rank
 FROM hyb
-WHERE (label ||| 'east wind')::pdb.top(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+WHERE (label ||| 'east wind')::pdb.top_bm25(100) OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(3)
 ORDER BY pdb.rrf(id)
 LIMIT 3;
 
--- a ::pdb.top arm cannot mix text and knn predicates
-SELECT id FROM hyb
-WHERE (label ||| 'east wind' AND vec ~~~ '[1,0,0]')::pdb.top(5)
+-- predicates inside a ::pdb.top_knn arm are filters: the arm ranks by
+-- proximity among the rows that pass them. The knn arm is gated to id < 3
+-- (docs 1, 2; doc 2 the nearer) and truncated to a window of 1, so only
+-- doc 2 gets vector credit: 1/62 + 1/61 beats doc 1's 1/61 and doc 3's 1/63.
+SELECT id, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind')::pdb.top_bm25(100)
+   OR (id < 3 AND vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(1)
 ORDER BY pdb.rrf(id)
 LIMIT 3;
 
--- multiple text arms are not supported yet
+-- a lone ::pdb.top_knn arm with a text filter is a filtered knn search:
+-- candidates must match the filter (docs 1, 2, 3), ranked purely by
+-- proximity (2, 3, 1); there is no text arm, so bm25 is NULL
+SELECT id, round(pdb.score(id)::numeric, 6) AS bm25, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind' AND vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(5)
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+
+-- a ::pdb.top_bm25 arm ranks by BM25, so a ~~~ inside it has no meaning
 SELECT id FROM hyb
-WHERE (label ||| 'east')::pdb.top(5) OR (label ||| 'wind')::pdb.top(5) OR vec ~~~ '[1,0,0]'
+WHERE (label ||| 'east wind' AND vec ~~~ '[1,0,0]')::pdb.top_bm25(5)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+
+-- a ::pdb.top_knn arm must have a ~~~ to rank by
+SELECT id FROM hyb
+WHERE (label ||| 'east wind')::pdb.top_knn(5)
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+
+-- multiple bm25 arms are not supported yet
+SELECT id FROM hyb
+WHERE (label ||| 'east')::pdb.top_bm25(5) OR (label ||| 'wind')::pdb.top_bm25(5) OR vec ~~~ '[1,0,0]'
 ORDER BY pdb.rrf(id)
 LIMIT 3;
 
 -- a window given both on the arm and on pdb.rrf() is a conflict
 SELECT id FROM hyb
-WHERE label ||| 'east wind' OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top(3)
+WHERE label ||| 'east wind' OR (vec ~~~ '[0.05,0.1,0.99]')::pdb.top_knn(3)
 ORDER BY pdb.rrf(id, vector_window_size => 5)
 LIMIT 3;
 
--- ::pdb.top requires the rank-fusion ordering
+-- the annotations require the rank-fusion ordering
 SELECT id FROM hyb
-WHERE (label ||| 'east wind')::pdb.top(5)
+WHERE (label ||| 'east wind')::pdb.top_bm25(5)
 ORDER BY id
 LIMIT 3;
 

--- a/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
+++ b/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
@@ -1,0 +1,306 @@
+-- Hybrid search via Reciprocal Rank Fusion:
+--
+--   SELECT ...
+--   FROM t
+--   WHERE <text predicate>                                  -- candidate set
+--   ORDER BY pdb.rrf(pdb.score(id), vec <op> '[...]' [, k]) -- fused ranking
+--   LIMIT n;
+--
+-- pdb.rrf() fuses the query's BM25 ranking with a vector-distance ranking
+-- and returns the fused rank (1 = best), so plain ascending ORDER BY puts
+-- the best match first (pgvector convention, no DESC needed).
+--
+-- pdb.score(relation, type) projects the components:
+--   * 'bm25'   — the text predicate's BM25 score (what pdb.score(relation)
+--                means in every scan shape)
+--   * 'vector' — the vector leg's similarity
+--   * 'hybrid' — the positive fused RRF score pdb.rrf() ranks by
+--   * 'rank'   — the 1-based fused rank, identical to pdb.rrf()'s value
+--
+-- The corpus is built so BM25 scores and vector similarities are distinct
+-- (no rank ties) in the flagship queries. Scores are rounded to 6 decimals.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+CREATE TABLE hyb (
+    id    int PRIMARY KEY,
+    label text,
+    vec   vector(3)
+);
+
+INSERT INTO hyb VALUES
+    (1, 'east wind',        '[1,   0,   0]'),
+    (2, 'east gate',        '[0.9, 0,   0.1]'),
+    (3, 'north wind blows', '[0,   1,   0]'),
+    (4, 'up draft',         '[0,   0,   1]'),
+    (5, 'mid point',        '[0.7, 0.7, 0]');
+
+CREATE INDEX hyb_idx ON hyb
+    USING bm25 (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+
+
+-- ============================================================
+-- flagship: fused ordering + all score components
+-- ============================================================
+-- Matches docs 1, 2, 3. BM25 ranks: 1, 2, 3. Vector ranks for [0.6,0.8,0]:
+-- doc3=1, doc1=2, doc2=3. RRF (k=60): doc1 = 1/61+1/62, doc3 = 1/63+1/61,
+-- doc2 = 1/62+1/63, so the fused order (1, 3, 2) differs from both legs.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]')
+LIMIT 3;
+
+SELECT id,
+       pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]')          AS fused_rank,
+       round(pdb.score(id)::numeric, 6)                       AS bm25,
+       round(pdb.score(id, type => 'bm25')::numeric, 6)       AS bm25_typed,
+       round(pdb.score(id, type => 'vector')::numeric, 6)     AS similarity,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6)     AS hybrid,
+       pdb.score(id, type => 'rank')                          AS rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]')
+LIMIT 3;
+
+-- ordering by the output alias works too
+SELECT id, r AS fused_rank
+FROM (
+    SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]') AS r
+    FROM hyb
+    WHERE label ||| 'east wind'
+    ORDER BY r
+    LIMIT 3
+) fused;
+
+-- the legs may be written in either order
+SELECT id, pdb.rrf(vec <=> '[0.6,0.8,0]', pdb.score(id)) AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(vec <=> '[0.6,0.8,0]', pdb.score(id))
+LIMIT 3;
+
+-- DESC honestly reverses the fused ranking (worst first)
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]') AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]') DESC
+LIMIT 3;
+
+-- k is tunable via named argument
+SELECT id,
+       pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', k => 1)      AS fused_rank,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6)         AS hybrid
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', k => 1)
+LIMIT 3;
+
+-- so is the per-leg candidate window (the overfetch); it shows in EXPLAIN
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', window_size => 200)
+LIMIT 3;
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', window_size => 200) AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', window_size => 200)
+LIMIT 3;
+
+
+-- ============================================================
+-- filtered semantics: WHERE defines the candidate set
+-- ============================================================
+-- doc4 is the nearest neighbor of [0.2,0.1,0.97] but does not match the text
+-- predicate, so it never surfaces. (docs 1 and 2 tie on the fused score by
+-- symmetric rank swap; the tie breaks deterministically by document order.)
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[0.2,0.1,0.97]') AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.2,0.1,0.97]')
+LIMIT 4;
+
+
+-- ============================================================
+-- union hybrid via the ~~~ knn predicate
+-- ============================================================
+-- Predicate scoping follows boolean position: predicates ANDed outside the
+-- OR apply to both legs; predicates grouped inside a branch apply to that
+-- leg only. With a ~~~ predicate the fully-implied form `pdb.rrf(id)`
+-- suffices: the BM25 leg is the relation's text query and the vector leg its
+-- knn predicate, so the query vector is written once. (The explicit two-leg
+-- form is still allowed and validated against the predicate.)
+
+-- doc4 'up draft' is the nearest neighbor of [0.05,0.1,0.99] but matches no
+-- text; with `OR vec ~~~ ...` it surfaces (union semantics), with a NULL
+-- bm25 score. Vector ranks over all docs: 4, 2, 5, 3, 1; bm25 ranks: 1, 2, 3.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+
+SELECT id,
+       round(pdb.score(id)::numeric, 6)                   AS bm25,
+       round(pdb.score(id, type => 'vector')::numeric, 6) AS similarity,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6) AS hybrid
+FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+
+-- a shared filter (ANDed outside the OR) constrains BOTH legs: doc5 is gone
+-- from the vector leg entirely
+SELECT id,
+       round(pdb.score(id)::numeric, 6) AS bm25,
+       pdb.score(id, type => 'rank')    AS fused_rank
+FROM hyb
+WHERE id < 5 AND (label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]')
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.05,0.1,0.99]')
+LIMIT 5;
+
+-- a predicate grouped with the text matcher applies to the bm25 leg only:
+-- doc3 matches the text but is excluded from the bm25 leg by id < 3, so it
+-- only surfaces (and ranks) via the vector leg
+SELECT id,
+       round(pdb.score(id)::numeric, 6) AS bm25,
+       pdb.score(id, type => 'rank')    AS fused_rank
+FROM hyb
+WHERE (label ||| 'east wind' AND id < 3) OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+
+-- intersection: text AND ~~~ — candidates must match BOTH legs, and the
+-- fusion still ranks by text relevance and proximity: bm25 ranks 1,2,3
+-- (docs 1,2,3) fuse with vector ranks 2,1,3 giving the order 2, 1, 3
+SELECT id,
+       round(pdb.score(id)::numeric, 6)                   AS bm25,
+       round(pdb.score(id, type => 'hybrid')::numeric, 6) AS hybrid,
+       pdb.score(id, type => 'rank')                      AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind' AND vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id)
+LIMIT 5;
+
+-- knn-only WHERE: every row surfaces via the vector leg, text scores NULL
+SELECT id, round(pdb.score(id)::numeric, 6) AS bm25, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(pdb.score(id))  -- relation reference may also be spelled pdb.score(id)
+LIMIT 3;
+
+
+-- ============================================================
+-- parameterized query vector (`<=> $1`) inside pdb.rrf()
+-- ============================================================
+SET plan_cache_mode = force_generic_plan;
+PREPARE hyb_p(vector) AS
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> $1)
+LIMIT 3;
+
+EXECUTE hyb_p('[0.6,0.8,0]');
+EXECUTE hyb_p('[0.2,0.1,0.97]');
+
+DEALLOCATE hyb_p;
+RESET plan_cache_mode;
+
+
+-- ============================================================
+-- typed score projection under a plain vector-distance ordering
+-- ============================================================
+-- pdb.score(relation) means the BM25 score in every scan shape, including
+-- here where the scan itself is ordered by similarity; 'vector' projects
+-- that similarity.
+SELECT id,
+       round(pdb.score(id)::numeric, 6)                   AS bm25,
+       round(pdb.score(id, type => 'vector')::numeric, 6) AS similarity,
+       pdb.score(id) = pdb.score(id, type => 'bm25')      AS score_is_bm25
+FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY vec <=> '[0.6,0.8,0]' LIMIT 3;
+
+-- plain pdb.score(id) on a text query is unchanged
+SELECT id, pdb.score(id) = pdb.score(id, type => 'bm25') AS typed_matches_untyped
+FROM hyb
+WHERE label @@@ 'wind'
+ORDER BY id;
+
+
+-- ============================================================
+-- error cases
+-- ============================================================
+-- pdb.rrf() must drive the ordering
+SELECT id, pdb.rrf(pdb.score(id), vec <=> '[1,0,0]') FROM hyb WHERE label @@@ 'wind';
+
+-- 'hybrid' requires a rank-fusion ordering
+SELECT id, pdb.score(id, type => 'hybrid') FROM hyb WHERE label @@@ 'wind';
+
+-- 'vector' requires a vector ranking
+SELECT id, pdb.score(id, type => 'vector') FROM hyb WHERE label @@@ 'wind';
+
+-- 'rank' requires a rank-fusion ordering
+SELECT id, pdb.score(id, type => 'rank') FROM hyb WHERE label @@@ 'wind';
+
+-- unrecognized score type
+SELECT id, pdb.score(id, type => 'nope') FROM hyb WHERE label @@@ 'wind';
+
+-- the score type must be a constant
+SELECT id, pdb.score(id, label) FROM hyb WHERE label @@@ 'wind';
+
+-- query vector dimensionality must match the indexed field
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[1,2]')
+LIMIT 3;
+SELECT id FROM hyb
+WHERE label ||| 'east wind'
+ORDER BY vec <=> '[1,2]'
+LIMIT 3;
+
+-- pdb.rrf() without a distance leg requires a ~~~ predicate
+SELECT id FROM hyb
+WHERE label @@@ 'wind'
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+
+-- ~~~ requires the rank-fusion ordering
+SELECT id FROM hyb WHERE label ||| 'east wind' OR vec ~~~ '[1,0,0]';
+
+-- ~~~ cannot be negated
+SELECT id FROM hyb
+WHERE label @@@ 'wind' AND NOT (vec ~~~ '[1,0,0]')
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[1,0,0]')
+LIMIT 3;
+
+-- only one ~~~ predicate per query
+SELECT id FROM hyb
+WHERE vec ~~~ '[1,0,0]' OR vec ~~~ '[0,1,0]'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[1,0,0]')
+LIMIT 3;
+
+-- the ~~~ query vector must match pdb.rrf()'s distance leg
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[1,0,0]'
+ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0,1,0]')
+LIMIT 3;
+
+
+-- partitioned tables are rejected: per-partition fused ranks cannot be
+-- merged into a global ranking
+CREATE TABLE hyb_part (id int, label text, vec vector(3), PRIMARY KEY (id)) PARTITION BY RANGE (id);
+CREATE TABLE hyb_part_1 PARTITION OF hyb_part FOR VALUES FROM (0) TO (100);
+CREATE TABLE hyb_part_2 PARTITION OF hyb_part FOR VALUES FROM (100) TO (200);
+INSERT INTO hyb_part VALUES (1, 'east wind', '[1,0,0]'), (101, 'east gate', '[0.9,0,0.1]');
+CREATE INDEX hyb_part_idx ON hyb_part USING bm25 (id, label, vec vector_cosine_ops) WITH (key_field = id);
+SELECT id FROM hyb_part
+WHERE label ||| 'east wind' OR vec ~~~ '[1,0,0]'
+ORDER BY pdb.rrf(id)
+LIMIT 3;
+DROP TABLE hyb_part;
+
+DROP TABLE hyb;

--- a/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
+++ b/pg_search/tests/pg_regress/sql/rrf_hybrid.sql
@@ -111,6 +111,22 @@ ORDER BY pdb.rrf(pdb.score(id), vec <=> '[0.6,0.8,0]', window_size => 200)
 LIMIT 3;
 
 
+-- per-arm windows: shrinking the vector arm's window to the page size
+-- truncates its contribution. Vector top-3 for [0.05,0.1,0.99] is docs
+-- 4, 2, 5, so doc 3 (vector rank 4 with the default window) loses its
+-- vector contribution and doc 4 overtakes it: 2, 1, 4 instead of 2, 1, 3.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id, vector_window_size => 3)
+LIMIT 3;
+SELECT id, pdb.score(id, type => 'rank') AS fused_rank
+FROM hyb
+WHERE label ||| 'east wind' OR vec ~~~ '[0.05,0.1,0.99]'
+ORDER BY pdb.rrf(id, vector_window_size => 3)
+LIMIT 3;
+
+
 -- ============================================================
 -- filtered semantics: WHERE defines the candidate set
 -- ============================================================


### PR DESCRIPTION
> [!NOTE]
> **This is a proof of concept**, exploring what first-class hybrid search could look like in SQL. It works end to end (regress-tested), but the version bump and upgrade scripts are dev-only artifacts, and several design questions are still open. Not intended to merge as-is.

## What this explores

Hybrid (BM25 + vector) search today means a ~20-line CTE recipe: rank each side, join, sum reciprocal ranks. This POC makes it a one-liner while keeping both communities' idioms (search operators in `WHERE` for ParadeDB users, ORDER BY + LIMIT ranking for pgvector users), fused with Reciprocal Rank Fusion so no cross-unit score arithmetic ever happens:

```sql
SELECT description, pdb.score(id, type => 'hybrid') AS score
FROM mock_items
WHERE description ||| 'running shoes' OR embedding ~~~ '[1,2,3,4,5,6,7,8]'
ORDER BY pdb.rrf(id)
LIMIT 5;
```

## Surface

- **`~~~ (vector, vector)`** — semantic match operator: true when the row is among the top-`window_size` nearest neighbors of the query vector. Metric comes from the vector column's opclass in the bm25 index (no operator/opclass mismatch class of errors). Constant query vectors only for now.
- **`pdb.rrf(relation [, k => 60, window_size => 0])`** — returns the fused *rank* (1 = best), so plain ascending ORDER BY does the right thing. The BM25 leg is the relation's text query; the vector leg is its `~~~` predicate, so the query vector is written once. An explicit two-leg form `pdb.rrf(pdb.score(id), embedding <=> '[...]')` covers filtered re-ranking without a knn predicate.
- **`pdb.score(relation, "type")`** — projects the components: `'bm25'` (now consistently the text score in every scan shape), `'vector'`, `'hybrid'` (fused RRF score), `'rank'`. Plain `pdb.score(relation)` is unchanged; the overload has no DEFAULT so one-argument calls stay unambiguous.
- **Predicate scoping is boolean position** — no new syntax: predicates ANDed around the `OR` of the two matchers constrain both legs; predicates grouped inside a branch constrain that leg only. `OR` = union hybrid, `AND` = semantically-gated intersection.

## Execution

One index scan: the WHERE tree is split into per-leg queries (knn leaf substituted for candidate sourcing, deleted from its boolean context for text-relevance scoring), each leg runs as a top-`window_size` search (the vector leg through the same IVF/adaptive-probe collector as plain vector ORDER BY pushdown — no full vector scan), candidates are fused with `1/(k + rank)` per present leg, and only the emitted LIMIT rows touch the heap. Cost is at or below the CTE recipe for equal window depth.

## Correctness guards

Rank fusion is only well-defined over a global candidate set, so shapes that would fuse partial rankings are rejected rather than silently mis-ordered:

- forced serial (per-worker ranks don't merge; plan-time `SerialOnly`, exec-time backstop)
- rejected on partitioned tables (per-partition ranks interleaved by Merge Append are not global fusion — verified wrong before the guard, now errors)
- one `~~~` per query, no negation, must be driven by an rrf ordering, `~~~`'s vector must match an explicit distance leg — all with actionable error messages

## Testing

`tests/pg_regress/rrf_hybrid` covers: fused ordering with hand-verified RRF values, all four `type =>` projections, `k`/`window_size` knobs, leg order/aliasing/DESC, union + intersection + shared-filter + leg-scoped predicate shapes, NULL text scores for vector-only rows, prepared-statement vectors on the distance leg, dimension mismatch errors, and every rejection above. Related suites (`vector_search_pushdown`, `reciprocal_rank_fusion`, score tests) pass unchanged.

## Dev-only artifacts (would not merge)

- `pg_search.control` pins `default_version = '0.25.0.2'` and `sql/pg_search--0.25.0--0.25.0.1.sql` / `--0.25.0.1--0.25.0.2.sql` are hand-written, purely to allow `ALTER EXTENSION UPDATE` on dev databases. SchemaBot owns the real migration; the control file should return to `@CARGO_VERSION@`.

## Open questions / follow-ups

- N-ary legs (multi-vector, multiple text rankings) and per-leg weights
- cross-relation fusion in joins (`pdb.rrf(pdb.score(a.id), pdb.score(b.id))` — the principled replacement for adding scores across corpora, lives in the join layer)
- parameterized `~~~` vectors (`$1`), via the existing runtime-RHS machinery
- deep-pagination rank stability when the auto window grows (pin `window_size` for stable pages today)