### PR TITLE
ci: let the cohere 10m baseline runs actually finish

### DIFF
--- a/benchmarks/datasets/cohere/queries/hnsw/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/hnsw/knn_top10_unfiltered.sql
@@ -1,3 +1,3 @@
-SET hnsw.ef_search={{ ef_search_unfiltered }}; SELECT _id, title FROM cohere_wiki
+SET enable_seqscan=off; SET enable_bitmapscan=off; SET enable_sort=off; SET hnsw.ef_search={{ ef_search_unfiltered }}; SELECT _id, title FROM cohere_wiki
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/ivfflat/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/ivfflat/knn_top10_unfiltered.sql
@@ -1,3 +1,3 @@
-SET ivfflat.probes={{ probes_unfiltered }}; SELECT _id, title FROM cohere_wiki
+SET enable_seqscan=off; SET enable_bitmapscan=off; SET enable_sort=off; SET ivfflat.probes={{ probes_unfiltered }}; SELECT _id, title FROM cohere_wiki
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/vchord/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/vchord/knn_top10_unfiltered.sql
@@ -1,3 +1,3 @@
-SET vchordrq.probes={{ vchord_probes_unfiltered }}; SET vchordrq.epsilon=1.9; SELECT _id, title FROM cohere_wiki
+SET enable_seqscan=off; SET enable_bitmapscan=off; SET enable_sort=off; SET vchordrq.probes={{ vchord_probes_unfiltered }}; SET vchordrq.epsilon=1.9; SELECT _id, title FROM cohere_wiki
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1176,13 +1176,21 @@ async fn run_benchmarks(args: &BenchmarkArgs) -> anyhow::Result<Vec<QueryResult>
             .with_context(|| "Failed to execute checkpoint.")?;
 
         println!("Query Type: {query_type}\nQuery: {query}");
+        // Alternatives are fixed reference plans -- the exact pre-filter, say -- never a swept
+        // operating point, so nothing builds a percentile series from them. Sampling one once per
+        // held-out vector costs hours at 10m rows to produce a distribution no series reads.
+        let query_vectors = if is_alternative(&query_type) {
+            &[][..]
+        } else {
+            &query_vectors[..]
+        };
         let result = execute_query_multiple_times(
             &args.url,
             &query_type,
             &query,
             args.runs,
             args.fail_on_error,
-            &query_vectors,
+            query_vectors,
         )
         .await?;
         match result {
@@ -1739,6 +1747,15 @@ fn extract_index_name(statement: &str) -> &str {
         .expect("Failed to parse index name")
 }
 
+/// Suffix given to a query file's second and later statements. Doubles as the dashboard's
+/// chart-grouping separator, so alternatives plot alongside the statement they vary.
+const ALTERNATIVE_MARKER: &str = " - alternative ";
+
+/// Whether `query_type` names a non-first statement of its file.
+fn is_alternative(query_type: &str) -> bool {
+    query_type.contains(ALTERNATIVE_MARKER)
+}
+
 fn benchmark_queries(file: &Path) -> Vec<(String, String)> {
     let query_type = file
         .file_stem()
@@ -1753,7 +1770,7 @@ fn benchmark_queries(file: &Path) -> Vec<(String, String)> {
             let query_type = if idx == 0 {
                 query_type.clone()
             } else {
-                format!("{query_type} - alternative {idx}")
+                format!("{query_type}{ALTERNATIVE_MARKER}{idx}")
             };
             (query_type, query)
         })
@@ -2247,5 +2264,26 @@ mod tests {
             json,
             r#"{"name":"i build time","unit":"min","value":1.0,"range":"","extra":""}"#
         );
+    }
+
+    /// The marker is produced in one place and matched in another; a rename that touched only one
+    /// would silently restore the 100x sampling cost on reference plans.
+    #[test]
+    fn only_non_first_statements_count_as_alternatives() {
+        let file_stem = "knn_top10_10pct";
+        let named: Vec<String> = (0..3)
+            .map(|idx| {
+                if idx == 0 {
+                    file_stem.to_owned()
+                } else {
+                    format!("{file_stem}{ALTERNATIVE_MARKER}{idx}")
+                }
+            })
+            .collect();
+
+        assert!(!is_alternative(&named[0]));
+        assert!(named[1..].iter().all(|n| is_alternative(n)));
+        // A swept operating point is still the file's first statement.
+        assert!(!is_alternative(&format!("{file_stem}@r95")));
     }
 }


### PR DESCRIPTION
Both the hnsw and ivfflat cohere baseline runs were killed at the 360-minute job timeout, mid-`Benchmark "cohere" Dataset (10M)`, so neither published a 10m suite. Two fixes, which together should bring them in around 4-4.5h.

**1. Reference plans were sampled 100×.** #5729 gave every benchmarked query the held-out-vector treatment, including a query file's second and later statements. Those are fixed reference plans — the exact pre-filter, which forces a GIN bitmap scan and an exact sort — never a swept operating point, so no percentile series is built from them. At 10m the 10pct reference plan sorts ~960k rows per execution, and it went from 11 executions to 200. Both runs died inside `knn_top10_10pct - alternative 1`. Alternatives get the repeat-one path back: ~2h saved per arm.

**2. Unfiltered queries could fall back to a seq scan.** `emb` is a 1024-dim vector (4100 bytes), so it lives out of line in TOAST and the main heap looks tiny to the planner. Detoasting is not costed, so a parallel seq scan + top-N heapsort can win on estimate and then reassemble a million vectors. ivfflat's 1m unfiltered points planned as:

| point | probes | plan | per query |
|---|---|---|---|
| `@r90` | 15 | Index Scan | 31 ms |
| `@r95` | **45** | **Gather Merge → top-N heapsort** | **15,100 ms** |
| `@r99` | 145 | Index Scan | 330 ms |

Not a cost crossover — 145 is strictly more expensive than 45 and did not flip — so the guard is needed at any sweep value. Those two points cost 51 minutes, and a brute-forced point scores recall the index never achieved, so the sweep can select it as if the index had reached the target. Every filtered query already sets these GUCs; the unfiltered ones were the only gap.

**pg_search is deliberately excluded** — its filtered queries are unhinted too, and forcing a plan there would hide regressions in the planner integration that arm exists to measure.

No timeout change: the job keeps the 360m default.