### PR TITLE
ci: Improve rigor of vector regression test

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -45,7 +45,7 @@ inputs:
     description: >-
       How regressions are detected. "point-ratio": only the alert_threshold point comparison.
       "paired-bootstrap": percentile series whose runs published per-query samples alert when the
-      bootstrapped lower 95% bound of the paired percentile ratio exceeds 1.05x -- pairing cancels
+      bootstrapped lower 95% bound of the paired percentile ratio exceeds 1.15x -- pairing cancels
       cross-query latency variance, so this is both less noisy and more sensitive than a point
       comparison. Series without samples fall back to disjoint-CI, then 15% point comparisons.
       p99 series stay charted but never alert; a single-run p99 cannot evidence a regression.

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: "Whether to push results to the gh-pages baseline that later runs are diffed against. Only a run on main should; every run compares against the baseline regardless."
     required: false
     default: "false"
+  alert_strategy:
+    description: >-
+      How regressions are detected. "point-ratio": github-action-benchmark alerts when a value
+      exceeds the baseline by 15%. "ci-overlap": alert only when a series' 95% confidence interval
+      sits entirely above the baseline's and the value regressed >5%, so single-run percentile
+      noise (wide tail CIs) cannot fire; series without CIs keep the point-ratio rule.
+    required: false
+    default: "point-ratio"
 
 runs:
   using: "composite"
@@ -79,10 +87,36 @@ runs:
         gh-pages-branch: gh-pages
         auto-push: ${{ inputs.publish }}
         benchmark-data-dir-path: benchmarks
-        alert-threshold: "115%"
+        # Under ci-overlap the compare step below owns alerting; 500% stays as a backstop for
+        # catastrophic regressions in case that step is skipped (e.g. no parseable baseline).
+        alert-threshold: ${{ inputs.alert_strategy == 'ci-overlap' && '500%' || '115%' }}
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us
         alert-comment-cc-users: "@${{ github.actor }}"
         comment-always: ${{ github.event_name == 'pull_request' }}
+
+    # The publish step above appends the current run to its local gh-pages clone, so the script
+    # takes the newest entry from a different commit as the baseline.
+    - name: Compare Against Baseline (CI Overlap)
+      if: inputs.alert_strategy == 'ci-overlap'
+      id: ci_overlap
+      shell: bash
+      run: |
+        python3 "${{ github.action_path }}/compare_baseline.py" \
+          --results benchmarks/results.json \
+          --data-js benchmark-data-repository/benchmarks/data.js \
+          --suite "pg_search '${{ inputs.dataset }} (${{ inputs.index }})' (${{ env.ROWS_LABEL }} rows)" \
+          --sha "${{ github.sha }}" \
+          --out benchmark-alert.md
+
+    - name: Comment on Alert (CI Overlap)
+      if: inputs.alert_strategy == 'ci-overlap' && steps.ci_overlap.outputs.alert == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        printf '\ncc @%s\n' "${{ github.actor }}" >> benchmark-alert.md
+        gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/comments" \
+          -F body=@benchmark-alert.md
 
     - name: Upload Benchmark Results to Slack (push only)
       if: github.ref == 'refs/heads/main'

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -102,7 +102,7 @@ runs:
         comment-always: ${{ github.event_name == 'pull_request' }}
 
     # The publish step above appends the current run to its local gh-pages clone, so the script
-    # takes the newest entry from a different commit as the baseline.
+    # takes the second-to-last entry as the baseline.
     - name: Compare Against Baseline (Paired Bootstrap)
       if: inputs.alert_strategy == 'paired-bootstrap'
       id: paired_bootstrap
@@ -112,7 +112,6 @@ runs:
           --results benchmarks/results.json \
           --data-js benchmark-data-repository/benchmarks/data.js \
           --suite "pg_search '${{ inputs.dataset }} (${{ inputs.index }})' (${{ env.ROWS_LABEL }} rows)" \
-          --sha "${{ github.sha }}" \
           --out benchmark-alert.md
 
     - name: Comment on Alert (Paired Bootstrap)

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -34,12 +34,19 @@ inputs:
     description: "Whether to push results to the gh-pages baseline that later runs are diffed against. Only a run on main should; every run compares against the baseline regardless."
     required: false
     default: "false"
+  alert_threshold:
+    description: >-
+      Ratio of current to baseline value above which github-action-benchmark alerts,
+      e.g. "115%". Callers using the ci-overlap strategy should loosen this into a
+      catastrophic-regression backstop, since the overlap check owns real alerting.
+    required: false
+    default: "115%"
   alert_strategy:
     description: >-
