### PR TITLE
feat: work-metered probe knob — remove epsilon, radii SRF, V2 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ CLAUDE.local.md
 
 .github/scripts/verify
 __pycache__
+
+# Lindera dictionary build cache (LINDERA_CACHE); regenerated locally.
+.lindera-cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -2911,7 +2911,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -7912,7 +7912,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -8308,7 +8308,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -8476,7 +8476,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -8088,7 +8088,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8144,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "bitpacking",
 ]
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8167,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8200,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8212,7 +8212,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8225,7 +8225,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c5526969ab6e5d1acf4d2847472129e1cadeb787#c5526969ab6e5d1acf4d2847472129e1cadeb787"
+source = "git+https://github.com/paradedb/tantivy.git?rev=b49a01cf0782ac0da21e69c552456eb4cf20e3b4#b49a01cf0782ac0da21e69c552456eb4cf20e3b4"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ debug-assertions = false
 inherits = "dev"
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "c5526969ab6e5d1acf4d2847472129e1cadeb787", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "b49a01cf0782ac0da21e69c552456eb4cf20e3b4", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -71,7 +71,7 @@ pgrx-tests = "=0.19.0"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c5526969ab6e5d1acf4d2847472129e1cadeb787" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "b49a01cf0782ac0da21e69c552456eb4cf20e3b4" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/benchmarks/datasets/cohere/config.toml
+++ b/benchmarks/datasets/cohere/config.toml
@@ -246,66 +246,56 @@ values = [
   "2000",
 ]
 
-# pg_search: the distance-ratio gate. Runs past 1.0 because 1% at 10m was still climbing at 0.9.
+# pg_search: the probe-budget fraction (paradedb.vector_cluster_max_probe) - the
+# single tuning knob; the distance-ratio epsilon gate was removed (recall/latency
+# now trades off on budget alone; the radius certificate needs no configuration).
 [sweeps.pg_search.knn_top10_unfiltered]
-param = "pg_search_probe_epsilon_unfiltered"
+param = "pg_search_probe_fraction_unfiltered"
 values = [
+  "0.01",
+  "0.015",
+  "0.02",
+  "0.03",
+  "0.04",
+  "0.05",
+  "0.075",
   "0.1",
   "0.15",
   "0.2",
-  "0.25",
   "0.3",
-  "0.35",
-  "0.4",
-  "0.45",
   "0.5",
-  "0.55",
-  "0.6",
-  "0.7",
-  "0.8",
-  "0.9",
-  "1.0",
-  "1.2",
 ]
 
 [sweeps.pg_search.knn_top10_10pct]
-param = "pg_search_probe_epsilon_10pct"
+param = "pg_search_probe_fraction_10pct"
 values = [
+  "0.01",
+  "0.015",
+  "0.02",
+  "0.03",
+  "0.04",
+  "0.05",
+  "0.075",
   "0.1",
   "0.15",
   "0.2",
-  "0.25",
   "0.3",
-  "0.35",
-  "0.4",
-  "0.45",
   "0.5",
-  "0.55",
-  "0.6",
-  "0.7",
-  "0.8",
-  "0.9",
-  "1.0",
-  "1.2",
 ]
 
 [sweeps.pg_search.knn_top10_1pct]
-param = "pg_search_probe_epsilon_1pct"
+param = "pg_search_probe_fraction_1pct"
 values = [
+  "0.01",
+  "0.015",
+  "0.02",
+  "0.03",
+  "0.04",
+  "0.05",
+  "0.075",
   "0.1",
   "0.15",
   "0.2",
-  "0.25",
   "0.3",
-  "0.35",
-  "0.4",
-  "0.45",
   "0.5",
-  "0.55",
-  "0.6",
-  "0.7",
-  "0.8",
-  "0.9",
-  "1.0",
-  "1.2",
 ]

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_10pct.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_10pct.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe=0.2; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_10pct }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_probe_fraction_10pct }}; SELECT _id, title FROM cohere_wiki
 WHERE text @@@ current_setting('cohere.titles_10pct')
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_1pct.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_1pct.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe=0.2; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_1pct }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_probe_fraction_1pct }}; SELECT _id, title FROM cohere_wiki
 WHERE text @@@ current_setting('cohere.titles_1pct')
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_unfiltered.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe=0.2; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_unfiltered }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_probe_fraction_unfiltered }}; SELECT _id, title FROM cohere_wiki
 WHERE _id @@@ paradedb.all()
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/docs/documentation/vector/tuning.mdx
+++ b/docs/documentation/vector/tuning.mdx
@@ -4,27 +4,76 @@ description: Trade recall against latency for vector search
 canonical: https://docs.paradedb.com/documentation/vector/tuning
 ---
 
-Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. Two session-level settings control this tradeoff:
+Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. One session-level setting controls this tradeoff:
 
 ```sql
-SET paradedb.vector_cluster_probe_epsilon = 0.5;
 SET paradedb.vector_cluster_max_probe = 0.02;
 ```
 
-<ParamField body="paradedb.vector_cluster_probe_epsilon" default={0.5}>
-  The primary recall driver. A higher epsilon improves recall by probing more
-  clusters at the expense of higher latency. Think of epsilon as an early
-  termination value, where lower epsilon terminates early more aggressively.
-  When tuning this value, we recommend sweeping in increments of `0.1`. Must be
-  between `0.0` and `100.0`.
-</ParamField>
-
 <ParamField body="paradedb.vector_cluster_max_probe" default={0.02}>
-  A control for tail latency. This setting enforces a ceiling on how many clusters a query may probe. For instance, at the default value of `0.02`, at most 2% of clusters are probed. Must be between `0.000001` and `1.0`, where `1.0` effectively means "no ceiling."
-
-Note that setting this value to `1.0` does not equal exhaustive search, since the epsilon value still drives early termination.
-
+  The probe budget, and the single tuning knob: the fraction of the index's
+  probe **work** a query may spend. One unit of work is one average cluster -
+  a fixed opening share plus a per-vector remainder, charged per unique
+  vector as rows stream - so unusually large clusters cost proportionally
+  more of the budget and replicated copies cost nothing when re-encountered.
+  A full scan costs exactly the cluster count, so the fraction always
+  means "this share of the index's work," and sweep-based tuning
+  self-calibrates. On **replicated** indexes (`cluster_replication > 1`) a
+  fixed fraction buys less candidate volume than it did under the older
+  cluster-count budget - by design, because replicated copies no longer
+  inflate spend - so retune the fraction upward once, roughly by the
+  replication factor, for matched recall; at matched recall the work
+  budget is then faster and much more predictable per query. Raising the
+  fraction improves recall at the cost of latency; sweep upward from the
+  default (e.g. `0.02`, `0.05`, `0.1`) until recall stops improving. Must
+  be between `0.000001` and `1.0`, where `1.0` means "scan everything."
 </ParamField>
