### PR TITLE
ci: (vector) Alert on paired per-query bootstrap instead of a 15% point ratio

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: "Whether to push results to the gh-pages baseline that later runs are diffed against. Only a run on main should; every run compares against the baseline regardless."
     required: false
     default: "false"
+  alert_strategy:
+    description: >-
+      How regressions are detected. "point-ratio": github-action-benchmark alerts when a value
+      exceeds the baseline by 15%. "ci-overlap": alert only when a series' 95% confidence interval
+      sits entirely above the baseline's and the value regressed >5%, so single-run percentile
+      noise (wide tail CIs) cannot fire; series without CIs keep the point-ratio rule.
+    required: false
+    default: "point-ratio"
 
 runs:
   using: "composite"
@@ -79,10 +87,36 @@ runs:
         gh-pages-branch: gh-pages
         auto-push: ${{ inputs.publish }}
         benchmark-data-dir-path: benchmarks
-        alert-threshold: "115%"
+        # Under ci-overlap the compare step below owns alerting; 500% stays as a backstop for
+        # catastrophic regressions in case that step is skipped (e.g. no parseable baseline).
+        alert-threshold: ${{ inputs.alert_strategy == 'ci-overlap' && '500%' || '115%' }}
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us
         alert-comment-cc-users: "@${{ github.actor }}"
         comment-always: ${{ github.event_name == 'pull_request' }}
+
+    # The publish step above appends the current run to its local gh-pages clone, so the script
+    # takes the newest entry from a different commit as the baseline.
+    - name: Compare Against Baseline (CI Overlap)
+      if: inputs.alert_strategy == 'ci-overlap'
+      id: ci_overlap
+      shell: bash
+      run: |
+        python3 "${{ github.action_path }}/compare_baseline.py" \
+          --results benchmarks/results.json \
+          --data-js benchmark-data-repository/benchmarks/data.js \
+          --suite "pg_search '${{ inputs.dataset }} (${{ inputs.index }})' (${{ env.ROWS_LABEL }} rows)" \
+          --sha "${{ github.sha }}" \
+          --out benchmark-alert.md
+
+    - name: Comment on Alert (CI Overlap)
+      if: inputs.alert_strategy == 'ci-overlap' && steps.ci_overlap.outputs.alert == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        printf '\ncc @%s\n' "${{ github.actor }}" >> benchmark-alert.md
+        gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/comments" \
+          -F body=@benchmark-alert.md
 
     - name: Upload Benchmark Results to Slack (push only)
       if: github.ref == 'refs/heads/main'

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -34,12 +34,19 @@ inputs:
     description: "Whether to push results to the gh-pages baseline that later runs are diffed against. Only a run on main should; every run compares against the baseline regardless."
     required: false
     default: "false"
+  alert_threshold:
+    description: >-
+      Ratio of current to baseline value above which github-action-benchmark alerts,
+      e.g. "115%". Callers using the ci-overlap strategy should loosen this into a
+      catastrophic-regression backstop, since the overlap check owns real alerting.
+    required: false
+    default: "115%"
   alert_strategy:
     description: >-
-      How regressions are detected. "point-ratio": github-action-benchmark alerts when a value
-      exceeds the baseline by 15%. "ci-overlap": alert only when a series' 95% confidence interval
-      sits entirely above the baseline's and the value regressed >5%, so single-run percentile
-      noise (wide tail CIs) cannot fire; series without CIs keep the point-ratio rule.
+      How regressions are detected. "point-ratio": only the alert_threshold point comparison.
+      "ci-overlap": additionally alert when a series' 95% confidence interval sits entirely above
+      the baseline's and the value regressed >5%, so single-run percentile noise (wide tail CIs)
+      cannot fire; series without CIs on both sides fall back to a 15% point comparison.
     required: false
     default: "point-ratio"
 
@@ -87,9 +94,7 @@ runs:
         gh-pages-branch: gh-pages
         auto-push: ${{ inputs.publish }}
         benchmark-data-dir-path: benchmarks
