### PR TITLE
test: validate #5758 with #5667 worker sizing

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -147,17 +147,12 @@ static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// `SET log_min_messages = DEBUG1` but invisible to CI's default WARNING capture.
 static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 
-/// Total number of MPP participants (leader + workers). Default 4 splits
-/// scan + shuffle + partial-aggregate work across 4 processes. PG's
-/// `max_parallel_workers_per_gather` still caps the actual worker count
-/// at exec time, so users in constrained environments see fewer.
-static MPP_WORKER_COUNT: GucSetting<i32> = GucSetting::<i32>::new(4);
-
 /// Per-edge shm_mq queue size in bytes. Each MPP query allocates
-/// `num_meshes × N×(N-1) × mpp_queue_size` of dynamic shared memory: at
-/// N=4 with 3 meshes (group-by aggregate's worst case) the default 64 MiB
-/// produces ~2.3 GiB per query, sized so a ~100 MiB Partial-aggregate burst
-/// on the post-agg mesh fits without backpressure. Operators on memory-
+/// `num_meshes × N×(N-1) × mpp_queue_size` of dynamic shared memory, where
+/// N is the proc count the plan-first launch derives from the plan (#5667):
+/// e.g. at N=4 with 3 meshes (group-by aggregate's worst case) the default
+/// 64 MiB produces ~2.3 GiB for that query, sized so a ~100 MiB
+/// Partial-aggregate burst on the post-agg mesh fits without backpressure. Operators on memory-
 /// constrained boxes will want to dial this down; that's the explicit
 /// reason it's exposed instead of held as a `pub const`.
 ///