+
+Two things happen automatically underneath that budget, neither of which
+needs configuration:
+
+- **The search stops once nothing left can help.** Clusters are examined in
+  order of the best score any vector they hold could possibly achieve, which
+  the index computes from per-cluster radii stored at index time. When the
+  best a cluster could offer is worse than the neighbors already found, the
+  same is true of every cluster behind it, so the query stops there. The
+  proof is exact, so this costs no recall - it just avoids reading the rest.
+- **The candidate clusters may simply run out** (common on small indexes or
+  highly selective filters), and the query finishes under budget.
+
+A query stops for one of three reasons: it proved nothing left can help, it
+spent its budget, or it ran out of clusters. Raising the budget only matters
+for queries that were stopping on it.
+
+### Upgrading an existing index
+
+This release changes the vector index format: every cluster now stores a
+radius, which is what lets a query prove a cluster is safe to skip.
+**Vector indexes built by an earlier release must be rebuilt.** Until they are,
+queries against them fail with an error saying exactly that - they are
+not quietly served by an older code path, because there is no longer one.
+
+The rebuild is two steps, because `REINDEX` writes small build segments
+and clustering happens when segments merge:
+
+```sql
+REINDEX INDEX my_bm25_index;
+VACUUM my_table;   -- schedules the background merge that clusters the segments
+```
+
+`VACUUM` returns immediately; the reorganization completes in the
+background (watch `paradedb.vector_info` until the segment counts
+settle). If you stop after `REINDEX`, the index still answers - flat
+segments are scanned exactly - just without clustering's speedup. An
+index created with `background_layer_sizes = '0'` must re-enable
+background merging first:
+`ALTER INDEX my_bm25_index SET (background_layer_sizes = '100mb');`
+
+Rebuild and retune in the same maintenance window: after the rebuild, a
+replicated index (`cluster_replication > 1`) wants
+`paradedb.vector_cluster_max_probe` raised roughly by its replication
+factor to hold the recall it had before. Both changes arrive together, so
+one sweep after the rebuild is all it takes.
 
 <Note>
   Recall also depends on the index's `centroid_ratio`, set at build time. See

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-KrEw9nRh2Kkpc893iDOfk2cCLPQ36kyqBVEYk4q1Zeo=";
+  cargoHash = "sha256-RnXZ5Ixu2nv1l3ibubb3Xgm68cbedwusgNkBfUffUtM=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-RnXZ5Ixu2nv1l3ibubb3Xgm68cbedwusgNkBfUffUtM=";
+  cargoHash = "sha256-x9lCorLZvifeYA6/OPzPWoUTo0UP/D7Dg7C7zgAL/AA=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.25.0--0.25.1.sql
+++ b/pg_search/sql/pg_search--0.25.0--0.25.1.sql
@@ -1,0 +1,24 @@
+-- Adds ivf_cluster_radii(index regclass, field text): a read-only
+-- set-returning function surfacing the stored per-cluster IVF radii
+-- (`.centroids` slot [3]) of one vector field, one row per cluster per
+-- segment - the observation instrument for the radius-aware probe gate.
+-- Radii are NATIVE-only (rank-0 members; replica spill excluded). A zero
+-- radius is a real value - every native member of that cluster sits on its
+-- centroid - not a missing one: indexes written before radii became
+-- required are refused at open with a REINDEX message and never reach here.
+-- Computes nothing new and adds no on-disk state. The CREATE below is the
+-- SchemaBot/pgrx canonical text verbatim (the schema checker compares
+-- statements textually); the DROP keeps the script re-runnable.
+DROP FUNCTION IF EXISTS ivf_cluster_radii(regclass, text);
+CREATE  FUNCTION "ivf_cluster_radii"(
+	"index" regclass, /* PgRelation */
+	"field" TEXT /* String */
+) RETURNS TABLE (
+	"segno" TEXT,  /* String */
+	"vector_field" TEXT,  /* String */
+	"cluster_ord" INT,  /* i32 */
+	"radius" real  /* f32 */
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'ivf_cluster_radii_wrapper';

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -478,6 +478,84 @@ fn vector_info(
     Ok(TableIterator::new(rows))
 }
 
+/// Returns the stored per-cluster IVF radii of one vector `field` of
+/// `index`, one row per cluster per segment - the observation instrument
+/// for the radius-aware probe gate. The radius is `.centroids` slot `[3]`:
+/// the max stored-representation displacement of the cluster's NATIVE
+/// (rank-0) members from its centroid (chord space for cosine fields).
+/// A zero radius is a real value, not a missing one: it says every native
+/// member of that cluster sits exactly on its centroid. Indexes built
+/// before radii became required do not reach this function at all - they
+/// fail to open, with a message naming REINDEX. Same field resolution and
+/// locking discipline as [`vector_info`]; flat segments contribute no
+/// rows.
+#[allow(clippy::type_complexity)]
+#[pg_extern]
+fn ivf_cluster_radii(
+    index: PgRelation,
+    field: String,
+) -> anyhow::Result<
+    TableIterator<
+        'static,
+        (
+            name!(segno, String),
+            name!(vector_field, String),
+            name!(cluster_ord, i32),
+            name!(radius, f32),
+        ),
+    >,
+> {
+    // # Safety
+    //
+    // Same read-only AccessShareLock discipline as `vector_info`.
+    let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
+    let index_kind = IndexKind::for_index(index.clone())?;
+    if !index.is_usable() {
+        return Ok(TableIterator::new(Vec::new()));
+    }
+
+    let mut rows = Vec::new();
+    for index in index_kind.partitions() {
+        if !index.is_usable() {
+            continue;
+        }
+        let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)?;
+        let resolved = search_reader
+            .schema()
+            .fields()
+            .find_map(|(f, field_entry)| {
+                (field_entry.name() == field
+                    && matches!(
+                        search_reader.schema().get_field_type(field_entry.name()),
+                        Some(SearchFieldType::Vector(..))
+                    ))
+                .then_some(f)
+            });
+        let Some(vector_field) = resolved else {
+            anyhow::bail!("`{field}` is not a vector field of the index");
+        };
+        for segment_reader in search_reader.segment_readers() {
+            let vec_reader = segment_reader.vector_index(vector_field)?;
+            let Some(ivf) = vec_reader.index() else {
+                continue;
+            };
+            let segno = segment_reader.segment_id().short_uuid_string();
+            for cluster in 0..ivf.num_clusters() {
+                rows.push((
+                    segno.clone(),
+                    field.clone(),
+                    cluster as i32,
+                    // `Radius` is the engine's validated type; the SRF
+                    // reports the magnitude.
+                    ivf.cluster_radius(cluster).get(),
+                ));
+            }
+        }
+    }
+
+    Ok(TableIterator::new(rows))
+}
+
 /// Returns the list of segments that contain the specified [`pg_sys::ItemPointerData]` heap tuple
 /// identifier.
 ///

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -206,29 +206,25 @@ static TERM_SET_BITSET_MAX_DENSITY_UNIQUE: GucSetting<f64> = GucSetting::<f64>::
 /// `tantivy::query::TermSetStrategyConfig::default()`.
 static TERM_SET_BITSET_MAX_DENSITY_MULTI: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 200.0);
 