-      How regressions are detected. "point-ratio": github-action-benchmark alerts when a value
-      exceeds the baseline by 15%. "ci-overlap": alert only when a series' 95% confidence interval
-      sits entirely above the baseline's and the value regressed >5%, so single-run percentile
-      noise (wide tail CIs) cannot fire; series without CIs keep the point-ratio rule.
+      How regressions are detected. "point-ratio": only the alert_threshold point comparison.
+      "ci-overlap": additionally alert when a series' 95% confidence interval sits entirely above
+      the baseline's and the value regressed >5%, so single-run percentile noise (wide tail CIs)
+      cannot fire; series without CIs on both sides fall back to a 15% point comparison.
     required: false
     default: "point-ratio"
 
@@ -87,9 +94,7 @@ runs:
         gh-pages-branch: gh-pages
         auto-push: ${{ inputs.publish }}
         benchmark-data-dir-path: benchmarks
-        # Under ci-overlap the compare step below owns alerting; 500% stays as a backstop for
-        # catastrophic regressions in case that step is skipped (e.g. no parseable baseline).
-        alert-threshold: ${{ inputs.alert_strategy == 'ci-overlap' && '500%' || '115%' }}
+        alert-threshold: ${{ inputs.alert_threshold }}
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us
         alert-comment-cc-users: "@${{ github.actor }}"
         comment-always: ${{ github.event_name == 'pull_request' }}

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -37,16 +37,17 @@ inputs:
   alert_threshold:
     description: >-
       Ratio of current to baseline value above which github-action-benchmark alerts,
-      e.g. "115%". Callers using the ci-overlap strategy should loosen this into a
-      catastrophic-regression backstop, since the overlap check owns real alerting.
+      e.g. "115%". Callers using the paired-bootstrap strategy should loosen this into a
+      catastrophic-regression backstop, since the comparison script owns real alerting.
     required: false
     default: "115%"
   alert_strategy:
     description: >-
       How regressions are detected. "point-ratio": only the alert_threshold point comparison.
-      "ci-overlap": additionally alert when a series' 95% confidence interval sits entirely above
-      the baseline's and the value regressed >5%, so single-run percentile noise (wide tail CIs)
-      cannot fire; series without CIs on both sides fall back to a 15% point comparison.
+      "paired-bootstrap": percentile series whose runs published per-query samples alert when the
+      bootstrapped lower 95% bound of the paired percentile ratio exceeds 1.05x -- pairing cancels
+      cross-query latency variance, so this is both less noisy and more sensitive than a point
+      comparison. Series without samples fall back to disjoint-CI, then 15% point comparisons.
     required: false
     default: "point-ratio"
 
@@ -101,9 +102,9 @@ runs:
 
     # The publish step above appends the current run to its local gh-pages clone, so the script
     # takes the newest entry from a different commit as the baseline.
-    - name: Compare Against Baseline (CI Overlap)
-      if: inputs.alert_strategy == 'ci-overlap'
-      id: ci_overlap
+    - name: Compare Against Baseline (Paired Bootstrap)
+      if: inputs.alert_strategy == 'paired-bootstrap'
+      id: paired_bootstrap
       shell: bash
       run: |
         python3 "${{ github.action_path }}/compare_baseline.py" \
@@ -113,8 +114,8 @@ runs:
           --sha "${{ github.sha }}" \
           --out benchmark-alert.md
 
-    - name: Comment on Alert (CI Overlap)
-      if: inputs.alert_strategy == 'ci-overlap' && steps.ci_overlap.outputs.alert == 'true'
+    - name: Comment on Alert (Paired Bootstrap)
+      if: inputs.alert_strategy == 'paired-bootstrap' && steps.paired_bootstrap.outputs.alert == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -48,6 +48,7 @@ inputs:
       bootstrapped lower 95% bound of the paired percentile ratio exceeds 1.05x -- pairing cancels
       cross-query latency variance, so this is both less noisy and more sensitive than a point
       comparison. Series without samples fall back to disjoint-CI, then 15% point comparisons.
+      p99 series stay charted but never alert; a single-run p99 cannot evidence a regression.
     required: false
     default: "point-ratio"
 

--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -74,8 +74,8 @@ def percentile_of(sorted_values, q):
     return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * (rank - lo)
 
 
-def paired_lower_bounds(base, cand):
-    """One-sided lower 95% bounds of the paired percentile ratios, per label.
+def paired_ratio_stats(base, cand):
+    """Per label, the (median, one-sided lower 95% bound) of the paired percentile ratio.
 
     Bootstraps query indices: each resample recomputes both sides' percentile over
     the same indices, so the statistic is the ratio of paired percentile estimates.
