### PR TITLE
chore: switch to forked metrics publishing action

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -68,7 +68,7 @@ runs:
       run: rm -rf ./benchmark-data-repository
 
     - name: Publish Benchmark Metrics
-      uses: benchmark-action/github-action-benchmark@v1
+      uses: paradedb/github-action-benchmark@pdb-v1
       with:
         name: "pg_search '${{ inputs.dataset }} (${{ inputs.index }})' (${{ env.ROWS_LABEL }} rows)"
         ref: ${{ inputs.ref }}

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -68,7 +68,7 @@ runs:
       run: rm -rf ./benchmark-data-repository
 
     - name: Publish Benchmark Metrics
-      uses: paradedb/github-action-benchmark@pdb-v1
+      uses: paradedb/github-action-benchmark@v1
       with:
         name: "pg_search '${{ inputs.dataset }} (${{ inputs.index }})' (${{ env.ROWS_LABEL }} rows)"
         ref: ${{ inputs.ref }}

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -131,7 +131,7 @@ runs:
       run: rm -rf ./benchmark-data-repository
 
     - name: Publish TPS Metrics
-      uses: benchmark-action/github-action-benchmark@v1
+      uses: paradedb/github-action-benchmark@pdb-v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - TPS"
         ref: ${{ inputs.ref }}
@@ -153,7 +153,7 @@ runs:
       run: rm -rf ./benchmark-data-repository
 
     - name: Publish Other Metrics
-      uses: benchmark-action/github-action-benchmark@v1
+      uses: paradedb/github-action-benchmark@pdb-v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - Other Metrics"
         ref: ${{ inputs.ref }}

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -131,7 +131,7 @@ runs:
       run: rm -rf ./benchmark-data-repository
 
     - name: Publish TPS Metrics
-      uses: paradedb/github-action-benchmark@pdb-v1
+      uses: paradedb/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - TPS"
         ref: ${{ inputs.ref }}
@@ -153,7 +153,7 @@ runs:
       run: rm -rf ./benchmark-data-repository
 
     - name: Publish Other Metrics
-      uses: paradedb/github-action-benchmark@pdb-v1
+      uses: paradedb/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - Other Metrics"
         ref: ${{ inputs.ref }}


### PR DESCRIPTION
## What
Changes our use of the benchmarking action to our forked version of it.

## Why
We now regularly have benchmarking runs delayed for 10+ minutes (with some up to an hour) due to contention over pushing commits to the `gh-pages` branch. The main reason for this is that the official action clones our entire repo each attempt (which can take a while). Our fork of it does a shallow-clone of only the `gh-pages` branch, which is significantly faster.