@@ -624,24 +619,13 @@ pub fn init() {
     );
 
     GucRegistry::define_int_guc(
-        c"paradedb.mpp_worker_count",
-        c"Total MPP participants (leader + parallel workers)",
-        c"Sets the number of MPP participants per query when parallel execution is enabled. \
-          The queue mesh and drain thread are general over N. Setting this below 3 disables MPP.",
-        &MPP_WORKER_COUNT,
-        1,
-        64,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_int_guc(
         c"paradedb.mpp_queue_size",
         c"Per-edge shm_mq queue size for MPP shuffles",
         c"Sets the per-edge shm_mq queue size for MPP shuffles. Accepts standard \
           Postgres byte units (e.g. '64MB', '1GB', '512kB'). Total DSM per query is \
-          `num_meshes × N×(N-1) × mpp_queue_size`; at the default 64MB and N=4 with \
-          3 meshes that is ~2.3GB per query. Lower this on memory-constrained boxes; \
+          `num_meshes × N×(N-1) × mpp_queue_size`, where N is the per-query proc count \
+          the launch derives from the plan; e.g. at the default 64MB and N=4 with \
+          3 meshes that is ~2.3GB. Lower this on memory-constrained boxes; \
           raise it only if a single shuffle batch routinely backs up the queue. \
           Foundation-era knob — likely to be replaced by a per-query DSM cap once \
           mesh multiplexing lands.",
@@ -854,10 +838,6 @@ pub fn mpp_debug() -> bool {
 
 pub fn mpp_trace() -> bool {
     MPP_TRACE.get()
-}
-
-pub fn mpp_worker_count() -> i32 {
-    MPP_WORKER_COUNT.get()
 }
 
 pub fn mpp_queue_size() -> usize {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1493,15 +1493,13 @@ impl AggregateScan {
         let ps = state.planstate();
         let runtime_planstate = (!ps.is_null()).then_some(ps);
 
-        // First exec call?
         let first_call = state
             .custom_state()
             .datafusion_state
             .as_ref()
             .is_some_and(|d| d.runtime.is_none());
 
-        // Plan-first MPP (#5667): take the stashed logical-plan bytes when this query attempts
-        // MPP. Taken up front (not inside the df_state borrow below) because the launch needs
+        // Taken up front (not inside the df_state borrow below) because the launch needs
         // `state` for the source manifests.
         let mpp_plan_bytes = if first_call && mpp_is_active() {
             state
@@ -1548,10 +1546,8 @@ impl AggregateScan {
                 )
             };
 
-            // Launch MPP against the built plan: size the producer pool from its stages, spawn
-            // exactly that many workers, and hand the coordinator the same stages to dispatch.
-            // On a fallback (nothing to distribute, short launch) no workers remain and the
-            // `DistributedExec` shape has no mesh to read from, so replan serially below.
+            // On a launch fallback (nothing to distribute, short launch) no workers remain and
+            // the `DistributedExec` shape has no mesh to read from, so replan serially below.
             let leader = match &mpp_plan_bytes {
                 Some(bytes) => Self::launch_mpp(state, &physical_plan, bytes.len()),
                 None => None,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -867,22 +867,15 @@ impl AggregateScan {
         df_state.mpp = MppLifecycle::PlanBytes(bytes.to_vec());
     }
 
-    /// First-exec MPP launch. The leader spawns its producer workers through the builder and, on
-    /// success, installs the leader state so the consumer plan reads from the mesh. A short launch
-    /// (or any setup fallback) leaves the lifecycle `Inactive` and the query runs serially.
-    fn maybe_prepare_mpp(state: &mut CustomScanStateWrapper<Self>) {
-        if !mpp_is_active() {
-            return;
-        }
-        let Some(plan_bytes) = state
-            .custom_state_mut()
-            .datafusion_state
-            .as_mut()
-            .and_then(|d| d.mpp.take_plan_bytes())
-        else {
-            return;
-        };
-
+    /// Plan-first MPP launch (#5667). Called with the leader's already-built physical plan:
+    /// sizes the producer pool from the plan's widest stage, builds the DSM, and spawns exactly
+    /// the needed workers. `None` means run serially — the plan had nothing to distribute (no
+    /// workers were forked at all) or the launch fell back.
+    fn launch_mpp(
+        state: &mut CustomScanStateWrapper<Self>,
+        physical: &Arc<dyn ExecutionPlan>,
+        plan_bytes_len: usize,
+    ) -> Option<crate::postgres::customscan::mpp::glue::MppLeaderState> {
         // Manifests were captured in `stash_mpp_plan_bytes` (begin); `ensure`
         // is idempotent.
         Self::ensure_source_manifests(state);
@@ -899,13 +892,50 @@ impl AggregateScan {
             with_aggregates: false,
         };
 
-        let Some(prep) =
-            crate::postgres::customscan::mpp::launch::prepare_mpp_aggregate(plan_bytes.len(), args)
-        else {
-            return;
-        };
-        if let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() {
-            df_state.mpp = MppLifecycle::Prepared(prep);
+        crate::postgres::customscan::mpp::launch::launch_mpp_aggregate(
+            physical,
+            plan_bytes_len,
+            args,
+        )
+    }
+
+    /// Build the aggregate's DataFusion physical plan under `ctx`. `is_mpp` marks that parallel
+    /// execution is being attempted and stamps each provider's per-source dispatch metadata
+    /// (`is_parallel`, `mpp_source_idx`); the worker-bound stage encodes carry that metadata, so
+    /// it must be present on the plan the dispatch payload is derived from. The serial fallback
+    /// plans without it. An associated fn (not a closure) so the `df_state` borrow it takes
+    /// ends at each call site, freeing `state` for the MPP launch in between.
+    fn build_agg_physical_plan(
+        df_state: &mut scan_state::DataFusionAggState,
+        runtime: &tokio::runtime::Runtime,
+        ctx: &datafusion::prelude::SessionContext,
+        is_mpp: bool,
+        runtime_expr_context: Option<*mut pg_sys::ExprContext>,
+        runtime_planstate: Option<*mut pg_sys::PlanState>,
+    ) -> Arc<dyn ExecutionPlan> {
+        let custom_exprs = df_state.custom_exprs;
+        let custom_scan_tlist = df_state.custom_scan_tlist;
+        let built = runtime.block_on(async {
+            let (logical, group_df_indices) = build_join_aggregate_plan(
+                &df_state.plan,
+                &df_state.targetlist,
+                df_state.topk.as_ref(),
+                &df_state.join_level_predicates,
+                custom_exprs,
+                custom_scan_tlist,
+                df_state.having_filter.as_ref(),
+                ctx,
+                runtime_expr_context,
+                runtime_planstate,
+                is_mpp,
+            )
+            .await?;
+            df_state.group_df_indices = group_df_indices;
+            build_physical_plan(ctx, logical).await
+        });
+        match built {
+            Ok(p) => p,
+            Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
         }
     }
 
@@ -960,7 +990,7 @@ impl AggregateScan {
             let ctx = if mpp_is_active() {
                 // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
                 // The shared session-context builder takes `mesh = None` and derives `n_workers`
-                // from `producer_worker_count()`, so the planner still emits a `DistributedExec`
+                // from `producer_worker_cap()`, so the planner still emits a `DistributedExec`
                 // root with the right stage sizing for display.
                 Self::build_mpp_session_context(None)
             } else {
@@ -1463,103 +1493,101 @@ impl AggregateScan {
         let ps = state.planstate();
         let runtime_planstate = (!ps.is_null()).then_some(ps);
 
-        // First exec call: build the MPP DSM before planning. The workers launch only after
-        // the leader's plan is built and its stages serialize (`launch_mpp_commit` below).
-        // Done before the df_state borrow below because it needs `state` for the source
-        // manifests.
+        // First exec call?
         let first_call = state
             .custom_state()
             .datafusion_state
             .as_ref()
             .is_some_and(|d| d.runtime.is_none());
-        if first_call {
-            Self::maybe_prepare_mpp(state);
-        }
 
-        let df_state = state
-            .custom_state_mut()
-            .datafusion_state
-            .as_mut()
-            .expect("DataFusion state must be initialized");
+        // Plan-first MPP (#5667): take the stashed logical-plan bytes when this query attempts
+        // MPP. Taken up front (not inside the df_state borrow below) because the launch needs
+        // `state` for the source manifests.
+        let mpp_plan_bytes = if first_call && mpp_is_active() {
+            state
+                .custom_state_mut()
+                .datafusion_state
+                .as_mut()
+                .and_then(|d| d.mpp.take_plan_bytes())
+        } else {
+            None
+        };
 
         // First call: build and execute the DataFusion plan
-        if df_state.runtime.is_none() {
+        if first_call {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e));
 
-            // When the MPP DSM is prepared, layer the DF-D fork's distributed planner over the
-            // aggregate profile so `create_physical_plan` produces a `DistributedExec`. The
-            // mesh and the dispatch source are execute-time concerns; the exec session below
-            // carries them once the workers are committed.
-            let prep = df_state.mpp.take_prep();
-            let plan_ctx = if prep.is_some() {
+            // On an MPP attempt, layer the DF-D fork's distributed planner over the aggregate
+            // profile so `create_physical_plan` produces a `DistributedExec`, with
+            // `producer_worker_cap()` acting as the planner's ceiling. The mesh and the
+            // dispatch source are execute-time concerns; the exec session below carries them
+            // once the workers are committed.
+            let is_mpp = mpp_plan_bytes.is_some();
+            let plan_ctx = if is_mpp {
                 Self::build_mpp_session_context(None)
             } else {
                 create_aggregate_session_context()
             };
 
-            let custom_exprs = df_state.custom_exprs;
-            let custom_scan_tlist = df_state.custom_scan_tlist;
-            // `is_mpp` marks that parallel execution is active and stamps each provider's
-            // per-source dispatch metadata (`is_parallel`, `mpp_source_idx`). The worker-bound
-            // stage encodes carry that metadata, so it must be present on the plan the
-            // dispatch payload is derived from; the serial fallback plans without it.
-            let mut build_plan = |ctx: &datafusion::prelude::SessionContext, is_mpp: bool| {
-                let built = runtime.block_on(async {
-                    let (logical, group_df_indices) = build_join_aggregate_plan(
-                        &df_state.plan,
-                        &df_state.targetlist,
-                        df_state.topk.as_ref(),
-                        &df_state.join_level_predicates,
-                        custom_exprs,
-                        custom_scan_tlist,
-                        df_state.having_filter.as_ref(),
-                        ctx,
-                        runtime_expr_context,
-                        runtime_planstate,
-                        is_mpp,
-                    )
-                    .await?;
-                    df_state.group_df_indices = group_df_indices;
-                    build_physical_plan(ctx, logical).await
-                });
-                match built {
-                    Ok(p) => p,
-                    Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
-                }
+            let physical_plan = {
+                let df_state = state
+                    .custom_state_mut()
+                    .datafusion_state
+                    .as_mut()
+                    .expect("DataFusion state must be initialized");
+                Self::build_agg_physical_plan(
+                    df_state,
+                    &runtime,
+                    &plan_ctx,
+                    is_mpp,
+                    runtime_expr_context,
+                    runtime_planstate,
+                )
             };
-            let is_mpp = prep.is_some();
-            let physical_plan = build_plan(&plan_ctx, is_mpp);
 
-            // Commit the MPP launch against the built plan: serialize its producer stages,
-            // spawn the workers, and hand the coordinator the same stages to dispatch. On a
-            // short launch the workers are gone and the `DistributedExec` shape has no mesh to
-            // read from, so replan serially.
-            let (ctx, physical_plan) = match prep {
-                Some(prep) => {
-                    match crate::postgres::customscan::mpp::launch::launch_mpp_commit(
-                        prep,
-                        &physical_plan,
-                    ) {
-                        Some(leader) => {
-                            let source =
-                                crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
-                            let exec_ctx =
-                                Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
-                                    .with_distributed_dispatch_plan_source(source);
-                            df_state.mpp = MppLifecycle::Launched(leader);
-                            (exec_ctx, physical_plan)
-                        }
-                        None => {
-                            let serial_ctx = create_aggregate_session_context();
-                            let plan = build_plan(&serial_ctx, false);
-                            (serial_ctx, plan)
-                        }
+            // Launch MPP against the built plan: size the producer pool from its stages, spawn
+            // exactly that many workers, and hand the coordinator the same stages to dispatch.
+            // On a fallback (nothing to distribute, short launch) no workers remain and the
+            // `DistributedExec` shape has no mesh to read from, so replan serially below.
+            let leader = match &mpp_plan_bytes {
+                Some(bytes) => Self::launch_mpp(state, &physical_plan, bytes.len()),
+                None => None,
+            };
+
+            let df_state = state
+                .custom_state_mut()
+                .datafusion_state
+                .as_mut()
+                .expect("DataFusion state must be initialized");
+            let (ctx, physical_plan) = if is_mpp {
+                match leader {
+                    Some(leader) => {
+                        let source =
+                            crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
+                        let exec_ctx =
+                            Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
+                                .with_distributed_dispatch_plan_source(source);
+                        df_state.mpp = MppLifecycle::Launched(leader);
+                        (exec_ctx, physical_plan)
+                    }
+                    None => {
+                        let serial_ctx = create_aggregate_session_context();
+                        let plan = Self::build_agg_physical_plan(
+                            df_state,
+                            &runtime,
+                            &serial_ctx,
+                            false,
+                            runtime_expr_context,
+                            runtime_planstate,
+                        );
+                        (serial_ctx, plan)
                     }
                 }
-                None => (plan_ctx, physical_plan),
+            } else {
+                (plan_ctx, physical_plan)
             };
 
             let task_ctx = build_task_context(
@@ -1597,6 +1625,12 @@ impl AggregateScan {
             df_state.physical_plan = Some(physical_plan);
             df_state.stream = Some(stream);
         }
+
+        let df_state = state
+            .custom_state_mut()
+            .datafusion_state
+            .as_mut()
+            .expect("DataFusion state must be initialized");
 
         // Consume batches row-by-row
         loop {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -421,6 +421,7 @@ impl CustomScan for AggregateScan {
                     batch_row_idx: 0,
                     group_df_indices: Vec::new(),
                     mpp: MppLifecycle::Inactive,
+                    launch_timing: None,
                 });
                 builder.build()
             }
@@ -520,6 +521,9 @@ impl CustomScan for AggregateScan {
                 // construction, not actual execute calls. Build failures
                 // here shouldn't crash EXPLAIN; surface them as a note.
                 Self::render_df_physical_plan(df_state, explainer);
+                if let Some(t) = df_state.launch_timing {
+                    explainer.add_text("MPP Launch", t.explain_text());
+                }
             }
             return;
         }
@@ -566,10 +570,10 @@ impl CustomScan for AggregateScan {
                 );
                 state.custom_state_mut().scan_slot = Some(scan_slot);
             }
-            // MPP: serialize the logical plan now, while the source manifests are alive, so
-            // the first-exec prepare can size the DSM payload region before the physical plan
-            // exists. Only the leader runs this branch (`ParallelWorkerNumber == -1` in the
-            // leader backend).
+            // MPP: serialize the logical plan now, while the source manifests are alive; the
+            // first exec call's launch sizes the DSM dispatch-payload region from its length.
+            // Only the leader runs this branch (`ParallelWorkerNumber == -1` in the leader
+            // backend).
             if mpp_is_active() && unsafe { pg_sys::ParallelWorkerNumber } == -1 {
                 Self::stash_mpp_plan_bytes(state);
             }
@@ -804,9 +808,8 @@ impl AggregateScan {
     }
 
     /// Serialize the leader's logical plan (already on `df_state`) and move the MPP lifecycle
-    /// to `PlanBytes`. The first-exec prepare uses the byte length to size the DSM payload
-    /// region; the dispatched stage plans themselves are derived later, from the leader's
-    /// physical plan.
+    /// to `PlanBytes`. `launch_mpp` uses the byte length to size the DSM payload region; the
+    /// dispatched stage plans themselves are derived later, from the leader's physical plan.
     fn stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
         // Capture source manifests BEFORE building the logical plan.
         // We pass `is_mpp: false` below because this plan is only serialized to compute `.len()`
@@ -819,8 +822,8 @@ impl AggregateScan {
             return;
         };
         // Build a logical plan eagerly. The DataFusion exec path normally
-        // builds it lazily on first `exec_custom_scan` call; for MPP we
-        // need it before estimate_dsm fires.
+        // builds it lazily on first `exec_custom_scan` call; MPP serializes
+        // it at begin time so the launch can size the dispatch payload.
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1530,6 +1533,7 @@ impl AggregateScan {
                 create_aggregate_session_context()
             };
 
+            let t_plan = std::time::Instant::now();
             let physical_plan = {
                 let df_state = state
                     .custom_state_mut()
@@ -1545,6 +1549,7 @@ impl AggregateScan {
                     runtime_planstate,
                 )
             };
+            let plan_us = t_plan.elapsed().as_micros() as u64;
 
             // On a launch fallback (nothing to distribute, short launch) no workers remain and
             // the `DistributedExec` shape has no mesh to read from, so replan serially below.
@@ -1566,6 +1571,9 @@ impl AggregateScan {
                         let exec_ctx =
                             Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
                                 .with_distributed_dispatch_plan_source(source);
+                        let mut timing = leader.timing;
+                        timing.plan_us = plan_us;
+                        df_state.launch_timing = Some(timing);
                         df_state.mpp = MppLifecycle::Launched(leader);
                         (exec_ctx, physical_plan)
                     }

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -80,10 +80,14 @@ pub struct DataFusionAggState {
     /// expressions (e.g. metadata.brand).
     pub group_df_indices: Vec<usize>,
     /// Where MPP sits in its launch lifecycle for this scan: plan bytes stashed at begin,
-    /// prepared on first exec before planning, launched once the plan's stages are committed.
-    /// Stays `Inactive` on the serial path. Applies only when parallel execution is enabled and
-    /// the query qualifies (binary join + supported aggregate).
+    /// launched on first exec once the built plan's stages are committed (#5667: the plan
+    /// comes first; workers spawn only after it exists). Stays `Inactive` on the serial path.
+    /// Applies only when parallel execution is enabled and the query qualifies (binary join +
+    /// supported aggregate).
     pub mpp: crate::postgres::customscan::mpp::launch::MppLifecycle,
+    /// Per-phase launch timing for `EXPLAIN ANALYZE`'s `MPP Launch` line. Set only when the
+    /// query launched distributed.
+    pub launch_timing: Option<crate::postgres::customscan::mpp::glue::MppLaunchTiming>,
 }
 
 /// State for projecting wrapped aggregate expressions through Postgres' own

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1356,9 +1356,6 @@ impl CustomScan for JoinScan {
                             .expect("Failed to create execution plan")
                     };
 
-                // Plan-first MPP (#5667): take the stashed logical-plan bytes when this query
-                // attempts MPP; the physical plan is built first (address-free) and the launch
-                // below sizes the worker pool from it. `None` means serial.
                 let mpp_plan_bytes = if mpp_is_active()
                     && !Self::source_queries_have_parameters(&state.custom_state().join_clause)
                 {
@@ -1380,11 +1377,8 @@ impl CustomScan for JoinScan {
                 let plan = build_plan(&plan_ctx);
                 launch_us.plan_us = t_plan.elapsed().as_micros() as u64;
 
-                // Launch MPP against the built plan: size the producer pool from its stages,
-                // spawn exactly that many workers, and hand the coordinator the same stages to
-                // dispatch. On a fallback (nothing to distribute, short launch) no workers
-                // remain and the `DistributedExec` shape has no mesh to read from, so replan
-                // serially.
+                // On a launch fallback (nothing to distribute, short launch) no workers remain
+                // and the `DistributedExec` shape has no mesh to read from, so replan serially.
                 let (ctx, plan) = match mpp_plan_bytes {
                     Some(bytes) => match Self::launch_mpp(state, &plan, bytes.len()) {
                         Some(leader) => {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -749,12 +749,11 @@ impl JoinScan {
 impl JoinScan {
     /// Capture lightweight segment manifests for all join sources.
     ///
-    /// Uses `SearchIndexManifest::capture` instead of opening full `SearchIndexReader`s
-    /// because this runs during DSM initialization (`estimate_dsm` / `initialize_dsm`),
-    /// which is part of executor startup — before `begin_custom_scan` sets up executor
-    /// state. Opening full readers would call `into_tantivy_query` on each source's
-    /// `scan_info.query`, which fails for parameterized predicates (prepared statements,
-    /// initplan-backed subqueries) that require a `PlanState` to evaluate.
+    /// Uses `SearchIndexManifest::capture` instead of opening full `SearchIndexReader`s:
+    /// manifests are cheap, hold the Tantivy segment pins the launch and workers rely on,
+    /// and avoid calling `into_tantivy_query` on each source's `scan_info.query` — which
+    /// fails for parameterized predicates (prepared statements, initplan-backed subqueries)
+    /// that require a `PlanState` to evaluate.
     ///
     /// Manifests also provide consistent segment counts for both DSM sizing and DSM
     /// population, avoiding the divergence that can occur when planning-time counts
@@ -1171,21 +1170,7 @@ impl CustomScan for JoinScan {
             // DataFusion plan, so surface its per-phase breakdown separately when the query ran
             // distributed.
             if let Some(t) = state.custom_state().launch_timing {
-                explainer.add_text(
-                    "MPP Launch",
-                    format!(
-                        "workers={} prepare={}us plan={}us payload={}us attach={}us \
-                         leader_setup={}us exec={}us first_frame={}us",
-                        t.workers,
-                        t.prepare_us,
-                        t.plan_us,
-                        t.payload_us,
-                        t.attach_us,
-                        t.leader_setup_us,
-                        t.exec_us,
-                        t.first_frame_us,
-                    ),
-                );
+                explainer.add_text("MPP Launch", t.explain_text());
             }
         } else if let Some(ref logical_plan) = state.custom_state().logical_plan {
             // Plain EXPLAIN reconstructs the physical plan by deserializing the logical
@@ -1244,10 +1229,11 @@ impl CustomScan for JoinScan {
                 state.custom_state_mut().result_slot = Some(state.csstate.ss.ps.ps_ResultTupleSlot);
                 state.runtime_context = state.csstate.ss.ps.ps_ExprContext;
             }
-            // MPP: stash the leader's serialized logical plan so estimate_dsm / initialize_dsm
-            // can write it into the DSM region. Only the leader runs this branch
-            // (`ParallelWorkerNumber == -1`); workers read the bytes back from DSM in
-            // initialize_worker_custom_scan via `worker_setup`.
+            // MPP: stash the leader's serialized logical plan for the first exec call, which
+            // deserializes it to build the physical plan and uses its length to size the DSM
+            // dispatch-payload region (`dispatch_plan_capacity`). Only the leader runs this
+            // branch (`ParallelWorkerNumber == -1`); workers receive per-stage physical
+            // subplans over the mesh, never these bytes.
             if mpp_is_active()
                 && !Self::source_queries_have_parameters(&state.custom_state().join_clause)
                 && unsafe { pg_sys::ParallelWorkerNumber } == -1

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -188,7 +188,6 @@ use crate::postgres::customscan::{CustomScan, JoinPathlistHookArgs};
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::ParallelScanArgs;
-use crate::postgres::ParallelScanState;
 use crate::scan::codec::{deserialize_logical_plan_with_runtime, serialize_logical_plan};
 use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 
@@ -862,19 +861,16 @@ impl JoinScan {
         )
     }
 
-    /// First-exec MPP prepare. Builds the DSM (mesh region + shared scan state) but launches no
-    /// workers yet: the leader plans first, and `launch_mpp_commit` spawns the producers only
-    /// once the plan's stages serialize. Any fallback here leaves the lifecycle `Inactive` and
-    /// the query runs serially.
-    fn maybe_prepare_mpp(state: &mut CustomScanStateWrapper<Self>) {
-        if !mpp_is_active()
-            || Self::source_queries_have_parameters(&state.custom_state().join_clause)
-        {
-            return;
-        }
-        let Some(plan_bytes) = state.custom_state_mut().mpp.take_plan_bytes() else {
-            return;
-        };
+    /// Plan-first MPP launch (#5667). Called with the leader's already-built physical plan:
+    /// sizes the producer pool from the plan's widest stage, builds the DSM, stamps the shared
+    /// scan state into the plan, and spawns exactly the needed workers. `None` means run
+    /// serially — the plan had nothing to distribute (no workers were forked at all) or the
+    /// launch fell back.
+    fn launch_mpp(
+        state: &mut CustomScanStateWrapper<Self>,
+        physical: &Arc<dyn ExecutionPlan>,
+        plan_bytes_len: usize,
+    ) -> Option<crate::postgres::customscan::mpp::glue::MppLeaderState> {
         Self::ensure_source_manifests(state);
         let all_sources: Vec<&[tantivy::SegmentReader]> = state
             .custom_state()
@@ -887,17 +883,7 @@ impl JoinScan {
             query: vec![],
             with_aggregates: false,
         };
-        if let Some(prep) =
-            crate::postgres::customscan::mpp::launch::prepare_mpp_join(plan_bytes.len(), args)
-        {
-            // The leader runs the top fragment itself. When a scan source lands there
-            // (e.g. under MPP's broadcast or shuffle strategy), its scan claims per-source segments against the
-            // same shared state the workers use, so the codec needs this pointer to install it.
-            // The canonical per-source segment sets feed the same deserialize the worker-bound
-            // stages are serialized from.
-            state.custom_state_mut().parallel_state = Some(prep.scan_ptr);
-            state.custom_state_mut().mpp = MppLifecycle::Prepared(prep);
-        }
+        crate::postgres::customscan::mpp::launch::launch_mpp_join(physical, plan_bytes_len, args)
     }
 }
 
@@ -1217,7 +1203,7 @@ impl CustomScan for JoinScan {
             // For plain EXPLAIN, reconstruct the plan using the same session configuration
             // that execution uses so `VisibilityFilterExec` appears in the displayed plan,
             // matching EXPLAIN ANALYZE. When MPP is active, pass `mesh = None`; the shared
-            // session-context builder derives `n_workers` from `producer_worker_count()` and
+            // session-context builder derives `n_workers` from `producer_worker_cap()` and
             // skips the shm_mq transport install (EXPLAIN doesn't execute).
             let expr_context = crate::postgres::utils::ExprContextGuard::new();
             let ctx = if mpp_is_active() {
@@ -1279,14 +1265,6 @@ impl CustomScan for JoinScan {
 
     fn exec_custom_scan(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
         let mut launch_us = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
-        if state.custom_state().datafusion_stream.is_none() {
-            // First exec call: build the MPP DSM before planning. The workers launch only after
-            // the leader's plan is built and its stages serialize (`launch_mpp_commit` below),
-            // so every planning fallback is a serial run with no workers to abort.
-            let t_prepare = std::time::Instant::now();
-            Self::maybe_prepare_mpp(state);
-            launch_us.prepare_us = t_prepare.elapsed().as_micros() as u64;
-        }
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
                 let runtime = tokio::runtime::Builder::new_current_thread()
@@ -1348,89 +1326,87 @@ impl CustomScan for JoinScan {
 
                 // Raw pointers precomputed so the planning closure below never borrows `state`.
                 let runtime_context = state.runtime_context;
-                let build_plan = |ctx: &datafusion::prelude::SessionContext,
-                                  parallel_state: Option<*mut ParallelScanState>|
-                 -> Arc<dyn ExecutionPlan> {
-                    let logical_plan = deserialize_logical_plan_with_runtime(
-                        &plan_bytes,
-                        &ctx.task_ctx(),
-                        parallel_state,
-                        Some(runtime_context),
-                        Some(planstate),
-                        index_segment_ids.clone(),
-                    )
-                    .expect("Failed to deserialize logical plan");
-                    let logical_plan = match runtime_fetch {
-                        Some(fetch) => {
-                            use datafusion::logical_expr::LogicalPlanBuilder;
-                            LogicalPlanBuilder::from(logical_plan)
-                                .limit(0, Some(fetch))
-                                .expect("failed to add Limit to logical plan")
-                                .build()
-                                .expect("failed to build logical plan with Limit")
-                        }
-                        None => logical_plan,
+                let build_plan =
+                    |ctx: &datafusion::prelude::SessionContext| -> Arc<dyn ExecutionPlan> {
+                        let logical_plan = deserialize_logical_plan_with_runtime(
+                            &plan_bytes,
+                            &ctx.task_ctx(),
+                            // Plans build address-free (#5667): on the MPP path `launch_mpp`
+                            // stamps the shared scan state into the built plan once the DSM
+                            // exists; serial plans never have one.
+                            None,
+                            Some(runtime_context),
+                            Some(planstate),
+                            index_segment_ids.clone(),
+                        )
+                        .expect("Failed to deserialize logical plan");
+                        let logical_plan = match runtime_fetch {
+                            Some(fetch) => {
+                                use datafusion::logical_expr::LogicalPlanBuilder;
+                                LogicalPlanBuilder::from(logical_plan)
+                                    .limit(0, Some(fetch))
+                                    .expect("failed to add Limit to logical plan")
+                                    .build()
+                                    .expect("failed to build logical plan with Limit")
+                            }
+                            None => logical_plan,
+                        };
+                        runtime
+                            .block_on(build_physical_plan(ctx, logical_plan))
+                            .expect("Failed to create execution plan")
                     };
-                    runtime
-                        .block_on(build_physical_plan(ctx, logical_plan))
-                        .expect("Failed to create execution plan")
-                };
 
-                // Leader session context: when the MPP DSM is prepared, layer the DF-D fork's
+                // Plan-first MPP (#5667): take the stashed logical-plan bytes when this query
+                // attempts MPP; the physical plan is built first (address-free) and the launch
+                // below sizes the worker pool from it. `None` means serial.
+                let mpp_plan_bytes = if mpp_is_active()
+                    && !Self::source_queries_have_parameters(&state.custom_state().join_clause)
+                {
+                    state.custom_state_mut().mpp.take_plan_bytes()
+                } else {
+                    None
+                };
+                // Leader session context: on an MPP attempt, layer the DF-D fork's
                 // distributed-planner knobs over the Join profile so the resulting physical
-                // plan is a `DistributedExec`. The mesh and the dispatch source are
-                // execute-time concerns; the exec session below carries them once the workers
-                // are committed.
-                let plan_ctx = if state.custom_state().mpp.is_prepared() {
+                // plan is a `DistributedExec`, with `producer_worker_cap()` acting as the
+                // planner's ceiling. The mesh and the dispatch source are execute-time
+                // concerns; the exec session below carries them once the workers are committed.
+                let plan_ctx = if mpp_plan_bytes.is_some() {
                     Self::build_mpp_session_context(None)
                 } else {
                     create_datafusion_session_context(SessionContextProfile::Join)
                 };
-                // A rescan after an MPP run replans serially: the launched generation's
-                // workers have already claimed the shared scan state, so binding the fresh
-                // plan to it would leave the leader with nothing to scan.
-                let plan_parallel_state = if state.custom_state().mpp.is_launched() {
-                    None
-                } else {
-                    state.custom_state().parallel_state
-                };
                 let t_plan = std::time::Instant::now();
-                let plan = build_plan(&plan_ctx, plan_parallel_state);
+                let plan = build_plan(&plan_ctx);
                 launch_us.plan_us = t_plan.elapsed().as_micros() as u64;
 
-                // Commit the MPP launch against the built plan: serialize its producer stages,
-                // spawn the workers, and hand the coordinator the same stages to dispatch. On a
-                // short launch the workers are gone and the `DistributedExec` shape has no mesh
-                // to read from, so replan serially.
-                let (ctx, plan) = match state.custom_state_mut().mpp.take_prep() {
-                    Some(prep) => {
-                        match crate::postgres::customscan::mpp::launch::launch_mpp_commit(
-                            prep, &plan,
-                        ) {
-                            Some(leader) => {
-                                let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
-                                let exec_ctx =
-                                    Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
-                                        .with_distributed_dispatch_plan_source(source);
-                                launch_us.payload_us = leader.timing.payload_us;
-                                launch_us.attach_us = leader.timing.attach_us;
-                                launch_us.leader_setup_us = leader.timing.leader_setup_us;
-                                launch_us.workers = leader.timing.workers;
-                                state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
-                                (exec_ctx, plan)
-                            }
-                            None => {
-                                // Flush the single-threaded context's index mappings so the re-built
-                                // single-threaded plan scans the full base tables instead of hitting
-                                // the empty parallel claims pool.
-                                state.custom_state_mut().parallel_state = None;
-                                let serial_ctx =
-                                    create_datafusion_session_context(SessionContextProfile::Join);
-                                let plan = build_plan(&serial_ctx, None);
-                                (serial_ctx, plan)
-                            }
+                // Launch MPP against the built plan: size the producer pool from its stages,
+                // spawn exactly that many workers, and hand the coordinator the same stages to
+                // dispatch. On a fallback (nothing to distribute, short launch) no workers
+                // remain and the `DistributedExec` shape has no mesh to read from, so replan
+                // serially.
+                let (ctx, plan) = match mpp_plan_bytes {
+                    Some(bytes) => match Self::launch_mpp(state, &plan, bytes.len()) {
+                        Some(leader) => {
+                            let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
+                            let exec_ctx =
+                                Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
+                                    .with_distributed_dispatch_plan_source(source);
+                            launch_us.prepare_us = leader.timing.prepare_us;
+                            launch_us.payload_us = leader.timing.payload_us;
+                            launch_us.attach_us = leader.timing.attach_us;
+                            launch_us.leader_setup_us = leader.timing.leader_setup_us;
+                            launch_us.workers = leader.timing.workers;
+                            state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
+                            (exec_ctx, plan)
                         }
-                    }
+                        None => {
+                            let serial_ctx =
+                                create_datafusion_session_context(SessionContextProfile::Join);
+                            let plan = build_plan(&serial_ctx);
+                            (serial_ctx, plan)
+                        }
+                    },
                     None => (plan_ctx, plan),
                 };
 

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -61,7 +61,6 @@ use crate::postgres::customscan::joinscan::privdat::{
 use crate::postgres::customscan::CustomScanState;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::ParallelScanState;
 use crate::scan::{PgSearchTableProvider, VisibilityMode};
 use async_trait::async_trait;
 use datafusion::execution::context::{QueryPlanner, SessionState};
@@ -197,28 +196,22 @@ pub struct JoinScanState {
     /// plus first scan plus the network hop to the leader).
     pub stream_built_at: Option<std::time::Instant>,
 
-    /// Shared state for parallel execution.
-    /// This is set by either `initialize_dsm_custom_scan` (in the leader) or
-    /// `initialize_worker_custom_scan` (in a worker), and then consumed in
-    /// `exec_custom_scan` to initialize the DataFusion execution plan.
-    pub parallel_state: Option<*mut ParallelScanState>,
-
     /// Captured source manifests held by the leader. Serves two purposes:
-    /// 1. Provides segment counts for DSM sizing in `estimate_dsm_custom_scan` and
-    ///    segment readers for DSM population in `initialize_dsm_custom_scan`.
+    /// 1. Provides the segment readers `launch_mpp` needs (via `ParallelScanArgs`) to size
+    ///    and populate the shared `ParallelScanState` in DSM.
     /// 2. Keeps the underlying Tantivy buffer pins alive for the full duration of the
     ///    scan, preventing background merges from recycling the canonical segments.
     ///
-    /// Must live on `JoinScanState` (not as a local in `initialize_dsm`) because the
-    /// buffer pins must survive from DSM initialization through `exec_custom_scan`,
+    /// Must live on `JoinScanState` (not as a local in the launch) because the
+    /// buffer pins must survive from DSM population through `exec_custom_scan`,
     /// where workers reopen the same segments via `MvccSatisfies::ParallelWorker(ids)`.
     /// Dropping manifests early would release the pins and allow segment recycling
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
 
     /// Where MPP sits in its launch lifecycle for this scan: plan bytes stashed at begin,
-    /// prepared on first exec before planning, launched once the plan's stages are committed.
-    /// Stays `Inactive` on the serial path.
+    /// launched on first exec once the built plan's stages are committed (#5667: the plan
+    /// comes first; workers spawn only after it exists). Stays `Inactive` on the serial path.
     pub mpp: crate::postgres::customscan::mpp::launch::MppLifecycle,
 }
 

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -233,9 +233,9 @@ pub(crate) fn run_mpp_worker(
         Err(e) => pgrx::error!("mpp worker: build fragment assignments failed: {e}"),
     };
     if fragments.is_empty() {
-        // Defensive: the plan-first launch (#5667) sizes the producer pool from the plan's
-        // widest stage, so every proc owns at least one fragment except in the single-task
-        // edge case (the 2-producer mesh floor can leave one proc idle).
+        // Unreachable by construction: the launch spawns at most `max_tasks` producers
+        // (with `max_tasks >= 2`), so the widest stage's round-robin covers every proc.
+        // Kept as a drift guard.
         pgrx::debug1!(
             "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
         );

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -52,7 +52,7 @@ use datafusion_distributed::shm::{
 use datafusion_distributed::PartitionSink;
 
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
-use crate::postgres::customscan::mpp::glue::producer_worker_count;
+use crate::postgres::customscan::mpp::glue::producer_worker_cap;
 use crate::postgres::customscan::mpp::interrupt::{check_for_interrupts, HeldInterrupts};
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::utils::ExprContextGuard;
@@ -93,16 +93,19 @@ pub(crate) fn build_mpp_session_context(
     mesh: Option<Arc<MppMesh>>,
 ) -> SessionContext {
     // Workers are procs 1..n_procs; leader is proc 0. Producer count = n_procs - 1.
-    // `mpp_is_active()` already guarantees n_procs >= 3 (callers gate first).
+    // n_procs >= 3 always holds: for mesh = Some, the launch clamps the spawned width to
+    // `MIN_PRODUCER_COUNT` (2) producers; for mesh = None, callers gate on `mpp_is_active()`
+    // which requires a cap of >= 2 producers.
     //
-    // `mesh = None` is the EXPLAIN-time path: the planner only needs `n_workers` for stage
-    // sizing and target_partitions. EXPLAIN never opens a `WorkerConnection`, so we skip
-    // the transport install and the fork's default sits unused. Both branches resolve to
-    // `mpp_worker_count() - 1` at call time, so EXPLAIN reflects the GUC at the time it
-    // ran; a later `SET paradedb.mpp_worker_count` shifts the next execute path.
+    // `mesh = None` is the EXPLAIN-time / plan-time path: the planner only needs `n_workers`
+    // for stage sizing and target_partitions, so it plans against the cap
+    // (`producer_worker_cap()`, from PG's parallelism GUCs). EXPLAIN never opens a
+    // `WorkerConnection`, so we skip the transport install and the fork's default sits
+    // unused. mesh = Some reads the launched width from the mesh header, which the plan-first
+    // launch sized from the plan's task counts (#5667).
     let n_workers = match mesh.as_ref() {
         Some(m) => m.n_workers() as usize,
-        None => producer_worker_count() as usize,
+        None => producer_worker_cap() as usize,
     };
     // Three knobs that have to be set for the planner to actually emit `NetworkShuffleExec`:
     //   1. target_partitions(N): without it, EnforceDistribution skips every
@@ -216,8 +219,8 @@ pub(crate) fn run_mpp_worker(
 
     // Build this worker's fragment assignments by decoding the leader's dispatched per-stage
     // subplans from the DSM payload (no re-planning), then run them on the dispatcher loop below.
-    // `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before reaching
-    // this), so `n_workers() = n_procs - 1` is safe.
+    // `worker_mesh.n_procs >= 3` is guaranteed by the launch's `MIN_PRODUCER_COUNT` clamp
+    // (it spawns at least 2 producers), so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();
     let (fragments, session) = match fragments_for_worker(
         &plan_bytes,
@@ -230,8 +233,9 @@ pub(crate) fn run_mpp_worker(
         Err(e) => pgrx::error!("mpp worker: build fragment assignments failed: {e}"),
     };
     if fragments.is_empty() {
-        // TODO(#5667): Wait to request parallel workers from Postgres until after the plan
-        // is generated so we only launch as many workers as we have fragments for.
+        // Defensive: the plan-first launch (#5667) sizes the producer pool from the plan's
+        // widest stage, so every proc owns at least one fragment except in the single-task
+        // edge case (the 2-producer mesh floor can leave one proc idle).
         pgrx::debug1!(
             "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
         );

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -94,7 +94,7 @@ pub(crate) fn build_mpp_session_context(
 ) -> SessionContext {
     // Workers are procs 1..n_procs; leader is proc 0. Producer count = n_procs - 1.
     // n_procs >= 3 always holds: for mesh = Some, the launch clamps the spawned width to
-    // `MIN_PRODUCER_COUNT` (2) producers; for mesh = None, callers gate on `mpp_is_active()`
+    // `MIN_TOTAL_WORKER_COUNT - 1` (2) producers; for mesh = None, callers gate on `mpp_is_active()`
     // which requires a cap of >= 2 producers.
     //
     // `mesh = None` is the EXPLAIN-time / plan-time path: the planner only needs `n_workers`
@@ -219,7 +219,7 @@ pub(crate) fn run_mpp_worker(
 
     // Build this worker's fragment assignments by decoding the leader's dispatched per-stage
     // subplans from the DSM payload (no re-planning), then run them on the dispatcher loop below.
-    // `worker_mesh.n_procs >= 3` is guaranteed by the launch's `MIN_PRODUCER_COUNT` clamp
+    // `worker_mesh.n_procs >= MIN_TOTAL_WORKER_COUNT` is guaranteed by the launch's clamp
     // (it spawns at least 2 producers), so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();
     let (fragments, session) = match fragments_for_worker(

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -114,6 +114,25 @@ pub struct MppLaunchTiming {
     pub workers: u32,
 }
 
+impl MppLaunchTiming {
+    /// The `MPP Launch` line for `EXPLAIN ANALYZE`, shared by JoinScan and AggregateScan so
+    /// the launched width is observable (and regress-assertable) on both paths.
+    pub fn explain_text(&self) -> String {
+        format!(
+            "workers={} prepare={}us plan={}us payload={}us attach={}us \
+             leader_setup={}us exec={}us first_frame={}us",
+            self.workers,
+            self.prepare_us,
+            self.plan_us,
+            self.payload_us,
+            self.attach_us,
+            self.leader_setup_us,
+            self.exec_us,
+            self.first_frame_us,
+        )
+    }
+}
+
 /// The leader's control senders behind their shared lock. The scan state and mesh cancel path
 /// share this `Arc`; `DsmDetachState` retains another reference so the detach callback can clear
 /// the stored senders while the DSM is still mapped.

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -18,17 +18,17 @@
 //! High-level glue between PostgreSQL parallel-query callbacks and the
 //! leader/worker MPP architecture.
 //!
-//! Customscan code calls into this module from four hooks; everything else (the shared-memory
-//! layout, the ring mesh, the `WorkerTransport` plumbing) lives in
+//! The leader-driven launch (`mpp::launch`) calls into this module; everything else (the
+//! shared-memory layout, the ring mesh, the `WorkerTransport` plumbing) lives in
 //! `datafusion_distributed::shm` and is reached through these thin wrappers:
 //!
 //! - [`mpp_is_active`] — gate for the customscan path-builder.
-//! - [`estimate_dsm_size`] — `estimate_dsm_custom_scan` body.
-//! - [`leader_setup`] — `initialize_dsm_custom_scan` body. Returns the
-//!   leader's [`MppLeaderState`] which carries the runtime [`MppMesh`]
+//! - [`estimate_dsm_size`] — mesh-region sizing for the plan-first launch.
+//! - [`leader_setup`] — leader-side mesh init, called by `launch_mpp` after the workers
+//!   spawn. Returns the leader's [`MppLeaderState`] which carries the runtime [`MppMesh`]
 //!   handle the customscan installs on its DataFusion `SessionContext`.
-//! - [`worker_setup`] — `initialize_worker_custom_scan` body. Returns the
-//!   worker's [`MppWorkerState`] which carries the worker's outbound
+//! - [`worker_setup`] — worker-side mesh attach, called from `run_launched_worker`. Returns
+//!   the worker's [`MppWorkerState`] which carries the worker's outbound
 //!   senders and the deserialized plan bytes the worker runs.
 
 use std::ffi::c_void;
@@ -39,46 +39,24 @@ use pgrx::pg_sys;
 use datafusion_distributed::shm::{self, Interrupt, MppMesh, MppSender, Wakeup};
 use datafusion_distributed::TaskKey;
 
-use crate::gucs::{
-    mpp_queue_size as gucs_mpp_queue_size, mpp_worker_count as gucs_mpp_worker_count,
-};
+use crate::gucs::mpp_queue_size as gucs_mpp_queue_size;
 use crate::postgres::customscan::mpp::pg_seams::{pack_receiver, PgInterrupt, PgWakeup};
-use crate::postgres::ParallelScanState;
 
-/// Minimum total procs for MPP: leader (consumer-only) plus at least 2 producers. Single
-/// source of truth so [`mpp_is_active`] and [`mpp_worker_count`] don't drift on the
-/// threshold. Below 3, [`producer_worker_count`] would be 1 while
-/// `build_mpp_session_context` still clamps `target_partitions` to 2; the mesh wouldn't
-/// have a queue for the second partition.
-const MIN_TOTAL_WORKER_COUNT: i32 = 3;
+/// Minimum producer count for MPP: the leader (proc 0) is consumer-only, and
+/// `build_mpp_session_context` clamps `target_partitions` to 2, so the mesh needs at least 2
+/// producers or it wouldn't have a queue for the second partition. Single source of truth so
+/// [`mpp_is_active`] and the launch's clamp floor don't drift on the threshold.
+pub const MIN_PRODUCER_COUNT: u32 = 2;
 
-/// True iff `paradedb.mpp_worker_count >= MIN_TOTAL_WORKER_COUNT` and the system has
-/// enough `max_parallel_workers` and `max_parallel_workers_per_gather` to launch
-/// the requested number of producers. Customscan path-builders gate `parallel_workers` on this.
+/// True iff PostgreSQL's parallelism budget allows at least [`MIN_PRODUCER_COUNT`] producer
+/// workers. There is no MPP-specific worker GUC (#5667): `max_parallel_workers_per_gather`
+/// caps the per-query width — the same knob that caps ordinary parallel scans, matching core
+/// PG's `compute_parallel_worker` convention — and `max_parallel_workers` is the cluster-wide
+/// pool. Setting `max_parallel_workers_per_gather` below 2 (or 0, PG's own
+/// parallelism-disable convention) disables MPP. Customscan path-builders gate
+/// `parallel_workers` on this.
 pub fn mpp_is_active() -> bool {
-    let active = gucs_mpp_worker_count() >= MIN_TOTAL_WORKER_COUNT;
-    if !active {
-        return false;
-    }
-
-    let producer_count = gucs_mpp_worker_count() - 1;
-    let max_per_gather = unsafe { pg_sys::max_parallel_workers_per_gather };
-    let max_workers = unsafe { pg_sys::max_parallel_workers };
-
-    producer_count <= max_per_gather && producer_count <= max_workers
-}
-
-/// Total proc count: leader + producers. Equals the GUC value when [`mpp_is_active`] is
-/// true. Callers must gate on [`mpp_is_active`] first. Debug builds assert; release builds
-/// return the raw GUC, which can leave [`producer_worker_count`] below 2 and break the
-/// planner's `target_partitions` / mesh-width invariant.
-// TODO(#5667): Evaluate bounding or replacing mpp_worker_count dynamically based on df-d planner output.
-pub fn mpp_worker_count() -> u32 {
-    debug_assert!(
-        mpp_is_active(),
-        "mpp_worker_count() called when mpp_is_active() is false — callers must gate first"
-    );
-    gucs_mpp_worker_count() as u32
+    producer_worker_cap() >= MIN_PRODUCER_COUNT
 }
 
 // The shared-memory transport pins 8-byte alignment (its ring headers hold `u64` atomics). The
@@ -91,20 +69,24 @@ pub(super) fn mpp_queue_size() -> usize {
     gucs_mpp_queue_size()
 }
 
-/// Body of `estimate_dsm_custom_scan`. Returns the total DSM bytes the leader will need
-/// for the header, the worker plan, and one MPSC inbox per process. `n_procs` is the
-/// total proc count (leader + `producer_worker_count()` parallel workers).
-pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
-    shm::dsm_region_bytes(mpp_worker_count(), mpp_queue_size(), plan_bytes_len)
-        .map_err(|e| e.to_string())
+/// Total DSM bytes the leader will need for the mesh header, the worker plan, and one MPSC
+/// inbox per process. `n_procs` is the total proc count (leader + launched producers) the
+/// plan-first launch computed from the physical plan — the mesh grows as `n_procs²`, so this
+/// is sized from the plan's needs, not the GUC ceiling (#5667).
+pub fn estimate_dsm_size(n_procs: u32, plan_bytes_len: usize) -> Result<usize, String> {
+    shm::dsm_region_bytes(n_procs, mpp_queue_size(), plan_bytes_len).map_err(|e| e.to_string())
 }
 
-/// Number of producer workers PG should launch as `parallel_workers`.
-/// `mpp_worker_count - 1` because proc 0 is the leader (consumer-only). Callers must gate
-/// on [`mpp_is_active`] first; when active, [`MIN_TOTAL_WORKER_COUNT`] guarantees this is
-/// `>= 2` without further clamping.
-pub fn producer_worker_count() -> u32 {
-    mpp_worker_count() - 1
+/// Maximum number of producer workers a launch may spawn:
+/// `min(max_parallel_workers_per_gather, max_parallel_workers)` (#5667). Also the planner's
+/// `target_partitions` ceiling. The plan-first launch spawns
+/// `clamp(max_stage_task_count, MIN_PRODUCER_COUNT, this)` producers, so the cap only bounds —
+/// the plan's task fragments decide the actual width. When [`mpp_is_active`] holds this is
+/// `>= MIN_PRODUCER_COUNT`.
+pub fn producer_worker_cap() -> u32 {
+    let max_per_gather = unsafe { pg_sys::max_parallel_workers_per_gather };
+    let max_workers = unsafe { pg_sys::max_parallel_workers };
+    max_per_gather.min(max_workers).max(0) as u32
 }
 
 /// Leader-observable per-phase timing of an MPP launch, in microseconds. Populated so
@@ -172,19 +154,13 @@ pub struct MppLeaderState {
     /// the workers and destroy the parallel context. `None` until `launch` installs it on the
     /// success path.
     pub finish: Option<crate::parallel_worker::builder::ParallelProcessFinish>,
-    /// The shared `ParallelScanState` the leader populated in DSM. The leader runs the top fragment
-    /// itself, and a scan source can land there (e.g. under MPP's broadcast or shuffle strategy),
-    /// where the scan claims per-source segments against this state just like a worker. The leader
-    /// stashes it on its custom state so the codec installs it into those providers. Null until
-    /// `launch` sets it.
-    pub parallel_state: *mut ParallelScanState,
     /// Per-phase launch timing the leader fills in as it commits, for `EXPLAIN ANALYZE`.
     pub timing: MppLaunchTiming,
 }
 
 /// The `(pgprocno, pid)` of this backend, packed into the receiver token the transport stores so a
 /// producer's [`PgWakeup`] can `SetLatch` us. Read on the backend thread (both setup paths run
-/// synchronously from PG's custom-scan init hooks before any tokio runtime spins up).
+/// synchronously from the launch / worker entry before any tokio runtime spins up).
 unsafe fn self_receiver_token() -> u64 {
     // `pg_sys::MyProcNumber` is the PG17+ global; PG15/16 carry the same value on
     // `MyProc->pgprocno` (it moved to a process-global plus a field rename in PG17).
@@ -201,10 +177,12 @@ unsafe fn self_receiver_token() -> u64 {
 ///
 /// # Safety
 /// - `coordinate` must be the MPP region pointer (a `ParallelState` byte blob the leader owns).
+/// - `n_procs` must equal the proc count passed to [`estimate_dsm_size`] for this region.
 /// - `plan_bytes` must have the same length passed to [`estimate_dsm_size`]
 ///   so the leader doesn't overrun the region.
 pub unsafe fn leader_setup(
     coordinate: *mut c_void,
+    n_procs: u32,
     plan_bytes: Vec<u8>,
 ) -> Result<MppLeaderState, String> {
     let wakeup: Arc<dyn Wakeup> = Arc::new(PgWakeup);
@@ -212,13 +190,13 @@ pub unsafe fn leader_setup(
     // Register the leader as receiver so producers' wakeups resolve to this backend's procLatch.
     let token = unsafe { self_receiver_token() };
     // `mpp_trace` reads a pgrx GucSetting, which requires the backend thread. Safe here
-    // because this runs synchronously from `initialize_dsm_custom_scan` before any tokio
-    // runtime spins up.
+    // because this runs synchronously on the leader backend from `launch_mpp`, before any
+    // tokio runtime spins up.
     let t_setup = crate::gucs::mpp_trace().then(std::time::Instant::now);
     let attach = unsafe {
         shm::leader_setup(
             coordinate,
-            mpp_worker_count(),
+            n_procs,
             mpp_queue_size(),
             &plan_bytes,
             wakeup,
@@ -248,7 +226,6 @@ pub unsafe fn leader_setup(
         mesh,
         control_senders,
         finish: None,
-        parallel_state: std::ptr::null_mut(),
         timing: MppLaunchTiming::default(),
     })
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -42,21 +42,21 @@ use datafusion_distributed::TaskKey;
 use crate::gucs::mpp_queue_size as gucs_mpp_queue_size;
 use crate::postgres::customscan::mpp::pg_seams::{pack_receiver, PgInterrupt, PgWakeup};
 
-/// Minimum producer count for MPP: the leader (proc 0) is consumer-only, and
-/// `build_mpp_session_context` clamps `target_partitions` to 2, so the mesh needs at least 2
-/// producers or it wouldn't have a queue for the second partition. Single source of truth so
-/// [`mpp_is_active`] and the launch's clamp floor don't drift on the threshold.
-pub const MIN_PRODUCER_COUNT: u32 = 2;
+/// Minimum total procs for MPP: leader (consumer-only, proc 0) plus at least 2 producers.
+/// Below that, `build_mpp_session_context` still clamps `target_partitions` to 2 and the mesh
+/// wouldn't have a queue for the second partition. Single source of truth so [`mpp_is_active`]
+/// and the launch's clamp floor don't drift on the threshold.
+pub const MIN_TOTAL_WORKER_COUNT: u32 = 3;
 
-/// True iff PostgreSQL's parallelism budget allows at least [`MIN_PRODUCER_COUNT`] producer
-/// workers. There is no MPP-specific worker GUC (#5667): `max_parallel_workers_per_gather`
-/// caps the per-query width — the same knob that caps ordinary parallel scans, matching core
-/// PG's `compute_parallel_worker` convention — and `max_parallel_workers` is the cluster-wide
-/// pool. Setting `max_parallel_workers_per_gather` below 2 (or 0, PG's own
-/// parallelism-disable convention) disables MPP. Customscan path-builders gate
-/// `parallel_workers` on this.
+/// True iff PostgreSQL's parallelism budget allows at least `MIN_TOTAL_WORKER_COUNT - 1`
+/// producer workers. There is no MPP-specific worker GUC (#5667):
+/// `max_parallel_workers_per_gather` caps the per-query width — the same knob that caps
+/// ordinary parallel scans, matching core PG's `compute_parallel_worker` convention — and
+/// `max_parallel_workers` is the cluster-wide pool. Setting
+/// `max_parallel_workers_per_gather` below 2 (or 0, PG's own parallelism-disable convention)
+/// disables MPP. Customscan path-builders gate `parallel_workers` on this.
 pub fn mpp_is_active() -> bool {
-    producer_worker_cap() >= MIN_PRODUCER_COUNT
+    producer_worker_cap() >= MIN_TOTAL_WORKER_COUNT - 1
 }
 
 // The shared-memory transport pins 8-byte alignment (its ring headers hold `u64` atomics). The
@@ -80,9 +80,9 @@ pub fn estimate_dsm_size(n_procs: u32, plan_bytes_len: usize) -> Result<usize, S
 /// Maximum number of producer workers a launch may spawn:
 /// `min(max_parallel_workers_per_gather, max_parallel_workers)` (#5667). Also the planner's
 /// `target_partitions` ceiling. The plan-first launch spawns
-/// `clamp(max_stage_task_count, MIN_PRODUCER_COUNT, this)` producers, so the cap only bounds —
-/// the plan's task fragments decide the actual width. When [`mpp_is_active`] holds this is
-/// `>= MIN_PRODUCER_COUNT`.
+/// `clamp(max_stage_task_count, MIN_TOTAL_WORKER_COUNT - 1, this)` producers, so the cap only
+/// bounds — the plan's task fragments decide the actual width. When [`mpp_is_active`] holds
+/// this is `>= MIN_TOTAL_WORKER_COUNT - 1`.
 pub fn producer_worker_cap() -> u32 {
     let max_per_gather = unsafe { pg_sys::max_parallel_workers_per_gather };
     let max_workers = unsafe { pg_sys::max_parallel_workers };

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -24,15 +24,19 @@
 //!
 //! The MPP DSM region rides as builder `ParallelState` entries instead of a hand-laid coordinate:
 //! a reserve-only region for the ring mesh (`shm::dsm_region_bytes`), a zeroed byte blob for the
-//! `ParallelScanState`, plus the partitioning-source index and a go flag. The leader initializes
-//! the mesh and populates the scan state in place between `build()` and worker attach; workers
-//! reconstruct their `MppWorkerInputs` from the same entries, with no PG plan node in reach.
+//! `ParallelScanState`, plus a go flag. Workers reconstruct their `MppWorkerInputs` from the same
+//! entries, with no PG plan node in reach.
 //!
-//! The launch is split around the leader's planning pass: [`launch_mpp_prepare`] builds the DSM
-//! and spawns the workers parked on the go flag, so worker process startup overlaps the
-//! leader's planning; [`launch_mpp_commit`] derives the dispatch payload from the leader's plan
-//! and releases them. One plan serves both dispatch and the leader's own execution, and every
-//! planning fallback aborts the parked workers before they touch the mesh.
+//! The launch is plan-first (#5667), mirroring core PG's parallel-query order (plan →
+//! size-by-walking-the-plan → create DSM → bind pointers → launch): the caller builds the
+//! distributed physical plan with `producer_worker_cap()` (PG's parallelism GUCs) as the
+//! planner's ceiling, then [`launch_mpp_join`] / [`launch_mpp_aggregate`] walk the finished plan to learn
+//! the largest producer-stage task count, size the mesh and spawn exactly
+//! `clamp(max_tasks, 2, cap)` producers, stamp the shared scan state into the plan
+//! ([`crate::scan::execution_plan::stamp_parallel_state`]), and dispatch. A plan with no
+//! producer stages spawns nothing at all. One plan serves both dispatch and the leader's own
+//! execution; the go flag holds spawned workers off the mesh until the rings and dispatch
+//! payload are initialized, and aborts them on a short launch (#5061).
 
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -56,8 +60,10 @@ use crate::postgres::customscan::mpp::dispatch::{
 };
 use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, producer_worker_count, worker_setup, MppLeaderState,
+    estimate_dsm_size, leader_setup, producer_worker_cap, worker_setup, MppLeaderState,
+    MIN_PRODUCER_COUNT,
 };
+use crate::postgres::customscan::mpp::worker_fragments::max_producer_task_count;
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
 
 /// `state_values()` order. Each index maps to a `ParallelState` TOC entry the workers look up.
@@ -103,7 +109,7 @@ unsafe fn go_flag(sm: &ParallelStateManager) -> &'static AtomicU32 {
 }
 
 /// AggregateScan worker entry point. PG resolves this symbol by name (passed to
-/// `ParallelProcessBuilder::build`), so the name must match the string in [`prepare_mpp_aggregate`].
+/// `ParallelProcessBuilder::build`), so the name must match the string in [`launch_mpp_aggregate`].
 #[no_mangle]
 #[pgrx::pg_guard]
 pub unsafe extern "C-unwind" fn mpp_launched_worker_agg(
@@ -117,7 +123,7 @@ pub unsafe extern "C-unwind" fn mpp_launched_worker_agg(
 }
 
 /// JoinScan worker entry point. PG resolves this symbol by name; it must match the string in
-/// [`prepare_mpp_join`].
+/// [`launch_mpp_join`].
 #[no_mangle]
 #[pgrx::pg_guard]
 pub unsafe extern "C-unwind" fn mpp_launched_worker_join(
@@ -135,8 +141,9 @@ pub unsafe extern "C-unwind" fn mpp_launched_worker_join(
 /// per-shape serial session context used only for plan deserialization.
 fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> SessionContext) {
     let go = unsafe { go_flag(&state_manager) };
-    // The wait spans the leader's planning pass, so back off to sleeping after a burst of
-    // yields; spinning here would steal cores from the planner.
+    // Under the plan-first launch the leader has already planned; this wait only spans the
+    // leader's ring init (`leader_setup`) and short-launch decision. Still back off to
+    // sleeping after a burst of yields rather than spin.
     let mut spins = 0u32;
     loop {
         check_for_interrupts!();
@@ -190,57 +197,30 @@ fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> Se
     run_mpp_worker(inputs, seed_ctx(), &runtime);
 }
 
-/// DSM prepared for an MPP launch, before the leader has planned. The workers are already
-/// spawned but parked on the go flag: their process startup (library load, backend init)
-/// overlaps the leader's planning pass, while the go flag keeps them off the mesh until the
-/// payload exists. The leader plans against `scan_ptr`, then hands the physical plan to
-/// [`launch_mpp_commit`].
-pub struct MppLaunchPrep {
-    attach: crate::parallel_worker::builder::ParallelProcessAttach,
-    pub scan_ptr: *mut ParallelScanState,
-    producer_count: u32,
-    payload_capacity: usize,
-}
-
 /// Where MPP sits in a scan's launch lifecycle. Every transition consumes the previous stage,
 /// so a scan is in exactly one stage at a time; a single field keeps the impossible
-/// combinations (prepared and launched at once, say) unrepresentable. Held only by the leader;
-/// builder-launched workers reconstruct their state from DSM and never carry this.
+/// combinations unrepresentable. Held only by the leader; builder-launched workers reconstruct
+/// their state from DSM and never carry this.
 #[derive(Default)]
 pub enum MppLifecycle {
     /// Serial execution: the query didn't qualify, a fallback abandoned the launch, or
     /// teardown already reclaimed the leader state.
     #[default]
     Inactive,
-    /// Serialized logical-plan bytes, stashed at begin time. Prepare uses their length to size
-    /// the DSM payload region before the physical plan exists.
+    /// Serialized logical-plan bytes, stashed at begin time. The launch uses their length to
+    /// size the DSM payload region.
     PlanBytes(Vec<u8>),
-    /// The DSM is built and the producer workers are spawned, parked on the go flag while the
-    /// leader plans.
-    Prepared(MppLaunchPrep),
     /// The workers are running dispatched fragments; carries the leader's mesh and finish
     /// handles until teardown.
     Launched(MppLeaderState),
 }
 
 impl MppLifecycle {
-    /// Consume the stashed plan bytes. Leaves `Inactive`, so a prepare fallback reads as the
+    /// Consume the stashed plan bytes. Leaves `Inactive`, so a launch fallback reads as the
     /// serial path from then on.
     pub fn take_plan_bytes(&mut self) -> Option<Vec<u8>> {
         match std::mem::take(self) {
             MppLifecycle::PlanBytes(bytes) => Some(bytes),
-            other => {
-                *self = other;
-                None
-            }
-        }
-    }
-
-    /// Consume the prepared launch. Leaves `Inactive`; [`launch_mpp_commit`] decides whether
-    /// the scan moves to `Launched` or stays serial.
-    pub fn take_prep(&mut self) -> Option<MppLaunchPrep> {
-        match std::mem::take(self) {
-            MppLifecycle::Prepared(prep) => Some(prep),
             other => {
                 *self = other;
                 None
@@ -273,27 +253,47 @@ impl MppLifecycle {
         }
     }
 
-    pub fn is_prepared(&self) -> bool {
-        matches!(self, MppLifecycle::Prepared(_))
-    }
-
     pub fn is_launched(&self) -> bool {
         matches!(self, MppLifecycle::Launched(_))
     }
 }
 
-/// Build the MPP DSM (mesh region, `ParallelScanState`, go flag) and spawn the workers parked
-/// on the go flag. `None` covers the fallbacks that must not deploy MPP: DSM too large, or no
-/// parallel context available.
-fn launch_mpp_prepare(
+/// Plan-first MPP launch (#5667): size the worker pool from the finished physical plan, build
+/// the DSM, stamp the shared scan state into the plan, spawn exactly the needed producers, and
+/// dispatch. `None` means run serially — the plan has nothing to distribute, the DSM couldn't
+/// be built, or the machine couldn't give us the full producer set. Nothing is forked on the
+/// nothing-to-distribute path. A `pgrx::error!` is reserved for setup that already committed a
+/// launched worker to the mesh, where a silent serial fallback would hide a real bug.
+fn launch_mpp(
+    physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
     plan_bytes_len: usize,
     args: ParallelScanArgs,
     worker_entrypoint: &'static str,
-) -> Option<MppLaunchPrep> {
-    let producer_count = producer_worker_count();
-    let payload_capacity = dispatch_plan_capacity(plan_bytes_len);
+) -> Option<MppLeaderState> {
+    let mut timing = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
 
-    let region_bytes = match estimate_dsm_size(payload_capacity) {
+    // The plan was built with `target_partitions = cap` (PG's parallelism GUCs as the
+    // ceiling); its stage task counts reflect the data (segment counts, since #5657). Launch
+    // only as many producers as the widest stage can occupy. The `MIN_PRODUCER_COUNT` floor
+    // keeps the mesh-width invariant (`build_mpp_session_context` clamps `target_partitions`
+    // to 2; the mesh needs a queue for the second partition).
+    let max_tasks = max_producer_task_count(physical);
+    if max_tasks == 0 {
+        // No producer stages: nothing to distribute, nothing to fork.
+        return None;
+    }
+    let cap = producer_worker_cap();
+    if cap < MIN_PRODUCER_COUNT {
+        // Callers gate on `mpp_is_active()`, so this is unreachable today — but `clamp`
+        // panics when min > max, and a GUC-dependent panic is a worse failure mode than a
+        // serial run if a future call site forgets the gate.
+        return None;
+    }
+    let producer_count = (max_tasks as u32).clamp(MIN_PRODUCER_COUNT, cap);
+
+    let t_prepare = std::time::Instant::now();
+    let payload_capacity = dispatch_plan_capacity(plan_bytes_len);
+    let region_bytes = match estimate_dsm_size(producer_count + 1, payload_capacity) {
         Ok(sz) => sz,
         Err(e) => {
             pgrx::warning!("mpp: estimate_dsm failed: {e}; running serially");
@@ -322,43 +322,18 @@ fn launch_mpp_prepare(
     )?;
 
     // Populate the ParallelScanState in place while the DSM is mapped and the leader still holds
-    // the source manifests `args` borrows. Done before planning so the leader's plan (the same
-    // one the dispatch payload is derived from) binds to the shared state the workers will use.
+    // the source manifests `args` borrows.
     let scan_ptr = match launcher.state_manager().slice_mut::<u8>(SCAN_IDX) {
         Ok(Some(s)) => s.as_mut_ptr() as *mut ParallelScanState,
         _ => pgrx::error!("mpp: parallel scan state region missing"),
     };
     unsafe { (*scan_ptr).create_and_populate(args) };
 
-    // Spawn the workers before the leader plans: their process startup overlaps the planning
-    // pass, and the go flag keeps them off the mesh until the payload is written.
+    timing.prepare_us = t_prepare.elapsed().as_micros() as u64;
+
+    // Spawn the workers; the go flag keeps them off the mesh until the rings and the dispatch
+    // payload are initialized below.
     let attach = launcher.launch()?;
-
-    Some(MppLaunchPrep {
-        attach,
-        scan_ptr,
-        producer_count,
-        payload_capacity,
-    })
-}
-
-/// Serialize the leader's plan into the dispatch payload, release the workers, and return the
-/// leader's mesh state, or `None` to run serially (the machine couldn't give us the full
-/// producer set, or the plan has nothing to distribute). A `pgrx::error!` is reserved for setup
-/// that already committed a launched worker to the mesh, where a silent serial fallback would
-/// hide a real bug.
-pub fn launch_mpp_commit(
-    prep: MppLaunchPrep,
-    physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-) -> Option<MppLeaderState> {
-    let MppLaunchPrep {
-        attach,
-        scan_ptr,
-        producer_count,
-        payload_capacity,
-    } = prep;
-
-    let mut timing = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
 
     // Derive the per-stage subplans from the plan the leader itself will execute. A failure
     // here is a hard error: a serialization gap is a codec bug, and the parked workers die
@@ -391,14 +366,27 @@ pub fn launch_mpp_commit(
         return None;
     }
 
-    // A plan with no producer stages has nothing to distribute; the workers would only exit
-    // with no fragments while the leader runs a plan whose per-source scans aren't executable
-    // without a worker's state. Release the workers and let the caller replan serially.
+    // `max_producer_task_count > 0` implies dispatch finds the same stages (both walks gate on
+    // `local_plan()`), so this should be unreachable — but if the two walks ever drift, a
+    // zero-stage dispatch would leave workers waiting on `SetPlan` frames that never come.
+    // Abort them and run serially rather than hang.
     if stage_count == 0 {
+        debug_assert!(
+            false,
+            "mpp: max_producer_task_count > 0 but dispatch found no stages"
+        );
         go.store(GO_ABORT, Ordering::Release);
         finish.wait_for_finish();
         return None;
     }
+
+    // The plan was built before the DSM existed, so its `Shared` scans carry no parallel state
+    // yet; bind the pointer now, before the leader's first `execute()`. Deliberately after the
+    // last serial-fallback `return None` above: a stamped plan must never outlive its DSM, and
+    // the fallback paths replan — stamping here makes "stamped plan, no committed launch"
+    // unrepresentable. The workers never see this — dispatch encodes are context-free and each
+    // worker injects its own pointer at decode.
+    crate::scan::execution_plan::stamp_parallel_state(physical, scan_ptr);
 
     // Initialize the leader's rings now that we're committed to the parallel path. After launch on
     // purpose: the serial fallbacks above never create the DSM-backed control senders.
@@ -407,7 +395,7 @@ pub fn launch_mpp_commit(
         _ => pgrx::error!("mpp: mesh region missing"),
     };
     let t_setup = std::time::Instant::now();
-    let mut leader = match unsafe { leader_setup(mesh_ptr, payload) } {
+    let mut leader = match unsafe { leader_setup(mesh_ptr, producer_count + 1, payload) } {
         Ok(l) => l,
         Err(e) => pgrx::error!("mpp: leader_setup failed: {e}"),
     };
@@ -422,19 +410,23 @@ pub fn launch_mpp_commit(
     go.store(GO_RUN, Ordering::Release);
 
     leader.finish = Some(finish);
-    leader.parallel_state = scan_ptr;
     Some(leader)
 }
 
-/// AggregateScan prepare entry: aggregate worker symbol.
-pub fn prepare_mpp_aggregate(
+/// AggregateScan launch entry: aggregate worker symbol.
+pub fn launch_mpp_aggregate(
+    physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
     plan_bytes_len: usize,
     args: ParallelScanArgs,
-) -> Option<MppLaunchPrep> {
-    launch_mpp_prepare(plan_bytes_len, args, "mpp_launched_worker_agg")
+) -> Option<MppLeaderState> {
+    launch_mpp(physical, plan_bytes_len, args, "mpp_launched_worker_agg")
 }
 
-/// JoinScan prepare entry: join worker symbol.
-pub fn prepare_mpp_join(plan_bytes_len: usize, args: ParallelScanArgs) -> Option<MppLaunchPrep> {
-    launch_mpp_prepare(plan_bytes_len, args, "mpp_launched_worker_join")
+/// JoinScan launch entry: join worker symbol.
+pub fn launch_mpp_join(
+    physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    plan_bytes_len: usize,
+    args: ParallelScanArgs,
+) -> Option<MppLeaderState> {
+    launch_mpp(physical, plan_bytes_len, args, "mpp_launched_worker_join")
 }

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -272,21 +272,18 @@ fn launch_mpp(
 ) -> Option<MppLeaderState> {
     let mut timing = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
 
-    // The plan was built with `target_partitions = cap` (PG's parallelism GUCs as the
-    // ceiling); its stage task counts reflect the data (segment counts, since #5657). Launch
-    // only as many producers as the widest stage can occupy. The `MIN_PRODUCER_COUNT` floor
-    // keeps the mesh-width invariant (`build_mpp_session_context` clamps `target_partitions`
-    // to 2; the mesh needs a queue for the second partition).
+    // Task counts were capped by `target_partitions = cap` at plan time and reflect segment
+    // counts (#5657). The `MIN_PRODUCER_COUNT` floor keeps the mesh-width invariant:
+    // `build_mpp_session_context` clamps `target_partitions` to 2, so the mesh needs a queue
+    // for the second partition.
     let max_tasks = max_producer_task_count(physical);
     if max_tasks == 0 {
-        // No producer stages: nothing to distribute, nothing to fork.
         return None;
     }
     let cap = producer_worker_cap();
     if cap < MIN_PRODUCER_COUNT {
-        // Callers gate on `mpp_is_active()`, so this is unreachable today — but `clamp`
-        // panics when min > max, and a GUC-dependent panic is a worse failure mode than a
-        // serial run if a future call site forgets the gate.
+        // Unreachable when callers gate on `mpp_is_active()`, but `clamp` panics when
+        // min > max; a forgotten gate should mean a serial run, not a panic.
         return None;
     }
     let producer_count = (max_tasks as u32).clamp(MIN_PRODUCER_COUNT, cap);
@@ -380,12 +377,10 @@ fn launch_mpp(
         return None;
     }
 
-    // The plan was built before the DSM existed, so its `Shared` scans carry no parallel state
-    // yet; bind the pointer now, before the leader's first `execute()`. Deliberately after the
-    // last serial-fallback `return None` above: a stamped plan must never outlive its DSM, and
-    // the fallback paths replan — stamping here makes "stamped plan, no committed launch"
-    // unrepresentable. The workers never see this — dispatch encodes are context-free and each
-    // worker injects its own pointer at decode.
+    // Bind the shared scan state into the plan the leader will execute. Must stay below the
+    // last serial-fallback `return None`: a stamped plan must never outlive its DSM, and the
+    // fallback paths replan. Workers are unaffected — dispatch encodes are context-free and
+    // each worker injects its own pointer at decode.
     crate::scan::execution_plan::stamp_parallel_state(physical, scan_ptr);
 
     // Initialize the leader's rings now that we're committed to the parallel path. After launch on

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -332,7 +332,9 @@ fn launch_mpp(
     timing.prepare_us = t_prepare.elapsed().as_micros() as u64;
 
     // Spawn the workers; the go flag keeps them off the mesh until the rings and the dispatch
-    // payload are initialized below.
+    // payload are initialized below. The trace doubles as the regress observable that a
+    // launch was attempted at all (mpp_worker_sizing).
+    crate::mpp_log!("launch: spawning {producer_count} producers");
     let attach = launcher.launch()?;
 
     // Derive the per-stage subplans from the plan the leader itself will execute. A failure

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -276,7 +276,11 @@ fn launch_mpp(
     // counts (#5657). The producer floor keeps the mesh-width invariant; see
     // [`MIN_TOTAL_WORKER_COUNT`].
     let max_tasks = max_producer_task_count(physical);
-    if max_tasks == 0 {
+    if max_tasks < 2 {
+        // 0: nothing to distribute. 1: no data parallelism — every 1-task stage lands on
+        // proc 1 (`proc_for_task`), leaving the second (floor) producer idle. Run serially.
+        // This also keeps `producer_count <= max_tasks`, so every launched proc owns at
+        // least one fragment of the widest stage.
         return None;
     }
     let cap = producer_worker_cap();

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -61,7 +61,7 @@ use crate::postgres::customscan::mpp::dispatch::{
 use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, producer_worker_cap, worker_setup, MppLeaderState,
-    MIN_PRODUCER_COUNT,
+    MIN_TOTAL_WORKER_COUNT,
 };
 use crate::postgres::customscan::mpp::worker_fragments::max_producer_task_count;
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
@@ -273,20 +273,19 @@ fn launch_mpp(
     let mut timing = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
 
     // Task counts were capped by `target_partitions = cap` at plan time and reflect segment
-    // counts (#5657). The `MIN_PRODUCER_COUNT` floor keeps the mesh-width invariant:
-    // `build_mpp_session_context` clamps `target_partitions` to 2, so the mesh needs a queue
-    // for the second partition.
+    // counts (#5657). The producer floor keeps the mesh-width invariant; see
+    // [`MIN_TOTAL_WORKER_COUNT`].
     let max_tasks = max_producer_task_count(physical);
     if max_tasks == 0 {
         return None;
     }
     let cap = producer_worker_cap();
-    if cap < MIN_PRODUCER_COUNT {
+    if cap < MIN_TOTAL_WORKER_COUNT - 1 {
         // Unreachable when callers gate on `mpp_is_active()`, but `clamp` panics when
         // min > max; a forgotten gate should mean a serial run, not a panic.
         return None;
     }
-    let producer_count = (max_tasks as u32).clamp(MIN_PRODUCER_COUNT, cap);
+    let producer_count = (max_tasks as u32).clamp(MIN_TOTAL_WORKER_COUNT - 1, cap);
 
     let t_prepare = std::time::Instant::now();
     let payload_capacity = dispatch_plan_capacity(plan_bytes_len);

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -19,8 +19,9 @@
 //!
 //! Hash-partitions every table by the join key and shuffles intermediate rows between
 //! workers through PostgreSQL `shm_mq` queues, so each row is scanned exactly once.
-//! Guarded by `paradedb.mpp_worker_count >= 3`, plus enough `max_parallel_workers` /
-//! `max_parallel_workers_per_gather` to launch the producers.
+//! Guarded by PostgreSQL's own parallelism budget: active iff
+//! `min(max_parallel_workers_per_gather, max_parallel_workers) >= 2` producers (#5667); the
+//! plan-first launch spawns only as many as the plan's task fragments can occupy.
 //!
 //! The transport lives in `datafusion_distributed::shm`. Deadlock avoidance is a
 //! cooperative inline drain: a producer stalled on a full outbound pulls its own inbound

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -199,15 +199,11 @@ fn collect_stages(
                     consumer_task: route_consumer_tasks()?,
                 }
             } else {
-                // Top-level NetworkShuffleExec / NetworkBroadcastExec isn't a shape our customscan plans produce.
-                // They emit partitioned or broadcast output into a parent consumer stage, not directly
-                // into the leader.
-                crate::postgres::customscan::mpp::fail_loud(format!(
-                    "mpp worker_fragments: top-level {} is unsupported \
-                     (stage_id={stage_id}). They emit output into a \
-                     parent consumer stage; a top-level boundary of this type is a planner anomaly.",
-                    plan.name()
-                ))
+                // Top-level NetworkShuffleExec / NetworkBroadcastExec means the entire consumer
+                // pipeline collapsed to a single partition and remained on the leader instead of
+                // becoming a nested consumer stage. In this case, the single leader task is the
+                // only consumer, so it behaves identically to a Coalesce.
+                FragmentRouting::Coalesce { dest_proc: 0 }
             }
         } else {
             // `as_network_boundary()` matched, but the node isn't one of the three concrete

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -108,6 +108,35 @@ pub struct StageEntry {
     pub routing: FragmentRouting,
 }
 
+/// Walk the distributed physical plan and report the largest producer-stage task count, or 0
+/// when the plan has no network boundaries (#5667).
+///
+/// The plan-first launch sizes the worker pool from this number *before* any DSM or process
+/// exists: `producers = clamp(max_tasks, 2, cap)`. Routing is not computed here — it depends on
+/// the final worker count, which this walk is an input to; [`collect_dispatched_stages`] derives
+/// routing later, at dispatch time. The recursion mirrors `collect_stages` (a boundary's
+/// `children()` returns its stage plan, so descend through `local_plan()` to keep visit counts
+/// exact) without the routing classification's `fail_loud` arms: an unrecognized boundary here
+/// just counts, and dispatch remains the single place that rejects unroutable shapes.
+pub fn max_producer_task_count(root: &Arc<dyn ExecutionPlan>) -> usize {
+    fn walk(plan: &Arc<dyn ExecutionPlan>, max: &mut usize) {
+        if let Some(nb) = plan.as_ref().as_network_boundary() {
+            let stage = nb.input_stage();
+            if let Some(stage_plan) = stage.local_plan() {
+                *max = (*max).max(stage.task_count());
+                walk(stage_plan, max);
+            }
+            return;
+        }
+        for child in plan.children() {
+            walk(child, max);
+        }
+    }
+    let mut max = 0;
+    walk(root, &mut max);
+    max
+}
+
 /// Walk the distributed physical plan and collect every producer stage, once per boundary. The
 /// leader runs this (replacing the worker-side re-plan) to classify routing from the boundary
 /// type. Not filtered by proc; the blob is shared and each worker selects its own
@@ -232,6 +261,15 @@ mod tests {
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
         let out = collect_dispatched_stages(&plan, 3).unwrap();
         assert!(out.is_empty());
+    }
+
+    /// #5667: the sizing walk must agree with `collect_dispatched_stages` on the base case —
+    /// a boundary-free plan has nothing to distribute, so the launch spawns no workers at all.
+    #[test]
+    fn boundary_free_plan_has_zero_max_tasks() {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        assert_eq!(max_producer_task_count(&plan), 0);
     }
 
     #[test]

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -1120,8 +1120,8 @@ pub(crate) fn stamp_parallel_state(plan: &Arc<dyn ExecutionPlan>, ps: *mut Paral
 /// Visit every [`PgSearchScanPlan`] reachable from `plan`, including scans wrapped in
 /// [`DistributedLeafExec`] — whose `children()` is empty, and whose `original`/`variants` may be
 /// a repartitioned instance not present anywhere else in the tree. Split from
-/// [`stamp_parallel_state`] so the traversal (the part that silently broke once) is unit-testable
-/// without a live `ParallelScanState`.
+/// [`stamp_parallel_state`] so the traversal is unit-testable without a live
+/// `ParallelScanState`.
 ///
 /// [`DistributedLeafExec`]: datafusion_distributed::DistributedLeafExec
 fn visit_scan_nodes(plan: &Arc<dyn ExecutionPlan>, visit: &mut impl FnMut(&PgSearchScanPlan)) {
@@ -1140,7 +1140,9 @@ fn visit_scan_nodes(plan: &Arc<dyn ExecutionPlan>, visit: &mut impl FnMut(&PgSea
     // the plain walk would still reach every scan — but that invariant lives in
     // `segmented_topk_rule`, not here. Descend through `inner()` explicitly so a future
     // wrapping of a scan cannot silently escape the stamp.
-    if let Some(fp) = plan.downcast_ref::<crate::scan::filter_passthrough_exec::FilterPassthroughExec>() {
+    if let Some(fp) =
+        plan.downcast_ref::<crate::scan::filter_passthrough_exec::FilterPassthroughExec>()
+    {
         visit_scan_nodes(fp.inner(), visit);
         return;
     }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -263,6 +263,9 @@ impl PgSearchScanPlan {
             .unwrap_or(0);
 
         if range_sample.is_none() {
+            // A partition count exceeding the segment count indicates a bug in
+            // PgSearchScanTaskEstimator::task_estimation, which should cap the tasks
+            // to the segment count when range sampling is disabled.
             assert!(
                 partition_count <= segment_count.max(1),
                 "partition_count {} exceeds segment_count {}",
@@ -1066,7 +1069,12 @@ impl TaskEstimator for PgSearchScanTaskEstimator {
 
         let partition_count = plan.properties().output_partitioning().partition_count();
 
-        Some(TaskEstimation::desired(partition_count))
+        // We use `maximum` rather than `desired` here because `partition_count` is already
+        // clamped to the number of physical index segments (when range sampling is disabled).
+        // Since a single segment cannot be concurrently scanned by multiple workers,
+        // allowing the stage to scale up beyond `partition_count` would just result in
+        // starved tasks doing useless setup work (like building empty hash tables) for zero rows.
+        Some(TaskEstimation::maximum(partition_count))
     }
 
     fn scale_up_leaf_node(

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -1135,6 +1135,15 @@ fn visit_scan_nodes(plan: &Arc<dyn ExecutionPlan>, visit: &mut impl FnMut(&PgSea
         }
         return;
     }
+    // `FilterPassthroughExec::children()` forwards to its inner node's children, skipping the
+    // inner node itself. Today it only ever wraps `SortPreservingMergeExec` (never a scan), so
+    // the plain walk would still reach every scan — but that invariant lives in
+    // `segmented_topk_rule`, not here. Descend through `inner()` explicitly so a future
+    // wrapping of a scan cannot silently escape the stamp.
+    if let Some(fp) = plan.downcast_ref::<crate::scan::filter_passthrough_exec::FilterPassthroughExec>() {
+        visit_scan_nodes(fp.inner(), visit);
+        return;
+    }
     for child in plan.children() {
         visit_scan_nodes(child, visit);
     }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -387,6 +387,23 @@ impl PgSearchScanPlan {
         })
     }
 
+    /// Late-bind the shared `ParallelScanState` into this scan's execution state (#5667).
+    ///
+    /// Under the plan-first MPP launch the leader builds its plan before the DSM exists, so
+    /// `Shared` scans start with `parallel_state: None`. Once the DSM is created and populated,
+    /// the launch stamps the leader's pointer in here — before the first `execute()`, which is
+    /// the only reader of the field. `RangePartitioned` and `Uninitialized` scans never consult
+    /// the pointer, so they are left untouched.
+    pub(crate) fn set_parallel_state(&self, ps: *mut ParallelScanState) {
+        let mut state_guard = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let ExecutionState::Shared { parallel_state, .. } = &mut *state_guard {
+            *parallel_state = Some(UnsafeSendSync(ps));
+        }
+    }
+
     pub fn has_deferred_fields(&self) -> bool {
         !self.deferred_fields.is_empty()
     }
@@ -1081,6 +1098,48 @@ impl TaskEstimator for PgSearchScanTaskEstimator {
     }
 }
 
+/// Stamp the leader's `ParallelScanState` pointer into every `PgSearchScanPlan` reachable from
+/// `plan` (#5667).
+///
+/// The plan-first MPP launch builds the leader's plan before the DSM exists; this walk binds the
+/// pointer afterwards, mirroring core PG's `ExecParallelInitializeDSM` (plans are address-free,
+/// execution state binds late). Network boundaries expose their stage plan through `children()`,
+/// so the walk reaches nested stages too — stamping worker-bound stage plans is inert: dispatch
+/// encodes are context-free recipes and workers inject their own pointer at decode.
+///
+/// `DistributedLeafExec` needs explicit descent: its `children()` is empty, and when
+/// `scale_up_leaf_node` repartitioned the scan, the wrapper's `original`/`variants` are a *new*
+/// `PgSearchScanPlan` instance — the wrapper is the only live path to it. The leader executes
+/// `original` (its `DistributedTaskContext` is `task_count = 1`), but stamp the variants too:
+/// they are usually clones of the same instance, and a future divergence must not silently
+/// un-stamp them.
+pub(crate) fn stamp_parallel_state(plan: &Arc<dyn ExecutionPlan>, ps: *mut ParallelScanState) {
+    visit_scan_nodes(plan, &mut |scan| scan.set_parallel_state(ps));
+}
+
+/// Visit every [`PgSearchScanPlan`] reachable from `plan`, including scans wrapped in
+/// [`DistributedLeafExec`] — whose `children()` is empty, and whose `original`/`variants` may be
+/// a repartitioned instance not present anywhere else in the tree. Split from
+/// [`stamp_parallel_state`] so the traversal (the part that silently broke once) is unit-testable
+/// without a live `ParallelScanState`.
+///
+/// [`DistributedLeafExec`]: datafusion_distributed::DistributedLeafExec
+fn visit_scan_nodes(plan: &Arc<dyn ExecutionPlan>, visit: &mut impl FnMut(&PgSearchScanPlan)) {
+    if let Some(scan) = plan.downcast_ref::<PgSearchScanPlan>() {
+        visit(scan);
+    }
+    if let Some(leaf) = plan.downcast_ref::<datafusion_distributed::DistributedLeafExec>() {
+        visit_scan_nodes(leaf.original(), visit);
+        for variant in leaf.variants() {
+            visit_scan_nodes(variant, visit);
+        }
+        return;
+    }
+    for child in plan.children() {
+        visit_scan_nodes(child, visit);
+    }
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
@@ -1095,6 +1154,47 @@ mod tests {
 
     fn empty_schema() -> SchemaRef {
         Arc::new(Schema::empty())
+    }
+
+    /// #5667: `DistributedLeafExec::children()` is empty, and after `repartition()` its
+    /// `original`/`variants` can be a scan instance not present anywhere else in the tree — so
+    /// a `children()`-only walk silently misses it and the leader would execute an unstamped
+    /// scan. This pins the explicit descent.
+    #[pg_test]
+    fn visit_scan_nodes_descends_through_distributed_leaf_exec() {
+        use datafusion::physical_plan::ExecutionPlan;
+        use datafusion_distributed::DistributedLeafExec;
+
+        fn make_scan() -> Arc<dyn ExecutionPlan> {
+            Arc::new(PgSearchScanPlan::new(
+                None,
+                empty_schema(),
+                SearchQueryInput::All,
+                None,
+                Vec::new(),
+                None,
+                0,
+                None,
+                1,
+                None,
+                None,
+            ))
+        }
+
+        // Distinct instances on purpose: `repartition()` gives the wrapper a scan that exists
+        // nowhere else in the tree, so the visitor must reach `original` and each variant
+        // independently — not merely alias the same node twice.
+        let leaf: Arc<dyn ExecutionPlan> = Arc::new(
+            DistributedLeafExec::try_new(make_scan(), [make_scan()]).expect("leaf construction"),
+        );
+
+        let mut visited = 0usize;
+        super::visit_scan_nodes(&leaf, &mut |_| visited += 1);
+        assert_eq!(
+            visited, 2,
+            "visit_scan_nodes must descend through DistributedLeafExec \
+             (original + 1 distinct variant); its children() is empty"
+        );
     }
 
     #[pg_test]

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -64,6 +64,7 @@ use crate::postgres::options::{SortByDirection, SortByField};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::ParallelScanState;
 use crate::query::SearchQueryInput;
+use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
 use crate::scan::late_materialization::DeferredField;
 use crate::scan::pre_filter::{collect_filters, try_dynamic_filter_pushdown, PreFilter};
 use crate::scan::range_partitioning::{RangePartitioning, RangePartitioningSample};
@@ -1140,9 +1141,7 @@ fn visit_scan_nodes(plan: &Arc<dyn ExecutionPlan>, visit: &mut impl FnMut(&PgSea
     // the plain walk would still reach every scan — but that invariant lives in
     // `segmented_topk_rule`, not here. Descend through `inner()` explicitly so a future
     // wrapping of a scan cannot silently escape the stamp.
-    if let Some(fp) =
-        plan.downcast_ref::<crate::scan::filter_passthrough_exec::FilterPassthroughExec>()
-    {
+    if let Some(fp) = plan.downcast_ref::<FilterPassthroughExec>() {
         visit_scan_nodes(fp.inner(), visit);
         return;
     }

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -7,8 +7,7 @@ SET paradedb.enable_join_custom_scan TO on;
 -- Use the closed chain's default worker count so PG sees enough workers
 -- to actually parallelize (with parallel_workers = 1, PG falls into the
 -- `Single Copy: true` path and never exercises the MPP shuffle).
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 -- Force parallel even on this tiny dataset; otherwise the cost-based
 -- planner picks the serial AggregateScan and MPP never activates.
@@ -146,7 +145,7 @@ LIMIT 5;
 (5 rows)
 
 -- =====================================================================
--- Pass 2: MPP path (max_parallel_workers_per_gather = 4). Same queries, same expected results.
+-- Pass 2: MPP path (max_parallel_workers_per_gather = 3). Same queries, same expected results.
 --
 -- The scalar COUNT(*) case still falls back to serial — PG won't
 -- parallelize scalar aggregates at this scale even with the parallel-
@@ -154,7 +153,7 @@ LIMIT 5;
 -- Parallel Custom Scan` shape with `Workers Planned > 0`, exercising
 -- the MPP DSM init / shm_mq mesh / `NetworkShuffleExec` path.
 -- =====================================================================
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -16,8 +16,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
 SET parallel_setup_cost TO 0;
@@ -93,7 +92,7 @@ ORDER BY f.category;
  cat-4    |       200 |      395076 |         3 |      4083
 (5 rows)
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.category,
        COUNT(*) AS row_count,
@@ -185,7 +184,7 @@ LIMIT 10;
  cat-0    | file-140 |              5
 (10 rows)
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.category, f.title, COUNT(*) AS pages_per_file
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -272,7 +271,7 @@ LIMIT 3;
  cat-3    | 200 | 395772
 (3 rows)
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -353,7 +352,7 @@ WHERE f.content @@@ 'Section';
   1000
 (1 row)
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -443,7 +442,7 @@ ORDER BY c.name;
  cat-4 |       200 |      395076
 (5 rows)
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
 FROM mpp_postagg_files f

--- a/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
@@ -12,10 +12,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_custom_scan = on;
 SET paradedb.enable_join_custom_scan = on;
-SET paradedb.mpp_worker_count = 4;
 SET paradedb.min_rows_per_worker = 0;
 SET max_parallel_workers = 4;
-SET max_parallel_workers_per_gather = 4;
+SET max_parallel_workers_per_gather = 3;
 SET parallel_tuple_cost = 0;
 SET parallel_setup_cost = 0;
 SET min_parallel_table_scan_size = 0;

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -4,14 +4,13 @@
 -- Same dataset shape as mpp_aggregate.sql but the queries don't
 -- aggregate — they project columns through a JOIN under a LIMIT,
 -- which is what JoinScan activates on. Two passes: serial baseline
--- (max_parallel_workers_per_gather = 0) and MPP path (max_parallel_workers_per_gather = 4). Results must
+-- (max_parallel_workers_per_gather = 0) and MPP path (max_parallel_workers_per_gather = 3). Results must
 -- match across the two passes; the EXPLAIN trees differ.
 -- =====================================================================
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 -- Force parallel even on this tiny dataset; otherwise the cost-based
 -- planner picks the serial JoinScan and MPP never activates.
@@ -119,12 +118,12 @@ LIMIT 10;
 (10 rows)
 
 -- =====================================================================
--- Pass 2: MPP path (max_parallel_workers_per_gather = 4). Same query, same results.
+-- Pass 2: MPP path (max_parallel_workers_per_gather = 3). Same query, same results.
 -- EXPLAIN tree should switch to a `Gather -> Parallel Custom Scan`
 -- shape, exercising the JoinScan MPP wiring (DSM init, shm_mq mesh,
 -- fragment dispatch, leader-side NetworkCoalesceExec gather).
 -- =====================================================================
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -221,7 +220,7 @@ DROP FUNCTION mpp_explain_analyze_lines(text);
 -- worker. This tests that the expression context is properly provided
 -- to the worker.
 -- =====================================================================
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -49,18 +49,6 @@ SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_after_set_on;
 (1 row)
 
 SET paradedb.mpp_debug TO off;
--- The legacy worker-count GUC is gone (#5667): MPP width now comes from
--- PostgreSQL's own parallelism GUCs (max_parallel_workers_per_gather /
--- max_parallel_workers), and the plan-first launch sizes the worker pool
--- from the plan's task fragments. Lock the removal in so a reintroduction
--- breaks loudly.
-DO $$
-BEGIN
-    PERFORM current_setting('paradedb.mpp_worker_count');
-    RAISE EXCEPTION 'expected paradedb.mpp_worker_count to be removed';
-EXCEPTION WHEN undefined_object THEN
-    RAISE NOTICE 'paradedb.mpp_worker_count correctly removed';
-END$$;
 -- Queue size: accepts standard Postgres byte units (kB, MB, GB).
 SET paradedb.mpp_queue_size TO '32MB';
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_32mb;

--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -21,12 +21,6 @@ SHOW paradedb.mpp_debug;
  off
 (1 row)
 
-SHOW paradedb.mpp_worker_count;
- paradedb.mpp_worker_count 
----------------------------
- 4
-(1 row)
-
 SHOW paradedb.mpp_queue_size;
  paradedb.mpp_queue_size 
 -------------------------
@@ -38,12 +32,6 @@ SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;
  mpp_debug_default_off 
 -----------------------
  f
-(1 row)
-
-SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default;
- worker_count_default 
-----------------------
-                    4
 (1 row)
 
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_default;
@@ -61,36 +49,17 @@ SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_after_set_on;
 (1 row)
 
 SET paradedb.mpp_debug TO off;
--- Worker count: accepts 1..64 per the GUC definition.
-SET paradedb.mpp_worker_count TO 2;
-SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_two;
- worker_count_two 
-------------------
-                2
-(1 row)
-
-SET paradedb.mpp_worker_count TO 4;
-SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_four;
- worker_count_four 
--------------------
-                 4
-(1 row)
-
--- Out-of-range worker count must fail (GUC min=1, max=64).
+-- The legacy worker-count GUC is gone (#5667): MPP width now comes from
+-- PostgreSQL's own parallelism GUCs (max_parallel_workers_per_gather /
+-- max_parallel_workers), and the plan-first launch sizes the worker pool
+-- from the plan's task fragments. Lock the removal in so a reintroduction
+-- breaks loudly.
 DO $$
 BEGIN
-    BEGIN
-        PERFORM set_config('paradedb.mpp_worker_count', '0', true);
-        RAISE EXCEPTION 'expected worker_count=0 to be rejected';
-    EXCEPTION WHEN invalid_parameter_value THEN
-        RAISE NOTICE 'worker_count=0 correctly rejected';
-    END;
-    BEGIN
-        PERFORM set_config('paradedb.mpp_worker_count', '65', true);
-        RAISE EXCEPTION 'expected worker_count=65 to be rejected';
-    EXCEPTION WHEN invalid_parameter_value THEN
-        RAISE NOTICE 'worker_count=65 correctly rejected';
-    END;
+    PERFORM current_setting('paradedb.mpp_worker_count');
+    RAISE EXCEPTION 'expected paradedb.mpp_worker_count to be removed';
+EXCEPTION WHEN undefined_object THEN
+    RAISE NOTICE 'paradedb.mpp_worker_count correctly removed';
 END$$;
 -- Queue size: accepts standard Postgres byte units (kB, MB, GB).
 SET paradedb.mpp_queue_size TO '32MB';
@@ -142,5 +111,4 @@ SELECT 1 AS trivial_query_still_works;
 
 SET paradedb.mpp_debug TO off;
 RESET paradedb.mpp_debug;
-RESET paradedb.mpp_worker_count;
 RESET paradedb.mpp_queue_size;

--- a/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
+++ b/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
@@ -11,12 +11,16 @@
 --     even attempted.
 --   - 4 segments per table under a cap of 2 launch exactly 2 producers;
 --     the extra tasks multiplex and results match the serial run.
+--   - AggregateScan rides the same launch: a 2-segment GROUP BY join
+--     also launches exactly 2 producers, and its 1-segment variant
+--     attempts no launch.
 --
 -- Outcomes are collected in a table (not NOTICEs) so the expected
 -- output stays stable under client_min_messages.
 -- =====================================================================
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_aggregate_custom_scan TO on;
 SET max_parallel_workers_per_gather TO 8;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
@@ -102,6 +106,30 @@ BEGIN
         INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially (no MPP launch recorded)');
     END IF;
 END$$;
+-- AggregateScan rides the same plan-first launch: same 2-segment tables under
+-- a cap of 8 must also launch exactly 2 producers.
+DO $$
+DECLARE
+    r record;
+    launched int := -1;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT p.age, count(*) FROM mpp_ws_users u JOIN mpp_ws_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' GROUP BY p.age ORDER BY p.age LIMIT 5'
+    LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            launched := (regexp_match(r."QUERY PLAN", 'workers=(\d+)'))[1]::int;
+        END IF;
+    END LOOP;
+    IF launched = 2 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment aggregate: launched exactly 2 producers');
+    ELSIF launched = -1 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment aggregate: UNEXPECTED serial run (no MPP Launch line)');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('2-segment aggregate: UNEXPECTED worker count ' || launched);
+    END IF;
+END$$;
 -- Four segments per index, cap of 2 (per_gather = 2): more tasks than workers.
 -- The launch must clamp to the cap and the extra tasks multiplex onto the two
 -- producers (dispatch::push_owned_tasks), returning the same results as serial.
@@ -181,19 +209,27 @@ BEGIN
     LOOP
         NULL;
     END LOOP;
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT p.age, count(*) FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' GROUP BY p.age ORDER BY p.age LIMIT 5'
+    LOOP
+        NULL;
+    END LOOP;
 END$$;
 SET paradedb.mpp_debug TO off;
 SELECT line FROM mpp_ws_outcome ORDER BY line;
                                 line                                 
 ---------------------------------------------------------------------
  1-segment join: ran serially (no MPP launch recorded)
+ 2-segment aggregate: launched exactly 2 producers
  2-segment join: launched exactly 2 producers
  4-segment join at cap 2: launched 2 producers, results match serial
-(3 rows)
+(4 rows)
 
 DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products,
            mpp_ws4_users, mpp_ws4_products;
 RESET paradedb.mpp_debug;
+RESET paradedb.enable_aggregate_custom_scan;
 RESET paradedb.enable_join_custom_scan;
 RESET max_parallel_workers_per_gather;
 RESET max_parallel_workers;

--- a/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
+++ b/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
@@ -6,8 +6,11 @@
 --     launch exactly 2 producers. EXPLAIN ANALYZE's "MPP Launch:
 --     workers=N" line is the launch's own report of what it spawned.
 --   - 1 segment per table produces no distributable stages: the query
---     runs serially and forks nothing ("MPP Launch" line absent — it is
---     only recorded when the query actually launched).
+--     runs serially ("MPP Launch" line absent), and under
+--     paradedb.mpp_debug no "spawning" trace appears — no launch is
+--     even attempted.
+--   - 4 segments per table under a cap of 2 launch exactly 2 producers;
+--     the extra tasks multiplex and results match the serial run.
 --
 -- Outcomes are collected in a table (not NOTICEs) so the expected
 -- output stays stable under client_min_messages.
@@ -96,17 +99,101 @@ BEGIN
     IF saw_launch THEN
         INSERT INTO mpp_ws_outcome VALUES ('1-segment join: UNEXPECTED distributed launch');
     ELSE
-        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially, no workers forked');
+        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially (no MPP launch recorded)');
     END IF;
 END$$;
-SELECT line FROM mpp_ws_outcome ORDER BY line;
-                      line                       
--------------------------------------------------
- 1-segment join: ran serially, no workers forked
- 2-segment join: launched exactly 2 producers
-(2 rows)
+-- Four segments per index, cap of 2 (per_gather = 2): more tasks than workers.
+-- The launch must clamp to the cap and the extra tasks multiplex onto the two
+-- producers (dispatch::push_owned_tasks), returning the same results as serial.
+CREATE TABLE mpp_ws4_users    (id bigserial PRIMARY KEY, name text, age int);
+CREATE TABLE mpp_ws4_products (id bigserial PRIMARY KEY, name text, age int);
+CREATE INDEX mpp_ws4_users_idx ON mpp_ws4_users USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX mpp_ws4_products_idx ON mpp_ws4_products USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(1, 2500) g;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(2501, 5000) g;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(5001, 7500) g;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(7501, 10000) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(1, 100) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(101, 200) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(201, 300) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(301, 400) g;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mpp_ws4_users;
+ANALYZE mpp_ws4_products;
+SET work_mem TO '64MB';
+DO $$
+DECLARE
+    r record;
+    launched int := -1;
+    serial_cnt bigint;
+    serial_sum bigint;
+    mpp_cnt bigint;
+    mpp_sum bigint;
+    q constant text := 'SELECT count(*), coalesce(sum(id), 0) FROM (
+        SELECT u.id FROM mpp_ws4_users u JOIN mpp_ws4_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 50000) t';
+BEGIN
+    PERFORM set_config('max_parallel_workers_per_gather', '0', false);
+    EXECUTE q INTO serial_cnt, serial_sum;
 
-DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products;
+    PERFORM set_config('max_parallel_workers_per_gather', '2', false);
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF) ' || q LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            launched := (regexp_match(r."QUERY PLAN", 'workers=(\d+)'))[1]::int;
+        END IF;
+    END LOOP;
+    EXECUTE q INTO mpp_cnt, mpp_sum;
+
+    IF launched = 2 AND mpp_cnt = serial_cnt AND mpp_sum = serial_sum THEN
+        INSERT INTO mpp_ws_outcome
+        VALUES ('4-segment join at cap 2: launched 2 producers, results match serial');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('4-segment join at cap 2: UNEXPECTED launched=' || launched
+                || ' rows=' || mpp_cnt || '/' || serial_cnt
+                || ' sum=' || mpp_sum || '/' || serial_sum);
+    END IF;
+END$$;
+RESET work_mem;
+SET max_parallel_workers_per_gather TO 8;
+-- A launch attempt traces "spawning N producers" as a WARNING under
+-- paradedb.mpp_debug. The 1-segment query must attempt none, distinguishing
+-- "never launched" from "launched then aborted": expect no warnings below.
+SET paradedb.mpp_debug TO on;
+DO $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT u.id FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        NULL;
+    END LOOP;
+END$$;
+SET paradedb.mpp_debug TO off;
+SELECT line FROM mpp_ws_outcome ORDER BY line;
+                                line                                 
+---------------------------------------------------------------------
+ 1-segment join: ran serially (no MPP launch recorded)
+ 2-segment join: launched exactly 2 producers
+ 4-segment join at cap 2: launched 2 producers, results match serial
+(3 rows)
+
+DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products,
+           mpp_ws4_users, mpp_ws4_products;
+RESET paradedb.mpp_debug;
 RESET paradedb.enable_join_custom_scan;
 RESET max_parallel_workers_per_gather;
 RESET max_parallel_workers;

--- a/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
+++ b/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
@@ -1,0 +1,115 @@
+-- =====================================================================
+-- #5667: the plan-first launch sizes the worker pool from the plan's
+-- task fragments, with PG's parallelism GUCs as the ceiling.
+--
+--   - 2 segments per table under an oversized cap (per_gather = 8) must
+--     launch exactly 2 producers. EXPLAIN ANALYZE's "MPP Launch:
+--     workers=N" line is the launch's own report of what it spawned.
+--   - 1 segment per table produces no distributable stages: the query
+--     runs serially and forks nothing ("MPP Launch" line absent — it is
+--     only recorded when the query actually launched).
+--
+-- Outcomes are collected in a table (not NOTICEs) so the expected
+-- output stays stable under client_min_messages.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 8;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+CREATE TABLE mpp_ws_outcome (line text);
+-- Two segments per index: two bulk inserts with the mutable segment disabled.
+CREATE TABLE mpp_ws_users    (id bigserial PRIMARY KEY, name text, age int);
+CREATE TABLE mpp_ws_products (id bigserial PRIMARY KEY, name text, age int);
+CREATE INDEX mpp_ws_users_idx ON mpp_ws_users USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX mpp_ws_products_idx ON mpp_ws_products USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_ws_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(1, 5000) g;
+INSERT INTO mpp_ws_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(5001, 10000) g;
+INSERT INTO mpp_ws_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(1, 5000) g;
+INSERT INTO mpp_ws_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(5001, 10000) g;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mpp_ws_users;
+ANALYZE mpp_ws_products;
+-- One segment per index: a single insert each.
+CREATE TABLE mpp_ws1_users    (id bigserial PRIMARY KEY, name text, age int);
+CREATE TABLE mpp_ws1_products (id bigserial PRIMARY KEY, name text, age int);
+CREATE INDEX mpp_ws1_users_idx ON mpp_ws1_users USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX mpp_ws1_products_idx ON mpp_ws1_products USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_ws1_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(1, 10000) g;
+INSERT INTO mpp_ws1_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(1, 10000) g;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mpp_ws1_users;
+ANALYZE mpp_ws1_products;
+-- 2-segment tables, cap of 8 producers: the plan's widest stage has 2
+-- tasks, so the launch must spawn exactly 2 workers, not the cap.
+DO $$
+DECLARE
+    r record;
+    launched int := -1;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT u.id FROM mpp_ws_users u JOIN mpp_ws_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            launched := (regexp_match(r."QUERY PLAN", 'workers=(\d+)'))[1]::int;
+        END IF;
+    END LOOP;
+    IF launched = 2 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment join: launched exactly 2 producers');
+    ELSIF launched = -1 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment join: UNEXPECTED serial run (no MPP Launch line)');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('2-segment join: UNEXPECTED worker count ' || launched);
+    END IF;
+END$$;
+-- 1-segment tables: nothing to distribute, so nothing is forked and no
+-- launch is recorded.
+DO $$
+DECLARE
+    r record;
+    saw_launch boolean := false;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT u.id FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            saw_launch := true;
+        END IF;
+    END LOOP;
+    IF saw_launch THEN
+        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: UNEXPECTED distributed launch');
+    ELSE
+        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially, no workers forked');
+    END IF;
+END$$;
+SELECT line FROM mpp_ws_outcome ORDER BY line;
+                      line                       
+-------------------------------------------------
+ 1-segment join: ran serially, no workers forked
+ 2-segment join: launched exactly 2 producers
+(2 rows)
+
+DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products;
+RESET paradedb.enable_join_custom_scan;
+RESET max_parallel_workers_per_gather;
+RESET max_parallel_workers;
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;

--- a/pg_search/tests/pg_regress/expected/mpp_workmem.out
+++ b/pg_search/tests/pg_regress/expected/mpp_workmem.out
@@ -16,8 +16,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
 SET parallel_setup_cost TO 0;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate.sql
@@ -10,8 +10,7 @@ SET paradedb.enable_join_custom_scan TO on;
 -- Use the closed chain's default worker count so PG sees enough workers
 -- to actually parallelize (with parallel_workers = 1, PG falls into the
 -- `Single Copy: true` path and never exercises the MPP shuffle).
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 -- Force parallel even on this tiny dataset; otherwise the cost-based
 -- planner picks the serial AggregateScan and MPP never activates.
@@ -114,7 +113,7 @@ ORDER BY f.title
 LIMIT 5;
 
 -- =====================================================================
--- Pass 2: MPP path (max_parallel_workers_per_gather = 4). Same queries, same expected results.
+-- Pass 2: MPP path (max_parallel_workers_per_gather = 3). Same queries, same expected results.
 --
 -- The scalar COUNT(*) case still falls back to serial — PG won't
 -- parallelize scalar aggregates at this scale even with the parallel-
@@ -123,7 +122,7 @@ LIMIT 5;
 -- the MPP DSM init / shm_mq mesh / `NetworkShuffleExec` path.
 -- =====================================================================
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
@@ -18,8 +18,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
 SET parallel_setup_cost TO 0;
@@ -99,7 +98,7 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.category
 ORDER BY f.category;
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.category,
@@ -135,7 +134,7 @@ GROUP BY f.category, f.title
 ORDER BY f.category, f.title
 LIMIT 10;
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.category, f.title, COUNT(*) AS pages_per_file
@@ -166,7 +165,7 @@ HAVING COUNT(*) > 100
 ORDER BY s DESC
 LIMIT 3;
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
@@ -198,7 +197,7 @@ SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
@@ -255,7 +254,7 @@ WHERE f.content @@@ 'Section'
 GROUP BY c.name
 ORDER BY c.name;
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes

--- a/pg_search/tests/pg_regress/sql/mpp_join_topk_ffhelper.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_join_topk_ffhelper.sql
@@ -14,10 +14,9 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_custom_scan = on;
 SET paradedb.enable_join_custom_scan = on;
-SET paradedb.mpp_worker_count = 4;
 SET paradedb.min_rows_per_worker = 0;
 SET max_parallel_workers = 4;
-SET max_parallel_workers_per_gather = 4;
+SET max_parallel_workers_per_gather = 3;
 SET parallel_tuple_cost = 0;
 SET parallel_setup_cost = 0;
 SET min_parallel_table_scan_size = 0;

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -4,7 +4,7 @@
 -- Same dataset shape as mpp_aggregate.sql but the queries don't
 -- aggregate — they project columns through a JOIN under a LIMIT,
 -- which is what JoinScan activates on. Two passes: serial baseline
--- (max_parallel_workers_per_gather = 0) and MPP path (max_parallel_workers_per_gather = 4). Results must
+-- (max_parallel_workers_per_gather = 0) and MPP path (max_parallel_workers_per_gather = 3). Results must
 -- match across the two passes; the EXPLAIN trees differ.
 -- =====================================================================
 
@@ -13,8 +13,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
 
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 -- Force parallel even on this tiny dataset; otherwise the cost-based
 -- planner picks the serial JoinScan and MPP never activates.
@@ -103,13 +102,13 @@ ORDER BY f.title, p.size_bytes
 LIMIT 10;
 
 -- =====================================================================
--- Pass 2: MPP path (max_parallel_workers_per_gather = 4). Same query, same results.
+-- Pass 2: MPP path (max_parallel_workers_per_gather = 3). Same query, same results.
 -- EXPLAIN tree should switch to a `Gather -> Parallel Custom Scan`
 -- shape, exercising the JoinScan MPP wiring (DSM init, shm_mq mesh,
 -- fragment dispatch, leader-side NetworkCoalesceExec gather).
 -- =====================================================================
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.title, p.size_bytes
@@ -159,7 +158,7 @@ DROP FUNCTION mpp_explain_analyze_lines(text);
 -- to the worker.
 -- =====================================================================
 
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.title, p.size_bytes

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -18,12 +18,10 @@ LOAD 'pg_search';
 
 -- GUCs must be visible after the extension loads.
 SHOW paradedb.mpp_debug;
-SHOW paradedb.mpp_worker_count;
 SHOW paradedb.mpp_queue_size;
 
 -- Defaults: the debug knob stays off.
 SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;
-SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default;
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_default;
 
 -- Toggle the boolean GUCs and verify they stick.
@@ -31,27 +29,17 @@ SET paradedb.mpp_debug TO on;
 SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_after_set_on;
 SET paradedb.mpp_debug TO off;
 
--- Worker count: accepts 1..64 per the GUC definition.
-SET paradedb.mpp_worker_count TO 2;
-SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_two;
-SET paradedb.mpp_worker_count TO 4;
-SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_four;
-
--- Out-of-range worker count must fail (GUC min=1, max=64).
+-- The legacy worker-count GUC is gone (#5667): MPP width now comes from
+-- PostgreSQL's own parallelism GUCs (max_parallel_workers_per_gather /
+-- max_parallel_workers), and the plan-first launch sizes the worker pool
+-- from the plan's task fragments. Lock the removal in so a reintroduction
+-- breaks loudly.
 DO $$
 BEGIN
-    BEGIN
-        PERFORM set_config('paradedb.mpp_worker_count', '0', true);
-        RAISE EXCEPTION 'expected worker_count=0 to be rejected';
-    EXCEPTION WHEN invalid_parameter_value THEN
-        RAISE NOTICE 'worker_count=0 correctly rejected';
-    END;
-    BEGIN
-        PERFORM set_config('paradedb.mpp_worker_count', '65', true);
-        RAISE EXCEPTION 'expected worker_count=65 to be rejected';
-    EXCEPTION WHEN invalid_parameter_value THEN
-        RAISE NOTICE 'worker_count=65 correctly rejected';
-    END;
+    PERFORM current_setting('paradedb.mpp_worker_count');
+    RAISE EXCEPTION 'expected paradedb.mpp_worker_count to be removed';
+EXCEPTION WHEN undefined_object THEN
+    RAISE NOTICE 'paradedb.mpp_worker_count correctly removed';
 END$$;
 
 -- Queue size: accepts standard Postgres byte units (kB, MB, GB).
@@ -87,5 +75,4 @@ SELECT 1 AS trivial_query_still_works;
 SET paradedb.mpp_debug TO off;
 
 RESET paradedb.mpp_debug;
-RESET paradedb.mpp_worker_count;
 RESET paradedb.mpp_queue_size;

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -29,19 +29,6 @@ SET paradedb.mpp_debug TO on;
 SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_after_set_on;
 SET paradedb.mpp_debug TO off;
 
--- The legacy worker-count GUC is gone (#5667): MPP width now comes from
--- PostgreSQL's own parallelism GUCs (max_parallel_workers_per_gather /
--- max_parallel_workers), and the plan-first launch sizes the worker pool
--- from the plan's task fragments. Lock the removal in so a reintroduction
--- breaks loudly.
-DO $$
-BEGIN
-    PERFORM current_setting('paradedb.mpp_worker_count');
-    RAISE EXCEPTION 'expected paradedb.mpp_worker_count to be removed';
-EXCEPTION WHEN undefined_object THEN
-    RAISE NOTICE 'paradedb.mpp_worker_count correctly removed';
-END$$;
-
 -- Queue size: accepts standard Postgres byte units (kB, MB, GB).
 SET paradedb.mpp_queue_size TO '32MB';
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_32mb;

--- a/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
@@ -6,8 +6,11 @@
 --     launch exactly 2 producers. EXPLAIN ANALYZE's "MPP Launch:
 --     workers=N" line is the launch's own report of what it spawned.
 --   - 1 segment per table produces no distributable stages: the query
---     runs serially and forks nothing ("MPP Launch" line absent — it is
---     only recorded when the query actually launched).
+--     runs serially ("MPP Launch" line absent), and under
+--     paradedb.mpp_debug no "spawning" trace appears — no launch is
+--     even attempted.
+--   - 4 segments per table under a cap of 2 launch exactly 2 producers;
+--     the extra tasks multiplex and results match the serial run.
 --
 -- Outcomes are collected in a table (not NOTICEs) so the expected
 -- output stays stable under client_min_messages.
@@ -105,13 +108,100 @@ BEGIN
     IF saw_launch THEN
         INSERT INTO mpp_ws_outcome VALUES ('1-segment join: UNEXPECTED distributed launch');
     ELSE
-        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially, no workers forked');
+        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially (no MPP launch recorded)');
     END IF;
 END$$;
 
+-- Four segments per index, cap of 2 (per_gather = 2): more tasks than workers.
+-- The launch must clamp to the cap and the extra tasks multiplex onto the two
+-- producers (dispatch::push_owned_tasks), returning the same results as serial.
+CREATE TABLE mpp_ws4_users    (id bigserial PRIMARY KEY, name text, age int);
+CREATE TABLE mpp_ws4_products (id bigserial PRIMARY KEY, name text, age int);
+CREATE INDEX mpp_ws4_users_idx ON mpp_ws4_users USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX mpp_ws4_products_idx ON mpp_ws4_products USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(1, 2500) g;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(2501, 5000) g;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(5001, 7500) g;
+INSERT INTO mpp_ws4_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(7501, 10000) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(1, 100) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(101, 200) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(201, 300) g;
+INSERT INTO mpp_ws4_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(301, 400) g;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mpp_ws4_users;
+ANALYZE mpp_ws4_products;
+
+SET work_mem TO '64MB';
+DO $$
+DECLARE
+    r record;
+    launched int := -1;
+    serial_cnt bigint;
+    serial_sum bigint;
+    mpp_cnt bigint;
+    mpp_sum bigint;
+    q constant text := 'SELECT count(*), coalesce(sum(id), 0) FROM (
+        SELECT u.id FROM mpp_ws4_users u JOIN mpp_ws4_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 50000) t';
+BEGIN
+    PERFORM set_config('max_parallel_workers_per_gather', '0', false);
+    EXECUTE q INTO serial_cnt, serial_sum;
+
+    PERFORM set_config('max_parallel_workers_per_gather', '2', false);
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF) ' || q LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            launched := (regexp_match(r."QUERY PLAN", 'workers=(\d+)'))[1]::int;
+        END IF;
+    END LOOP;
+    EXECUTE q INTO mpp_cnt, mpp_sum;
+
+    IF launched = 2 AND mpp_cnt = serial_cnt AND mpp_sum = serial_sum THEN
+        INSERT INTO mpp_ws_outcome
+        VALUES ('4-segment join at cap 2: launched 2 producers, results match serial');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('4-segment join at cap 2: UNEXPECTED launched=' || launched
+                || ' rows=' || mpp_cnt || '/' || serial_cnt
+                || ' sum=' || mpp_sum || '/' || serial_sum);
+    END IF;
+END$$;
+RESET work_mem;
+SET max_parallel_workers_per_gather TO 8;
+
+-- A launch attempt traces "spawning N producers" as a WARNING under
+-- paradedb.mpp_debug. The 1-segment query must attempt none, distinguishing
+-- "never launched" from "launched then aborted": expect no warnings below.
+SET paradedb.mpp_debug TO on;
+DO $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT u.id FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        NULL;
+    END LOOP;
+END$$;
+SET paradedb.mpp_debug TO off;
+
 SELECT line FROM mpp_ws_outcome ORDER BY line;
 
-DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products;
+DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products,
+           mpp_ws4_users, mpp_ws4_products;
+RESET paradedb.mpp_debug;
 RESET paradedb.enable_join_custom_scan;
 RESET max_parallel_workers_per_gather;
 RESET max_parallel_workers;

--- a/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
@@ -11,6 +11,9 @@
 --     even attempted.
 --   - 4 segments per table under a cap of 2 launch exactly 2 producers;
 --     the extra tasks multiplex and results match the serial run.
+--   - AggregateScan rides the same launch: a 2-segment GROUP BY join
+--     also launches exactly 2 producers, and its 1-segment variant
+--     attempts no launch.
 --
 -- Outcomes are collected in a table (not NOTICEs) so the expected
 -- output stays stable under client_min_messages.
@@ -19,6 +22,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_aggregate_custom_scan TO on;
 SET max_parallel_workers_per_gather TO 8;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
@@ -112,6 +116,31 @@ BEGIN
     END IF;
 END$$;
 
+-- AggregateScan rides the same plan-first launch: same 2-segment tables under
+-- a cap of 8 must also launch exactly 2 producers.
+DO $$
+DECLARE
+    r record;
+    launched int := -1;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT p.age, count(*) FROM mpp_ws_users u JOIN mpp_ws_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' GROUP BY p.age ORDER BY p.age LIMIT 5'
+    LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            launched := (regexp_match(r."QUERY PLAN", 'workers=(\d+)'))[1]::int;
+        END IF;
+    END LOOP;
+    IF launched = 2 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment aggregate: launched exactly 2 producers');
+    ELSIF launched = -1 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment aggregate: UNEXPECTED serial run (no MPP Launch line)');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('2-segment aggregate: UNEXPECTED worker count ' || launched);
+    END IF;
+END$$;
+
 -- Four segments per index, cap of 2 (per_gather = 2): more tasks than workers.
 -- The launch must clamp to the cap and the extra tasks multiplex onto the two
 -- producers (dispatch::push_owned_tasks), returning the same results as serial.
@@ -194,6 +223,12 @@ BEGIN
     LOOP
         NULL;
     END LOOP;
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT p.age, count(*) FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' GROUP BY p.age ORDER BY p.age LIMIT 5'
+    LOOP
+        NULL;
+    END LOOP;
 END$$;
 SET paradedb.mpp_debug TO off;
 
@@ -202,6 +237,7 @@ SELECT line FROM mpp_ws_outcome ORDER BY line;
 DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products,
            mpp_ws4_users, mpp_ws4_products;
 RESET paradedb.mpp_debug;
+RESET paradedb.enable_aggregate_custom_scan;
 RESET paradedb.enable_join_custom_scan;
 RESET max_parallel_workers_per_gather;
 RESET max_parallel_workers;

--- a/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
@@ -1,0 +1,120 @@
+-- =====================================================================
+-- #5667: the plan-first launch sizes the worker pool from the plan's
+-- task fragments, with PG's parallelism GUCs as the ceiling.
+--
+--   - 2 segments per table under an oversized cap (per_gather = 8) must
+--     launch exactly 2 producers. EXPLAIN ANALYZE's "MPP Launch:
+--     workers=N" line is the launch's own report of what it spawned.
+--   - 1 segment per table produces no distributable stages: the query
+--     runs serially and forks nothing ("MPP Launch" line absent — it is
+--     only recorded when the query actually launched).
+--
+-- Outcomes are collected in a table (not NOTICEs) so the expected
+-- output stays stable under client_min_messages.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 8;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+CREATE TABLE mpp_ws_outcome (line text);
+
+-- Two segments per index: two bulk inserts with the mutable segment disabled.
+CREATE TABLE mpp_ws_users    (id bigserial PRIMARY KEY, name text, age int);
+CREATE TABLE mpp_ws_products (id bigserial PRIMARY KEY, name text, age int);
+CREATE INDEX mpp_ws_users_idx ON mpp_ws_users USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX mpp_ws_products_idx ON mpp_ws_products USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_ws_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(1, 5000) g;
+INSERT INTO mpp_ws_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(5001, 10000) g;
+INSERT INTO mpp_ws_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(1, 5000) g;
+INSERT INTO mpp_ws_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(5001, 10000) g;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mpp_ws_users;
+ANALYZE mpp_ws_products;
+
+-- One segment per index: a single insert each.
+CREATE TABLE mpp_ws1_users    (id bigserial PRIMARY KEY, name text, age int);
+CREATE TABLE mpp_ws1_products (id bigserial PRIMARY KEY, name text, age int);
+CREATE INDEX mpp_ws1_users_idx ON mpp_ws1_users USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX mpp_ws1_products_idx ON mpp_ws1_products USING bm25 (id, name, age)
+WITH (key_field='id', text_fields='{"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_ws1_users (name, age)
+SELECT (ARRAY['bob','alice'])[1 + (g % 2)], g % 50 FROM generate_series(1, 10000) g;
+INSERT INTO mpp_ws1_products (name, age)
+SELECT 'x', g % 50 FROM generate_series(1, 10000) g;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mpp_ws1_users;
+ANALYZE mpp_ws1_products;
+
+-- 2-segment tables, cap of 8 producers: the plan's widest stage has 2
+-- tasks, so the launch must spawn exactly 2 workers, not the cap.
+DO $$
+DECLARE
+    r record;
+    launched int := -1;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT u.id FROM mpp_ws_users u JOIN mpp_ws_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            launched := (regexp_match(r."QUERY PLAN", 'workers=(\d+)'))[1]::int;
+        END IF;
+    END LOOP;
+    IF launched = 2 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment join: launched exactly 2 producers');
+    ELSIF launched = -1 THEN
+        INSERT INTO mpp_ws_outcome VALUES ('2-segment join: UNEXPECTED serial run (no MPP Launch line)');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('2-segment join: UNEXPECTED worker count ' || launched);
+    END IF;
+END$$;
+
+-- 1-segment tables: nothing to distribute, so nothing is forked and no
+-- launch is recorded.
+DO $$
+DECLARE
+    r record;
+    saw_launch boolean := false;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+        SELECT u.id FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        IF r."QUERY PLAN" LIKE '%MPP Launch:%' THEN
+            saw_launch := true;
+        END IF;
+    END LOOP;
+    IF saw_launch THEN
+        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: UNEXPECTED distributed launch');
+    ELSE
+        INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially, no workers forked');
+    END IF;
+END$$;
+
+SELECT line FROM mpp_ws_outcome ORDER BY line;
+
+DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products;
+RESET paradedb.enable_join_custom_scan;
+RESET max_parallel_workers_per_gather;
+RESET max_parallel_workers;
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;

--- a/pg_search/tests/pg_regress/sql/mpp_workmem.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_workmem.sql
@@ -18,8 +18,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
-SET paradedb.mpp_worker_count TO 4;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
 SET parallel_setup_cost TO 0;

--- a/tests/tests/mpp_cancel.rs
+++ b/tests/tests/mpp_cancel.rs
@@ -82,11 +82,11 @@ ANALYZE mpp_orders;
 "#;
 
 // Forces the join through MPP and zeroes the parallel costs so the planner always picks it.
+// MPP width comes from PG's own parallelism GUCs (#5667): per_gather = 2 caps the launch at
+// 2 producers, matching this test's 2-segment tables.
 const MPP_GUCS: &str = r#"
 SET paradedb.enable_join_custom_scan TO on;
-SET paradedb.enable_mpp TO on;
-SET paradedb.mpp_worker_count TO 3;
-SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers_per_gather TO 2;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
 SET parallel_setup_cost TO 0;


### PR DESCRIPTION
## What

Combines #5756 with #5758's two production fixes in an isolated verification branch.

## Why

#5756 enables two-producer MPP at the stock PostgreSQL parallel-worker setting. This draft checks whether #5758's hard task cap and top-level broadcast/shuffle routing fix the concurrent JoinScan CI failures before either PR is merged.

## Validation

- cargo fmt --check
- git diff --check
- GitHub Actions pending