@@ -92,7 +92,10 @@ def paired_lower_bounds(base, cand):
             if base_q > 0:
                 stats[label].append(percentile_of(cand_sorted, q) / base_q)
     return {
-        label: sorted(ratios)[int((1 - CONFIDENCE) * len(ratios))]
+        label: (
+            sorted(ratios)[len(ratios) // 2],
+            sorted(ratios)[int((1 - CONFIDENCE) * len(ratios))],
+        )
         for label, ratios in stats.items()
         if ratios
     }
@@ -124,24 +127,38 @@ def pairable(cur_groups, base_groups, group):
     )
 
 
-def judge(bench, base, cur_groups, base_groups, bounds_cache):
-    """Return (regressed, rule) for one series under the strategy ladder."""
+def judge(bench, base, cur_groups, base_groups, stats_cache):
+    """Return (regressed, rule, ratio_display) for one series under the strategy ladder.
+
+    ratio_display is the statistic the decision was made on, so tables and logs stay
+    consistent with the alert: the bootstrapped ratio for paired series, the raw point
+    ratio otherwise.
+    """
     ratio = bench["value"] / base["value"]
     group, sep, label = bench["name"].rpartition(" - ")
     if sep and label in NEVER_ALERT:
-        return False, f"{label} charted but not alerted"
+        return False, f"{label} charted but not alerted", f"{ratio:.2f}x"
     if sep and label in QUANTILES and pairable(cur_groups, base_groups, group):
-        if group not in bounds_cache:
-            bounds_cache[group] = paired_lower_bounds(
+        if group not in stats_cache:
+            stats_cache[group] = paired_ratio_stats(
                 base_groups[group][1], cur_groups[group][1]
             )
-        bound = bounds_cache[group].get(label)
-        if bound is not None:
-            return bound > EFFECT_FLOOR, f"paired bootstrap (lower bound {bound:.2f}x)"
+        stats = stats_cache[group].get(label)
+        if stats is not None:
+            median, bound = stats
+            return (
+                bound > EFFECT_FLOOR,
+                "paired bootstrap",
+                f"{median:.2f}x (>={bound:.2f}x at 95%)",
+            )
     cur_ci, base_ci = parse_ci(bench.get("range")), parse_ci(base.get("range"))
     if cur_ci and base_ci:
-        return cur_ci[0] > base_ci[1] and ratio > EFFECT_FLOOR, "CIs disjoint"
-    return ratio > FALLBACK_RATIO, "point ratio"
+        return (
+            cur_ci[0] > base_ci[1] and ratio > EFFECT_FLOOR,
+            "CIs disjoint",
+            f"{ratio:.2f}x",
+        )
+    return ratio > FALLBACK_RATIO, "point ratio", f"{ratio:.2f}x"
 
 
 def write_alert_report(path, suite, baseline, alerts):
@@ -160,12 +177,12 @@ def write_alert_report(path, suite, baseline, alerts):
         "| Benchmark | Baseline | Current | Ratio | Rule |",
         "|-|-|-|-|-|",
     ]
-    for bench, base, ratio, rule in alerts:
+    for bench, base, ratio_display, rule in alerts:
         lines.append(
             f"| `{bench['name']}` "
             f"| {base['value']:.3f} {base['unit']} {base.get('range', '')} "
             f"| {bench['value']:.3f} {bench['unit']} {bench.get('range', '')} "
-            f"| {ratio:.2f}x | {rule} |"
+            f"| {ratio_display} | {rule} |"
         )
     with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
@@ -176,20 +193,21 @@ def collect_alerts(current, baseline):
     baseline_by_name = {b["name"]: b for b in baseline["benches"]}
     cur_groups = samples_by_group(current)
     base_groups = samples_by_group(baseline["benches"])
-    bounds_cache = {}
+    stats_cache = {}
     alerts = []
     for bench in current:
         base = baseline_by_name.get(bench["name"])
         if base is None or base["value"] <= 0:
             continue
-        regressed, rule = judge(bench, base, cur_groups, base_groups, bounds_cache)
-        ratio = bench["value"] / base["value"]
+        regressed, rule, ratio_display = judge(
+            bench, base, cur_groups, base_groups, stats_cache
+        )
         if regressed:
-            alerts.append((bench, base, ratio, rule))
+            alerts.append((bench, base, ratio_display, rule))
         print(
             f"{'ALERT' if regressed else 'ok':5} {bench['name']}: "
             f"{base['value']:.3f} -> {bench['value']:.3f} {bench['unit']} "
-            f"({ratio:.2f}x, {rule})"
+            f"({ratio_display}, {rule})"
         )
     return alerts
 

--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
-"""Alert on regressions by comparing confidence intervals rather than point values.
+"""Alert on regressions using paired per-query statistics rather than point values.
 
