### PR TITLE
feat: Push down ORDER BY range into the index (#2688)

### DIFF
--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -284,6 +284,20 @@ await dbContext
 
 </CodeGroup>
 
+## Sorting by Range
+
+Postgres range columns (`int4range`, `int8range`, `numrange`, `daterange`, `tsrange`, `tstzrange`) can receive the Top K optimization when they appear as the **leading** `ORDER BY` key. ParadeDB compares range values using the same rules as Postgres `range_cmp` (empty ranges, unbounded bounds, and inclusive/exclusive endpoints).
+
+Range columns must be indexed as fast fields (the default for range types). A range in a later `ORDER BY` position is not pushed down; Postgres sorts any tiebreaker columns after the index returns its prefix.
+
+```sql
+SELECT id, title, valid_period
+FROM events
+WHERE title @@@ 'conference'
+ORDER BY valid_period
+LIMIT 10;
+```
+
 ## Sorting by JSON
 
 Ordering by a JSON subfield directly is not yet supported. For example, this query will not receive an optimized Top K scan:

--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -288,13 +288,13 @@ await dbContext
 
 Postgres range columns (`int4range`, `int8range`, `numrange`, `daterange`, `tsrange`, `tstzrange`) can receive the Top K optimization when they appear as the **leading** `ORDER BY` key. ParadeDB compares range values using the same rules as Postgres `range_cmp` (empty ranges, unbounded bounds, and inclusive/exclusive endpoints).
 
-Range columns must be indexed as fast fields (the default for range types). A range in a later `ORDER BY` position is not pushed down; Postgres sorts any tiebreaker columns after the index returns its prefix.
+Range columns are always indexed as fast fields, so no extra configuration is needed. A range in a later `ORDER BY` position is not pushed down; Postgres sorts any tiebreaker columns after the index returns its prefix.
 
 ```sql
-SELECT id, title, valid_period
-FROM events
-WHERE title @@@ 'conference'
-ORDER BY valid_period
+SELECT description, rating, weight_range
+FROM mock_items
+WHERE description @@@ 'shoes'
+ORDER BY weight_range
 LIMIT 10;
 ```
 

--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -288,7 +288,7 @@ await dbContext
 
 Postgres range columns (`int4range`, `int8range`, `numrange`, `daterange`, `tsrange`, `tstzrange`) can receive the Top K optimization when they appear as the **leading** `ORDER BY` key. ParadeDB compares range values using the same rules as Postgres `range_cmp` (empty ranges, unbounded bounds, and inclusive/exclusive endpoints).
 
-Range columns are always indexed as fast fields, so no extra configuration is needed. A range in a later `ORDER BY` position is not pushed down; Postgres sorts any tiebreaker columns after the index returns its prefix.
+Range columns are always indexed as fast fields, so no extra configuration is needed. If a range column appears in a later `ORDER BY` position, the whole `ORDER BY` falls back to a regular Postgres sort. Tiebreaker columns after a leading range key are fine.
 
 ```sql
 SELECT description, rating, weight_range

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -960,7 +960,8 @@ impl SearchIndexReader {
                         n,
                         offset,
                         aux_collector,
-                    ));
+                    ))
+                    .into();
                 }
 
                 match field.field_entry().field_type().value_type() {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -30,6 +30,7 @@ use crate::index::fast_fields_helper::FFHelper;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::io_stats;
 use crate::index::reader::scorer::{DeferredScorer, LazyWeight, ScorerIter};
+use crate::index::reader::sort_by_range::SortByRange;
 use crate::index::setup_tokenizers;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::{SortByDirection, SortByField};
@@ -39,7 +40,7 @@ use crate::postgres::storage::metadata::MetaPage;
 use crate::query::SearchQueryInput;
 use crate::query::estimate_tree::QueryWithEstimates;
 use crate::scan::info::RowEstimate;
-use crate::schema::SearchIndexSchema;
+use crate::schema::{SearchFieldType, SearchIndexSchema};
 
 use anyhow::Result;
 use tantivy::aggregation::DistributedAggregationCollector;
@@ -946,6 +947,20 @@ impl SearchIndexReader {
                         ))
                         .into()
                     }};
+                }
+
+                // Range fields are stored as a tantivy JSON object, so they'd land in the
+                // `JsonObject` arm below and panic. They get their own computer, which compares
+                // the bound sub-columns the way Postgres' `range_cmp` does.
+                if matches!(field.field_type(), SearchFieldType::Range(_)) {
+                    return TopKSearchResults::new_for_discarded_field(self.top_in_segments(
+                        segment_ids,
+                        (SortByRange::for_field(sort_field), order),
+                        erased_features,
+                        n,
+                        offset,
+                        aux_collector,
+                    ));
                 }
 
                 match field.field_entry().field_type().value_type() {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -1628,7 +1628,8 @@ impl SearchIndexReader {
                     direction,
                 } => {
                     // NOTE: The list of supported field types for `SortByErasedType` must be synced with
-                    // `SearchField::is_sortable`.
+                    // `SearchField::is_sortable`, except Range: `is_sortable` accepts it, but only as
+                    // the leading key, which `sortable_at_position` enforces before we get here.
                     erased_features
                         .push_feature(SortByErasedType::for_field(sort_field), *direction);
                 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -949,9 +949,12 @@ impl SearchIndexReader {
                     }};
                 }
 
-                // Range fields are stored as a tantivy JSON object, so they'd land in the
-                // `JsonObject` arm below and panic. They get their own computer, which compares
-                // the bound sub-columns the way Postgres' `range_cmp` does.
+                // A range is indexed as a tantivy JSON object, so `value_type()` below reports
+                // `Type::Json`, which no arm handles — it would reach the catch-all `panic!`.
+                // Dispatch on the Postgres type instead: tantivy cannot distinguish a range's
+                // JSON from a user-supplied JSON column, and only the former is sortable (see
+                // `SearchField::is_sortable`). `SortByRange` compares the bound sub-columns the
+                // way Postgres' `range_cmp` does.
                 if matches!(field.field_type(), SearchFieldType::Range(_)) {
                     return TopKSearchResults::new_for_discarded_field(self.top_in_segments(
                         segment_ids,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -926,9 +926,12 @@ impl SearchIndexReader {
                     }};
                 }
 
-                // Range fields are stored as a tantivy JSON object, so they'd land in the
-                // `JsonObject` arm below and panic. They get their own computer, which compares
-                // the bound sub-columns the way Postgres' `range_cmp` does.
+                // A range is indexed as a tantivy JSON object, so `value_type()` below reports
+                // `Type::Json`, which no arm handles — it would reach the catch-all `panic!`.
+                // Dispatch on the Postgres type instead: tantivy cannot distinguish a range's
+                // JSON from a user-supplied JSON column, and only the former is sortable (see
+                // `SearchField::is_sortable`). `SortByRange` compares the bound sub-columns the
+                // way Postgres' `range_cmp` does.
                 if matches!(field.field_type(), SearchFieldType::Range(_)) {
                     return TopKSearchResults::new_for_discarded_field(self.top_in_segments(
                         segment_ids,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -937,7 +937,8 @@ impl SearchIndexReader {
                         n,
                         offset,
                         aux_collector,
-                    ));
+                    ))
+                    .into();
                 }
 
                 match field.field_entry().field_type().value_type() {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -29,6 +29,7 @@ use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, SortDirection}
 use crate::index::fast_fields_helper::FFHelper;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::scorer::{DeferredScorer, LazyWeight, ScorerIter};
+use crate::index::reader::sort_by_range::SortByRange;
 use crate::index::setup_tokenizers;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::{SortByDirection, SortByField};
@@ -38,7 +39,7 @@ use crate::postgres::storage::metadata::MetaPage;
 use crate::query::SearchQueryInput;
 use crate::query::estimate_tree::QueryWithEstimates;
 use crate::scan::info::RowEstimate;
-use crate::schema::SearchIndexSchema;
+use crate::schema::{SearchFieldType, SearchIndexSchema};
 
 use anyhow::Result;
 use tantivy::aggregation::DistributedAggregationCollector;
@@ -923,6 +924,20 @@ impl SearchIndexReader {
                         ))
                         .into()
                     }};
+                }
+
+                // Range fields are stored as a tantivy JSON object, so they'd land in the
+                // `JsonObject` arm below and panic. They get their own computer, which compares
+                // the bound sub-columns the way Postgres' `range_cmp` does.
+                if matches!(field.field_type(), SearchFieldType::Range(_)) {
+                    return TopKSearchResults::new_for_discarded_field(self.top_in_segments(
+                        segment_ids,
+                        (SortByRange::for_field(sort_field), order),
+                        erased_features,
+                        n,
+                        offset,
+                        aux_collector,
+                    ));
                 }
 
                 match field.field_entry().field_type().value_type() {

--- a/pg_search/src/index/reader/mod.rs
+++ b/pg_search/src/index/reader/mod.rs
@@ -19,3 +19,4 @@ pub mod index;
 pub mod io_stats;
 pub mod scorer;
 pub mod segment_component;
+pub mod sort_by_range;

--- a/pg_search/src/index/reader/mod.rs
+++ b/pg_search/src/index/reader/mod.rs
@@ -18,3 +18,4 @@
 pub mod index;
 pub mod scorer;
 pub mod segment_component;
+pub mod sort_by_range;

--- a/pg_search/src/index/reader/sort_by_range.rs
+++ b/pg_search/src/index/reader/sort_by_range.rs
@@ -134,11 +134,16 @@ impl SortKeyComputer for SortByRange {
         // `SortableDecimal`); every other range type indexes its bounds as a numeric or date
         // column. Probe for the string form first and fall back to the numeric form.
         //
-        // The `u64_lenient_for_type` mapping is monotonic within one column type, and a range column's
-        // subtype fixes that type (integer bounds are always `i64`, date/timestamp bounds always
-        // `Date`), so the same value maps to the same `u64` in every segment. A segment holding
-        // no finite bounds at all resolves to no columns, which is harmless: its keys are all
-        // unbounded or empty, and the bounded/unbounded discriminant is compared first.
+        // The `u64_lenient_for_type` mapping is monotonic within one column type, and a range
+        // column's subtype fixes that type (integer bounds are always `i64`, date/timestamp
+        // bounds always `Date`), so the same value maps to the same `u64` in every segment.
+        // Pinning the accepted types ties that to the write side: bounds stored under any other
+        // type resolve to no column and would then read as unbounded, so this list has to move
+        // whenever the writer does.
+        //
+        // A segment holding no finite bounds at all also resolves to no columns, which is
+        // harmless: its keys are all unbounded or empty, and the bounded/unbounded discriminant
+        // is compared first.
         const RANGE_BOUND_COLUMN_TYPES: &[ColumnType] = &[ColumnType::I64, ColumnType::DateTime];
         let bounds = match (
             fast_fields.str(&self.path("lower"))?,

--- a/pg_search/src/index/reader/sort_by_range.rs
+++ b/pg_search/src/index/reader/sort_by_range.rs
@@ -36,7 +36,7 @@
 use tantivy::collector::sort_key::ComparatorEnum;
 use tantivy::collector::sort_key::shared_threshold::SharedThresholdArcOpt;
 use tantivy::collector::{SegmentSortKeyComputer, SortKeyComputer};
-use tantivy::columnar::{Column, StrColumn};
+use tantivy::columnar::{Column, ColumnType, StrColumn};
 use tantivy::termdict::TermOrdinal;
 use tantivy::{DocId, Score, SegmentReader};
 
@@ -134,21 +134,28 @@ impl SortKeyComputer for SortByRange {
         // `SortableDecimal`); every other range type indexes its bounds as a numeric or date
         // column. Probe for the string form first and fall back to the numeric form.
         //
-        // The `u64_lenient` mapping is monotonic within one column type, and a range column's
+        // The `u64_lenient_for_type` mapping is monotonic within one column type, and a range column's
         // subtype fixes that type (integer bounds are always `i64`, date/timestamp bounds always
         // `Date`), so the same value maps to the same `u64` in every segment. A segment holding
         // no finite bounds at all resolves to no columns, which is harmless: its keys are all
         // unbounded or empty, and the bounded/unbounded discriminant is compared first.
+        const RANGE_BOUND_COLUMN_TYPES: &[ColumnType] = &[ColumnType::I64, ColumnType::DateTime];
         let bounds = match (
             fast_fields.str(&self.path("lower"))?,
             fast_fields.str(&self.path("upper"))?,
         ) {
             (None, None) => SegmentBounds::Numeric {
                 lower: fast_fields
-                    .u64_lenient(&self.path("lower"))?
+                    .u64_lenient_for_type(
+                        Some(RANGE_BOUND_COLUMN_TYPES),
+                        &self.path("lower"),
+                    )?
                     .map(|(column, _)| column),
                 upper: fast_fields
-                    .u64_lenient(&self.path("upper"))?
+                    .u64_lenient_for_type(
+                        Some(RANGE_BOUND_COLUMN_TYPES),
+                        &self.path("upper"),
+                    )?
                     .map(|(column, _)| column),
             },
             (lower, upper) => SegmentBounds::Text { lower, upper },

--- a/pg_search/src/index/reader/sort_by_range.rs
+++ b/pg_search/src/index/reader/sort_by_range.rs
@@ -146,16 +146,10 @@ impl SortKeyComputer for SortByRange {
         ) {
             (None, None) => SegmentBounds::Numeric {
                 lower: fast_fields
-                    .u64_lenient_for_type(
-                        Some(RANGE_BOUND_COLUMN_TYPES),
-                        &self.path("lower"),
-                    )?
+                    .u64_lenient_for_type(Some(RANGE_BOUND_COLUMN_TYPES), &self.path("lower"))?
                     .map(|(column, _)| column),
                 upper: fast_fields
-                    .u64_lenient_for_type(
-                        Some(RANGE_BOUND_COLUMN_TYPES),
-                        &self.path("upper"),
-                    )?
+                    .u64_lenient_for_type(Some(RANGE_BOUND_COLUMN_TYPES), &self.path("upper"))?
                     .map(|(column, _)| column),
             },
             (lower, upper) => SegmentBounds::Text { lower, upper },

--- a/pg_search/src/index/reader/sort_by_range.rs
+++ b/pg_search/src/index/reader/sort_by_range.rs
@@ -33,8 +33,8 @@
 //! [`tantivy::collector::sort_key::ComparatorEnum`] places according to the query's
 //! NULLS FIRST/LAST direction.
 
-use tantivy::collector::sort_key::shared_threshold::SharedThresholdArcOpt;
 use tantivy::collector::sort_key::ComparatorEnum;
+use tantivy::collector::sort_key::shared_threshold::SharedThresholdArcOpt;
 use tantivy::collector::{SegmentSortKeyComputer, SortKeyComputer};
 use tantivy::columnar::{Column, StrColumn};
 use tantivy::termdict::TermOrdinal;

--- a/pg_search/src/index/reader/sort_by_range.rs
+++ b/pg_search/src/index/reader/sort_by_range.rs
@@ -1,0 +1,370 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Top-N sorting by a Postgres range column, matching Postgres' own `range_cmp`.
+//!
+//! Range columns are indexed as a tantivy JSON object (see
+//! [`crate::schema::range::TantivyRange`]) with a fixed set of keys, each of which becomes its
+//! own fast field column: `lower`, `upper`, `empty`, `lower_inclusive`, `upper_inclusive`,
+//! `lower_unbounded`, `upper_unbounded`. This module reads those columns and assembles a
+//! composite sort key whose natural `Ord` reproduces `range_cmp`:
+//!
+//! - empty ranges sort before every non-empty range
+//! - an unbounded lower bound sorts before any finite lower bound
+//! - on equal lower bound values, inclusive sorts before exclusive (`[5,…` < `(5,…`)
+//! - an unbounded upper bound sorts after any finite upper bound
+//! - on equal upper bound values, exclusive sorts before inclusive (`…,10)` < `…,10]`)
+//!
+//! A SQL `NULL` range yields `None`, which the surrounding
+//! [`tantivy::collector::sort_key::ComparatorEnum`] places according to the query's
+//! NULLS FIRST/LAST direction.
+
+use tantivy::collector::sort_key::shared_threshold::SharedThresholdArcOpt;
+use tantivy::collector::sort_key::ComparatorEnum;
+use tantivy::collector::{SegmentSortKeyComputer, SortKeyComputer};
+use tantivy::columnar::{Column, StrColumn};
+use tantivy::termdict::TermOrdinal;
+use tantivy::{DocId, Score, SegmentReader};
+
+/// Ranks for the discriminant components of [`RangeSortKey`]. Named rather than inlined because
+/// the whole correctness argument of this module is that these values are in `range_cmp` order.
+const EMPTY: u8 = 0;
+const NON_EMPTY: u8 = 1;
+const LOWER_UNBOUNDED: u8 = 0;
+const LOWER_FINITE: u8 = 1;
+const LOWER_INCLUSIVE: u8 = 0;
+const LOWER_EXCLUSIVE: u8 = 1;
+const UPPER_FINITE: u8 = 0;
+const UPPER_UNBOUNDED: u8 = 1;
+const UPPER_EXCLUSIVE: u8 = 0;
+const UPPER_INCLUSIVE: u8 = 1;
+
+/// The composite sort key for one range value.
+///
+/// Field order *is* the comparison order, and the derived lexicographic `Ord` is what makes this
+/// equal to `range_cmp`. Do not reorder the fields.
+///
+/// `V` is the bound representation: [`TermOrdinal`]-or-`u64` while collecting within a single
+/// segment, and order-preserving bytes once keys have to be compared across segments.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RangeSortKey<V: Ord> {
+    empty: u8,
+    lower_bounded: u8,
+    lower: Option<V>,
+    lower_inclusive: u8,
+    upper_bounded: u8,
+    upper: Option<V>,
+    upper_inclusive: u8,
+}
+
+impl<V: Ord> RangeSortKey<V> {
+    /// The key every empty range collapses to. Bound components are fixed so that all empty
+    /// ranges compare equal to each other regardless of what the bound columns happen to hold.
+    fn empty() -> Self {
+        Self {
+            empty: EMPTY,
+            lower_bounded: LOWER_UNBOUNDED,
+            lower: None,
+            lower_inclusive: LOWER_INCLUSIVE,
+            upper_bounded: UPPER_FINITE,
+            upper: None,
+            upper_inclusive: UPPER_EXCLUSIVE,
+        }
+    }
+}
+
+/// Sorts by a Postgres range column, per `range_cmp`.
+///
+/// `column_name` is the name of the range field itself; the JSON sub-paths are derived from it.
+#[derive(Clone, Debug)]
+pub struct SortByRange {
+    column_name: String,
+}
+
+impl SortByRange {
+    pub fn for_field(column_name: impl ToString) -> Self {
+        SortByRange {
+            column_name: column_name.to_string(),
+        }
+    }
+
+    fn path(&self, key: &str) -> String {
+        format!("{}.{key}", self.column_name)
+    }
+}
+
+impl SortKeyComputer for SortByRange {
+    type SortKey = Option<RangeSortKey<Vec<u8>>>;
+    type Child = SegmentSortByRange;
+    type Comparator = ComparatorEnum;
+
+    fn shared_threshold(
+        &self,
+    ) -> SharedThresholdArcOpt<
+        <<Self as SortKeyComputer>::Child as SegmentSortKeyComputer>::SegmentSortKey,
+    > {
+        // Same caveat as `SortByString`/`SortByBytes`: a text-bounded range compares by
+        // `TermOrdinal` within a segment, and those are not comparable across segments, so there
+        // is nothing safe to publish as a shared threshold.
+        None
+    }
+
+    fn segment_sort_key_computer(
+        &self,
+        segment_reader: &SegmentReader,
+    ) -> tantivy::Result<Self::Child> {
+        let fast_fields = segment_reader.fast_fields();
+        let flag = |key: &str| fast_fields.column_opt::<bool>(&self.path(key));
+
+        // `numrange` bounds are indexed as hex-encoded sortable decimal strings (see
+        // `SortableDecimal`); every other range type indexes its bounds as a numeric or date
+        // column. Probe for the string form first and fall back to the numeric form.
+        //
+        // The `u64_lenient` mapping is monotonic within one column type, and a range column's
+        // subtype fixes that type (integer bounds are always `i64`, date/timestamp bounds always
+        // `Date`), so the same value maps to the same `u64` in every segment. A segment holding
+        // no finite bounds at all resolves to no columns, which is harmless: its keys are all
+        // unbounded or empty, and the bounded/unbounded discriminant is compared first.
+        let bounds = match (
+            fast_fields.str(&self.path("lower"))?,
+            fast_fields.str(&self.path("upper"))?,
+        ) {
+            (None, None) => SegmentBounds::Numeric {
+                lower: fast_fields
+                    .u64_lenient(&self.path("lower"))?
+                    .map(|(column, _)| column),
+                upper: fast_fields
+                    .u64_lenient(&self.path("upper"))?
+                    .map(|(column, _)| column),
+            },
+            (lower, upper) => SegmentBounds::Text { lower, upper },
+        };
+
+        Ok(SegmentSortByRange {
+            empty: flag("empty")?,
+            lower_unbounded: flag("lower_unbounded")?,
+            upper_unbounded: flag("upper_unbounded")?,
+            lower_inclusive: flag("lower_inclusive")?,
+            upper_inclusive: flag("upper_inclusive")?,
+            bounds,
+        })
+    }
+}
+
+/// The bound columns of a range field, in whichever representation the range's subtype uses.
+enum SegmentBounds {
+    Numeric {
+        lower: Option<Column<u64>>,
+        upper: Option<Column<u64>>,
+    },
+    Text {
+        lower: Option<StrColumn>,
+        upper: Option<StrColumn>,
+    },
+}
+
+pub struct SegmentSortByRange {
+    empty: Option<Column<bool>>,
+    lower_unbounded: Option<Column<bool>>,
+    upper_unbounded: Option<Column<bool>>,
+    lower_inclusive: Option<Column<bool>>,
+    upper_inclusive: Option<Column<bool>>,
+    bounds: SegmentBounds,
+}
+
+impl SegmentSortByRange {
+    /// Resolve a within-segment bound ordinal into order-preserving bytes.
+    ///
+    /// For text bounds this is the term itself: the terms are hex-encoded sortable decimals, so
+    /// byte order is numeric order. For numeric bounds the `u64` is already monotonic in the
+    /// underlying value, so big-endian bytes preserve it.
+    fn bound_bytes(&self, is_lower: bool, ord: u64) -> Option<Vec<u8>> {
+        match &self.bounds {
+            SegmentBounds::Numeric { .. } => Some(ord.to_be_bytes().to_vec()),
+            SegmentBounds::Text { lower, upper } => {
+                let column = if is_lower { lower } else { upper }.as_ref()?;
+                let mut bytes = Vec::new();
+                column
+                    .dictionary()
+                    .ord_to_term(ord as TermOrdinal, &mut bytes)
+                    .ok()?;
+                Some(bytes)
+            }
+        }
+    }
+
+    fn bound(&self, is_lower: bool, doc: DocId) -> Option<u64> {
+        match &self.bounds {
+            SegmentBounds::Numeric { lower, upper } => {
+                if is_lower { lower } else { upper }.as_ref()?.first(doc)
+            }
+            SegmentBounds::Text { lower, upper } => if is_lower { lower } else { upper }
+                .as_ref()?
+                .ords()
+                .first(doc),
+        }
+    }
+
+    fn flag(column: &Option<Column<bool>>, doc: DocId) -> bool {
+        column
+            .as_ref()
+            .and_then(|column| column.first(doc))
+            .unwrap_or(false)
+    }
+}
+
+impl SegmentSortKeyComputer for SegmentSortByRange {
+    type SortKey = Option<RangeSortKey<Vec<u8>>>;
+    type SegmentSortKey = Option<RangeSortKey<u64>>;
+    type SegmentComparator = ComparatorEnum;
+
+    fn segment_sort_key(&mut self, doc: DocId, _score: Score) -> Self::SegmentSortKey {
+        // `empty` is written for every non-NULL range, so its absence is how a SQL NULL range is
+        // distinguished from an `'empty'` one.
+        let is_empty = self.empty.as_ref()?.first(doc)?;
+        if is_empty {
+            return Some(RangeSortKey::empty());
+        }
+
+        let lower_unbounded = Self::flag(&self.lower_unbounded, doc);
+        let upper_unbounded = Self::flag(&self.upper_unbounded, doc);
+
+        Some(RangeSortKey {
+            empty: NON_EMPTY,
+            lower_bounded: if lower_unbounded {
+                LOWER_UNBOUNDED
+            } else {
+                LOWER_FINITE
+            },
+            lower: (!lower_unbounded).then(|| self.bound(true, doc)).flatten(),
+            lower_inclusive: if Self::flag(&self.lower_inclusive, doc) {
+                LOWER_INCLUSIVE
+            } else {
+                LOWER_EXCLUSIVE
+            },
+            upper_bounded: if upper_unbounded {
+                UPPER_UNBOUNDED
+            } else {
+                UPPER_FINITE
+            },
+            upper: (!upper_unbounded).then(|| self.bound(false, doc)).flatten(),
+            upper_inclusive: if Self::flag(&self.upper_inclusive, doc) {
+                UPPER_INCLUSIVE
+            } else {
+                UPPER_EXCLUSIVE
+            },
+        })
+    }
+
+    fn convert_segment_sort_key(&self, sort_key: Self::SegmentSortKey) -> Self::SortKey {
+        let sort_key = sort_key?;
+        // Resolve each bound independently: `lower` and `upper` have their own term dictionaries.
+        Some(RangeSortKey {
+            empty: sort_key.empty,
+            lower_bounded: sort_key.lower_bounded,
+            lower: sort_key.lower.and_then(|ord| self.bound_bytes(true, ord)),
+            lower_inclusive: sort_key.lower_inclusive,
+            upper_bounded: sort_key.upper_bounded,
+            upper: sort_key.upper.and_then(|ord| self.bound_bytes(false, ord)),
+            upper_inclusive: sort_key.upper_inclusive,
+        })
+    }
+
+    fn supports_bm25_pruning(&self) -> bool {
+        false
+    }
+
+    fn bm25_pruning_threshold(
+        &self,
+        _threshold: &Self::SegmentSortKey,
+        _segment_ord: tantivy::SegmentOrdinal,
+        _threshold_ord: tantivy::SegmentOrdinal,
+    ) -> Option<Score> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds the key a non-empty range with `u64` bounds would get.
+    fn key(
+        lower: Option<u64>,
+        lower_inclusive: bool,
+        upper: Option<u64>,
+        upper_inclusive: bool,
+    ) -> RangeSortKey<u64> {
+        RangeSortKey {
+            empty: NON_EMPTY,
+            lower_bounded: if lower.is_none() {
+                LOWER_UNBOUNDED
+            } else {
+                LOWER_FINITE
+            },
+            lower,
+            lower_inclusive: if lower_inclusive {
+                LOWER_INCLUSIVE
+            } else {
+                LOWER_EXCLUSIVE
+            },
+            upper_bounded: if upper.is_none() {
+                UPPER_UNBOUNDED
+            } else {
+                UPPER_FINITE
+            },
+            upper,
+            upper_inclusive: if upper_inclusive {
+                UPPER_INCLUSIVE
+            } else {
+                UPPER_EXCLUSIVE
+            },
+        }
+    }
+
+    /// The ordering asserted here is the one Postgres produces for
+    /// `SELECT unnest(ARRAY['empty','(,10)','(,)','[4,10)','[5,10)','[5,10]','[5,11)','[5,)']::numrange[]) ORDER BY 1`.
+    #[test]
+    fn matches_postgres_range_cmp_order() {
+        let ascending = vec![
+            RangeSortKey::empty(),               // 'empty'
+            key(None, true, Some(10), false),    // (,10)
+            key(None, true, None, false),        // (,)
+            key(Some(4), true, Some(10), false), // [4,10)
+            key(Some(5), true, Some(10), false), // [5,10)
+            key(Some(5), true, Some(10), true),  // [5,10]
+            key(Some(5), true, Some(11), false), // [5,11)
+            key(Some(5), true, None, false),     // [5,)
+        ];
+
+        let mut sorted = ascending.clone();
+        sorted.sort();
+        assert_eq!(sorted, ascending);
+    }
+
+    #[test]
+    fn inclusive_lower_sorts_before_exclusive_lower() {
+        // `[5,10) < (5,10)`
+        assert!(key(Some(5), true, Some(10), false) < key(Some(5), false, Some(10), false));
+    }
+
+    #[test]
+    fn exclusive_upper_sorts_before_inclusive_upper() {
+        // `[5,10) < [5,10]`
+        assert!(key(Some(5), true, Some(10), false) < key(Some(5), true, Some(10), true));
+    }
+}

--- a/pg_search/src/index/reader/sort_by_range.rs
+++ b/pg_search/src/index/reader/sort_by_range.rs
@@ -37,8 +37,9 @@ use tantivy::collector::sort_key::ComparatorEnum;
 use tantivy::collector::sort_key::shared_threshold::SharedThresholdArcOpt;
 use tantivy::collector::{SegmentSortKeyComputer, SortKeyComputer};
 use tantivy::columnar::{Column, ColumnType, StrColumn};
+use tantivy::fastfield::FastFieldReaders;
 use tantivy::termdict::TermOrdinal;
-use tantivy::{DocId, Score, SegmentReader};
+use tantivy::{DocId, Score, SegmentReader, TantivyError};
 
 /// Ranks for the discriminant components of [`RangeSortKey`]. Named rather than inlined because
 /// the whole correctness argument of this module is that these values are in `range_cmp` order.
@@ -105,6 +106,29 @@ impl SortByRange {
     fn path(&self, key: &str) -> String {
         format!("{}.{key}", self.column_name)
     }
+
+    /// Opens the numeric column behind one bound, or none when the segment holds no finite value
+    /// for it. Errors when the column exists under a type this computer can't order, so a stale
+    /// or foreign encoding surfaces as an error instead of a wrong sort.
+    fn numeric_bound(
+        &self,
+        fast_fields: &FastFieldReaders,
+        key: &str,
+    ) -> tantivy::Result<Option<Column<u64>>> {
+        const ACCEPTED: &[ColumnType] = &[ColumnType::I64, ColumnType::DateTime];
+        let path = self.path(key);
+        let mut column = None;
+        for handle in fast_fields.dynamic_column_handles(&path)? {
+            if !ACCEPTED.contains(&handle.column_type()) {
+                return Err(TantivyError::SchemaError(format!(
+                    "range bound `{path}` is stored as {:?}; reindex to sort by this column",
+                    handle.column_type()
+                )));
+            }
+            column = handle.open_u64_lenient()?;
+        }
+        Ok(column)
+    }
 }
 
 impl SortKeyComputer for SortByRange {
@@ -134,28 +158,24 @@ impl SortKeyComputer for SortByRange {
         // `SortableDecimal`); every other range type indexes its bounds as a numeric or date
         // column. Probe for the string form first and fall back to the numeric form.
         //
-        // The `u64_lenient_for_type` mapping is monotonic within one column type, and a range
-        // column's subtype fixes that type (integer bounds are always `i64`, date/timestamp
-        // bounds always `Date`), so the same value maps to the same `u64` in every segment.
-        // Pinning the accepted types ties that to the write side: bounds stored under any other
-        // type resolve to no column and would then read as unbounded, so this list has to move
-        // whenever the writer does.
+        // The `u64_lenient` mapping is monotonic within one column type, and a range column's
+        // subtype fixes that type: integer bounds are `I64`, and date/timestamp bounds are `I64`
+        // microseconds on current indexes or `DateTime` on ones built before the switch to `I64`
+        // storage. `created_by_version` is fixed per index, so every segment of one index agrees,
+        // and the same value maps to the same `u64` everywhere.
         //
-        // A segment holding no finite bounds at all also resolves to no columns, which is
-        // harmless: its keys are all unbounded or empty, and the bounded/unbounded discriminant
-        // is compared first.
-        const RANGE_BOUND_COLUMN_TYPES: &[ColumnType] = &[ColumnType::I64, ColumnType::DateTime];
+        // A segment holding no finite bounds at all resolves to no columns, which is harmless:
+        // its keys are all unbounded or empty, and the bounded/unbounded discriminant is compared
+        // first. A bound column of any other type is a different matter. Reading it as absent
+        // would make every finite range in the segment tie, so the scan would return a wrong
+        // order instead of falling back to Postgres. Refuse it instead.
         let bounds = match (
             fast_fields.str(&self.path("lower"))?,
             fast_fields.str(&self.path("upper"))?,
         ) {
             (None, None) => SegmentBounds::Numeric {
-                lower: fast_fields
-                    .u64_lenient_for_type(Some(RANGE_BOUND_COLUMN_TYPES), &self.path("lower"))?
-                    .map(|(column, _)| column),
-                upper: fast_fields
-                    .u64_lenient_for_type(Some(RANGE_BOUND_COLUMN_TYPES), &self.path("upper"))?
-                    .map(|(column, _)| column),
+                lower: self.numeric_bound(fast_fields, "lower")?,
+                upper: self.numeric_bound(fast_fields, "upper")?,
             },
             (lower, upper) => SegmentBounds::Text { lower, upper },
         };

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -797,7 +797,9 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 let Some(search_field) = schema.search_field(field_name.root()) else {
                     return false;
                 };
-                if !search_field.is_lower_sortable() {
+                if !search_field.is_lower_sortable()
+                    || !sortable_at_position(&search_field, position)
+                {
                     return false;
                 }
             }

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -504,6 +504,17 @@ pub fn is_collation_pushdown_safe(collation: pg_sys::Oid) -> bool {
     }
 }
 
+/// Whether `search_field` may be pushed down as the sort key at `position` in the ORDER BY.
+///
+/// Range fields are only supported as the leading sort key: every key after the first is
+/// collected via `SortByErasedType`, which reads a single dynamic column, whereas a range
+/// compares by a composite of its bound sub-columns (see
+/// [`crate::index::reader::sort_by_range`]). A range in a later position yields a usable prefix,
+/// so Postgres sorts the remaining keys itself.
+fn sortable_at_position(search_field: &SearchField, position: usize) -> bool {
+    position == 0 || !matches!(search_field.field_type(), SearchFieldType::Range(_))
+}
+
 /// Extract pathkeys from ORDER BY clauses using comprehensive expression handling
 /// This function handles score functions, lower functions, relabel types, and regular variables
 ///
@@ -599,6 +610,7 @@ where
                         if let Some(field_name) = field_name_opt
                             && let Some(search_field) = schema.search_field(field_name.root())
                             && regular_sortability_check(&search_field)
+                            && sortable_at_position(&search_field, pathkey_styles.len())
                         {
                             pathkey_styles.push(OrderByStyle::Field {
                                 pathkey,
@@ -613,6 +625,7 @@ where
                         if let Some(field_name) = field_name_opt
                             && let Some(search_field) = schema.search_field(field_name.root())
                             && search_field.is_fast()
+                            && sortable_at_position(&search_field, pathkey_styles.len())
                         {
                             pathkey_styles.push(OrderByStyle::Field {
                                 pathkey,
@@ -702,7 +715,7 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
         PgList<pg_sys::Expr>,
     )> = None;
 
-    for sort_clause in sort_list.iter_ptr() {
+    for (position, sort_clause) in sort_list.iter_ptr().enumerate() {
         let tle_ref = (*sort_clause).tleSortGroupRef;
         let Some(te) = find_target_entry_by_ref(&target_list, tle_ref) else {
             return false;
@@ -794,7 +807,8 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 let Some(search_field) = schema.search_field(field_name.root()) else {
                     return false;
                 };
-                if !search_field.is_raw_sortable() {
+                if !search_field.is_raw_sortable() || !sortable_at_position(&search_field, position)
+                {
                     return false;
                 }
             }
@@ -805,7 +819,7 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 let Some(search_field) = schema.search_field(field_name.root()) else {
                     return false;
                 };
-                if !search_field.is_fast() {
+                if !search_field.is_fast() || !sortable_at_position(&search_field, position) {
                     return false;
                 }
             }

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -596,6 +596,7 @@ where
                         if let Some(field_name) = field_name_opt
                             && let Some(search_field) = schema.search_field(field_name.root())
                             && lower_sortability_check(&search_field)
+                            && sortable_at_position(&search_field, pathkey_styles.len())
                         {
                             pathkey_styles.push(OrderByStyle::Field {
                                 pathkey,

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -509,8 +509,9 @@ pub fn is_collation_pushdown_safe(collation: pg_sys::Oid) -> bool {
 /// Range fields are only supported as the leading sort key: every key after the first is
 /// collected via `SortByErasedType`, which reads a single dynamic column, whereas a range
 /// compares by a composite of its bound sub-columns (see
-/// [`crate::index::reader::sort_by_range`]). A range in a later position yields a usable prefix,
-/// so Postgres sorts the remaining keys itself.
+/// [`crate::index::reader::sort_by_range`]). A range in a later position makes the whole
+/// ORDER BY unpushable: Top K can't run on a prefix of the pathkeys, so Postgres sorts the
+/// unsorted scan itself.
 fn sortable_at_position(search_field: &SearchField, position: usize) -> bool {
     position == 0 || !matches!(search_field.field_type(), SearchFieldType::Range(_))
 }

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -491,6 +491,17 @@ pub fn is_collation_pushdown_safe(collation: pg_sys::Oid) -> bool {
     }
 }
 
+/// Whether `search_field` may be pushed down as the sort key at `position` in the ORDER BY.
+///
+/// Range fields are only supported as the leading sort key: every key after the first is
+/// collected via `SortByErasedType`, which reads a single dynamic column, whereas a range
+/// compares by a composite of its bound sub-columns (see
+/// [`crate::index::reader::sort_by_range`]). A range in a later position yields a usable prefix,
+/// so Postgres sorts the remaining keys itself.
+fn sortable_at_position(search_field: &SearchField, position: usize) -> bool {
+    position == 0 || !matches!(search_field.field_type(), SearchFieldType::Range(_))
+}
+
 /// Extract pathkeys from ORDER BY clauses using comprehensive expression handling
 /// This function handles score functions, lower functions, relabel types, and regular variables
 ///
@@ -586,6 +597,7 @@ where
                         if let Some(field_name) = field_name_opt
                             && let Some(search_field) = schema.search_field(field_name.root())
                             && regular_sortability_check(&search_field)
+                            && sortable_at_position(&search_field, pathkey_styles.len())
                         {
                             pathkey_styles.push(OrderByStyle::Field {
                                 pathkey,
@@ -600,6 +612,7 @@ where
                         if let Some(field_name) = field_name_opt
                             && let Some(search_field) = schema.search_field(field_name.root())
                             && search_field.is_fast()
+                            && sortable_at_position(&search_field, pathkey_styles.len())
                         {
                             pathkey_styles.push(OrderByStyle::Field {
                                 pathkey,
@@ -689,7 +702,7 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
         PgList<pg_sys::Expr>,
     )> = None;
 
-    for sort_clause in sort_list.iter_ptr() {
+    for (position, sort_clause) in sort_list.iter_ptr().enumerate() {
         let tle_ref = (*sort_clause).tleSortGroupRef;
         let Some(te) = find_target_entry_by_ref(&target_list, tle_ref) else {
             return false;
@@ -781,7 +794,8 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 let Some(search_field) = schema.search_field(field_name.root()) else {
                     return false;
                 };
-                if !search_field.is_raw_sortable() {
+                if !search_field.is_raw_sortable() || !sortable_at_position(&search_field, position)
+                {
                     return false;
                 }
             }
@@ -792,7 +806,7 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 let Some(search_field) = schema.search_field(field_name.root()) else {
                     return false;
                 };
-                if !search_field.is_fast() {
+                if !search_field.is_fast() || !sortable_at_position(&search_field, position) {
                     return false;
                 }
             }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -746,6 +746,14 @@ impl SearchField {
     }
 
     fn is_sortable(&self, desired_normalizer: SearchNormalizer) -> bool {
+        // Range fields are stored as a tantivy JSON object, so they'd otherwise fall into the
+        // `JsonObject` arm below. They are sortable via `SortByRange`, which reads the bound
+        // sub-columns and compares them the way Postgres' `range_cmp` does. Only raw sorting:
+        // range bounds are never tokenized, so there is no lowercased variant to sort by.
+        if matches!(self.field_type, SearchFieldType::Range(_)) {
+            return matches!(desired_normalizer, SearchNormalizer::Raw) && self.is_fast();
+        }
+
         // NOTE: This list of supported field types must be synced with the field types which are
         // specialized (in a few spots!) in SearchIndexReader.
         match self.field_entry.field_type() {
@@ -760,7 +768,8 @@ impl SearchField {
             FieldType::Bool(options) => options.is_fast(),
             FieldType::Date(options) => options.is_fast(),
             FieldType::Bytes(options) => options.is_fast(),
-            // TODO: JSON and range fields are not yet sortable by us
+            // TODO: JSON fields are not yet sortable by us. Range fields are, and are handled
+            // above before this match.
             FieldType::JsonObject(_) => false,
             _ => false,
         }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -750,6 +750,8 @@ impl SearchField {
         // `JsonObject` arm below. They are sortable via `SortByRange`, which reads the bound
         // sub-columns and compares them the way Postgres' `range_cmp` does. Only raw sorting:
         // range bounds are never tokenized, so there is no lowercased variant to sort by.
+        // A true here is not enough on its own: `SortByErasedType` can't read a range, so
+        // `sortable_at_position` restricts it to the leading key.
         if matches!(self.field_type, SearchFieldType::Range(_)) {
             return matches!(desired_normalizer, SearchNormalizer::Raw) && self.is_fast();
         }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -708,6 +708,14 @@ impl SearchField {
     }
 
     fn is_sortable(&self, desired_normalizer: SearchNormalizer) -> bool {
+        // Range fields are stored as a tantivy JSON object, so they'd otherwise fall into the
+        // `JsonObject` arm below. They are sortable via `SortByRange`, which reads the bound
+        // sub-columns and compares them the way Postgres' `range_cmp` does. Only raw sorting:
+        // range bounds are never tokenized, so there is no lowercased variant to sort by.
+        if matches!(self.field_type, SearchFieldType::Range(_)) {
+            return matches!(desired_normalizer, SearchNormalizer::Raw) && self.is_fast();
+        }
+
         // NOTE: This list of supported field types must be synced with the field types which are
         // specialized (in a few spots!) in SearchIndexReader.
         match self.field_entry.field_type() {
@@ -722,7 +730,8 @@ impl SearchField {
             FieldType::Bool(options) => options.is_fast(),
             FieldType::Date(options) => options.is_fast(),
             FieldType::Bytes(options) => options.is_fast(),
-            // TODO: JSON and range fields are not yet sortable by us
+            // TODO: JSON fields are not yet sortable by us. Range fields are, and are handled
+            // above before this match.
             FieldType::JsonObject(_) => false,
             _ => false,
         }

--- a/pg_search/tests/pg_regress/expected/fast_fields_options.out
+++ b/pg_search/tests/pg_regress/expected/fast_fields_options.out
@@ -167,18 +167,17 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: valid_period
-         ->  Custom Scan (ParadeDB Base Scan) on data_records
-               Table: data_records
-               Index: records_no_fast_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Custom Scan (ParadeDB Base Scan) on data_records
+         Table: data_records
+         Index: records_no_fast_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: valid_period asc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (9 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -281,18 +280,17 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: valid_period
-         ->  Custom Scan (ParadeDB Base Scan) on data_records
-               Table: data_records
-               Index: records_with_fast_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Custom Scan (ParadeDB Base Scan) on data_records
+         Table: data_records
+         Index: records_with_fast_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: valid_period asc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (9 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -397,18 +395,17 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: valid_period
-         ->  Custom Scan (ParadeDB Base Scan) on data_records
-               Table: data_records
-               Index: records_with_fast_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Custom Scan (ParadeDB Base Scan) on data_records
+         Table: data_records
+         Index: records_with_fast_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: valid_period asc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (9 rows)
 
 -- 'Test 7: ORDER BY with no LIMIT (should use ColumnarExecState)'

--- a/pg_search/tests/pg_regress/expected/issue_2688.out
+++ b/pg_search/tests/pg_regress/expected/issue_2688.out
@@ -1,3 +1,9 @@
+-- Issue #2688: `ORDER BY <range column>` is pushed into the index as a Top-N scan, ordered the
+-- way Postgres' `range_cmp` orders ranges. Exhaustive coverage lives in `order_by_range.sql`.
+--
+-- Several queries below have no tiebreaker, so rows that tie on the range sort key have an
+-- unspecified relative order; the expected output just records whatever the current
+-- implementation produces.
 DROP TABLE IF EXISTS data_records;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 CREATE TABLE data_records (
@@ -45,7 +51,6 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
  id |   title    |                          valid_period                           
 ----+------------+-----------------------------------------------------------------
   1 | Product 1  | ["Mon Jan 02 00:00:00 2023 PST","Thu Feb 02 00:00:00 2023 PST")
@@ -66,18 +71,17 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: valid_period
-         ->  Custom Scan (ParadeDB Base Scan) on data_records
-               Table: data_records
-               Index: records_no_fast_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Custom Scan (ParadeDB Base Scan) on data_records
+         Table: data_records
+         Index: records_no_fast_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: valid_period asc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (9 rows)
 
 SELECT id, title, quantity_range
@@ -85,15 +89,14 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY quantity_range
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
  id |   title    | quantity_range 
 ----+------------+----------------
  10 | Product 10 | [0,10)
  20 | Product 20 | [0,10)
- 11 | Product 11 | [10,20)
   1 | Product 1  | [10,20)
- 12 | Product 12 | [20,30)
+ 11 | Product 11 | [10,20)
   2 | Product 2  | [20,30)
+ 12 | Product 12 | [20,30)
   3 | Product 3  | [30,40)
  13 | Product 13 | [30,40)
   4 | Product 4  | [40,50)
@@ -106,18 +109,17 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY quantity_range
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: quantity_range
-         ->  Custom Scan (ParadeDB Base Scan) on data_records
-               Table: data_records
-               Index: records_no_fast_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Custom Scan (ParadeDB Base Scan) on data_records
+         Table: data_records
+         Index: records_no_fast_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: quantity_range asc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (9 rows)
 
 SELECT id, title, quantity_range, valid_period
@@ -125,7 +127,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY quantity_range, valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
  id |   title    | quantity_range |                          valid_period                           
 ----+------------+----------------+-----------------------------------------------------------------
  10 | Product 10 | [0,10)         | ["Wed Jan 11 00:00:00 2023 PST","Sat Feb 11 00:00:00 2023 PST")
@@ -146,7 +148,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY quantity_range, valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/order_by_range.out
+++ b/pg_search/tests/pg_regress/expected/order_by_range.out
@@ -492,6 +492,17 @@ WHERE title @@@ 'product' ORDER BY valid_period, id LIMIT 10;
  10 | Product 10 | Books
 (10 rows)
 
+SET
+ check_range_order 
+-------------------
+ ok
+(1 row)
+
+ check_range_order 
+-------------------
+ ok
+(1 row)
+
 DROP FUNCTION check_range_order(text, text, text, int, int);
 DROP TABLE data_records CASCADE;
 DROP TABLE range_segments CASCADE;

--- a/pg_search/tests/pg_regress/expected/order_by_range.out
+++ b/pg_search/tests/pg_regress/expected/order_by_range.out
@@ -492,12 +492,15 @@ WHERE title @@@ 'product' ORDER BY valid_period, id LIMIT 10;
  10 | Product 10 | Books
 (10 rows)
 
-SET
+-- Parallel TopK: range sort stays correct with parallelism enabled.
+SET max_parallel_workers_per_gather = 2;
+SELECT check_range_order('range_items', 'nr', 'ASC', 5, 0);
  check_range_order 
 -------------------
  ok
 (1 row)
 
+SELECT check_range_order('range_items', 'dr', 'DESC NULLS LAST', 4, 0);
  check_range_order 
 -------------------
  ok

--- a/pg_search/tests/pg_regress/expected/order_by_range.out
+++ b/pg_search/tests/pg_regress/expected/order_by_range.out
@@ -492,20 +492,53 @@ WHERE title @@@ 'product' ORDER BY valid_period, id LIMIT 10;
  10 | Product 10 | Books
 (10 rows)
 
--- Parallel TopK: range sort stays correct with parallelism enabled.
+-- =============================================================================
+-- Parallel TopK. The range key is merged across workers here, not just across
+-- segments. `range_segments` is the table to use: a single segment offers no
+-- useful workers, so `range_items` would stay serial whatever the cost knobs say.
+-- =============================================================================
 SET max_parallel_workers_per_gather = 2;
-SELECT check_range_order('range_items', 'nr', 'ASC', 5, 0);
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+CREATE FUNCTION plan_contains(query text, needle text) RETURNS bool LANGUAGE plpgsql AS $$
+DECLARE
+    line text;
+BEGIN
+    FOR line IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query LOOP
+        IF line LIKE '%' || needle || '%' THEN
+            RETURN true;
+        END IF;
+    END LOOP;
+    RETURN false;
+END;
+$$;
+-- Guards the two checks below. Without a Gather they would silently re-test the
+-- serial path, which the rest of the file already covers.
+SELECT plan_contains(
+    'SELECT nr FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5',
+    'Gather') AS parallel_plan;
+ parallel_plan 
+---------------
+ t
+(1 row)
+
+SELECT check_range_order('range_segments', 'nr', 'ASC', 5, 0);
  check_range_order 
 -------------------
  ok
 (1 row)
 
-SELECT check_range_order('range_items', 'dr', 'DESC NULLS LAST', 4, 0);
+SELECT check_range_order('range_segments', 'tzr', 'DESC NULLS LAST', 4, 0);
  check_range_order 
 -------------------
  ok
 (1 row)
 
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET min_parallel_table_scan_size;
+DROP FUNCTION plan_contains(text, text);
 DROP FUNCTION check_range_order(text, text, text, int, int);
 DROP TABLE data_records CASCADE;
 DROP TABLE range_segments CASCADE;

--- a/pg_search/tests/pg_regress/expected/order_by_range.out
+++ b/pg_search/tests/pg_regress/expected/order_by_range.out
@@ -297,12 +297,17 @@ DECLARE
     line text;
     pushed_down bool := false;
 BEGIN
+    -- The EXPLAIN and the two EXECUTEs share one statement text on purpose. If
+    -- they drifted, the plan check could pass on one shape while the values
+    -- came from another, and a lost pushdown would compare native to native.
     query := format(
-        'SELECT %I::text AS v FROM %I WHERE title @@@ ''doc'' ORDER BY %I %s LIMIT %s OFFSET %s',
+        'SELECT array_agg(v) FROM ('
+        '  SELECT %I::text AS v FROM %I WHERE title @@@ ''doc'' ORDER BY %I %s LIMIT %s OFFSET %s'
+        ') s',
         col, tbl, col, dir, lim, off);
 
     SET paradedb.enable_custom_scan = on;
-    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO pushed;
+    EXECUTE query INTO pushed;
     FOR line IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query LOOP
         IF line LIKE '%TopK%' THEN
             pushed_down := true;
@@ -310,7 +315,7 @@ BEGIN
     END LOOP;
 
     SET paradedb.enable_custom_scan = off;
-    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO native;
+    EXECUTE query INTO native;
     SET paradedb.enable_custom_scan = on;
 
     IF pushed IS DISTINCT FROM native THEN
@@ -383,6 +388,36 @@ WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). 
   3 | (,10)
   4 | [4,10)
   5 | [5,10)
+(5 rows)
+
+-- `lower(anyrange)` is a different function from the `lower(text)` the planner
+-- recognises, and a scalar bound orders differently from the whole range, so this
+-- must not be mistaken for a sort on `nr`. It stays a Postgres Sort.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY lower(nr) LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (lower(nr))
+         ->  Custom Scan (ParadeDB Base Scan) on range_items
+               Table: range_items
+               Index: range_items_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"doc","lenient":null,"conjunction_mode":null}}}}
+(9 rows)
+
+SELECT id, lower(nr) FROM range_items WHERE title @@@ 'doc' ORDER BY lower(nr), id LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+ id |    lower     
+----+--------------
+ 13 |     -0.00001
+ 14 | 0.0000000001
+  4 |            4
+  5 |            5
+  6 |            5
 (5 rows)
 
 -- =============================================================================
@@ -514,13 +549,22 @@ BEGIN
 END;
 $$;
 -- Guards the two checks below. Without a Gather they would silently re-test the
--- serial path, which the rest of the file already covers.
+-- serial path, which the rest of the file already covers. The statement is the
+-- same wrapped shape `check_range_order` measures, so the plan being asserted is
+-- the plan whose values get compared.
 SELECT plan_contains(
-    'SELECT nr FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5',
-    'Gather') AS parallel_plan;
- parallel_plan 
----------------
- t
+    'SELECT array_agg(v) FROM ('
+    '  SELECT nr::text AS v FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5'
+    ') s',
+    'Gather') AS parallel_plan,
+    plan_contains(
+    'SELECT array_agg(v) FROM ('
+    '  SELECT nr::text AS v FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5'
+    ') s',
+    'TopK') AS topk_plan;
+ parallel_plan | topk_plan 
+---------------+-----------
+ t             | t
 (1 row)
 
 SELECT check_range_order('range_segments', 'nr', 'ASC', 5, 0);

--- a/pg_search/tests/pg_regress/expected/order_by_range.out
+++ b/pg_search/tests/pg_regress/expected/order_by_range.out
@@ -39,7 +39,7 @@ INSERT INTO range_items (title, i4, i8, nr, dr, tr, tzr) VALUES
  ('doc', '[0,1)', '[0,1)', '[0.0000000001,123456789.123456789)', '[2020-01-01,2020-01-02)', '[2020-01-01 00:00:00.000001,2020-01-02)', '[2020-01-01 00:00:00.000001,2020-01-02)');
 -- Range fields are fast by default, so no explicit field configuration is needed.
 CREATE INDEX range_items_idx ON range_items
-USING bm25 (id, title, i4, i8, nr, dr, tr, tzr) WITH (key_field = 'id');
+USING paradedb (id, title, i4, i8, nr, dr, tr, tzr) WITH (key_field = 'id');
 -- =============================================================================
 -- The plan: ORDER BY range + LIMIT is a Top-N scan, with no Postgres Sort above it.
 -- Before this was supported, the same query produced a `Sort` over a
@@ -393,7 +393,7 @@ WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). 
 -- =============================================================================
 CREATE TABLE range_segments (id SERIAL PRIMARY KEY, title TEXT, nr NUMRANGE, tzr TSTZRANGE);
 CREATE INDEX range_segments_idx ON range_segments
-USING bm25 (id, title, nr, tzr) WITH (key_field = 'id');
+USING paradedb (id, title, nr, tzr) WITH (key_field = 'id');
 DO $$
 BEGIN
     FOR batch IN 0..5 LOOP
@@ -459,7 +459,7 @@ SELECT 'Product ' || i,
        numrange((i % 10) * 10, (i % 10 + 1) * 10)
 FROM generate_series(1, 100) i;
 CREATE INDEX records_no_fast_idx ON data_records
-USING bm25 (id, title, category, valid_period, quantity_range) WITH (key_field = 'id');
+USING paradedb (id, title, category, valid_period, quantity_range) WITH (key_field = 'id');
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT id, title, category FROM data_records
 WHERE title @@@ 'product' ORDER BY valid_period LIMIT 10;

--- a/pg_search/tests/pg_regress/expected/order_by_range.out
+++ b/pg_search/tests/pg_regress/expected/order_by_range.out
@@ -1,0 +1,499 @@
+-- Tests `ORDER BY <range column>` pushdown into the BM25 index (issue #2688).
+--
+-- Range columns are indexed as a tantivy JSON object with `lower`/`upper`/`empty` and the four
+-- bound flags as fast field sub-columns. `SortByRange` reads those and assembles a composite
+-- sort key ordered exactly like Postgres' `range_cmp`: empty first, unbounded lower first,
+-- unbounded upper last, inclusive-before-exclusive on an equal lower bound, and
+-- exclusive-before-inclusive on an equal upper bound.
+--
+-- The correctness oracle throughout is native Postgres: every pushed-down result is compared
+-- against the same query with `paradedb.enable_custom_scan = off`.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET max_parallel_workers_per_gather = 0;
+CREATE TABLE range_items (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    i4  INT4RANGE,
+    i8  INT8RANGE,
+    nr  NUMRANGE,
+    dr  DATERANGE,
+    tr  TSRANGE,
+    tzr TSTZRANGE
+);
+-- Every interesting shape: empty, fully unbounded, half unbounded, inclusive/exclusive
+-- variations on the same bound values, a duplicate row, and SQL NULL.
+INSERT INTO range_items (title, i4, i8, nr, dr, tr, tzr) VALUES
+ ('doc', 'empty', 'empty', 'empty', 'empty', 'empty', 'empty'),
+ ('doc', '(,)', '(,)', '(,)', '(,)', '(,)', '(,)'),
+ ('doc', '(,10)', '(,10)', '(,10)', '(,2020-01-10)', '(,2020-01-10)', '(,2020-01-10)'),
+ ('doc', '[4,10)', '[4,10)', '[4,10)', '[2020-01-04,2020-01-10)', '[2020-01-04,2020-01-10)', '[2020-01-04,2020-01-10)'),
+ ('doc', '[5,10)', '[5,10)', '[5,10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)'),
+ ('doc', '[5,10]', '[5,10]', '[5,10]', '[2020-01-05,2020-01-10]', '[2020-01-05,2020-01-10]', '[2020-01-05,2020-01-10]'),
+ ('doc', '[5,11)', '[5,11)', '[5,11)', '[2020-01-05,2020-01-11)', '[2020-01-05,2020-01-11)', '[2020-01-05,2020-01-11)'),
+ ('doc', '[5,)', '[5,)', '[5,)', '[2020-01-05,)', '[2020-01-05,)', '[2020-01-05,)'),
+ ('doc', '(5,10)', '(5,10)', '(5,10)', '(2020-01-05,2020-01-10)', '(2020-01-05,2020-01-10)', '(2020-01-05,2020-01-10)'),
+ ('doc', '(5,10]', '(5,10]', '(5,10]', '(2020-01-05,2020-01-10]', '(2020-01-05,2020-01-10]', '(2020-01-05,2020-01-10]'),
+ ('doc', NULL, NULL, NULL, NULL, NULL, NULL),
+ ('doc', '[5,10)', '[5,10)', '[5,10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)'),
+ ('doc', '[-100,-50)', '[-9223372036854775808,0)', '[-0.00001,0.5)', '[1900-01-01,1901-01-01)', '[1900-01-01,1901-01-01)', '[1900-01-01,1901-01-01)'),
+ ('doc', '[0,1)', '[0,1)', '[0.0000000001,123456789.123456789)', '[2020-01-01,2020-01-02)', '[2020-01-01 00:00:00.000001,2020-01-02)', '[2020-01-01 00:00:00.000001,2020-01-02)');
+-- Range fields are fast by default, so no explicit field configuration is needed.
+CREATE INDEX range_items_idx ON range_items
+USING bm25 (id, title, i4, i8, nr, dr, tr, tzr) WITH (key_field = 'id');
+-- =============================================================================
+-- The plan: ORDER BY range + LIMIT is a Top-N scan, with no Postgres Sort above it.
+-- Before this was supported, the same query produced a `Sort` over a
+-- `NormalScanExecState` scan and a "not using Top K scan" warning.
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY tzr LIMIT 5;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: id, tzr
+   ->  Custom Scan (ParadeDB Base Scan) on public.range_items
+         Output: id, tzr
+         Table: range_items
+         Index: range_items_idx
+         Worker Selection: Cost model
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: tzr asc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"doc","lenient":null,"conjunction_mode":null}}}}
+(12 rows)
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC LIMIT 5;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: id, nr
+   ->  Custom Scan (ParadeDB Base Scan) on public.range_items
+         Output: id, nr
+         Table: range_items
+         Index: range_items_idx
+         Worker Selection: Cost model
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: nr desc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"doc","lenient":null,"conjunction_mode":null}}}}
+(12 rows)
+
+-- =============================================================================
+-- The ordering itself, per range type. `id` is the tiebreaker so the duplicate
+-- row does not make the output non-deterministic.
+-- =============================================================================
+SELECT id, i4 FROM range_items WHERE title @@@ 'doc' ORDER BY i4, id LIMIT 14;
+ id |     i4     
+----+------------
+  1 | empty
+  3 | (,10)
+  2 | (,)
+ 13 | [-100,-50)
+ 14 | [0,1)
+  4 | [4,10)
+  5 | [5,10)
+ 12 | [5,10)
+  6 | [5,11)
+  7 | [5,11)
+  8 | [5,)
+  9 | [6,10)
+ 10 | [6,11)
+ 11 | 
+(14 rows)
+
+SELECT id, i8 FROM range_items WHERE title @@@ 'doc' ORDER BY i8, id LIMIT 14;
+ id |            i8            
+----+--------------------------
+  1 | empty
+  3 | (,10)
+  2 | (,)
+ 13 | [-9223372036854775808,0)
+ 14 | [0,1)
+  4 | [4,10)
+  5 | [5,10)
+ 12 | [5,10)
+  6 | [5,11)
+  7 | [5,11)
+  8 | [5,)
+  9 | [6,10)
+ 10 | [6,11)
+ 11 | 
+(14 rows)
+
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr, id LIMIT 14;
+ id |                 nr                 
+----+------------------------------------
+  1 | empty
+  3 | (,10)
+  2 | (,)
+ 13 | [-0.00001,0.5)
+ 14 | [0.0000000001,123456789.123456789)
+  4 | [4,10)
+  5 | [5,10)
+ 12 | [5,10)
+  6 | [5,10]
+  7 | [5,11)
+  8 | [5,)
+  9 | (5,10)
+ 10 | (5,10]
+ 11 | 
+(14 rows)
+
+SELECT id, dr FROM range_items WHERE title @@@ 'doc' ORDER BY dr, id LIMIT 14;
+ id |           dr            
+----+-------------------------
+  1 | empty
+  3 | (,01-10-2020)
+  2 | (,)
+ 13 | [01-01-1900,01-01-1901)
+ 14 | [01-01-2020,01-02-2020)
+  4 | [01-04-2020,01-10-2020)
+  5 | [01-05-2020,01-10-2020)
+ 12 | [01-05-2020,01-10-2020)
+  6 | [01-05-2020,01-11-2020)
+  7 | [01-05-2020,01-11-2020)
+  8 | [01-05-2020,)
+  9 | [01-06-2020,01-10-2020)
+ 10 | [01-06-2020,01-11-2020)
+ 11 | 
+(14 rows)
+
+SELECT id, tr FROM range_items WHERE title @@@ 'doc' ORDER BY tr, id LIMIT 14;
+ id |                               tr                               
+----+----------------------------------------------------------------
+  1 | empty
+  3 | (,"Fri Jan 10 00:00:00 2020")
+  2 | (,)
+ 13 | ["Mon Jan 01 00:00:00 1900","Tue Jan 01 00:00:00 1901")
+ 14 | ["Wed Jan 01 00:00:00.000001 2020","Thu Jan 02 00:00:00 2020")
+  4 | ["Sat Jan 04 00:00:00 2020","Fri Jan 10 00:00:00 2020")
+  5 | ["Sun Jan 05 00:00:00 2020","Fri Jan 10 00:00:00 2020")
+ 12 | ["Sun Jan 05 00:00:00 2020","Fri Jan 10 00:00:00 2020")
+  6 | ["Sun Jan 05 00:00:00 2020","Fri Jan 10 00:00:00 2020"]
+  7 | ["Sun Jan 05 00:00:00 2020","Sat Jan 11 00:00:00 2020")
+  8 | ["Sun Jan 05 00:00:00 2020",)
+  9 | ("Sun Jan 05 00:00:00 2020","Fri Jan 10 00:00:00 2020")
+ 10 | ("Sun Jan 05 00:00:00 2020","Fri Jan 10 00:00:00 2020"]
+ 11 | 
+(14 rows)
+
+SELECT id, tzr FROM range_items WHERE title @@@ 'doc' ORDER BY tzr, id LIMIT 14;
+ id |                                  tzr                                   
+----+------------------------------------------------------------------------
+  1 | empty
+  3 | (,"Fri Jan 10 00:00:00 2020 PST")
+  2 | (,)
+ 13 | ["Mon Jan 01 00:00:00 1900 PST","Tue Jan 01 00:00:00 1901 PST")
+ 14 | ["Wed Jan 01 00:00:00.000001 2020 PST","Thu Jan 02 00:00:00 2020 PST")
+  4 | ["Sat Jan 04 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+  5 | ["Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+ 12 | ["Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+  6 | ["Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST"]
+  7 | ["Sun Jan 05 00:00:00 2020 PST","Sat Jan 11 00:00:00 2020 PST")
+  8 | ["Sun Jan 05 00:00:00 2020 PST",)
+  9 | ("Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+ 10 | ("Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST"]
+ 11 | 
+(14 rows)
+
+-- Continuous types keep their inclusivity, so they exercise the bound-flag tiebreaks that
+-- discrete types normalize away (`(5,10)` becomes `[6,10)` for int4range).
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC, id LIMIT 14;
+ id |                 nr                 
+----+------------------------------------
+ 11 | 
+ 10 | (5,10]
+  9 | (5,10)
+  8 | [5,)
+  7 | [5,11)
+  6 | [5,10]
+  5 | [5,10)
+ 12 | [5,10)
+  4 | [4,10)
+ 14 | [0.0000000001,123456789.123456789)
+ 13 | [-0.00001,0.5)
+  2 | (,)
+  3 | (,10)
+  1 | empty
+(14 rows)
+
+SELECT id, tzr FROM range_items WHERE title @@@ 'doc' ORDER BY tzr DESC, id LIMIT 14;
+ id |                                  tzr                                   
+----+------------------------------------------------------------------------
+ 11 | 
+ 10 | ("Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST"]
+  9 | ("Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+  8 | ["Sun Jan 05 00:00:00 2020 PST",)
+  7 | ["Sun Jan 05 00:00:00 2020 PST","Sat Jan 11 00:00:00 2020 PST")
+  6 | ["Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST"]
+  5 | ["Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+ 12 | ["Sun Jan 05 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+  4 | ["Sat Jan 04 00:00:00 2020 PST","Fri Jan 10 00:00:00 2020 PST")
+ 14 | ["Wed Jan 01 00:00:00.000001 2020 PST","Thu Jan 02 00:00:00 2020 PST")
+ 13 | ["Mon Jan 01 00:00:00 1900 PST","Tue Jan 01 00:00:00 1901 PST")
+  2 | (,)
+  3 | (,"Fri Jan 10 00:00:00 2020 PST")
+  1 | empty
+(14 rows)
+
+-- NULL placement follows the query, not the storage.
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr ASC NULLS FIRST, id LIMIT 3;
+ id |  nr   
+----+-------
+ 11 | 
+  1 | empty
+  3 | (,10)
+(3 rows)
+
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr ASC NULLS LAST, id LIMIT 3;
+ id |  nr   
+----+-------
+  1 | empty
+  3 | (,10)
+  2 | (,)
+(3 rows)
+
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC NULLS FIRST, id LIMIT 3;
+ id |   nr   
+----+--------
+ 11 | 
+ 10 | (5,10]
+  9 | (5,10)
+(3 rows)
+
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC NULLS LAST, id LIMIT 3;
+ id |   nr   
+----+--------
+ 10 | (5,10]
+  9 | (5,10)
+  8 | [5,)
+(3 rows)
+
+-- OFFSET walks past the leading keys.
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr, id LIMIT 4 OFFSET 6;
+ id |   nr   
+----+--------
+  5 | [5,10)
+ 12 | [5,10)
+  6 | [5,10]
+  7 | [5,11)
+(4 rows)
+
+-- =============================================================================
+-- Differential check against native Postgres, for every range type crossed with
+-- every direction/NULLS combination and a few limits. Compares the ordered
+-- sequence of range values, so rows that tie on the sort key cannot register as
+-- a difference. Must report zero mismatches and no declines.
+-- =============================================================================
+CREATE FUNCTION check_range_order(tbl text, col text, dir text, lim int, off int)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE
+    query text;
+    pushed text[];
+    native text[];
+    line text;
+    pushed_down bool := false;
+BEGIN
+    query := format(
+        'SELECT %I::text AS v FROM %I WHERE title @@@ ''doc'' ORDER BY %I %s LIMIT %s OFFSET %s',
+        col, tbl, col, dir, lim, off);
+
+    SET paradedb.enable_custom_scan = on;
+    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO pushed;
+    FOR line IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query LOOP
+        IF line LIKE '%TopK%' THEN
+            pushed_down := true;
+        END IF;
+    END LOOP;
+
+    SET paradedb.enable_custom_scan = off;
+    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO native;
+    SET paradedb.enable_custom_scan = on;
+
+    IF pushed IS DISTINCT FROM native THEN
+        RETURN format('MISMATCH %s %s limit %s offset %s: pushed=%s native=%s',
+                      col, dir, lim, off, pushed, native);
+    END IF;
+    IF NOT pushed_down THEN
+        RETURN format('NOT PUSHED DOWN: %s %s', col, dir);
+    END IF;
+    RETURN 'ok';
+END $$;
+SELECT result, count(*)
+FROM (
+    SELECT check_range_order('range_items', col, dir, lim, off) AS result
+    FROM unnest(ARRAY['i4', 'i8', 'nr', 'dr', 'tr', 'tzr']) col,
+         unnest(ARRAY['ASC', 'DESC', 'ASC NULLS FIRST', 'DESC NULLS LAST']) dir,
+         unnest(ARRAY[1, 3, 14, 20]) lim,
+         unnest(ARRAY[0, 5]) off
+) s
+GROUP BY result
+ORDER BY result;
+ result | count 
+--------+-------
+ ok     |   192
+(1 row)
+
+-- =============================================================================
+-- A range is only pushed down as the *leading* sort key: later keys are collected
+-- via `SortByErasedType`, which reads a single column and cannot express the
+-- composite bound comparison. Range-then-column pushes; column-then-range declines
+-- to a Postgres Sort, which is correct but unaccelerated.
+-- =============================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY nr, id LIMIT 5;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on range_items
+         Table: range_items
+         Index: range_items_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: nr asc, id asc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"doc","lenient":null,"conjunction_mode":null}}}}
+(9 rows)
+
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: id, nr
+         ->  Custom Scan (ParadeDB Base Scan) on range_items
+               Table: range_items
+               Index: range_items_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"doc","lenient":null,"conjunction_mode":null}}}}
+(9 rows)
+
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+ id |   nr   
+----+--------
+  1 | empty
+  2 | (,)
+  3 | (,10)
+  4 | [4,10)
+  5 | [5,10)
+(5 rows)
+
+-- =============================================================================
+-- Cross-segment merge. Within a segment, a `numrange` bound compares by term
+-- ordinal; ordinals are not comparable across segments, so the key has to be
+-- resolved to bytes before segments are merged. Several batched inserts build
+-- several segments to exercise that path.
+-- =============================================================================
+CREATE TABLE range_segments (id SERIAL PRIMARY KEY, title TEXT, nr NUMRANGE, tzr TSTZRANGE);
+CREATE INDEX range_segments_idx ON range_segments
+USING bm25 (id, title, nr, tzr) WITH (key_field = 'id');
+DO $$
+BEGIN
+    FOR batch IN 0..5 LOOP
+        INSERT INTO range_segments (title, nr, tzr)
+        SELECT 'doc',
+               CASE WHEN i % 31 = 0 THEN NULL
+                    WHEN i % 29 = 0 THEN 'empty'::numrange
+                    WHEN i % 23 = 0 THEN numrange(NULL, (i % 500)::numeric / 7, '()')
+                    WHEN i % 19 = 0 THEN numrange((i % 500)::numeric / 7, NULL, '[)')
+                    ELSE numrange((i % 500)::numeric / 7,
+                                  (i % 500)::numeric / 7 + 3,
+                                  CASE WHEN i % 2 = 0 THEN '[)' ELSE '(]' END)
+               END,
+               CASE WHEN i % 37 = 0 THEN NULL
+                    WHEN i % 17 = 0 THEN 'empty'::tstzrange
+                    ELSE tstzrange('2020-01-01'::timestamptz + ((i % 300) || ' hours')::interval,
+                                   '2020-01-01'::timestamptz + ((i % 300) || ' hours')::interval + '3 days')
+               END
+        FROM generate_series(batch * 500 + 1, (batch + 1) * 500) i;
+    END LOOP;
+END $$;
+SELECT count(*) > 1 AS has_multiple_segments FROM paradedb.index_info('range_segments_idx');
+ has_multiple_segments 
+-----------------------
+ t
+(1 row)
+
+SELECT result, count(*)
+FROM (
+    SELECT check_range_order('range_segments', col, dir, lim, off) AS result
+    FROM unnest(ARRAY['nr', 'tzr']) col,
+         unnest(ARRAY['ASC', 'DESC', 'ASC NULLS FIRST', 'DESC NULLS LAST']) dir,
+         unnest(ARRAY[1, 25, 500]) lim,
+         unnest(ARRAY[0, 13, 2900]) off
+) s
+GROUP BY result
+ORDER BY result;
+ result | count 
+--------+-------
+ ok     |    72
+(1 row)
+
+-- =============================================================================
+-- Issue #2688's original query. It used to fail outright with
+-- `SchemaError("Fast field not available: '\"valid_period\"'")`, then later
+-- silently degraded to a Postgres Sort. Now it is a Top-N scan.
+-- =============================================================================
+CREATE TABLE data_records (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    valid_period TSTZRANGE,
+    quantity_range NUMRANGE
+);
+INSERT INTO data_records (title, category, valid_period, quantity_range)
+SELECT 'Product ' || i,
+       CASE WHEN i % 4 = 0 THEN 'Electronics'
+            WHEN i % 4 = 1 THEN 'Clothing'
+            WHEN i % 4 = 2 THEN 'Books'
+            ELSE 'Home' END,
+       tstzrange('2023-01-01'::timestamptz + ((i % 365) || ' days')::interval,
+                 '2023-01-01'::timestamptz + ((i % 365) || ' days')::interval + '1 month'::interval),
+       numrange((i % 10) * 10, (i % 10 + 1) * 10)
+FROM generate_series(1, 100) i;
+CREATE INDEX records_no_fast_idx ON data_records
+USING bm25 (id, title, category, valid_period, quantity_range) WITH (key_field = 'id');
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id, title, category FROM data_records
+WHERE title @@@ 'product' ORDER BY valid_period LIMIT 10;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on data_records
+         Table: data_records
+         Index: records_no_fast_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: valid_period asc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+(9 rows)
+
+SELECT id, title, category FROM data_records
+WHERE title @@@ 'product' ORDER BY valid_period, id LIMIT 10;
+ id |   title    |  category   
+----+------------+-------------
+  1 | Product 1  | Clothing
+  2 | Product 2  | Books
+  3 | Product 3  | Home
+  4 | Product 4  | Electronics
+  5 | Product 5  | Clothing
+  6 | Product 6  | Books
+  7 | Product 7  | Home
+  8 | Product 8  | Electronics
+  9 | Product 9  | Clothing
+ 10 | Product 10 | Books
+(10 rows)
+
+DROP FUNCTION check_range_order(text, text, text, int, int);
+DROP TABLE data_records CASCADE;
+DROP TABLE range_segments CASCADE;
+DROP TABLE range_items CASCADE;
+RESET max_parallel_workers_per_gather;

--- a/pg_search/tests/pg_regress/expected/top_k_scan.out
+++ b/pg_search/tests/pg_regress/expected/top_k_scan.out
@@ -137,18 +137,17 @@ WHERE tenant_id = 'tenant-1'
   AND (id @@@ paradedb.all())
 ORDER BY time_period DESC
 LIMIT 25;
-WARNING:  Query has LIMIT 25 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: records)
-                                                                                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: time_period DESC
-         ->  Custom Scan (ParadeDB Base Scan) on records
-               Table: records
-               Index: records_search_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"source_id"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"removed_at"}}]}}}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
+   ->  Custom Scan (ParadeDB Base Scan) on records
+         Table: records
+         Index: records_search_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: time_period desc
+            TopK Limit: 25
+         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"source_id"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"removed_at"}}]}}}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
 (9 rows)
 
 -- Test 3: Same query without paradedb.all() operator
@@ -165,18 +164,17 @@ WHERE tenant_id = 'tenant-1'
   AND (NOT id @@@ paradedb.exists('removed_at'))
 ORDER BY time_period DESC
 LIMIT 25;
-WARNING:  Query has LIMIT 25 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: records)
-                                                                                                                                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: time_period DESC
-         ->  Custom Scan (ParadeDB Base Scan) on records
-               Table: records
-               Index: records_search_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"source_id"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"removed_at"}}]}}}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
+   ->  Custom Scan (ParadeDB Base Scan) on records
+         Table: records
+         Index: records_search_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: time_period desc
+            TopK Limit: 25
+         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"source_id"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"removed_at"}}]}}}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
 (9 rows)
 
 -- Test 4: Testing the impact of paradedb.all() alone
@@ -257,18 +255,17 @@ WHERE tenant_id = 'tenant-1'
   AND id @@@ paradedb.match('notes', 'check')
 ORDER BY time_period DESC
 LIMIT 25;
-WARNING:  Query has LIMIT 25 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: records)
-                                                                                                                                                         QUERY PLAN                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                      QUERY PLAN                                                                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: time_period DESC
-         ->  Custom Scan (ParadeDB Base Scan) on records
-               Table: records
-               Index: records_search_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
+   ->  Custom Scan (ParadeDB Base Scan) on records
+         Table: records
+         Index: records_search_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: time_period desc
+            TopK Limit: 25
+         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
 (9 rows)
 
 -- Test 8: Testing with each complex component isolated
@@ -314,18 +311,17 @@ WHERE tenant_id = 'tenant-1'
   AND (id @@@ paradedb.all())
 ORDER BY time_period DESC
 LIMIT 25;
-WARNING:  Query has LIMIT 25 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: records)
-                                                                                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: time_period DESC
-         ->  Custom Scan (ParadeDB Base Scan) on records
-               Table: records
-               Index: records_search_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"source_id"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"removed_at"}}]}}}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
+   ->  Custom Scan (ParadeDB Base Scan) on records
+         Table: records
+         Index: records_search_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: time_period desc
+            TopK Limit: 25
+         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"source_id"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"removed_at"}}]}}}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
 (9 rows)
 
 -- Test 10: Fast-field only solution - selecting only indexed fast fields
@@ -339,18 +335,17 @@ WHERE tenant_id = 'tenant-1'
   AND (id @@@ paradedb.match('notes', 'check'))
 ORDER BY time_period DESC
 LIMIT 25;
-WARNING:  Query has LIMIT 25 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: records)
-                                                                                                                                                         QUERY PLAN                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                      QUERY PLAN                                                                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: time_period DESC
-         ->  Custom Scan (ParadeDB Base Scan) on records
-               Table: records
-               Index: records_search_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
+   ->  Custom Scan (ParadeDB Base Scan) on records
+         Table: records
+         Index: records_search_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: time_period desc
+            TopK Limit: 25
+         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1"}}]}}
 (9 rows)
 
 -- Test 11: ORDER BY on column containing NULL.

--- a/pg_search/tests/pg_regress/sql/issue_2688.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2688.sql
@@ -1,3 +1,9 @@
+-- Issue #2688: `ORDER BY <range column>` is pushed into the index as a Top-N scan, ordered the
+-- way Postgres' `range_cmp` orders ranges. Exhaustive coverage lives in `order_by_range.sql`.
+--
+-- Several queries below have no tiebreaker, so rows that tie on the range sort key have an
+-- unspecified relative order; the expected output just records whatever the current
+-- implementation produces.
 DROP TABLE IF EXISTS data_records;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 

--- a/pg_search/tests/pg_regress/sql/order_by_range.sql
+++ b/pg_search/tests/pg_regress/sql/order_by_range.sql
@@ -1,0 +1,233 @@
+-- Tests `ORDER BY <range column>` pushdown into the BM25 index (issue #2688).
+--
+-- Range columns are indexed as a tantivy JSON object with `lower`/`upper`/`empty` and the four
+-- bound flags as fast field sub-columns. `SortByRange` reads those and assembles a composite
+-- sort key ordered exactly like Postgres' `range_cmp`: empty first, unbounded lower first,
+-- unbounded upper last, inclusive-before-exclusive on an equal lower bound, and
+-- exclusive-before-inclusive on an equal upper bound.
+--
+-- The correctness oracle throughout is native Postgres: every pushed-down result is compared
+-- against the same query with `paradedb.enable_custom_scan = off`.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET max_parallel_workers_per_gather = 0;
+
+CREATE TABLE range_items (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    i4  INT4RANGE,
+    i8  INT8RANGE,
+    nr  NUMRANGE,
+    dr  DATERANGE,
+    tr  TSRANGE,
+    tzr TSTZRANGE
+);
+
+-- Every interesting shape: empty, fully unbounded, half unbounded, inclusive/exclusive
+-- variations on the same bound values, a duplicate row, and SQL NULL.
+INSERT INTO range_items (title, i4, i8, nr, dr, tr, tzr) VALUES
+ ('doc', 'empty', 'empty', 'empty', 'empty', 'empty', 'empty'),
+ ('doc', '(,)', '(,)', '(,)', '(,)', '(,)', '(,)'),
+ ('doc', '(,10)', '(,10)', '(,10)', '(,2020-01-10)', '(,2020-01-10)', '(,2020-01-10)'),
+ ('doc', '[4,10)', '[4,10)', '[4,10)', '[2020-01-04,2020-01-10)', '[2020-01-04,2020-01-10)', '[2020-01-04,2020-01-10)'),
+ ('doc', '[5,10)', '[5,10)', '[5,10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)'),
+ ('doc', '[5,10]', '[5,10]', '[5,10]', '[2020-01-05,2020-01-10]', '[2020-01-05,2020-01-10]', '[2020-01-05,2020-01-10]'),
+ ('doc', '[5,11)', '[5,11)', '[5,11)', '[2020-01-05,2020-01-11)', '[2020-01-05,2020-01-11)', '[2020-01-05,2020-01-11)'),
+ ('doc', '[5,)', '[5,)', '[5,)', '[2020-01-05,)', '[2020-01-05,)', '[2020-01-05,)'),
+ ('doc', '(5,10)', '(5,10)', '(5,10)', '(2020-01-05,2020-01-10)', '(2020-01-05,2020-01-10)', '(2020-01-05,2020-01-10)'),
+ ('doc', '(5,10]', '(5,10]', '(5,10]', '(2020-01-05,2020-01-10]', '(2020-01-05,2020-01-10]', '(2020-01-05,2020-01-10]'),
+ ('doc', NULL, NULL, NULL, NULL, NULL, NULL),
+ ('doc', '[5,10)', '[5,10)', '[5,10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)', '[2020-01-05,2020-01-10)'),
+ ('doc', '[-100,-50)', '[-9223372036854775808,0)', '[-0.00001,0.5)', '[1900-01-01,1901-01-01)', '[1900-01-01,1901-01-01)', '[1900-01-01,1901-01-01)'),
+ ('doc', '[0,1)', '[0,1)', '[0.0000000001,123456789.123456789)', '[2020-01-01,2020-01-02)', '[2020-01-01 00:00:00.000001,2020-01-02)', '[2020-01-01 00:00:00.000001,2020-01-02)');
+
+-- Range fields are fast by default, so no explicit field configuration is needed.
+CREATE INDEX range_items_idx ON range_items
+USING bm25 (id, title, i4, i8, nr, dr, tr, tzr) WITH (key_field = 'id');
+
+-- =============================================================================
+-- The plan: ORDER BY range + LIMIT is a Top-N scan, with no Postgres Sort above it.
+-- Before this was supported, the same query produced a `Sort` over a
+-- `NormalScanExecState` scan and a "not using Top K scan" warning.
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY tzr LIMIT 5;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC LIMIT 5;
+
+-- =============================================================================
+-- The ordering itself, per range type. `id` is the tiebreaker so the duplicate
+-- row does not make the output non-deterministic.
+-- =============================================================================
+SELECT id, i4 FROM range_items WHERE title @@@ 'doc' ORDER BY i4, id LIMIT 14;
+SELECT id, i8 FROM range_items WHERE title @@@ 'doc' ORDER BY i8, id LIMIT 14;
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr, id LIMIT 14;
+SELECT id, dr FROM range_items WHERE title @@@ 'doc' ORDER BY dr, id LIMIT 14;
+SELECT id, tr FROM range_items WHERE title @@@ 'doc' ORDER BY tr, id LIMIT 14;
+SELECT id, tzr FROM range_items WHERE title @@@ 'doc' ORDER BY tzr, id LIMIT 14;
+
+-- Continuous types keep their inclusivity, so they exercise the bound-flag tiebreaks that
+-- discrete types normalize away (`(5,10)` becomes `[6,10)` for int4range).
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC, id LIMIT 14;
+SELECT id, tzr FROM range_items WHERE title @@@ 'doc' ORDER BY tzr DESC, id LIMIT 14;
+
+-- NULL placement follows the query, not the storage.
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr ASC NULLS FIRST, id LIMIT 3;
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr ASC NULLS LAST, id LIMIT 3;
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC NULLS FIRST, id LIMIT 3;
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr DESC NULLS LAST, id LIMIT 3;
+
+-- OFFSET walks past the leading keys.
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY nr, id LIMIT 4 OFFSET 6;
+
+-- =============================================================================
+-- Differential check against native Postgres, for every range type crossed with
+-- every direction/NULLS combination and a few limits. Compares the ordered
+-- sequence of range values, so rows that tie on the sort key cannot register as
+-- a difference. Must report zero mismatches and no declines.
+-- =============================================================================
+CREATE FUNCTION check_range_order(tbl text, col text, dir text, lim int, off int)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE
+    query text;
+    pushed text[];
+    native text[];
+    line text;
+    pushed_down bool := false;
+BEGIN
+    query := format(
+        'SELECT %I::text AS v FROM %I WHERE title @@@ ''doc'' ORDER BY %I %s LIMIT %s OFFSET %s',
+        col, tbl, col, dir, lim, off);
+
+    SET paradedb.enable_custom_scan = on;
+    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO pushed;
+    FOR line IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query LOOP
+        IF line LIKE '%TopK%' THEN
+            pushed_down := true;
+        END IF;
+    END LOOP;
+
+    SET paradedb.enable_custom_scan = off;
+    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO native;
+    SET paradedb.enable_custom_scan = on;
+
+    IF pushed IS DISTINCT FROM native THEN
+        RETURN format('MISMATCH %s %s limit %s offset %s: pushed=%s native=%s',
+                      col, dir, lim, off, pushed, native);
+    END IF;
+    IF NOT pushed_down THEN
+        RETURN format('NOT PUSHED DOWN: %s %s', col, dir);
+    END IF;
+    RETURN 'ok';
+END $$;
+
+SELECT result, count(*)
+FROM (
+    SELECT check_range_order('range_items', col, dir, lim, off) AS result
+    FROM unnest(ARRAY['i4', 'i8', 'nr', 'dr', 'tr', 'tzr']) col,
+         unnest(ARRAY['ASC', 'DESC', 'ASC NULLS FIRST', 'DESC NULLS LAST']) dir,
+         unnest(ARRAY[1, 3, 14, 20]) lim,
+         unnest(ARRAY[0, 5]) off
+) s
+GROUP BY result
+ORDER BY result;
+
+-- =============================================================================
+-- A range is only pushed down as the *leading* sort key: later keys are collected
+-- via `SortByErasedType`, which reads a single column and cannot express the
+-- composite bound comparison. Range-then-column pushes; column-then-range declines
+-- to a Postgres Sort, which is correct but unaccelerated.
+-- =============================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY nr, id LIMIT 5;
+
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
+
+SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
+
+-- =============================================================================
+-- Cross-segment merge. Within a segment, a `numrange` bound compares by term
+-- ordinal; ordinals are not comparable across segments, so the key has to be
+-- resolved to bytes before segments are merged. Several batched inserts build
+-- several segments to exercise that path.
+-- =============================================================================
+CREATE TABLE range_segments (id SERIAL PRIMARY KEY, title TEXT, nr NUMRANGE, tzr TSTZRANGE);
+CREATE INDEX range_segments_idx ON range_segments
+USING bm25 (id, title, nr, tzr) WITH (key_field = 'id');
+
+DO $$
+BEGIN
+    FOR batch IN 0..5 LOOP
+        INSERT INTO range_segments (title, nr, tzr)
+        SELECT 'doc',
+               CASE WHEN i % 31 = 0 THEN NULL
+                    WHEN i % 29 = 0 THEN 'empty'::numrange
+                    WHEN i % 23 = 0 THEN numrange(NULL, (i % 500)::numeric / 7, '()')
+                    WHEN i % 19 = 0 THEN numrange((i % 500)::numeric / 7, NULL, '[)')
+                    ELSE numrange((i % 500)::numeric / 7,
+                                  (i % 500)::numeric / 7 + 3,
+                                  CASE WHEN i % 2 = 0 THEN '[)' ELSE '(]' END)
+               END,
+               CASE WHEN i % 37 = 0 THEN NULL
+                    WHEN i % 17 = 0 THEN 'empty'::tstzrange
+                    ELSE tstzrange('2020-01-01'::timestamptz + ((i % 300) || ' hours')::interval,
+                                   '2020-01-01'::timestamptz + ((i % 300) || ' hours')::interval + '3 days')
+               END
+        FROM generate_series(batch * 500 + 1, (batch + 1) * 500) i;
+    END LOOP;
+END $$;
+
+SELECT count(*) > 1 AS has_multiple_segments FROM paradedb.index_info('range_segments_idx');
+
+SELECT result, count(*)
+FROM (
+    SELECT check_range_order('range_segments', col, dir, lim, off) AS result
+    FROM unnest(ARRAY['nr', 'tzr']) col,
+         unnest(ARRAY['ASC', 'DESC', 'ASC NULLS FIRST', 'DESC NULLS LAST']) dir,
+         unnest(ARRAY[1, 25, 500]) lim,
+         unnest(ARRAY[0, 13, 2900]) off
+) s
+GROUP BY result
+ORDER BY result;
+
+-- =============================================================================
+-- Issue #2688's original query. It used to fail outright with
+-- `SchemaError("Fast field not available: '\"valid_period\"'")`, then later
+-- silently degraded to a Postgres Sort. Now it is a Top-N scan.
+-- =============================================================================
+CREATE TABLE data_records (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    valid_period TSTZRANGE,
+    quantity_range NUMRANGE
+);
+
+INSERT INTO data_records (title, category, valid_period, quantity_range)
+SELECT 'Product ' || i,
+       CASE WHEN i % 4 = 0 THEN 'Electronics'
+            WHEN i % 4 = 1 THEN 'Clothing'
+            WHEN i % 4 = 2 THEN 'Books'
+            ELSE 'Home' END,
+       tstzrange('2023-01-01'::timestamptz + ((i % 365) || ' days')::interval,
+                 '2023-01-01'::timestamptz + ((i % 365) || ' days')::interval + '1 month'::interval),
+       numrange((i % 10) * 10, (i % 10 + 1) * 10)
+FROM generate_series(1, 100) i;
+
+CREATE INDEX records_no_fast_idx ON data_records
+USING bm25 (id, title, category, valid_period, quantity_range) WITH (key_field = 'id');
+
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id, title, category FROM data_records
+WHERE title @@@ 'product' ORDER BY valid_period LIMIT 10;
+
+SELECT id, title, category FROM data_records
+WHERE title @@@ 'product' ORDER BY valid_period, id LIMIT 10;
+
+DROP FUNCTION check_range_order(text, text, text, int, int);
+DROP TABLE data_records CASCADE;
+DROP TABLE range_segments CASCADE;
+DROP TABLE range_items CASCADE;
+RESET max_parallel_workers_per_gather;

--- a/pg_search/tests/pg_regress/sql/order_by_range.sql
+++ b/pg_search/tests/pg_regress/sql/order_by_range.sql
@@ -96,12 +96,17 @@ DECLARE
     line text;
     pushed_down bool := false;
 BEGIN
+    -- The EXPLAIN and the two EXECUTEs share one statement text on purpose. If
+    -- they drifted, the plan check could pass on one shape while the values
+    -- came from another, and a lost pushdown would compare native to native.
     query := format(
-        'SELECT %I::text AS v FROM %I WHERE title @@@ ''doc'' ORDER BY %I %s LIMIT %s OFFSET %s',
+        'SELECT array_agg(v) FROM ('
+        '  SELECT %I::text AS v FROM %I WHERE title @@@ ''doc'' ORDER BY %I %s LIMIT %s OFFSET %s'
+        ') s',
         col, tbl, col, dir, lim, off);
 
     SET paradedb.enable_custom_scan = on;
-    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO pushed;
+    EXECUTE query INTO pushed;
     FOR line IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query LOOP
         IF line LIKE '%TopK%' THEN
             pushed_down := true;
@@ -109,7 +114,7 @@ BEGIN
     END LOOP;
 
     SET paradedb.enable_custom_scan = off;
-    EXECUTE format('SELECT array_agg(v) FROM (%s) s', query) INTO native;
+    EXECUTE query INTO native;
     SET paradedb.enable_custom_scan = on;
 
     IF pushed IS DISTINCT FROM native THEN
@@ -146,6 +151,14 @@ EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
 
 SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
+
+-- `lower(anyrange)` is a different function from the `lower(text)` the planner
+-- recognises, and a scalar bound orders differently from the whole range, so this
+-- must not be mistaken for a sort on `nr`. It stays a Postgres Sort.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY lower(nr) LIMIT 5;
+
+SELECT id, lower(nr) FROM range_items WHERE title @@@ 'doc' ORDER BY lower(nr), id LIMIT 5;
 
 -- =============================================================================
 -- Cross-segment merge. Within a segment, a `numrange` bound compares by term
@@ -250,10 +263,19 @@ END;
 $$;
 
 -- Guards the two checks below. Without a Gather they would silently re-test the
--- serial path, which the rest of the file already covers.
+-- serial path, which the rest of the file already covers. The statement is the
+-- same wrapped shape `check_range_order` measures, so the plan being asserted is
+-- the plan whose values get compared.
 SELECT plan_contains(
-    'SELECT nr FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5',
-    'Gather') AS parallel_plan;
+    'SELECT array_agg(v) FROM ('
+    '  SELECT nr::text AS v FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5'
+    ') s',
+    'Gather') AS parallel_plan,
+    plan_contains(
+    'SELECT array_agg(v) FROM ('
+    '  SELECT nr::text AS v FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5'
+    ') s',
+    'TopK') AS topk_plan;
 
 SELECT check_range_order('range_segments', 'nr', 'ASC', 5, 0);
 SELECT check_range_order('range_segments', 'tzr', 'DESC NULLS LAST', 4, 0);

--- a/pg_search/tests/pg_regress/sql/order_by_range.sql
+++ b/pg_search/tests/pg_regress/sql/order_by_range.sql
@@ -43,7 +43,7 @@ INSERT INTO range_items (title, i4, i8, nr, dr, tr, tzr) VALUES
 
 -- Range fields are fast by default, so no explicit field configuration is needed.
 CREATE INDEX range_items_idx ON range_items
-USING bm25 (id, title, i4, i8, nr, dr, tr, tzr) WITH (key_field = 'id');
+USING paradedb (id, title, i4, i8, nr, dr, tr, tzr) WITH (key_field = 'id');
 
 -- =============================================================================
 -- The plan: ORDER BY range + LIMIT is a Top-N scan, with no Postgres Sort above it.
@@ -155,7 +155,7 @@ SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
 -- =============================================================================
 CREATE TABLE range_segments (id SERIAL PRIMARY KEY, title TEXT, nr NUMRANGE, tzr TSTZRANGE);
 CREATE INDEX range_segments_idx ON range_segments
-USING bm25 (id, title, nr, tzr) WITH (key_field = 'id');
+USING paradedb (id, title, nr, tzr) WITH (key_field = 'id');
 
 DO $$
 BEGIN
@@ -217,7 +217,7 @@ SELECT 'Product ' || i,
 FROM generate_series(1, 100) i;
 
 CREATE INDEX records_no_fast_idx ON data_records
-USING bm25 (id, title, category, valid_period, quantity_range) WITH (key_field = 'id');
+USING paradedb (id, title, category, valid_period, quantity_range) WITH (key_field = 'id');
 
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT id, title, category FROM data_records

--- a/pg_search/tests/pg_regress/sql/order_by_range.sql
+++ b/pg_search/tests/pg_regress/sql/order_by_range.sql
@@ -226,6 +226,11 @@ WHERE title @@@ 'product' ORDER BY valid_period LIMIT 10;
 SELECT id, title, category FROM data_records
 WHERE title @@@ 'product' ORDER BY valid_period, id LIMIT 10;
 
+-- Parallel TopK: range sort stays correct with parallelism enabled.
+SET max_parallel_workers_per_gather = 2;
+SELECT check_range_order('range_items', 'nr', 'ASC', 5, 0);
+SELECT check_range_order('range_items', 'dr', 'DESC NULLS LAST', 4, 0);
+
 DROP FUNCTION check_range_order(text, text, text, int, int);
 DROP TABLE data_records CASCADE;
 DROP TABLE range_segments CASCADE;

--- a/pg_search/tests/pg_regress/sql/order_by_range.sql
+++ b/pg_search/tests/pg_regress/sql/order_by_range.sql
@@ -226,11 +226,43 @@ WHERE title @@@ 'product' ORDER BY valid_period LIMIT 10;
 SELECT id, title, category FROM data_records
 WHERE title @@@ 'product' ORDER BY valid_period, id LIMIT 10;
 
--- Parallel TopK: range sort stays correct with parallelism enabled.
+-- =============================================================================
+-- Parallel TopK. The range key is merged across workers here, not just across
+-- segments. `range_segments` is the table to use: a single segment offers no
+-- useful workers, so `range_items` would stay serial whatever the cost knobs say.
+-- =============================================================================
 SET max_parallel_workers_per_gather = 2;
-SELECT check_range_order('range_items', 'nr', 'ASC', 5, 0);
-SELECT check_range_order('range_items', 'dr', 'DESC NULLS LAST', 4, 0);
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
 
+CREATE FUNCTION plan_contains(query text, needle text) RETURNS bool LANGUAGE plpgsql AS $$
+DECLARE
+    line text;
+BEGIN
+    FOR line IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query LOOP
+        IF line LIKE '%' || needle || '%' THEN
+            RETURN true;
+        END IF;
+    END LOOP;
+    RETURN false;
+END;
+$$;
+
+-- Guards the two checks below. Without a Gather they would silently re-test the
+-- serial path, which the rest of the file already covers.
+SELECT plan_contains(
+    'SELECT nr FROM range_segments WHERE title @@@ ''doc'' ORDER BY nr LIMIT 5',
+    'Gather') AS parallel_plan;
+
+SELECT check_range_order('range_segments', 'nr', 'ASC', 5, 0);
+SELECT check_range_order('range_segments', 'tzr', 'DESC NULLS LAST', 4, 0);
+
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET min_parallel_table_scan_size;
+
+DROP FUNCTION plan_contains(text, text);
 DROP FUNCTION check_range_order(text, text, text, int, int);
 DROP TABLE data_records CASCADE;
 DROP TABLE range_segments CASCADE;


### PR DESCRIPTION
Fixes #2688

Pushes `ORDER BY` on Postgres range columns into the BM25/paradedb index TopK path. `SortByRange` reads the indexed bound sub-columns and compares them using the same ordering as Postgres `range_cmp`.

**Limitations**
- Range columns must be the **leading** `ORDER BY` key; later keys fall back to Postgres sorting.
- Only raw range columns are supported (not `lower(range_col)` or other expressions).

**Mapping**
Empty ranges sort first, unbounded lowers before finite lowers, unbounded uppers after finite uppers, and inclusive/exclusive endpoints tie-break like `range_cmp`.