-/// Per-segment ceiling on IVF clusters probed by a vector ORDER BY query,
-/// expressed as a fraction of the segment's own cluster count and resolved
-/// per-segment (`ceil(fraction * num_clusters)`, at least one cluster). A
-/// fraction rather than an absolute count because every segment can have a
-/// different cluster count — an absolute cap scans small segments
-/// exhaustively while barely probing large ones. Default 0.02 (2% of
-/// clusters): with the default 0.01 centroid ratio that is ~2% of ~1% of
-/// rows, in line with SPANN Fig. 2 (99% of SIFT1M queries reach perfect
-/// recall@1 within ~1% of clusters). `1.0` probes every cluster.
+/// The single user-facing tuning knob for IVF vector probing: the
+/// fraction of the index's probe WORK a vector ORDER BY query may spend.
+/// Denominated in work units - 1 unit = one average cluster (a fixed
+/// opening share plus a per-vector remainder, charged per deduplicated
+/// vector as rows stream) - so uneven clusters charge proportionally to
+/// what they actually hold and replicas cost nothing on re-encounter.
+/// An exhaustive scan costs exactly the cluster count (capacity and the
+/// fraction's meaning - "this share of the index's work" - are
+/// unchanged, and sweep-based tuning self-calibrates). Every IVF segment
+/// meters this way; there is no second budget. On REPLICATED indexes a
+/// fixed fraction buys less candidate volume than the old count budget
+/// did - by design, because replicas no longer inflate spend; retune the
+/// fraction upward once (about x the replication factor for matched
+/// recall). Default 0.02. `1.0` scans everything. Allocation is per
+/// segment - f of the index's work, spent where the work is.
 static VECTOR_CLUSTER_MAX_PROBE: GucSetting<f64> = GucSetting::<f64>::new(0.02);
 
 pub fn vector_cluster_max_probe() -> f32 {
     VECTOR_CLUSTER_MAX_PROBE.get() as f32
-}
-
-/// Query-time pruning factor for tantivy's `AdaptiveProbeParams`: how far
-/// past the best centroid the IVF probe loop keeps probing clusters. Lower
-/// epsilon probes fewer clusters, decreasing latency at the expense of
-/// recall. Default `0.5`.
-static VECTOR_CLUSTER_PROBE_EPSILON: GucSetting<f64> = GucSetting::<f64>::new(0.5);
-
-pub fn vector_cluster_probe_epsilon() -> f32 {
-    VECTOR_CLUSTER_PROBE_EPSILON.get() as f32
 }
 
 /// Doc-count boundary at which a merged segment's vector storage switches