-The `ci-overlap` alert strategy: a series alerts only when its current confidence
-interval is entirely above the baseline's (the difference exceeds sampling noise)
-AND the point value regressed by more than a practical floor. Series without a
-parseable CI on both sides (index build time/size, pre-CI baselines) fall back to
-the same point-ratio rule github-action-benchmark applies.
+Baseline and candidate runs measure the same held-out query vectors, so their samples
+pair up index-by-index. For each operating point that published raw samples on both
+sides (carried in the p50 entry's `extra`), query indices are bootstrapped and each
+percentile series alerts when the one-sided lower 95% bound of the paired percentile
+ratio exceeds a practical floor. Pairing cancels cross-query latency variance, which
+dominates the width of the single-run percentile CIs but is irrelevant to whether the
+code got slower.
+
+Fallbacks, in order, for series where pairing isn't possible: disjoint 95% CIs plus
+the same floor (percentile entries without baseline samples), then the plain point
+ratio github-action-benchmark applies (build time/size, pre-CI baselines).
 
 Reads the current run's results.json and the gh-pages data.js that the
 github-action-benchmark step has already cloned (and appended the current run to,
@@ -14,19 +20,79 @@ which is why the baseline is the newest entry from a *different* commit).
 
 import argparse
 import json
+import math
 import os
+import random
 import re
 import sys
 
 CI_RANGE = re.compile(r"95% CI \[([0-9.]+), ([0-9.]+)\]")
+SAMPLES = re.compile(r"samples_fnv=([0-9a-f]{16}); samples=\[([0-9.,eE+-]*)\]")
+QUANTILES = {"p50": 0.50, "p95": 0.95, "p99": 0.99}
 EFFECT_FLOOR = 1.05
 FALLBACK_RATIO = 1.15
+BOOTSTRAP_RESAMPLES = 10_000
+CONFIDENCE = 0.95
 
 
 def parse_ci(range_str):
     """Extract (lo, hi) from a '95% CI [lo, hi]' range string, or None."""
     m = CI_RANGE.fullmatch(range_str or "")
     return (float(m.group(1)), float(m.group(2))) if m else None
+
+
+def parse_samples(extra):
+    """Extract (vector_hash, [latencies]) from an entry's extra, or None."""
+    m = SAMPLES.search(extra or "")
+    if not m:
+        return None
+    values = [float(v) for v in m.group(2).split(",") if v]
+    return (m.group(1), values) if values else None
+
+
+def samples_by_group(benches):
+    """Map operating point -> (vector_hash, samples) from its p50 carrier entry."""
+    groups = {}
+    for bench in benches:
+        group, sep, label = bench["name"].rpartition(" - ")
+        if sep and label == "p50":
+            parsed = parse_samples(bench.get("extra"))
+            if parsed:
+                groups[group] = parsed
+    return groups
+
+
+def percentile_of(sorted_values, q):
+    """Linearly interpolated quantile, matching the Rust percentile()."""
+    rank = q * (len(sorted_values) - 1)
+    lo, hi = math.floor(rank), math.ceil(rank)
+    if lo == hi:
+        return sorted_values[lo]
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * (rank - lo)
+
+
+def paired_lower_bounds(base, cand):
+    """One-sided lower 95% bounds of the paired percentile ratios, per label.
+
+    Bootstraps query indices: each resample recomputes both sides' percentile over
+    the same indices, so the statistic is the ratio of paired percentile estimates.
+    """
+    n = len(base)
+    rng = random.Random(0)
+    stats = {label: [] for label in QUANTILES}
+    for _ in range(BOOTSTRAP_RESAMPLES):
+        ids = rng.choices(range(n), k=n)
+        base_sorted = sorted(base[i] for i in ids)
+        cand_sorted = sorted(cand[i] for i in ids)
+        for label, q in QUANTILES.items():
+            base_q = percentile_of(base_sorted, q)
+            if base_q > 0:
+                stats[label].append(percentile_of(cand_sorted, q) / base_q)
+    return {
+        label: sorted(ratios)[int((1 - CONFIDENCE) * len(ratios))]
+        for label, ratios in stats.items()
+        if ratios
+    }
 
 
 def load_baseline(data_js_path, suite, current_sha):
@@ -41,14 +107,45 @@ def load_baseline(data_js_path, suite, current_sha):
     return None
 
 
+def pairable(cur_groups, base_groups, group):
+    """True when both sides published samples for the same vector set."""
+    cur, base = cur_groups.get(group), base_groups.get(group)
+    return (
+        cur is not None
+        and base is not None
+        and cur[0] == base[0]
+        and len(cur[1]) == len(base[1])
+    )
+
+
+def judge(bench, base, cur_groups, base_groups, bounds_cache):
+    """Return (regressed, rule) for one series under the strategy ladder."""
+    ratio = bench["value"] / base["value"]
+    group, sep, label = bench["name"].rpartition(" - ")
+    if sep and label in QUANTILES and pairable(cur_groups, base_groups, group):
+        if group not in bounds_cache:
+            bounds_cache[group] = paired_lower_bounds(
+                base_groups[group][1], cur_groups[group][1]
+            )
+        bound = bounds_cache[group].get(label)
+        if bound is not None:
+            return bound > EFFECT_FLOOR, f"paired bootstrap (lower bound {bound:.2f}x)"
+    cur_ci, base_ci = parse_ci(bench.get("range")), parse_ci(base.get("range"))
+    if cur_ci and base_ci:
+        return cur_ci[0] > base_ci[1] and ratio > EFFECT_FLOOR, "CIs disjoint"
+    return ratio > FALLBACK_RATIO, "point ratio"
+
+
 def write_alert_report(path, suite, baseline, alerts):
     """Write the alert comment body as a markdown table."""
     lines = [
         f"## :warning: Possible performance regression vs `{baseline['commit']['id'][:7]}`",
         "",
-        "A series alerts when its 95% CI sits entirely above the baseline's and the "
-        f"value regressed >{(EFFECT_FLOOR - 1) * 100:.0f}% (or, without CIs, when the "
-        f"value regressed >{(FALLBACK_RATIO - 1) * 100:.0f}%).",
+        "Percentile series with paired per-query samples alert when the bootstrapped "
+        "one-sided lower 95% bound of the paired percentile ratio exceeds "
+        f"{EFFECT_FLOOR:.2f}x. Without samples, a series alerts when its 95% CI sits "
+        f"entirely above the baseline's and the value regressed >{EFFECT_FLOOR:.2f}x; "
+        f"without CIs, when the value regressed >{FALLBACK_RATIO:.2f}x.",
         "",
         f"### {suite}",
         "",
@@ -64,6 +161,29 @@ def write_alert_report(path, suite, baseline, alerts):
         )
     with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
+
+
+def collect_alerts(current, baseline):
+    """Judge every current series against the baseline; return the regressed ones."""
+    baseline_by_name = {b["name"]: b for b in baseline["benches"]}
+    cur_groups = samples_by_group(current)
+    base_groups = samples_by_group(baseline["benches"])
+    bounds_cache = {}
+    alerts = []
+    for bench in current:
+        base = baseline_by_name.get(bench["name"])
+        if base is None or base["value"] <= 0:
+            continue
+        regressed, rule = judge(bench, base, cur_groups, base_groups, bounds_cache)
+        ratio = bench["value"] / base["value"]
+        if regressed:
+            alerts.append((bench, base, ratio, rule))
+        print(
+            f"{'ALERT' if regressed else 'ok':5} {bench['name']}: "
+            f"{base['value']:.3f} -> {bench['value']:.3f} {bench['unit']} "
+            f"({ratio:.2f}x, {rule})"
+        )
+    return alerts
 
 
 def main():
@@ -84,28 +204,7 @@ def main():
         print(f"No baseline entry for suite '{args.suite}'; nothing to compare.")
         return
 
-    baseline_by_name = {b["name"]: b for b in baseline["benches"]}
-    alerts = []
-    for bench in current:
-        base = baseline_by_name.get(bench["name"])
-        if base is None or base["value"] <= 0:
-            continue
-        ratio = bench["value"] / base["value"]
-        cur_ci, base_ci = parse_ci(bench.get("range")), parse_ci(base.get("range"))
-        if cur_ci and base_ci:
-            regressed = cur_ci[0] > base_ci[1] and ratio > EFFECT_FLOOR
-            rule = "CIs disjoint"
-        else:
-            regressed = ratio > FALLBACK_RATIO
-            rule = "point ratio"
-        if regressed:
-            alerts.append((bench, base, ratio, rule))
-        print(
-            f"{'ALERT' if regressed else 'ok':5} {bench['name']}: "
-            f"{base['value']:.3f} -> {bench['value']:.3f} {bench['unit']} "
-            f"({ratio:.2f}x, {rule})"
-        )
-
+    alerts = collect_alerts(current, baseline)
     if alerts:
         write_alert_report(args.out, args.suite, baseline, alerts)
 

--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Alert on regressions by comparing confidence intervals rather than point values.
+
+The `ci-overlap` alert strategy: a series alerts only when its current confidence
+interval is entirely above the baseline's (the difference exceeds sampling noise)
+AND the point value regressed by more than a practical floor. Series without a
+parseable CI on both sides (index build time/size, pre-CI baselines) fall back to
+the same point-ratio rule github-action-benchmark applies.
+
+Reads the current run's results.json and the gh-pages data.js that the
+github-action-benchmark step has already cloned (and appended the current run to,
+which is why the baseline is the newest entry from a *different* commit).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+CI_RANGE = re.compile(r"95% CI \[([0-9.]+), ([0-9.]+)\]")
+EFFECT_FLOOR = 1.05
+FALLBACK_RATIO = 1.15
+
+
+def parse_ci(range_str):
+    """Extract (lo, hi) from a '95% CI [lo, hi]' range string, or None."""
+    m = CI_RANGE.fullmatch(range_str or "")
+    return (float(m.group(1)), float(m.group(2))) if m else None
+
+
+def load_baseline(data_js_path, suite, current_sha):
+    """Return the suite's newest entry not authored by the current commit."""
+    with open(data_js_path, encoding="utf-8") as f:
+        raw = f.read()
+    data = json.loads(raw[raw.index("=") + 1 :])
+    entries = data.get("entries", {}).get(suite, [])
+    for entry in reversed(entries):
+        if entry["commit"]["id"] != current_sha:
+            return entry
+    return None
+
+
+def write_alert_report(path, suite, baseline, alerts):
+    """Write the alert comment body as a markdown table."""
+    lines = [
+        f"## :warning: Possible performance regression vs `{baseline['commit']['id'][:7]}`",
+        "",
+        "A series alerts when its 95% CI sits entirely above the baseline's and the "
+        f"value regressed >{(EFFECT_FLOOR - 1) * 100:.0f}% (or, without CIs, when the "
+        f"value regressed >{(FALLBACK_RATIO - 1) * 100:.0f}%).",
+        "",
+        f"### {suite}",
+        "",
+        "| Benchmark | Baseline | Current | Ratio | Rule |",
+        "|-|-|-|-|-|",
+    ]
+    for bench, base, ratio, rule in alerts:
+        lines.append(
+            f"| `{bench['name']}` "
+            f"| {base['value']:.3f} {base['unit']} {base.get('range', '')} "
+            f"| {bench['value']:.3f} {bench['unit']} {bench.get('range', '')} "
+            f"| {ratio:.2f}x | {rule} |"
+        )
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def main():
+    """Compare the current results against the baseline and report alerts."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", required=True)
+    parser.add_argument("--data-js", required=True)
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    with open(args.results, encoding="utf-8") as f:
+        current = json.load(f)
+
+    baseline = load_baseline(args.data_js, args.suite, args.sha)
+    if baseline is None:
+        print(f"No baseline entry for suite '{args.suite}'; nothing to compare.")
+        return
+
+    baseline_by_name = {b["name"]: b for b in baseline["benches"]}
+    alerts = []
+    for bench in current:
+        base = baseline_by_name.get(bench["name"])
+        if base is None or base["value"] <= 0:
+            continue
+        ratio = bench["value"] / base["value"]
+        cur_ci, base_ci = parse_ci(bench.get("range")), parse_ci(base.get("range"))
+        if cur_ci and base_ci:
+            regressed = cur_ci[0] > base_ci[1] and ratio > EFFECT_FLOOR
+            rule = "CIs disjoint"
+        else:
+            regressed = ratio > FALLBACK_RATIO
+            rule = "point ratio"
+        if regressed:
+            alerts.append((bench, base, ratio, rule))
+        print(
+            f"{'ALERT' if regressed else 'ok':5} {bench['name']}: "
+            f"{base['value']:.3f} -> {bench['value']:.3f} {bench['unit']} "
+            f"({ratio:.2f}x, {rule})"
+        )
+
+    if alerts:
+        write_alert_report(args.out, args.suite, baseline, alerts)
+
+    if github_output := os.environ.get("GITHUB_OUTPUT"):
+        with open(github_output, "a", encoding="utf-8") as f:
+            f.write(f"alert={'true' if alerts else 'false'}\n")
+    print(f"\n{len(alerts)} alert(s) out of {len(current)} series.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -28,7 +28,10 @@ import sys
 
 CI_RANGE = re.compile(r"95% CI \[([0-9.]+), ([0-9.]+)\]")
 SAMPLES = re.compile(r"samples_fnv=([0-9a-f]{16}); samples=\[([0-9.,eE+-]*)\]")
-QUANTILES = {"p50": 0.50, "p95": 0.95, "p99": 0.99}
+QUANTILES = {"p50": 0.50, "p95": 0.95}
+# Charted but never alerted: at ~100 query vectors a p99 estimate rests on the top one or two
+# order statistics, which no comparison rule can turn into reliable evidence of a regression.
+NEVER_ALERT = {"p99"}
 EFFECT_FLOOR = 1.05
 FALLBACK_RATIO = 1.15
 BOOTSTRAP_RESAMPLES = 10_000
@@ -122,6 +125,8 @@ def judge(bench, base, cur_groups, base_groups, bounds_cache):
     """Return (regressed, rule) for one series under the strategy ladder."""
     ratio = bench["value"] / base["value"]
     group, sep, label = bench["name"].rpartition(" - ")
+    if sep and label in NEVER_ALERT:
+        return False, f"{label} charted but not alerted"
     if sep and label in QUANTILES and pairable(cur_groups, base_groups, group):
         if group not in bounds_cache:
             bounds_cache[group] = paired_lower_bounds(

--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -32,7 +32,7 @@ QUANTILES = {"p50": 0.50, "p95": 0.95}
 # Charted but never alerted: at ~100 query vectors a p99 estimate rests on the top one or two
 # order statistics, which no comparison rule can turn into reliable evidence of a regression.
 NEVER_ALERT = {"p99"}
-EFFECT_FLOOR = 1.05
+EFFECT_FLOOR = 1.15
 FALLBACK_RATIO = 1.15
 BOOTSTRAP_RESAMPLES = 10_000
 CONFIDENCE = 0.95

--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -15,7 +15,7 @@ ratio github-action-benchmark applies (build time/size, pre-CI baselines).
 
 Reads the current run's results.json and the gh-pages data.js that the
 github-action-benchmark step has already cloned (and appended the current run to,
-which is why the baseline is the newest entry from a *different* commit).
+which is why the baseline is the second-to-last entry).
 """
 
 import argparse
@@ -98,16 +98,19 @@ def paired_lower_bounds(base, cand):
     }
 
 
