### PR TITLE
ci: untap aws/tap in Postgres.app publish workflow

### DIFF
--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -46,6 +46,10 @@ jobs:
       # which sigstore/cosign-installer needs and which isn't on PATH by default.
       - name: Install Dependencies
         run: |
+          # The GitHub macOS runner images ship with aws/tap pre-tapped but untrusted,
+          # which makes Homebrew print a "taps are not trusted" warning on every brew
+          # invocation. We don't use it, so untap it to keep the logs clean.
+          brew untap aws/tap || true
           brew reinstall git
           brew install gettext
           echo "$(brew --prefix gettext)/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
The GitHub macOS runner images ship with `aws/tap` pre-tapped but untrusted, so every `brew` invocation prints a "taps are not trusted" warning, which surfaces as a job annotation on the Postgres.app publish job.

We don't use that tap, so untap it — same fix already in `publish-pg_search-macos.yml`.

https://claude.ai/code/session_01QuWpsupEkqVZp3PrGoPmD7