### PR TITLE
fix: Encode/decode dynamic filters during dispatch encode/decode so that dynamic filters survive across fragments

### DIFF
--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -49,6 +49,9 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
 };
 use datafusion_distributed::{TaskEstimation, TaskEstimator};
+use datafusion_proto::physical_plan::{
+    DefaultPhysicalExtensionCodec, PhysicalPlanDecodeContext, PhysicalProtoConverterExtension,
+};
 use futures::Stream;
 use pgrx::pg_sys;
 use tantivy::Score;
@@ -427,7 +430,15 @@ impl PgSearchScanPlan {
     /// readers, visibility checkers) is process-local and gets rebuilt on the receiving worker
     /// from its own `ParallelScanState`. `resolved_query` is the filter-combined,
     /// param-solved query the reader was opened with, so the receiver needs no `ExprContext`.
-    pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
+    ///
+    /// Installed dynamic filters travel as proto expression nodes stamped with their
+    /// `expression_id`; decoding the fragment with a deduplicating proto converter re-shares
+    /// each filter's inner state with the operator that updates it (see
+    /// `deserialize_physical_plan_with_runtime`).
+    pub(crate) fn encode_for_dispatch(
+        &self,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<Vec<u8>> {
         let state_guard = self
             .state
             .lock()
@@ -453,8 +464,21 @@ impl PgSearchScanPlan {
                 DataFusionError::Internal(format!("PgSearchScan dispatch: schema encode: {e}"))
             })?;
 
+        // Dynamic filters self-serialize (columns/literals/comparisons only — no pg_search
+        // extension exprs), so the default codec suffices.
+        let codec = DefaultPhysicalExtensionCodec {};
+        let dynamic_filters = self
+            .dynamic_filters
+            .iter()
+            .map(|f| {
+                let node = proto_converter.physical_expr_to_proto(f, &codec)?;
+                Ok(prost::Message::encode_to_vec(&node))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
         let descriptor = ScanDispatchDescriptor {
             schema_proto: prost::Message::encode_to_vec(&schema_proto),
+            dynamic_filters,
             query: self.resolved_query.clone(),
             score_needed: scanner_config.score_needed,
             sort_order: self.sort_order.clone(),
@@ -479,10 +503,16 @@ impl PgSearchScanPlan {
     /// state. Mirrors the tail of `PgSearchTableProvider::scan_inner`: open the index reader
     /// under the worker's MVCC view, build the fast-field helper + visibility checker, and wrap
     /// a single lazy partition that claims segments at runtime from `parallel_state`.
+    ///
+    /// Dynamic filters decode through `proto_converter` — the fragment-wide deduplicating
+    /// deserializer — so the rebuilt instances share inner state with the copies decoded
+    /// inside the operators that update them (hash-join bounds, aggregate group filters).
     pub(crate) fn decode_for_dispatch(
         buf: &[u8],
         parallel_state: Option<*mut ParallelScanState>,
         expr_context: Option<*mut pg_sys::ExprContext>,
+        ctx: &TaskContext,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let descriptor: ScanDispatchDescriptor = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("PgSearchScan dispatch: deserialize: {e}"))
@@ -497,6 +527,25 @@ impl PgSearchScanPlan {
         let schema: SchemaRef = Arc::new((&schema_proto).try_into().map_err(|e| {
             DataFusionError::Internal(format!("PgSearchScan dispatch: schema parse: {e}"))
         })?);
+
+        let codec = DefaultPhysicalExtensionCodec {};
+        let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &codec);
+        let dynamic_filters = descriptor
+            .dynamic_filters
+            .iter()
+            .map(|bytes| {
+                let node =
+                    <datafusion_proto::protobuf::PhysicalExprNode as prost::Message>::decode(
+                        bytes.as_slice(),
+                    )
+                    .map_err(|e| {
+                        DataFusionError::Internal(format!(
+                            "PgSearchScan dispatch: dynamic filter decode: {e}"
+                        ))
+                    })?;
+                proto_converter.proto_to_physical_expr(&node, schema.as_ref(), &decode_ctx)
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         let index_rel = PgSearchRelation::open(pg_sys::Oid::from(descriptor.indexrelid));
         let heap_rel = PgSearchRelation::open(pg_sys::Oid::from(descriptor.heap_relid));
@@ -573,6 +622,7 @@ impl PgSearchScanPlan {
             descriptor.range_sample,
         );
         plan.assigned_partition = descriptor.assigned_partition;
+        plan.dynamic_filters = dynamic_filters;
         Ok(Arc::new(plan))
     }
 }
@@ -584,6 +634,10 @@ impl PgSearchScanPlan {
 struct ScanDispatchDescriptor {
     /// Arrow schema, `datafusion_proto::protobuf::Schema`-encoded (arrow schema isn't serde).
     schema_proto: Vec<u8>,
+    /// Installed dynamic filters (join-key bounds, top-k thresholds), each a prost-encoded
+    /// `PhysicalExprNode`. Their `expr_id` lets a deduplicating decode re-share one instance
+    /// with the operator that updates it.
+    dynamic_filters: Vec<Vec<u8>>,
     query: SearchQueryInput,
     score_needed: bool,
     sort_order: Option<SortByField>,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -35,8 +35,8 @@ use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::DistributedCodec;
 use datafusion_proto::physical_plan::{
-    ComposedPhysicalExtensionCodec, PhysicalExtensionCodec, PhysicalPlanNodeExt,
-    PhysicalProtoConverterExtension,
+    ComposedPhysicalExtensionCodec, PhysicalExtensionCodec, PhysicalPlanDecodeContext,
+    PhysicalPlanNodeExt, PhysicalProtoConverterExtension,
 };
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use tantivy::index::SegmentId;
@@ -85,7 +85,7 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         buf: &[u8],
         inputs: &[Arc<dyn ExecutionPlan>],
         ctx: &TaskContext,
-        _proto_converter: &dyn PhysicalProtoConverterExtension,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let Some((&tag, payload)) = buf.split_first() else {
             return Err(DataFusionError::Internal(
@@ -97,6 +97,8 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                 payload,
                 self.parallel_state,
                 self.expr_context,
+                ctx,
+                proto_converter,
             ),
             // The deferred execs (visibility ctid resolvers, tantivy lookup, segmented top-k)
             // carry live `FFHelper`s that can't travel. Decode is bottom-up, so the scans below
@@ -149,11 +151,11 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         &self,
         node: Arc<dyn ExecutionPlan>,
         buf: &mut Vec<u8>,
-        _proto_converter: &dyn PhysicalProtoConverterExtension,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<()> {
         if let Some(scan) = node.downcast_ref::<PgSearchScanPlan>() {
             buf.push(TAG_PG_SEARCH_SCAN);
-            buf.extend_from_slice(&scan.encode_for_dispatch()?);
+            buf.extend_from_slice(&scan.encode_for_dispatch(proto_converter)?);
             return Ok(());
         }
         if let Some(vis) = node.downcast_ref::<VisibilityFilterExec>() {
@@ -373,8 +375,9 @@ fn combined_codec(user: PgSearchPhysicalExtensionCodec) -> ComposedPhysicalExten
     ])
 }
 
-/// Serialize one stage's physical subplan for dispatch. Context-free: only the recipe travels,
-/// the receiving worker injects its own runtime state on decode.
+/// Serialize one stage's physical subplan for dispatch. The recipe travels plus the scans'
+/// installed dynamic filters (identity-stamped proto exprs); the receiving worker injects its
+/// own runtime state on decode and re-shares the filters with the operators that update them.
 pub fn serialize_physical_plan(
     plan: Arc<dyn ExecutionPlan>,
     proto_converter: &dyn PhysicalProtoConverterExtension,
@@ -414,21 +417,21 @@ pub fn deserialize_physical_plan_with_runtime(
     let proto = <PhysicalPlanNode as prost::Message>::decode(bytes).map_err(|e| {
         DataFusionError::Internal(format!("Failed to decode dispatched PhysicalPlanNode: {e}"))
     })?;
-    let plan = proto.try_into_physical_plan_with_converter(ctx, &codec, proto_converter)?;
-    // Dynamic filters (hash-join keys, top-k bounds) are process-local Arcs shared between a
-    // node and the scans below it; unless decode re-shares them, each occurrence rebuilds as a
-    // disconnected instance. Re-running the post-optimization pushdown pass on the decoded
-    // fragment re-creates the links, so this task's probe scans prune against its own build
-    // side instead of scanning every segment. The relink is possible only because a fragment
-    // keeps an operator and its probe scans in the same process; a link that crossed fragments
-    // would need the filter values shipped between processes.
+    let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &codec);
+    let plan = proto_converter.proto_to_execution_plan(&proto, &decode_ctx)?;
+    // Dynamic filters (hash-join keys, top-k bounds) are process-local Arcs shared between an
+    // operator and the scans below it, and the two link mechanisms differ:
     //
-    // Prior art: the same pass was proposed for datafusion-distributed
-    // (https://github.com/datafusion-contrib/datafusion-distributed/pull/348) and closed in
-    // favor of fixing it in DataFusion proper, by serializing and deduping dynamic filters so
-    // decode re-shares one instance (https://github.com/apache/datafusion/pull/20416, design
-    // discussion in https://github.com/apache/datafusion/issues/21207). The pinned DataFusion
-    // rev ships that machinery and the MPP worker decodes with `DeduplicatingProtoConverter`;
-    // once the re-shared links are verified end-to-end, this pass can go.
+    // - HashJoinExec/AggregateExec links ride the wire by identity: the scan ships its
+    //   installed filters (`ScanDispatchDescriptor::dynamic_filters`) and the deduplicating
+    //   converter re-shares each with the operator's own decoded copy via `expr_id` (the
+    //   apache/datafusion#20416 machinery; design discussion in
+    //   https://github.com/apache/datafusion/issues/21207). Those operators skip re-pushing
+    //   when they already carry a filter, so this pass cannot relink them.
+    // - SegmentedTopKExec recreates its filter fresh on decode and re-pushes it every Post
+    //   phase, so this pass is what wires the worker's top-k threshold into its scans.
+    //
+    // Both mechanisms are fragment-local; a link that crossed fragments would need the filter
+    // values shipped between processes.
     FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())
 }


### PR DESCRIPTION
## What
This PR fixes the performance regression show in the `join_semi_filter` alternatives 1 and 4 benchmark that was introduced by #5634. 

## How
During dispatch encoding and decoding, use the provided proto converter to encode/decode the dynamic filters.

## Tests
The benchmark run in this PR shows the 50% perf improvement for the 2 `join_semi_filter` benchmarks.