-        # Under ci-overlap the compare step below owns alerting; 500% stays as a backstop for
-        # catastrophic regressions in case that step is skipped (e.g. no parseable baseline).
-        alert-threshold: ${{ inputs.alert_strategy == 'ci-overlap' && '500%' || '115%' }}
+        alert-threshold: ${{ inputs.alert_threshold }}
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us
         alert-comment-cc-users: "@${{ github.actor }}"
         comment-always: ${{ github.event_name == 'pull_request' }}

--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Alert on regressions by comparing confidence intervals rather than point values.
+
+The `ci-overlap` alert strategy: a series alerts only when its current confidence
+interval is entirely above the baseline's (the difference exceeds sampling noise)
+AND the point value regressed by more than a practical floor. Series without a
+parseable CI on both sides (index build time/size, pre-CI baselines) fall back to
+the same point-ratio rule github-action-benchmark applies.
+
+Reads the current run's results.json and the gh-pages data.js that the
+github-action-benchmark step has already cloned (and appended the current run to,
+which is why the baseline is the newest entry from a *different* commit).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+CI_RANGE = re.compile(r"95% CI \[([0-9.]+), ([0-9.]+)\]")
+EFFECT_FLOOR = 1.05
+FALLBACK_RATIO = 1.15
+
+
+def parse_ci(range_str):
+    """Extract (lo, hi) from a '95% CI [lo, hi]' range string, or None."""
+    m = CI_RANGE.fullmatch(range_str or "")
+    return (float(m.group(1)), float(m.group(2))) if m else None
+
+
+def load_baseline(data_js_path, suite, current_sha):
+    """Return the suite's newest entry not authored by the current commit."""
+    with open(data_js_path, encoding="utf-8") as f:
+        raw = f.read()
+    data = json.loads(raw[raw.index("=") + 1 :])
+    entries = data.get("entries", {}).get(suite, [])
+    for entry in reversed(entries):
+        if entry["commit"]["id"] != current_sha:
+            return entry
+    return None
+
+
+def write_alert_report(path, suite, baseline, alerts):
+    """Write the alert comment body as a markdown table."""
+    lines = [
+        f"## :warning: Possible performance regression vs `{baseline['commit']['id'][:7]}`",
+        "",
+        "A series alerts when its 95% CI sits entirely above the baseline's and the "
+        f"value regressed >{(EFFECT_FLOOR - 1) * 100:.0f}% (or, without CIs, when the "
+        f"value regressed >{(FALLBACK_RATIO - 1) * 100:.0f}%).",
+        "",
+        f"### {suite}",
+        "",
+        "| Benchmark | Baseline | Current | Ratio | Rule |",
+        "|-|-|-|-|-|",
+    ]
+    for bench, base, ratio, rule in alerts:
+        lines.append(
+            f"| `{bench['name']}` "
+            f"| {base['value']:.3f} {base['unit']} {base.get('range', '')} "
+            f"| {bench['value']:.3f} {bench['unit']} {bench.get('range', '')} "
+            f"| {ratio:.2f}x | {rule} |"
+        )
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def main():
+    """Compare the current results against the baseline and report alerts."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", required=True)
+    parser.add_argument("--data-js", required=True)
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    with open(args.results, encoding="utf-8") as f:
+        current = json.load(f)
+
+    baseline = load_baseline(args.data_js, args.suite, args.sha)
+    if baseline is None:
+        print(f"No baseline entry for suite '{args.suite}'; nothing to compare.")
+        return
+
+    baseline_by_name = {b["name"]: b for b in baseline["benches"]}
+    alerts = []
+    for bench in current:
+        base = baseline_by_name.get(bench["name"])
+        if base is None or base["value"] <= 0:
+            continue
+        ratio = bench["value"] / base["value"]
+        cur_ci, base_ci = parse_ci(bench.get("range")), parse_ci(base.get("range"))
+        if cur_ci and base_ci:
+            regressed = cur_ci[0] > base_ci[1] and ratio > EFFECT_FLOOR
+            rule = "CIs disjoint"
+        else:
+            regressed = ratio > FALLBACK_RATIO
+            rule = "point ratio"
+        if regressed:
+            alerts.append((bench, base, ratio, rule))
+        print(
+            f"{'ALERT' if regressed else 'ok':5} {bench['name']}: "
+            f"{base['value']:.3f} -> {bench['value']:.3f} {bench['unit']} "
+            f"({ratio:.2f}x, {rule})"
+        )
+
+    if alerts:
+        write_alert_report(args.out, args.suite, baseline, alerts)
+
+    if github_output := os.environ.get("GITHUB_OUTPUT"):
+        with open(github_output, "a", encoding="utf-8") as f:
+            f.write(f"alert={'true' if alerts else 'false'}\n")
+    print(f"\n{len(alerts)} alert(s) out of {len(current)} series.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -394,7 +394,7 @@ jobs:
           # ci-overlap owns real alerting; the point threshold stays only as a
           # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
-          alert_threshold: 500%
+          alert_threshold: 200%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
@@ -441,7 +441,7 @@ jobs:
           # ci-overlap owns real alerting; the point threshold stays only as a
           # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
-          alert_threshold: 500%
+          alert_threshold: 200%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -391,7 +391,10 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 1m
+          # ci-overlap owns real alerting; the point threshold stays only as a
+          # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
+          alert_threshold: 500%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
@@ -435,7 +438,10 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 10m
+          # ci-overlap owns real alerting; the point threshold stays only as a
+          # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
+          alert_threshold: 500%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -391,6 +391,7 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 1m
+          alert_strategy: ci-overlap
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
@@ -434,6 +435,7 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 10m
+          alert_strategy: ci-overlap
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}


### PR DESCRIPTION
## What

Adds an `alert_strategy` input to the `benchmark-queries` action. `point-ratio` (default) keeps today's behavior. `paired-bootstrap`, now used by the cohere invocations, publishes each operating point's raw per-vector samples (on its p50 entry, with an FNV-1a hash of the vector set) and alerts when the bootstrapped one-sided lower 95% bound of the paired percentile ratio exceeds 1.15x.

## Why

Vector percentiles come from a single run over ~100 held-out query vectors, so a flat 115% point threshold alerts on sampling noise — the current hnsw baseline has a p95 whose CI spans `[13.8, 21.7]` ms. Comparing independently-computed CIs fixes the false positives but throws away the pairing: baseline and candidate measure the *same* vectors, and a uniform slowdown leaves both CIs overlapping (their width is cross-vector variance, irrelevant to whether the code got slower). Bootstrapping query indices and taking the ratio of paired percentile estimates cancels that variance — less noisy *and* more sensitive. The alert now means: with 95% confidence, the workload percentile regressed by more than 15%.

## How

- `compare_baseline.py` parses the current `results.json` and the gh-pages `data.js` the publish step already clones, and posts a commit comment on alert
- Fallback ladder per series: paired bootstrap (samples + matching vector hash on both sides) → disjoint 95% CIs + 15% floor (percentile entries without baseline samples) → 15% point ratio (build time/size, pre-existing baselines)
- p99 series stay charted but never alert: at n~100 a p99 rests on the top one or two order statistics and cannot evidence a regression
- Under `paired-bootstrap`, github-action-benchmark's threshold is loosened to a 200% backstop for catastrophic regressions in case the compare step is skipped
- stackoverflow invocations are unchanged

On synthetic paired fixtures: a uniform +20% regression alerts on all p50/p95 series via the paired bootstrap; identical runs, +10% shifts, per-query jitter without a shift, and a changed vector set alert on none.

## Rollout

Existing baselines carry no samples, so first runs fall back to the disjoint-CI rule. One `workflow_dispatch` per cohere index on main (with `publish_baseline`) writes sample-bearing baselines; runs after that get the paired test automatically. A label-triggered run on this PR exercises the full pipeline pre-merge (label runs use the PR's actions and harness).