@@ -446,22 +442,11 @@ pub fn init() {
 
     GucRegistry::define_float_guc(
         c"paradedb.vector_cluster_max_probe",
-        c"Per-segment IVF cluster probe ceiling, as a fraction of cluster count, for vector ORDER BY queries",
-        c"Fraction of a segment's IVF clusters probed per vector ORDER BY query, resolved per-segment as ceil(fraction * cluster_count) and floored at one cluster. A fraction rather than an absolute count so the ceiling tracks each segment's own cluster count instead of scanning small segments exhaustively and barely probing large ones. 1.0 probes every cluster. Lower values reduce latency at the cost of recall.",
+        c"Fraction of the index's IVF probe work spent per vector ORDER BY query",
+        c"Fraction of the index's IVF probe WORK spent per vector ORDER BY query. One work unit is one average cluster: a fixed opening share plus a per-vector remainder, charged per deduplicated vector as rows stream - uneven clusters charge proportionally and replicas cost nothing on re-encounter. On replicated indexes a fixed fraction buys less candidate volume than the previous cluster-count budget (replicas no longer inflate spend); retune upward once, roughly by the replication factor, for matched recall. 1.0 scans everything.",
         &VECTOR_CLUSTER_MAX_PROBE,
         0.000001,
         1.0,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_float_guc(
-        c"paradedb.vector_cluster_probe_epsilon",
-        c"SPANN-style pruning factor (ε₂) for vector ORDER BY queries",
-        c"How far past the best centroid the IVF probe loop keeps probing clusters. Lower epsilon probes fewer clusters, decreasing latency at the expense of recall.",
-        &VECTOR_CLUSTER_PROBE_EPSILON,
-        0.0,
-        100.0,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -1033,8 +1033,32 @@ impl SearchIndexReader {
                     .and_offset(offset)
                     .order_by_similarity(tantivy_field, query_vector)
                     .with_adaptive_params(AdaptiveProbeParams {
-                        epsilon: crate::gucs::vector_cluster_probe_epsilon(),
                         max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
+                        // Query init is the one place the whole index is in
+                        // hand: prime the global work model (n_bar = native
+                        // docs / clusters across IVF segments) so the
+                        // budget allocates f of the INDEX's work per
+                        // segment. Unprimed, tantivy falls back to
+                        // per-segment normalization.
+                        work_model: match tantivy::vector::ivf::WorkModel::for_searcher(
+                            &self.searcher,
+                            tantivy_field,
+                        ) {
+                            Ok(model) => model,
+                            // Opening a segment's vector index is where an
+                            // index built by an older release is refused
+                            // (its `.centroids` predates required per-cluster
+                            // radii). Surface the reader's own message plus
+                            // the pg-side completion of the remedy: REINDEX
+                            // rebuilds the format, and the follow-up VACUUM
+                            // schedules the merge that restores clustering
+                            // (verified end to end; see tuning.mdx).
+                            Err(err) => pgrx::error!(
+                                "{err} After REINDEX, run VACUUM on the table to restore \
+                                 clustering (the index answers exactly, but slower, until \
+                                 the background merge completes)."
+                            ),
+                        },
                         ..Default::default()
                     });
 

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -1104,3 +1104,70 @@ pub struct ClaimedSegmentData {
     deleted_docs: u32,
     max_doc: u32,
 }
+
+#[cfg(test)]
+mod segment_info_budget_tests {
+    use super::SEGMENT_INFO_MAX_PER_SEG;
+    use tantivy::vector::{
+        IvfSearchMetrics, NeighborhoodGraphSearchMetrics, ProbeStats, ProbeTermination,
+        SearchTerminationReason,
+    };
+
+    /// The DSM slot per primary segment is a FIXED [`SEGMENT_INFO_MAX_PER_SEG`]
+    /// bytes, and `set_segment_info` drops the ENTIRE payload for a segment
+    /// (with a warning) when the JSON exceeds it - parallel queries would
+    /// silently lose that segment's telemetry. This test serializes a
+    /// worst-case `ProbeStats` - radius mode, every counter at the u32 row
+    /// ceiling (10 digits; counters are bounded by per-segment row counts),
+    /// routing graph populated, the longest `termination` variant - and pins
+    /// the byte length against the budget so the NEXT field someone adds
+    /// fails here first, not as a dropped EXPLAIN section in production.
+    #[test]
+    fn worst_case_probe_stats_fits_dsm_segment_info_slot() {
+        let worst = ProbeStats {
+            candidates_scored: u32::MAX as usize,
+            vectors_visited: u32::MAX as usize,
+            pruned_filter: u32::MAX as usize,
+            pruned_dead: u32::MAX as usize,
+            pruned_seen: u32::MAX as usize,
+            postings_row: u32::MAX as usize,
+            postings_skipped: u32::MAX as usize,
+            exact_rows_read: u32::MAX as usize,
+            routing: IvfSearchMetrics {
+                visited_count: u32::MAX as usize,
+                saturated_clusters: u32::MAX as usize,
+                graph: Some(NeighborhoodGraphSearchMetrics {
+                    visited_count: u32::MAX as usize,
+                    expanded_count: u32::MAX as usize,
+                    edges_scanned: u32::MAX as usize,
+                    evictions: u32::MAX as usize,
+                    result_count: u32::MAX as usize,
+                    // Longest variant name wins the byte count.
+                    termination_reason: SearchTerminationReason::SearchConverged,
+                }),
+            },
+            // "Exhausted" is the longest ProbeTermination variant.
+            termination: ProbeTermination::Exhausted,
+            work_charged: f32::MAX, // widest float rendering
+            gate_armed_at_probe: Some(u32::MAX as usize),
+            radius_skips: u32::MAX as usize,
+        };
+        let json = serde_json::to_vec(&worst).expect("ProbeStats serializes");
+        assert!(
+            json.len() <= SEGMENT_INFO_MAX_PER_SEG,
+            "worst-case ProbeStats JSON is {} bytes - over the {}-byte DSM \
+             segment-info slot; parallel EXPLAIN would silently drop this \
+             segment's telemetry. Shrink or #[serde(skip)] a field (or take \
+             the slot size up with its owner).",
+            json.len(),
+            SEGMENT_INFO_MAX_PER_SEG,
+        );
+        // Headroom, stated as a number so budget spend shows up in review.
+        eprintln!(
+            "worst-case ProbeStats JSON: {} bytes; headroom {} of {}",
+            json.len(),
+            SEGMENT_INFO_MAX_PER_SEG - json.len(),
+            SEGMENT_INFO_MAX_PER_SEG,
+        );
+    }
+}

--- a/pg_search/tests/pg_regress/expected/vector_cluster_radii.out
+++ b/pg_search/tests/pg_regress/expected/vector_cluster_radii.out
@@ -1,0 +1,105 @@
+-- paradedb.ivf_cluster_radii: the read-only per-cluster radius dump
+-- (`.centroids` slot [3], NATIVE members only). Structural assertions only -
+-- radius values are f32 distances whose exact digits depend on the trained
+-- centroids, so the test pins shape and invariants, not floats.
+--
+-- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
+-- NOTICE with nondeterministic millisecond values - keep it out of the
+-- captured output.
+SET client_min_messages = WARNING;
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS radii_probe;
+CREATE TABLE radii_probe (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+-- Same forcing recipe as vector_merge: immutable inserts, foreground merges,
+-- a layer that closes at >= 10000 docs so the merge target is IVF-clustered,
+-- with cluster_replication = 3 so replica spill exists for the native-only
+-- fold to exclude.
+CREATE INDEX radii_probe_idx ON radii_probe
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (
+        key_field = id,
+        cluster_replication = 3,
+        target_segment_count = 1,
+        mutable_segment_rows = 0,
+        layer_sizes = '600kb',
+        background_layer_sizes = '0'
+    );
+INSERT INTO radii_probe
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(1, 15000) g;
+-- The merge produced a clustered segment to read radii from.
+SELECT bool_or(vector_format = 'ivf') AS has_ivf
+FROM paradedb.vector_info('radii_probe_idx', 'vec');
+ has_ivf 
+---------
+ t
+(1 row)
+
+-- One radius row per cluster: the radii SRF's (segno, cluster_ord) iteration
+-- covers exactly the clusters vector_info counts.
+SELECT (SELECT count(*) FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'vec'))
+     = (SELECT sum(vector_num_centroids)
+        FROM paradedb.vector_info('radii_probe_idx', 'vec')
+        WHERE vector_format = 'ivf')
+    AS one_radius_per_cluster;
+ one_radius_per_cluster 
+------------------------
+ t
+(1 row)
+
+-- Radii are finite, non-negative, and the corpus (89 distinct points per
+-- dimension pattern) gives at least one cluster real spread.
+SELECT count(*) > 0          AS has_rows,
+       bool_and(radius >= 0) AS non_negative,
+       max(radius) > 0       AS has_spread
+FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'vec');
+ has_rows | non_negative | has_spread 
+----------+--------------+------------
+ t        | t            | t
+(1 row)
+
+-- Native-only sanity: the 89 distinct line points span ||[88,...] - [0,...]||
+-- = 88*4 = 352 end to end; a NATIVE per-cluster radius must be well under a
+-- fraction of that span, while a replica-inclusive fold (3 cells per point)
+-- could drag clusters toward it. Loose bound: every radius under half the
+-- span.
+SELECT bool_and(radius < 176) AS radii_native_tight
+FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'vec');
+ radii_native_tight 
+--------------------
+ t
+(1 row)
+
+-- Asking for a non-vector field is an error, same resolution as vector_info.
+SELECT * FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'id');
+ERROR:  `id` is not a vector field of the index
+-- A flat (unmerged, mutable-only) index contributes no rows - the SRF is
+-- IVF-segments-only, like vector_info's cluster columns.
+DROP TABLE IF EXISTS radii_flat;
+CREATE TABLE radii_flat (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+CREATE INDEX radii_flat_idx ON radii_flat
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (key_field = id);
+INSERT INTO radii_flat
+SELECT g, ('[' || repeat((g % 7)::text || ',', 15) || (g % 7)::text || ']')::vector
+FROM generate_series(1, 50) g;
+SELECT count(*) AS flat_rows FROM paradedb.ivf_cluster_radii('radii_flat_idx', 'vec');
+ flat_rows 
+-----------
+         0
+(1 row)
+
+DROP TABLE radii_probe;
+DROP TABLE radii_flat;

--- a/pg_search/tests/pg_regress/expected/vector_segment_info_parallel.out
+++ b/pg_search/tests/pg_regress/expected/vector_segment_info_parallel.out
@@ -1,0 +1,127 @@
+-- Parallel-plan coverage for EXPLAIN's per-segment vector telemetry: only
+-- parallel scans route Segment Info through the fixed 1024-byte DSM slots
+-- (serial scans keep a backend-local map and never touch them), so the
+-- serial suites cannot catch a payload outgrowing its slot. This test forces
+-- a parallel vector TopK, then asserts structurally over
+-- EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON):
+--   * the scan really ran parallel (workers launched);
+--   * Segment Info covers every segment claimed in Parallel Workers
+--     (both are keyed by short segment UUID);
+--   * every Segment Info entry still carries the probe-stats fields the
+--     harness derives clusters_probed from (postings_row + postings_skipped).
+-- An oversized payload would surface here twice: a "segment explain info ...
+-- exceed ... bytes; skipping" WARNING in the captured output, and a claimed
+-- segment missing from Segment Info.
+--
+-- client_min_messages is pinned to NOTICE for the assertion block: the pgrx
+-- server starts with -c client_min_messages=warning, which would swallow the
+-- success NOTICE; WARNINGs (the DSM overflow signal this test guards) pass
+-- either way.
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS seginfo_par;
+CREATE TABLE seginfo_par (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+-- Same forcing recipe as vector_merge: immutable inserts, foreground merges,
+-- one clustered segment.
+CREATE INDEX seginfo_par_idx ON seginfo_par
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (
+        key_field = id,
+        target_segment_count = 1,
+        mutable_segment_rows = 0,
+        layer_sizes = '600kb',
+        background_layer_sizes = '0'
+    );
+SET client_min_messages = WARNING;
+INSERT INTO seginfo_par
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(1, 15000) g;
+RESET client_min_messages;
+-- Force a parallel TopK plan.
+SET max_parallel_workers_per_gather = 2;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET paradedb.min_rows_per_worker = 1000;
+SET client_min_messages = notice;
+DO $$
+DECLARE
+    plan jsonb;
+    scan jsonb;
+    seg_info jsonb;
+    workers jsonb;
+    launched int;
+    claimed text;
+    claimed_total int := 0;
+    entry record;
+BEGIN
+    EXECUTE 'EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON, COSTS OFF, TIMING OFF, SUMMARY OFF)
+             SELECT id FROM seginfo_par
+             WHERE id @@@ paradedb.all()
+             ORDER BY vec <-> ' || quote_literal('[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]') || '::vector
+             LIMIT 10'
+    INTO plan;
+
+    -- The ParadeDB scan node, wherever it sits in the (Gather-wrapped) tree.
+    scan := jsonb_path_query_first(plan, '$[0].** ? (exists(@."Segment Info"))');
+    IF scan IS NULL THEN
+        RAISE EXCEPTION 'no plan node carries Segment Info: %', plan;
+    END IF;
+    -- add_json emits these as TEXT properties whose value is JSON - re-parse.
+    seg_info := (scan ->> 'Segment Info')::jsonb;
+    workers  := (scan ->> 'Parallel Workers')::jsonb;
+
+    launched := (jsonb_path_query_first(plan, '$[0].** ? (exists(@."Workers Launched"))')
+                   ->> 'Workers Launched')::int;
+    IF launched IS NULL OR launched < 1 THEN
+        RAISE EXCEPTION 'plan did not run parallel (workers launched = %)', launched;
+    END IF;
+
+    IF workers IS NULL THEN
+        RAISE EXCEPTION 'parallel scan emitted no Parallel Workers section: %', scan;
+    END IF;
+
+    -- Every claimed segment must have survived the DSM round-trip into
+    -- Segment Info, with the probe counters intact.
+    FOR entry IN SELECT value FROM jsonb_each(workers)
+    LOOP
+        FOR claimed IN
+            SELECT seg ->> 'id' FROM jsonb_array_elements(entry.value -> 'claimed_segments') seg
+        LOOP
+            claimed_total := claimed_total + 1;
+            IF NOT seg_info ? claimed THEN
+                RAISE EXCEPTION 'claimed segment % missing from Segment Info % (dropped DSM payload?)',
+                    claimed, seg_info;
+            END IF;
+            IF seg_info -> claimed -> 'postings_row' IS NULL
+               OR seg_info -> claimed -> 'postings_skipped' IS NULL THEN
+                RAISE EXCEPTION 'segment % info lacks postings counters: %',
+                    claimed, seg_info -> claimed;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    IF claimed_total < 1 THEN
+        RAISE EXCEPTION 'no segments were claimed by any worker: %', workers;
+    END IF;
+
+    RAISE NOTICE 'parallel segment info intact: % claimed segment(s), % worker(s)',
+        claimed_total, launched;
+END
+$$;
+NOTICE:  parallel segment info intact: 4 claimed segment(s), 2 worker(s)
+RESET client_min_messages;
+RESET max_parallel_workers_per_gather;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET min_parallel_table_scan_size;
+RESET paradedb.min_rows_per_worker;
+DROP TABLE seginfo_par;

--- a/pg_search/tests/pg_regress/expected/vector_uniform_budget.out
+++ b/pg_search/tests/pg_regress/expected/vector_uniform_budget.out
@@ -1,0 +1,125 @@
+-- One budget, one gate policy: every IVF segment meters the same work-unit
+-- budget, and the radius certificate is the only thing besides the budget
+-- that can end a scan. The searcher ranks clusters by the best score any
+-- point in them could reach, so the first cluster that cannot reach the
+-- band settles every cluster behind it. There is no second budget and no
+-- un-metered path to fall into, so this asserts the invariant from the SQL
+-- side, over EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON):
+--   * every segment reports work_charged > 0 -- it was metered in units;
+--   * work_charged <= the segment's cluster count -- the normalization
+--     identity's ceiling (an exhaustive scan costs exactly C units), which
+--     is what keeps the fraction meaning "this share of the index's work";
+--   * the certificate's telemetry fields are present on every segment,
+--     which they can only be if the policy ran.
+--
+-- The negative half of the format contract -- an index built before radii
+-- were required, which now fails to open with a REINDEX message -- cannot
+-- be built here: this binary writes V2 `.centroids` for every index it
+-- creates. That path is covered end-to-end in tantivy
+-- (v1_file_errors_with_reindex_hint, which writes a genuine V1 file) and by
+-- a two-binary upgrade check recorded in the PR.
+--
+-- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
+-- NOTICE with nondeterministic millisecond values -- keep it out of the
+-- captured output, then pin NOTICE for the assertion block's success
+-- message (the pgrx server starts at warning).
+SET client_min_messages = WARNING;
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS budget_probe;
+CREATE TABLE budget_probe (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+-- Same forcing recipe as vector_merge: immutable inserts, foreground merges,
+-- one clustered segment, replicas present so dedup is exercised.
+CREATE INDEX budget_probe_idx ON budget_probe
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (
+        key_field = id,
+        cluster_replication = 2,
+        target_segment_count = 1,
+        mutable_segment_rows = 0,
+        layer_sizes = '600kb',
+        background_layer_sizes = '0'
+    );
+INSERT INTO budget_probe
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(1, 15000) g;
+-- The merge produced a clustered segment to meter.
+SELECT bool_or(vector_format = 'ivf') AS has_ivf
+FROM paradedb.vector_info('budget_probe_idx', 'vec');
+ has_ivf 
+---------
+ t
+(1 row)
+
+SET client_min_messages = notice;
+DO $$
+DECLARE
+    plan jsonb;
+    scan jsonb;
+    seg_info jsonb;
+    seg record;
+    charged double precision;
+    centroids bigint;
+    metered int := 0;
+BEGIN
+    EXECUTE 'EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON, COSTS OFF, TIMING OFF, SUMMARY OFF)
+             SELECT id FROM budget_probe
+             WHERE id @@@ paradedb.all()
+             ORDER BY vec <-> ' || quote_literal('[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]') || '::vector
+             LIMIT 10'
+    INTO plan;
+
+    scan := jsonb_path_query_first(plan, '$[0].** ? (exists(@."Segment Info"))');
+    IF scan IS NULL THEN
+        RAISE EXCEPTION 'no plan node carries Segment Info: %', plan;
+    END IF;
+    -- add_json emits Segment Info as a TEXT property whose value is JSON.
+    seg_info := (scan ->> 'Segment Info')::jsonb;
+
+    FOR seg IN SELECT key AS segno, value AS info FROM jsonb_each(seg_info)
+    LOOP
+        -- Flat segments have no clusters and no budget; skip them.
+        SELECT sum(vector_num_centroids) INTO centroids
+        FROM paradedb.vector_info('budget_probe_idx', 'vec')
+        WHERE vector_format = 'ivf' AND segno = seg.segno;
+        IF centroids IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        charged := (seg.info ->> 'work_charged')::double precision;
+        IF charged IS NULL THEN
+            RAISE EXCEPTION 'segment % reports no work_charged: %', seg.segno, seg.info;
+        END IF;
+        IF charged <= 0 THEN
+            RAISE EXCEPTION 'segment % was not metered (work_charged = %)', seg.segno, charged;
+        END IF;
+        -- Capacity is the cluster count, exactly; nothing may charge past it.
+        IF charged > centroids::double precision + 1e-3 THEN
+            RAISE EXCEPTION 'segment % charged % units past its capacity of %',
+                seg.segno, charged, centroids;
+        END IF;
+        -- The certificate ran: its telemetry is folded in unconditionally.
+        IF NOT (seg.info ? 'radius_skips') OR NOT (seg.info ? 'gate_armed_at_probe') THEN
+            RAISE EXCEPTION 'segment % lacks certificate telemetry: %', seg.segno, seg.info;
+        END IF;
+        metered := metered + 1;
+    END LOOP;
+
+    IF metered < 1 THEN
+        RAISE EXCEPTION 'no IVF segment was metered: %', seg_info;
+    END IF;
+
+    RAISE NOTICE 'work-unit budget metered % IVF segment(s), all within capacity', metered;
+END
+$$;
+NOTICE:  work-unit budget metered 1 IVF segment(s), all within capacity
+RESET client_min_messages;
+DROP TABLE budget_probe;

--- a/pg_search/tests/pg_regress/sql/vector_cluster_radii.sql
+++ b/pg_search/tests/pg_regress/sql/vector_cluster_radii.sql
@@ -1,0 +1,85 @@
+-- paradedb.ivf_cluster_radii: the read-only per-cluster radius dump
+-- (`.centroids` slot [3], NATIVE members only). Structural assertions only -
+-- radius values are f32 distances whose exact digits depend on the trained
+-- centroids, so the test pins shape and invariants, not floats.
+--
+-- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
+-- NOTICE with nondeterministic millisecond values - keep it out of the
+-- captured output.
+SET client_min_messages = WARNING;
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS radii_probe;
+CREATE TABLE radii_probe (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+
+-- Same forcing recipe as vector_merge: immutable inserts, foreground merges,
+-- a layer that closes at >= 10000 docs so the merge target is IVF-clustered,
+-- with cluster_replication = 3 so replica spill exists for the native-only
+-- fold to exclude.
+CREATE INDEX radii_probe_idx ON radii_probe
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (
+        key_field = id,
+        cluster_replication = 3,
+        target_segment_count = 1,
+        mutable_segment_rows = 0,
+        layer_sizes = '600kb',
+        background_layer_sizes = '0'
+    );
+
+INSERT INTO radii_probe
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(1, 15000) g;
+
+-- The merge produced a clustered segment to read radii from.
+SELECT bool_or(vector_format = 'ivf') AS has_ivf
+FROM paradedb.vector_info('radii_probe_idx', 'vec');
+
+-- One radius row per cluster: the radii SRF's (segno, cluster_ord) iteration
+-- covers exactly the clusters vector_info counts.
+SELECT (SELECT count(*) FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'vec'))
+     = (SELECT sum(vector_num_centroids)
+        FROM paradedb.vector_info('radii_probe_idx', 'vec')
+        WHERE vector_format = 'ivf')
+    AS one_radius_per_cluster;
+
+-- Radii are finite, non-negative, and the corpus (89 distinct points per
+-- dimension pattern) gives at least one cluster real spread.
+SELECT count(*) > 0          AS has_rows,
+       bool_and(radius >= 0) AS non_negative,
+       max(radius) > 0       AS has_spread
+FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'vec');
+
+-- Native-only sanity: the 89 distinct line points span ||[88,...] - [0,...]||
+-- = 88*4 = 352 end to end; a NATIVE per-cluster radius must be well under a
+-- fraction of that span, while a replica-inclusive fold (3 cells per point)
+-- could drag clusters toward it. Loose bound: every radius under half the
+-- span.
+SELECT bool_and(radius < 176) AS radii_native_tight
+FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'vec');
+
+-- Asking for a non-vector field is an error, same resolution as vector_info.
+SELECT * FROM paradedb.ivf_cluster_radii('radii_probe_idx', 'id');
+
+-- A flat (unmerged, mutable-only) index contributes no rows - the SRF is
+-- IVF-segments-only, like vector_info's cluster columns.
+DROP TABLE IF EXISTS radii_flat;
+CREATE TABLE radii_flat (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+CREATE INDEX radii_flat_idx ON radii_flat
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (key_field = id);
+INSERT INTO radii_flat
+SELECT g, ('[' || repeat((g % 7)::text || ',', 15) || (g % 7)::text || ']')::vector
+FROM generate_series(1, 50) g;
+
+SELECT count(*) AS flat_rows FROM paradedb.ivf_cluster_radii('radii_flat_idx', 'vec');
+
+DROP TABLE radii_probe;
+DROP TABLE radii_flat;

--- a/pg_search/tests/pg_regress/sql/vector_segment_info_parallel.sql
+++ b/pg_search/tests/pg_regress/sql/vector_segment_info_parallel.sql
@@ -1,0 +1,128 @@
+-- Parallel-plan coverage for EXPLAIN's per-segment vector telemetry: only
+-- parallel scans route Segment Info through the fixed 1024-byte DSM slots
+-- (serial scans keep a backend-local map and never touch them), so the
+-- serial suites cannot catch a payload outgrowing its slot. This test forces
+-- a parallel vector TopK, then asserts structurally over
+-- EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON):
+--   * the scan really ran parallel (workers launched);
+--   * Segment Info covers every segment claimed in Parallel Workers
+--     (both are keyed by short segment UUID);
+--   * every Segment Info entry still carries the probe-stats fields the
+--     harness derives clusters_probed from (postings_row + postings_skipped).
+-- An oversized payload would surface here twice: a "segment explain info ...
+-- exceed ... bytes; skipping" WARNING in the captured output, and a claimed
+-- segment missing from Segment Info.
+--
+-- client_min_messages is pinned to NOTICE for the assertion block: the pgrx
+-- server starts with -c client_min_messages=warning, which would swallow the
+-- success NOTICE; WARNINGs (the DSM overflow signal this test guards) pass
+-- either way.
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS seginfo_par;
+CREATE TABLE seginfo_par (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+
+-- Same forcing recipe as vector_merge: immutable inserts, foreground merges,
+-- one clustered segment.
+CREATE INDEX seginfo_par_idx ON seginfo_par
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (
+        key_field = id,
+        target_segment_count = 1,
+        mutable_segment_rows = 0,
+        layer_sizes = '600kb',
+        background_layer_sizes = '0'
+    );
+
+SET client_min_messages = WARNING;
+INSERT INTO seginfo_par
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(1, 15000) g;
+RESET client_min_messages;
+
+-- Force a parallel TopK plan.
+SET max_parallel_workers_per_gather = 2;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET paradedb.min_rows_per_worker = 1000;
+SET client_min_messages = notice;
+
+DO $$
+DECLARE
+    plan jsonb;
+    scan jsonb;
+    seg_info jsonb;
+    workers jsonb;
+    launched int;
+    claimed text;
+    claimed_total int := 0;
+    entry record;
+BEGIN
+    EXECUTE 'EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON, COSTS OFF, TIMING OFF, SUMMARY OFF)
+             SELECT id FROM seginfo_par
+             WHERE id @@@ paradedb.all()
+             ORDER BY vec <-> ' || quote_literal('[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]') || '::vector
+             LIMIT 10'
+    INTO plan;
+
+    -- The ParadeDB scan node, wherever it sits in the (Gather-wrapped) tree.
+    scan := jsonb_path_query_first(plan, '$[0].** ? (exists(@."Segment Info"))');
+    IF scan IS NULL THEN
+        RAISE EXCEPTION 'no plan node carries Segment Info: %', plan;
+    END IF;
+    -- add_json emits these as TEXT properties whose value is JSON - re-parse.
+    seg_info := (scan ->> 'Segment Info')::jsonb;
+    workers  := (scan ->> 'Parallel Workers')::jsonb;
+
+    launched := (jsonb_path_query_first(plan, '$[0].** ? (exists(@."Workers Launched"))')
+                   ->> 'Workers Launched')::int;
+    IF launched IS NULL OR launched < 1 THEN
+        RAISE EXCEPTION 'plan did not run parallel (workers launched = %)', launched;
+    END IF;
+
+    IF workers IS NULL THEN
+        RAISE EXCEPTION 'parallel scan emitted no Parallel Workers section: %', scan;
+    END IF;
+
+    -- Every claimed segment must have survived the DSM round-trip into
+    -- Segment Info, with the probe counters intact.
+    FOR entry IN SELECT value FROM jsonb_each(workers)
+    LOOP
+        FOR claimed IN
+            SELECT seg ->> 'id' FROM jsonb_array_elements(entry.value -> 'claimed_segments') seg
+        LOOP
+            claimed_total := claimed_total + 1;
+            IF NOT seg_info ? claimed THEN
+                RAISE EXCEPTION 'claimed segment % missing from Segment Info % (dropped DSM payload?)',
+                    claimed, seg_info;
+            END IF;
+            IF seg_info -> claimed -> 'postings_row' IS NULL
+               OR seg_info -> claimed -> 'postings_skipped' IS NULL THEN
+                RAISE EXCEPTION 'segment % info lacks postings counters: %',
+                    claimed, seg_info -> claimed;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    IF claimed_total < 1 THEN
+        RAISE EXCEPTION 'no segments were claimed by any worker: %', workers;
+    END IF;
+
+    RAISE NOTICE 'parallel segment info intact: % claimed segment(s), % worker(s)',
+        claimed_total, launched;
+END
+$$;
+
+RESET client_min_messages;
+RESET max_parallel_workers_per_gather;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET min_parallel_table_scan_size;
+RESET paradedb.min_rows_per_worker;
+
+DROP TABLE seginfo_par;

--- a/pg_search/tests/pg_regress/sql/vector_uniform_budget.sql
+++ b/pg_search/tests/pg_regress/sql/vector_uniform_budget.sql
@@ -1,0 +1,122 @@
+-- One budget, one gate policy: every IVF segment meters the same work-unit
+-- budget, and the radius certificate is the only thing besides the budget
+-- that can end a scan. The searcher ranks clusters by the best score any
+-- point in them could reach, so the first cluster that cannot reach the
+-- band settles every cluster behind it. There is no second budget and no
+-- un-metered path to fall into, so this asserts the invariant from the SQL
+-- side, over EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON):
+--   * every segment reports work_charged > 0 -- it was metered in units;
+--   * work_charged <= the segment's cluster count -- the normalization
+--     identity's ceiling (an exhaustive scan costs exactly C units), which
+--     is what keeps the fraction meaning "this share of the index's work";
+--   * the certificate's telemetry fields are present on every segment,
+--     which they can only be if the policy ran.
+--
+-- The negative half of the format contract -- an index built before radii
+-- were required, which now fails to open with a REINDEX message -- cannot
+-- be built here: this binary writes V2 `.centroids` for every index it
+-- creates. That path is covered end-to-end in tantivy
+-- (v1_file_errors_with_reindex_hint, which writes a genuine V1 file) and by
+-- a two-binary upgrade check recorded in the PR.
+--
+-- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
+-- NOTICE with nondeterministic millisecond values -- keep it out of the
+-- captured output, then pin NOTICE for the assertion block's success
+-- message (the pgrx server starts at warning).
+SET client_min_messages = WARNING;
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS budget_probe;
+CREATE TABLE budget_probe (
+    id  int PRIMARY KEY,
+    vec vector(16)
+);
+
+-- Same forcing recipe as vector_merge: immutable inserts, foreground merges,
+-- one clustered segment, replicas present so dedup is exercised.
+CREATE INDEX budget_probe_idx ON budget_probe
+    USING bm25 (id, vec vector_l2_ops)
+    WITH (
+        key_field = id,
+        cluster_replication = 2,
+        target_segment_count = 1,
+        mutable_segment_rows = 0,
+        layer_sizes = '600kb',
+        background_layer_sizes = '0'
+    );
+
+INSERT INTO budget_probe
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(1, 15000) g;
+
+-- The merge produced a clustered segment to meter.
+SELECT bool_or(vector_format = 'ivf') AS has_ivf
+FROM paradedb.vector_info('budget_probe_idx', 'vec');
+
+SET client_min_messages = notice;
+
+DO $$
+DECLARE
+    plan jsonb;
+    scan jsonb;
+    seg_info jsonb;
+    seg record;
+    charged double precision;
+    centroids bigint;
+    metered int := 0;
+BEGIN
+    EXECUTE 'EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON, COSTS OFF, TIMING OFF, SUMMARY OFF)
+             SELECT id FROM budget_probe
+             WHERE id @@@ paradedb.all()
+             ORDER BY vec <-> ' || quote_literal('[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]') || '::vector
+             LIMIT 10'
+    INTO plan;
+
+    scan := jsonb_path_query_first(plan, '$[0].** ? (exists(@."Segment Info"))');
+    IF scan IS NULL THEN
+        RAISE EXCEPTION 'no plan node carries Segment Info: %', plan;
+    END IF;
+    -- add_json emits Segment Info as a TEXT property whose value is JSON.
+    seg_info := (scan ->> 'Segment Info')::jsonb;
+
+    FOR seg IN SELECT key AS segno, value AS info FROM jsonb_each(seg_info)
+    LOOP
+        -- Flat segments have no clusters and no budget; skip them.
+        SELECT sum(vector_num_centroids) INTO centroids
+        FROM paradedb.vector_info('budget_probe_idx', 'vec')
+        WHERE vector_format = 'ivf' AND segno = seg.segno;
+        IF centroids IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        charged := (seg.info ->> 'work_charged')::double precision;
+        IF charged IS NULL THEN
+            RAISE EXCEPTION 'segment % reports no work_charged: %', seg.segno, seg.info;
+        END IF;
+        IF charged <= 0 THEN
+            RAISE EXCEPTION 'segment % was not metered (work_charged = %)', seg.segno, charged;
+        END IF;
+        -- Capacity is the cluster count, exactly; nothing may charge past it.
+        IF charged > centroids::double precision + 1e-3 THEN
+            RAISE EXCEPTION 'segment % charged % units past its capacity of %',
+                seg.segno, charged, centroids;
+        END IF;
+        -- The certificate ran: its telemetry is folded in unconditionally.
+        IF NOT (seg.info ? 'radius_skips') OR NOT (seg.info ? 'gate_armed_at_probe') THEN
+            RAISE EXCEPTION 'segment % lacks certificate telemetry: %', seg.segno, seg.info;
+        END IF;
+        metered := metered + 1;
+    END LOOP;
+
+    IF metered < 1 THEN
+        RAISE EXCEPTION 'no IVF segment was metered: %', seg_info;
+    END IF;
+
+    RAISE NOTICE 'work-unit budget metered % IVF segment(s), all within capacity', metered;
+END
+$$;
+
+RESET client_min_messages;
+
+DROP TABLE budget_probe;


