### PR TITLE
chore: bump pgvector and pg_cron

### DIFF
--- a/.github/actions/setup-benchmark-cluster/action.yml
+++ b/.github/actions/setup-benchmark-cluster/action.yml
@@ -134,8 +134,7 @@ runs:
     # index-build time. vchord requires `shared_preload_libraries = ...,vchord`; because a restored
     # heap snapshot overwrites postgresql.auto.conf, the benchmark workflow re-applies that preload
     # after restore rather than baking it in here (snapshots are shared with non-vchord runs).
-    # TODO: confirm VCHORD_VERSION against the version we intend to benchmark (latest release as of
-    # writing is 1.1.1). `vchordrq.prefilter` requires >= 0.4.0.
+    # `vchordrq.prefilter` requires VCHORD_VERSION >= 0.4.0.
     - name: Install VectorChord
       shell: bash
       env:

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Install pgvector (pgrx-managed Postgres)
         run: |
-          git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.6 https://github.com/pgvector/pgvector.git
           cd pgvector/
           PG_CONFIG=$(ls -d ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config | head -n 1)
           make PG_CONFIG="$PG_CONFIG" -j

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -125,7 +125,7 @@ jobs:
       # Needed for hybrid search unit tests
       - name: Install pgvector
         run: |
-          git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.6 https://github.com/pgvector/pgvector.git
           cd pgvector/
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install pgvector (system)
         if: matrix.pg_impl == 'system'
         run: |
-          git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.6 https://github.com/pgvector/pgvector.git
           cd pgvector/
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j
@@ -165,7 +165,7 @@ jobs:
       - name: Install pgvector (pgrx)
         if: matrix.pg_impl == 'pgrx'
         run: |
-          git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.6 https://github.com/pgvector/pgvector.git
           cd pgvector/
           PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make -j
           PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make install -j

--- a/docker/Dockerfile.antithesis-18
+++ b/docker/Dockerfile.antithesis-18
@@ -40,8 +40,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-18-cron=1.6.7-2.pgdg13+1 \
+    postgresql-18-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-18-cron=1.6.7-3.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.official-15
+++ b/docker/Dockerfile.official-15
@@ -31,8 +31,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-15-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-15-cron=1.6.7-2.pgdg13+1 \
+    postgresql-15-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-15-cron=1.6.7-3.pgdg13+1 \
     postgresql-15-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.official-16
+++ b/docker/Dockerfile.official-16
@@ -31,8 +31,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-16-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-16-cron=1.6.7-2.pgdg13+1 \
+    postgresql-16-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-16-cron=1.6.7-3.pgdg13+1 \
     postgresql-16-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.official-17
+++ b/docker/Dockerfile.official-17
@@ -31,8 +31,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-17-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-17-cron=1.6.7-2.pgdg13+1 \
+    postgresql-17-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-17-cron=1.6.7-3.pgdg13+1 \
     postgresql-17-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.official-18
+++ b/docker/Dockerfile.official-18
@@ -31,8 +31,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-18-cron=1.6.7-2.pgdg13+1 \
+    postgresql-18-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-18-cron=1.6.7-3.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.paradedb-15
+++ b/docker/Dockerfile.paradedb-15
@@ -45,8 +45,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-15-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-15-cron=1.6.7-2.pgdg13+1 \
+    postgresql-15-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-15-cron=1.6.7-3.pgdg13+1 \
     postgresql-15-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.paradedb-16
+++ b/docker/Dockerfile.paradedb-16
@@ -45,8 +45,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-16-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-16-cron=1.6.7-2.pgdg13+1 \
+    postgresql-16-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-16-cron=1.6.7-3.pgdg13+1 \
     postgresql-16-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.paradedb-17
+++ b/docker/Dockerfile.paradedb-17
@@ -45,8 +45,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-17-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-17-cron=1.6.7-2.pgdg13+1 \
+    postgresql-17-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-17-cron=1.6.7-3.pgdg13+1 \
     postgresql-17-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.paradedb-18
+++ b/docker/Dockerfile.paradedb-18
@@ -45,8 +45,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-18-cron=1.6.7-2.pgdg13+1 \
+    postgresql-18-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-18-cron=1.6.7-3.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR-scripts \

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -60,8 +60,8 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.4-1.pgdg13+1 \
-    postgresql-@@PG_VERSION_MAJOR@@-cron=1.6.7-2.pgdg13+1 \
+    postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.5-1.pgdg13+1 \
+    postgresql-@@PG_VERSION_MAJOR@@-cron=1.6.7-3.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-postgis-$POSTGIS_VERSION_MAJOR \
     postgresql-@@PG_VERSION_MAJOR@@-postgis-$POSTGIS_VERSION_MAJOR-scripts \


### PR DESCRIPTION
## What

Bumps the third-party Postgres extensions we ship and test against.

| Extension | Where | Before | After |
| --- | --- | --- | --- |
| pgvector | CI (source build) | v0.8.4 | **v0.8.6** |
| pgvector | Docker (PGDG apt) | 0.8.4-1.pgdg13+1 | **0.8.5-1.pgdg13+1** |
| pg_cron | Docker (PGDG apt) | 1.6.7-2.pgdg13+1 | **1.6.7-3.pgdg13+1** |

## Why the two pgvector versions differ

The CI jobs clone and `make install` pgvector, so they can take 0.8.6 directly. The Docker images install from `trixie-pgdg-archive`, and PGDG has not packaged 0.8.6 yet -- 0.8.5 is the newest available for PG 15-18 in both the live repo and the archive. Worth a follow-up to align the images on 0.8.6 once it lands in PGDG.

Every new pin was verified present in the archive's `main/binary-amd64` index for all four majors.

## Not bumped

- **pg_ivm** -- upstream is at 1.15, but PGDG only ever packaged 1.13 for trixie. Nothing to bump without vendoring a source build.
- **pg_cron** upstream -- 1.6.7-3 is a Debian packaging revision only; upstream is still 1.6.7.
- **PostGIS** -- pinned by major (`POSTGIS_VERSION_MAJOR=3`) and unpinned at minor, so it already floats.
- **VectorChord** -- `setup-benchmark-cluster` pins 1.1.1, still the latest release.

## Note on the generated Dockerfiles

Edited in place rather than regenerated. `generate-dockerfiles.sh` redownloads the release `.deb`s to recompute the pg_search checksums, which would have produced unrelated churn; the same edit was applied to the template and all nine flavours, so they stay in sync.

https://claude.ai/code/session_01HxWg4VkgDz7HLNjZSz9Vn7