-def load_baseline(data_js_path, suite, current_sha):
-    """Return the suite's newest entry not authored by the current commit."""
+def load_baseline(data_js_path, suite):
+    """Return the newest baseline entry: the one before the just-appended current run.
+
+    The publish step always appends the current run to its local gh-pages clone before
+    this script runs, so the last entry is the current run itself, never the baseline.
+    Commit ids can't disambiguate instead: a labeled PR run and a dispatch baseline of
+    the same branch both record the branch head sha.
+    """
     with open(data_js_path, encoding="utf-8") as f:
         raw = f.read()
     data = json.loads(raw[raw.index("=") + 1 :])
     entries = data.get("entries", {}).get(suite, [])
-    for entry in reversed(entries):
-        if entry["commit"]["id"] != current_sha:
-            return entry
-    return None
+    return entries[-2] if len(entries) >= 2 else None
 
 
 def pairable(cur_groups, base_groups, group):
@@ -197,14 +200,13 @@ def main():
     parser.add_argument("--results", required=True)
     parser.add_argument("--data-js", required=True)
     parser.add_argument("--suite", required=True)
-    parser.add_argument("--sha", required=True)
     parser.add_argument("--out", required=True)
     args = parser.parse_args()
 
     with open(args.results, encoding="utf-8") as f:
         current = json.load(f)
 
