### PR TITLE
ci: let a publish run be scoped to one image kind

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -10,6 +10,11 @@
 # so they can run compatibility checks against the new version. This is done in
 # `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
 #
+# Both image kinds are built from an already-published .deb, pinned by checksum, so either kind can be
+# rebuilt for a release that has already shipped — to pick up a Dockerfile fix, or a base image with a
+# CVE patched. The `images` input scopes a run to one kind, leaving the other kind's tags, the ORM
+# dispatch, and the Dockerfile PRs untouched.
+#
 # This workflow is dispatched by `publish-pg_search-debian.yml` (once the Debian binaries are published) via
 # `workflow_dispatch` pinned to the release ref so that it runs on the same commit as the other deploy jobs.
 
@@ -26,6 +31,15 @@ on:
         description: "The Postgres major version(s) to build ParadeDB for. This needs to be a comma-separated list of integers (e.g. [15] or [15, 16, 17, 18]). Beta (-rc.) releases always resolve to [18] regardless of this value."
         required: false
         default: "[15, 16, 17, 18]"
+      images:
+        description: "Which images to publish. Both image kinds are pinned to an already-published .deb, so a single kind can be rebuilt for an existing release without moving the other's tags or re-notifying the ORM repos."
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - runnable
+          - extension
 
 concurrency:
   group: publish-paradedb-docker-${{ github.event.inputs.version || github.ref }}
@@ -169,6 +183,8 @@ jobs:
       ref: ${{ needs.generate-dockerfiles.outputs.branch }}
     secrets: inherit
 
+  # Skipping this job also skips `open-dockerfile-prs` and `notify-orm-repos`, which
+  # need it — an extension-only rebuild must not re-announce the release.
   publish-paradedb-docker-image:
     name: Publish ParadeDB Docker Image for PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubuntu-latest
@@ -176,6 +192,7 @@ jobs:
       - set-matrix
       - generate-dockerfiles
       - test-generated-dockerfiles
+    if: ${{ (github.event.inputs.images || 'all') != 'extension' }}
     strategy:
       matrix:
         pg_version: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
@@ -293,7 +310,7 @@ jobs:
     needs:
       - generate-dockerfiles
       - test-generated-dockerfiles
-    if: ${{ !contains(needs.generate-dockerfiles.outputs.version, '-rc.') }}
+    if: ${{ !contains(needs.generate-dockerfiles.outputs.version, '-rc.') && (github.event.inputs.images || 'all') != 'runnable' }}
     strategy:
       matrix:
         # Mounted extension images require PostgreSQL 18+ because

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -10,11 +10,6 @@
 # so they can run compatibility checks against the new version. This is done in
 # `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
 #
-# Both image kinds are built from an already-published .deb, pinned by checksum, so either kind can be
-# rebuilt for a release that has already shipped — to pick up a Dockerfile fix, or a base image with a
-# CVE patched. The `images` input scopes a run to one kind, leaving the other kind's tags, the ORM
-# dispatch, and the Dockerfile PRs untouched.
-#
 # This workflow is dispatched by `publish-pg_search-debian.yml` (once the Debian binaries are published) via
 # `workflow_dispatch` pinned to the release ref so that it runs on the same commit as the other deploy jobs.
 
@@ -32,7 +27,7 @@ on:
         required: false
         default: "[15, 16, 17, 18]"
       images:
-        description: "Which images to publish. Both image kinds are pinned to an already-published .deb, so a single kind can be rebuilt for an existing release without moving the other's tags or re-notifying the ORM repos."
+        description: "Which images to publish."
         required: false
         type: choice
         default: all
@@ -183,8 +178,7 @@ jobs:
       ref: ${{ needs.generate-dockerfiles.outputs.branch }}
     secrets: inherit
 
-  # Skipping this job also skips `open-dockerfile-prs` and `notify-orm-repos`, which
-  # need it — an extension-only rebuild must not re-announce the release.
+  # Skipping this job also skips `open-dockerfile-prs` and `notify-orm-repos`, which need it.
   publish-paradedb-docker-image:
     name: Publish ParadeDB Docker Image for PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds an `images` input to `publish-paradedb-docker.yml` — `all` (default), `runnable`, or `extension` — scoping a dispatch to one image kind.

## Why

Both image kinds are built from an already-published `.deb`, pinned by checksum, so either can be rebuilt for a release that has already shipped: to pick up a Dockerfile fix, or a base image with a CVE patched. #5800 is the immediate case — `paradedb/paradedb-extension:0.25.0-18-trixie` crash-loops Postgres, and the fix is a Dockerfile change against the same 0.25.0 `.deb`.

Until now a rebuild meant re-publishing everything. Dispatching with `version=0.25.0` to fix the extension image would also move `latest`, `pg18`, `latest-pg18` and `0.25.0` on `paradedb/paradedb` to fresh digests, and re-fire the `repository_dispatch` to all five ORM repos as if 0.25.0 were a new release.

## How

`publish-paradedb-docker-image` is gated on `images != 'extension'`, `publish-extension-image` on `images != 'runnable'`. Skipping the runnable job also skips `open-dockerfile-prs` and `notify-orm-repos`, which `need` it — so an extension-only rebuild can't re-announce the release. `notify-slack-on-failure` already matches on `result == 'failure'` under `always()`, so a skipped job doesn't page anyone.

Defaults to `all`, and the input is optional, so the release path and the `gh workflow run` dispatch from `publish-pg_search-debian.yml` are unchanged.

## Tests

No behaviour to unit-test. Prettier passes. The gating was checked by parsing the workflow and confirming the two `if` expressions and the input defaults, and by tracing that `open-dockerfile-prs` / `notify-orm-repos` inherit the skip through `needs` — neither uses `always()`.