### PR DESCRIPTION
pg_search side of paradedb/tantivy#192 + paradedb/tantivy#193 + paradedb/tantivy#194. The vector tuning surface
is one knob: `paradedb.vector_cluster_max_probe`, now metering work (a fraction of the
index's total work, in average-cluster units).

- `feat!:` **`paradedb.vector_cluster_probe_epsilon` removed**. A stale `SET` of it is
  silently accepted as an inert placeholder rather than erroring — release-note item.
  `tuning.mdx` rewritten; the CI vector sweeps re-targeted to a 12-point fraction ladder
  (@rebasedming — first cut, reshape as you see fit).
- **`paradedb.ivf_cluster_radii(index, field)`**: per-cluster, per-segment native radii —
  the geometry the certificate uses. A `0` radius is a real value (every native member
  sits on its centroid), and `Infinity` means a degenerate cluster the engine has marked
  permanently unskippable; both are expected output, not display bugs.
- **Extension version bumped to 0.25.1** with the SRF in a new
  `pg_search--0.25.0--0.25.1.sql` upgrade script. v0.25.0's scripts are tagged and stay
  untouched.
- DSM telemetry pinned (worst-case `ProbeStats` against the 1024-byte slot) plus a
  parallel regress case proving the publish/take round trip.

## Migration

One event. On upgrade, pre-V2 vector indexes error at open with the remedy in the
message: `REINDEX`, then `VACUUM` — REINDEX alone leaves flat build segments, since
clustering happens at merge. Verified end to end; transcript in the first comment.

Note for the release: the version stamp also covers `.vec`, so **downgrading after this
upgrade requires another rebuild** — the old binary will not read the new files either.

## Tests

Full regress green. Merge after paradedb/tantivy#194; re-pin both Cargo entries
(workspace `tantivy` and the `tantivy-tokenizer-api` patch) to its merge commit first.