-    baseline = load_baseline(args.data_js, args.suite, args.sha)
+    baseline = load_baseline(args.data_js, args.suite)
     if baseline is None:
         print(f"No baseline entry for suite '{args.suite}'; nothing to compare.")
         return

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -391,9 +391,9 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 1m
-          # ci-overlap owns real alerting; the point threshold stays only as a
+          # paired-bootstrap owns real alerting; the point threshold stays only as a
           # catastrophic-regression backstop in case the overlap step is skipped.
-          alert_strategy: ci-overlap
+          alert_strategy: paired-bootstrap
           alert_threshold: 200%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -438,9 +438,9 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 10m
-          # ci-overlap owns real alerting; the point threshold stays only as a
+          # paired-bootstrap owns real alerting; the point threshold stays only as a
           # catastrophic-regression backstop in case the overlap step is skipped.
-          alert_strategy: ci-overlap
+          alert_strategy: paired-bootstrap
           alert_threshold: 200%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -394,7 +394,7 @@ jobs:
           # ci-overlap owns real alerting; the point threshold stays only as a
           # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
-          alert_threshold: 500%
+          alert_threshold: 200%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
@@ -441,7 +441,7 @@ jobs:
           # ci-overlap owns real alerting; the point threshold stays only as a
           # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
-          alert_threshold: 500%
+          alert_threshold: 200%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -391,7 +391,10 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 1m
+          # ci-overlap owns real alerting; the point threshold stays only as a
+          # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
+          alert_threshold: 500%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
@@ -435,7 +438,10 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 10m
+          # ci-overlap owns real alerting; the point threshold stays only as a
+          # catastrophic-regression backstop in case the overlap step is skipped.
           alert_strategy: ci-overlap
