### PR TITLE
ci: read the pgrx pin from the rev the upgrade test builds

### DIFF
--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -15,11 +15,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Extract pgrx Version
-      id: pgrx
-      shell: bash
-      run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
-
     - name: Preserve SQL Files
       shell: bash
       run: |
@@ -111,6 +106,13 @@ runs:
           git fetch origin ${{ github.sha }}:commit-${{ github.sha }}
           git checkout commit-${{ github.sha }}
         fi
+
+    # Must read the rev checked out above, not the `actions/checkout` merge ref
+    # at the top: they disagree whenever the base bumps pgrx after a PR is cut.
+    - name: Extract pgrx Version
+      id: pgrx
+      shell: bash
+      run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
 
     - name: Install the pgrx version for ParadeDB
       shell: bash


### PR DESCRIPTION
## What

Move the `Extract pgrx Version` step in `.github/actions/test-pg_search-upgrade/action.yml` from the top of the action to just below the `Fetch and Checkout PR Head` step, so the cargo-pgrx it installs is derived from the same rev it goes on to compile.

## Why

The action read the pin from `Cargo.toml` in its **first** step. For a `pull_request` event that runs against the `actions/checkout` rev, which is the **merge ref** (PR head merged into base). It then re-checks-out the **PR head alone** and builds that.

Those two revs agree right up until the base bumps pgrx while a PR is open — then the merge ref carries the new pin and the head still carries the old one. The job installs cargo-pgrx for the merge ref, and `cargo pgrx install` rejects it against the head's `Cargo.toml`:

```
The installed cargo-pgrx 0.19.2 is not compatible with the dependencies in ./Cargo.toml:
  pgrx = 0.19.0, pgrx-macros = 0.19.0, pgrx-sql-entity-graph = 0.19.0, pgrx-tests = 0.19.0
  cargo-pgrx and pgrx library versions must be identical.
```

This is not hypothetical: #5794 bumped pgrx to `=0.19.2` and immediately broke both `Test upgrading pg_search via ALTER EXTENSION` jobs on #5795, whose branch predated it. Every open PR that hasn't merged the pgrx bump hits it, and the only way out today is to update each branch — the failure has nothing to do with what those PRs change.

`test-pg_search-schema.yml` already handles the same hazard the same way: it re-reads the pin after switching git revs and reinstalls cargo-pgrx if it differs. This brings the upgrade action in line with that.

## How

The extracted value is consumed by exactly one step (`Install the pgrx version for ParadeDB`), so relocating the extraction between the checkout and that install is sufficient — no other step reads `steps.pgrx.outputs.version`. The prior-version half of the test is unaffected; it installs from the `prior_pgrx_version` input, not from this step.

`Preserve SQL Files` still runs first, so the newest harness SQL is still carried across the tag checkout as before. The action continues to build the PR head rather than the merge ref — that is the existing design intent here and this change does not alter it, it only makes the toolchain follow it.

## Tests

Covered by the workflow itself: `test-pg_search-upgrade.yml` triggers on changes under `.github/actions/test-pg_search-upgrade/**`, so both matrix legs (`v0.21.0` and the dynamically-resolved prior release) exercise the reordered steps on this PR. Since this branch is cut from current `main`, the two revs agree here and the run confirms the reordering is not itself a regression; the skew case is what the reasoning above covers.

YAML parses and step order verified locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NL1d7PGYBL3kEuxmFwPpgL)_