+          alert_threshold: 500%
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -391,6 +391,7 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 1m
+          alert_strategy: ci-overlap
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
@@ -434,6 +435,7 @@ jobs:
           dataset: cohere
           index: ${{ env.COHERE_INDEX }}
           size: 10m
+          alert_strategy: ci-overlap
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -132,6 +132,19 @@ pub fn percentile_confidence_interval(data: &[f64], p: f64, confidence_level: f6
     (sorted[lo], sorted[hi])
 }
 
+/// FNV-1a over the strings in order. Stable across platforms and Rust versions, unlike
+/// `DefaultHasher`, so hashes published in one benchmark run stay comparable in later ones.
+pub fn fnv1a(strings: &[String]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for s in strings {
+        for byte in s.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    hash
+}
+
 /// Returns the variance of the slice contents
 fn variance(data: &[f64]) -> f64 {
     assert!(!data.is_empty());

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -18,7 +18,7 @@
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use paradedb::{
-    Window, confidence_interval_half_width, mean, percentile, percentile_confidence_interval,
+    Window, confidence_interval_half_width, fnv1a, mean, percentile, percentile_confidence_interval,
 };
 use sqlx::{Connection, PgConnection, Row};
 use std::collections::{HashMap, HashSet};
@@ -208,6 +208,10 @@ pub struct QueryRunResults {
     /// True when each sample is a distinct query vector rather than a repeat of one. Only then is
     /// the sample set a latency distribution, so only then are percentiles meaningful.
     pub per_vector: bool,
+    /// Hash of the held-out query vectors, in sample order. Published alongside the samples so a
+    /// later run can pair its samples with a baseline's index-by-index, and detect when the vector
+    /// set changed and pairing would be meaningless.
+    pub vector_hash: Option<u64>,
 }
 
 enum IndexCreationResult {
@@ -321,10 +325,28 @@ impl JSONBenchmarkResult {
             res.results.samples.len()
         );
 
+        // The raw per-vector samples ride along on the p50 entry (once per operating point, not
+        // per percentile), so a later run can pair its samples with this one's by index and test
+        // per-query latency ratios instead of comparing independent percentile estimates.
+        let samples_prefix = res.results.vector_hash.map(|hash| {
+            let samples = res
+                .results
+                .samples
+                .iter()
+                .map(|v| format!("{v:.3}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("samples_fnv={hash:016x}; samples=[{samples}]; ")
+        });
+
         TRACKED_PERCENTILES
             .iter()
             .map(|(label, p)| {
                 let (lo, hi) = percentile_confidence_interval(&res.results.samples, *p, 0.95);
+                let extra = match (*label, &samples_prefix) {
+                    ("p50", Some(prefix)) => format!("{prefix}{extra}"),
+                    _ => extra.clone(),
+                };
                 Self {
                     // " - " is the dashboard's chart-grouping separator, so an operating point's
                     // three percentiles share one chart instead of getting one each.
@@ -332,7 +354,7 @@ impl JSONBenchmarkResult {
                     unit: "ms",
                     value: percentile(&res.results.samples, *p),
                     range: format!("95% CI [{lo:.3}, {hi:.3}]"),
-                    extra: extra.clone(),
+                    extra,
                 }
             })
             .collect()
@@ -1932,6 +1954,7 @@ async fn execute_query_multiple_times(
             }
         }
         results.per_vector = true;
+        results.vector_hash = Some(fnv1a(query_vectors));
         for vector in query_vectors {
             set_query_vector(&mut conn, vector).await?;
             match run_once(&mut conn, query, stats_reset_query, &stats_query).await {
@@ -2117,6 +2140,7 @@ mod tests {
                 samples,
                 num_results: 10,
                 per_vector,
+                vector_hash: per_vector.then_some(0xdead_beef),
             },
         }
     }
@@ -2140,8 +2164,20 @@ mod tests {
             out.iter()
                 .all(|r| r.unit == "ms" && r.range.starts_with("95% CI ["))
         );
+        // The raw samples ride on the p50 entry only, prefixed so the pairing metadata cannot
+        // collide with the free-form query text at the end.
+        assert!(
+            out[0]
+                .extra
+                .starts_with("samples_fnv=00000000deadbeef; samples=[1.000,2.000,"),
+            "{}",
+            out[0].extra
+        );
+        assert!(out[0].extra.ends_with(
+            "cold_query_ms=11.108; n=100; p50=50.500; p95=95.050; p99=99.010; query=SELECT 1"
+        ));
         assert_eq!(
-            out[0].extra,
+            out[1].extra,
             "cold_query_ms=11.108; n=100; p50=50.500; p95=95.050; p99=99.010; query=SELECT 1"
         );
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Previously we were comparing the P50, 95, and 99 latencies of runs. This was noisy since these numbers can vary a lot between runs.

To solve for this, we use bootstrapping -- store all 100 latency measurements in the baseline. When new measurements are obtained, we bootstrap (ie sample with replacement) 10,000 indices. For each pair of samples, we generate a percentile ratio (`current percentile` / `baseline percentile`) -- we take the 5th percentile of these ratios to get a lower 95% confidence bound, and alert when this ratio exceeds 1.15.

Additionally, alerting for P99 has been removed since it's still too noisy.

## Why

## How

## Tests
