### PR TITLE
chore: upgrade sqlx to 0.9 and pgvector to 0.4.2

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -59,7 +59,7 @@ runs:
       working-directory: benchmarks/
       shell: bash
       run: |
-        POSTGRES_URL="postgresql://localhost:288${{ env.pg_version }}/postgres"
+        POSTGRES_URL="postgresql://$(whoami)@localhost:288${{ env.pg_version }}/postgres"
 
         # The heap is assumed to already be restored from a snapshot; the benchmark builds the
         # index and runs queries against it.

--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -200,7 +200,7 @@ runs:
       working-directory: tests/
       shell: bash
       run: |
-        export DATABASE_URL=postgresql://localhost:288${{ inputs.pg_version }}/postgres
+        export DATABASE_URL=postgresql://$(whoami)@localhost:288${{ inputs.pg_version }}/postgres
         export PG_CONFIG=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config
         RUST_BACKTRACE=1 cargo test --jobs $(nproc)
 

--- a/.github/workflows/generate-benchmark-snapshots.yml
+++ b/.github/workflows/generate-benchmark-snapshots.yml
@@ -110,7 +110,7 @@ jobs:
           cargo run --release -- load-heap \
             --dataset "${{ matrix.dataset }}" \
             --size "${{ matrix.size }}" \
-            --url "postgresql://localhost:288${{ env.pg_version }}/postgres" \
+            --url "postgresql://$(whoami)@localhost:288${{ env.pg_version }}/postgres" \
             --data-source "s3://${BACKREST_REPO_BUCKET}/datasets/${{ matrix.dataset }}"
 
       # Clear any pre-existing snapshot at this path. Each run inits a fresh cluster (new system

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Run pg_search Integration Tests (system)
         if: matrix.pg_impl == 'system'
         run: |
-          export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
+          export DATABASE_URL=postgresql://$(whoami)@localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.pg_version }}" != "18" ]]; then
             RUST_BACKTRACE=1 cargo test --jobs $(nproc) --package tests --package tokenizers
@@ -286,7 +286,7 @@ jobs:
         working-directory: pg_search/
         run: |
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/
-          export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
+          export DATABASE_URL=postgresql://$(whoami)@localhost:288${{ matrix.pg_version }}/postgres
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.pg_version }}" != "18" ]]; then
             RUST_BACKTRACE=1 cargo test --jobs $(nproc) --features pg${{ matrix.pg_version }} --no-default-features
           else
@@ -295,7 +295,7 @@ jobs:
 
       - name: Run pg_search Integration Tests (pgrx-managed)
         if: matrix.pg_impl == 'pgrx'
-        run: RUST_BACKTRACE=1 DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --jobs $(nproc) --no-default-features --package tests --package tokenizers -- --skip replication --skip ephemeral
+        run: RUST_BACKTRACE=1 DATABASE_URL=postgresql://$(whoami)@localhost:288${{ matrix.pg_version }}/pg_search cargo test --jobs $(nproc) --no-default-features --package tests --package tokenizers -- --skip replication --skip ephemeral
 
       - name: Run pg_search Regression Tests (pgrx-managed)
         if: matrix.pg_impl == 'pgrx'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,10 +658,21 @@ checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.5.0",
- "futures-lite 2.6.1",
+ "fastrand",
+ "futures-lite",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -672,31 +683,11 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
- "async-io 2.6.0",
- "async-lock 3.4.2",
+ "async-io",
+ "async-lock",
  "blocking",
- "futures-lite 2.6.1",
+ "futures-lite",
  "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.28",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
 ]
 
 [[package]]
@@ -709,21 +700,12 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.1",
+ "futures-lite",
  "parking",
- "polling 3.11.0",
+ "polling",
  "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -746,13 +728,13 @@ dependencies = [
  "async-attributes",
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 2.6.0",
- "async-lock 3.4.2",
+ "async-io",
+ "async-lock",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 2.6.1",
+ "futures-lite",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -895,12 +877,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
@@ -1063,7 +1039,7 @@ dependencies = [
  "async-channel 2.5.0",
  "async-task",
  "futures-io",
- "futures-lite 2.6.1",
+ "futures-lite",
  "piper",
 ]
 
@@ -1578,12 +1554,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -2807,17 +2777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,9 +2846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -2899,7 +2856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -2993,7 +2950,7 @@ dependencies = [
  "comfy-table",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
  "strum",
@@ -3255,13 +3212,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3354,15 +3310,6 @@ checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
@@ -3433,9 +3380,9 @@ checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3620,26 +3567,11 @@ checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.5.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -3827,8 +3759,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3864,16 +3794,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -3889,20 +3822,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -3912,15 +3836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4041,7 +3956,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4354,15 +4269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,17 +4289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,7 +4300,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -4657,9 +4552,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lebe"
@@ -4809,10 +4701,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
- "bitflags 2.13.1",
  "libc",
- "plain",
- "redox_syscall 0.9.1",
 ]
 
 [[package]]
@@ -4992,12 +4881,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
@@ -5106,16 +4989,6 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -5188,7 +5061,7 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
- "async-lock 3.4.2",
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -5311,22 +5184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.7",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5399,7 +5256,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -5602,7 +5459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5646,7 +5503,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -5725,15 +5582,6 @@ checksum = "da983bc5e582ab17179c190b4b66c7d76c5943a69c6d34df2a2b6bf8a2977b05"
 dependencies = [
  "anyhow",
  "libc",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -5946,9 +5794,9 @@ dependencies = [
 
 [[package]]
 name = "pgvector"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
  "sqlx",
 ]
@@ -6017,7 +5865,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand 2.5.0",
+ "fastrand",
  "phf_shared 0.13.1",
 ]
 
@@ -6087,29 +5935,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.5.0",
+ "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -6117,12 +5944,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -6198,29 +6019,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6289,8 +6094,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac 0.13.0",
- "md-5 0.11.0",
+ "hmac",
+ "md-5",
  "memchr",
  "rand 0.10.2",
  "sha2 0.11.0",
@@ -6625,7 +6430,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6664,7 +6469,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6910,15 +6715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7109,26 +6905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7209,20 +6985,6 @@ checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
 dependencies = [
  "rustc_version",
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7505,18 +7267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7531,13 +7281,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7609,16 +7359,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7721,16 +7461,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -7746,16 +7476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -7781,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7794,15 +7514,17 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
- "async-io 1.13.0",
+ "async-fs",
+ "async-io",
  "async-std",
  "base64",
  "bigdecimal",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -7812,12 +7534,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -7832,9 +7553,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7845,16 +7566,16 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
  "async-std",
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -7865,60 +7586,45 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.119",
+ "thiserror 2.0.19",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bigdecimal",
  "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5 0.10.6",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.7",
- "rsa",
  "serde",
  "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.19",
  "time",
  "tracing",
  "uuid",
- "whoami 1.6.1",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -7934,18 +7640,16 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.12.1",
- "home",
+ "hmac",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5",
  "memchr",
  "num-bigint",
- "once_cell",
- "rand 0.8.7",
+ "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7953,18 +7657,19 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami 1.6.1",
+ "whoami",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -7974,7 +7679,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.19",
  "time",
@@ -8199,7 +7903,7 @@ dependencies = [
  "deranged 0.4.0",
  "downcast-rs",
  "fastdivide",
- "fastrand 2.5.0",
+ "fastrand",
  "fnv",
  "futures-channel",
  "futures-util",
@@ -8386,8 +8090,8 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.5.0",
- "getrandom 0.3.4",
+ "fastrand",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.52.0",
@@ -8600,7 +8304,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8647,10 +8351,10 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.10.2",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tokio-util",
- "whoami 2.1.2",
+ "whoami",
 ]
 
 [[package]]
@@ -9141,12 +8845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9188,12 +8886,6 @@ checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasite"
@@ -9306,16 +8998,6 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite 0.1.0",
-]
-
-[[package]]
-name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
@@ -9323,7 +9005,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite 1.0.2",
+ "wasite",
  "web-sys",
 ]
 
@@ -9349,7 +9031,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9365,7 +9047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9398,7 +9080,7 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9491,7 +9173,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9514,20 +9196,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9536,7 +9209,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9550,33 +9223,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -9590,33 +9248,15 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9632,21 +9272,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9656,21 +9284,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8133,7 +8133,6 @@ dependencies = [
  "soa_derive",
  "sqlx",
  "strum",
- "strum_macros",
  "tantivy",
  "tempfile",
  "time",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 clap = { version = "4.6.1", features = ["derive", "env"] }
 anyhow = "1.0"
 serde_json = "1.0"
-sqlx = { version = "0.8.6", features = [
+sqlx = { version = "0.9.0", features = [
   "postgres",
   "runtime-async-std",
   "time",
@@ -33,3 +33,4 @@ rstest = "0.25.0"
 [lib]
 name = "paradedb"
 path = "src/lib.rs"
+

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,4 +33,3 @@ rstest = "0.25.0"
 [lib]
 name = "paradedb"
 path = "src/lib.rs"
-

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -20,7 +20,7 @@ use clap::{Parser, Subcommand};
 use paradedb::{
     Window, confidence_interval_half_width, fnv1a, mean, percentile, percentile_confidence_interval,
 };
-use sqlx::{Connection, PgConnection, Row};
+use sqlx::{AssertSqlSafe, Connection, PgConnection, Row};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Write;
@@ -498,7 +498,7 @@ async fn eval_param(
     vars: &HashMap<String, String>,
 ) -> anyhow::Result<String> {
     let expr = substitute_vars(expr, vars).with_context(|| format!("In [params] `{name}`"))?;
-    sqlx::query_scalar(&format!("SELECT ({expr})::numeric::text"))
+    sqlx::query_scalar(AssertSqlSafe(format!("SELECT ({expr})::numeric::text")))
         .fetch_one(&mut *conn)
         .await
         .with_context(|| format!("Failed to evaluate [params] `{name}` = `{expr}`"))
@@ -540,7 +540,7 @@ async fn process_index_creation(args: &BenchmarkArgs) -> anyhow::Result<Vec<Inde
         println!("{statement}");
 
         let start = Instant::now();
-        sqlx::query(&statement)
+        sqlx::query(AssertSqlSafe(statement.as_str()))
             .execute(&mut conn)
             .await
             .with_context(|| "Failed to execute index creation SQL")?;
@@ -559,9 +559,9 @@ async fn process_index_creation(args: &BenchmarkArgs) -> anyhow::Result<Vec<Inde
         // `paradedb.index_info()` (segment count) only applies to pg_search (bm25) indexes;
         // other access methods (e.g. pgvector's hnsw/ivfflat) have no segments.
         let result = if amname == "bm25" {
-            let segment_count = sqlx::query_scalar(&format!(
+            let segment_count = sqlx::query_scalar(AssertSqlSafe(format!(
                 "SELECT count(*) FROM paradedb.index_info('{index_name}')"
-            ))
+            )))
             .fetch_one(&mut conn)
             .await
             .with_context(|| "Failed to get segment count")?;
@@ -601,7 +601,7 @@ async fn process_after_create_index_sql(args: &BenchmarkArgs) -> anyhow::Result<
             .await?;
     for statement in statements {
         let statement = substitute_vars(&statement, &params)?;
-        sqlx::query(&statement)
+        sqlx::query(AssertSqlSafe(statement.as_str()))
             .execute(&mut conn)
             .await
             .with_context(|| {
@@ -699,7 +699,7 @@ async fn run_recall(args: &RecallArgs) -> anyhow::Result<()> {
 
     // Apply the query file's SET statements so recall runs at the latency query's operating point.
     for stmt in &set_statements {
-        sqlx::query(stmt)
+        sqlx::query(AssertSqlSafe(stmt.as_str()))
             .execute(&mut conn)
             .await
             .with_context(|| format!("Failed to apply query setting: {stmt}"))?;
@@ -747,7 +747,7 @@ async fn load_recall_fixtures(
     // (Keying on the CREATE statement, not table existence, avoids loading a leftover table from a
     // prior run before recall.sql drops/recreates it.)
     for statement in queries(Path::new(&recall_sql)) {
-        sqlx::query(&statement)
+        sqlx::query(AssertSqlSafe(statement.as_str()))
             .execute(&mut *conn)
             .await
             .with_context(|| format!("Failed to run recall setup statement: {statement}"))?;
@@ -802,11 +802,11 @@ async fn score_recall(
 ) -> anyhow::Result<f64> {
     let mut total_hits = 0usize;
     for (id, emb_text) in &fixtures.vectors {
-        sqlx::raw_sql(&format!("SET {QVEC_GUC} = '{emb_text}';"))
+        sqlx::raw_sql(AssertSqlSafe(format!("SET {QVEC_GUC} = '{emb_text}';")))
             .execute(&mut *conn)
             .await
             .with_context(|| format!("Failed to set {QVEC_GUC} for query {id}"))?;
-        let rows = sqlx::raw_sql(knn_query)
+        let rows = sqlx::raw_sql(AssertSqlSafe(knn_query))
             .fetch_all(&mut *conn)
             .await
             .with_context(|| format!("Failed to run recall query for query {id}"))?;
@@ -938,7 +938,7 @@ async fn sweep_query(
         let query = substitute_vars(raw_variant, &params)?;
         let (sets, knn_query) = split_operating_point(&query)?;
         for stmt in &sets {
-            sqlx::query(stmt)
+            sqlx::query(AssertSqlSafe(stmt.as_str()))
                 .execute(&mut *conn)
                 .await
                 .with_context(|| format!("Failed to apply sweep setting: {stmt}"))?;
@@ -1277,7 +1277,7 @@ async fn root_table_row_count(args: &BenchmarkArgs) -> anyhow::Result<i64> {
         .await
         .with_context(|| "Failed to connect to database")?;
     let table = &config.root_table.name;
-    let row = sqlx::query(&format!("SELECT count(*) FROM \"{table}\""))
+    let row = sqlx::query(AssertSqlSafe(format!("SELECT count(*) FROM \"{table}\"")))
         .fetch_one(&mut conn)
         .await
         .with_context(|| format!("Failed to count rows in '{table}'"))?;
@@ -1327,7 +1327,7 @@ async fn write_postgres_settings_csv(url: &str) -> anyhow::Result<()> {
         .await
         .with_context(|| "Failed to connect to database")?;
     for setting in settings {
-        let row = sqlx::query(&format!("SHOW {setting}"))
+        let row = sqlx::query(AssertSqlSafe(format!("SHOW {setting}")))
             .fetch_one(&mut conn)
             .await
             .with_context(|| "Failed to get postgres setting")?;
@@ -1443,7 +1443,7 @@ async fn write_postgres_settings(file: &mut File, url: &str) -> anyhow::Result<(
         .await
         .with_context(|| "Failed to connect to database")?;
     for setting in settings {
-        let row = sqlx::query(&format!("SHOW {setting}"))
+        let row = sqlx::query(AssertSqlSafe(format!("SHOW {setting}")))
             .fetch_one(&mut conn)
             .await
             .with_context(|| "Failed to get postgres setting")?;
@@ -1785,7 +1785,7 @@ fn benchmark_queries(file: &Path) -> Vec<(String, String)> {
 async fn prewarm_indexes(conn: &mut PgConnection, dataset: &str) -> anyhow::Result<()> {
     let prewarm_sql = format!("datasets/{dataset}/prewarm.sql");
     for statement in queries(Path::new(&prewarm_sql)) {
-        sqlx::query(&statement)
+        sqlx::query(AssertSqlSafe(statement.as_str()))
             .execute(&mut *conn)
             .await
             .with_context(|| "Failed to prewarm indexes")?;
@@ -1796,7 +1796,9 @@ async fn prewarm_indexes(conn: &mut PgConnection, dataset: &str) -> anyhow::Resu
 async fn get_query_id(query: &str, conn: &mut PgConnection) -> anyhow::Result<i64> {
     let explain_str = format!("EXPLAIN (VERBOSE, FORMAT JSON) {query}");
     let sqlx::types::Json(res): sqlx::types::Json<serde_json::Value> =
-        sqlx::query_scalar(&explain_str).fetch_one(conn).await?;
+        sqlx::query_scalar(AssertSqlSafe(explain_str.as_str()))
+            .fetch_one(conn)
+            .await?;
 
     let query_id = res[0]["Query Identifier"]
         .as_i64()
@@ -1826,7 +1828,7 @@ async fn get_query_id(query: &str, conn: &mut PgConnection) -> anyhow::Result<i6
 /// `current_setting`, so the SQL text -- and therefore its `pg_stat_statements` queryid -- is
 /// identical for every vector.
 async fn set_query_vector(conn: &mut PgConnection, vector: &str) -> anyhow::Result<()> {
-    sqlx::raw_sql(&format!("SET {QVEC_GUC} = '{vector}';"))
+    sqlx::raw_sql(AssertSqlSafe(format!("SET {QVEC_GUC} = '{vector}';")))
         .execute(&mut *conn)
         .await
         .with_context(|| format!("Failed to set {QVEC_GUC}"))?;
@@ -1840,18 +1842,19 @@ async fn run_once(
     stats_reset_query: &str,
     stats_query: &str,
 ) -> anyhow::Result<(f64, i64)> {
-    sqlx::raw_sql(stats_reset_query)
+    sqlx::raw_sql(AssertSqlSafe(stats_reset_query))
         .execute(&mut *conn)
         .await
         .with_context(|| format!("Failed to execute query: {stats_reset_query}"))?;
-    sqlx::raw_sql(query)
+    sqlx::raw_sql(AssertSqlSafe(query))
         .execute(&mut *conn)
         .await
         .with_context(|| format!("Failed to execute query: {query}"))?;
-    let (exec_time_ms, plan_time_ms, rows): (f64, f64, i64) = sqlx::query_as(stats_query)
-        .fetch_one(&mut *conn)
-        .await
-        .with_context(|| format!("Failed to execute query: {stats_query}"))?;
+    let (exec_time_ms, plan_time_ms, rows): (f64, f64, i64) =
+        sqlx::query_as(AssertSqlSafe(stats_query))
+            .fetch_one(&mut *conn)
+            .await
+            .with_context(|| format!("Failed to execute query: {stats_query}"))?;
     Ok((exec_time_ms + plan_time_ms, rows))
 }
 
@@ -1906,7 +1909,7 @@ async fn execute_query_multiple_times(
     for stmt in query.split(';') {
         let stmt = stmt.trim();
         if stmt.len() >= 4 && stmt[..4].eq_ignore_ascii_case("set ") {
-            sqlx::raw_sql(&format!("{stmt};"))
+            sqlx::raw_sql(AssertSqlSafe(format!("{stmt};")))
                 .execute(&mut conn)
                 .await
                 .with_context(|| format!("Failed to apply query setting: {stmt}"))?;
@@ -1940,13 +1943,19 @@ async fn execute_query_multiple_times(
     // prefix.
     {
         use sqlx::Row;
-        sqlx::raw_sql(query).execute(&mut conn).await.ok();
+        sqlx::raw_sql(AssertSqlSafe(query))
+            .execute(&mut conn)
+            .await
+            .ok();
         // VERBOSE because the JoinScan renderer only includes per-node `elapsed_compute`
         // timing for verbose EXPLAINs.
         let explain = format!(
             "EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF) {measured_query}"
         );
-        match sqlx::raw_sql(&explain).fetch_all(&mut conn).await {
+        match sqlx::raw_sql(AssertSqlSafe(explain.as_str()))
+            .fetch_all(&mut conn)
+            .await
+        {
             Ok(rows) => {
                 println!("plan for `{query_type}`:");
                 for row in rows {

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-NfUk2k9TpAUt/ecUCUYhs2crd8djDSyEpCTLDjn1uQk=";
+  cargoHash = "sha256-z9hWK+GCzwvZs99An10dFQbIUTM6YdtxUlO+jkH1+fU=";
 
   inherit cargo-pgrx postgresql;
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -49,4 +49,3 @@ num-traits = "0.2.19"
 proptest = "1.11.0"
 proptest-derive = "0.6.0"
 env_logger = "0.11.10"
-

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,8 +37,7 @@ sqlx = { version = "0.9.0", features = [
   "uuid",
   "chrono",
 ] }
-strum = "0.27.2"
-strum_macros = "0.27.2"
+strum = { version = "0.27.2", features = ["derive"] }
 tantivy.workspace = true
 tempfile = "3.27.0"
 time = { version = "0.3.47", features = ["serde"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,7 +29,7 @@ rstest = "0.25.0"
 rustc-hash = "2.1.2"
 serde_json = "1.0.149"
 soa_derive = "0.14.0"
-sqlx = { version = "0.8.6", features = [
+sqlx = { version = "0.9.0", features = [
   "postgres",
   "runtime-async-std",
   "time",
@@ -49,3 +49,4 @@ num-traits = "0.2.19"
 proptest = "1.11.0"
 proptest-derive = "0.6.0"
 env_logger = "0.11.10"
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ If you are using pgrx’s bundled PostgreSQL, follow these steps from the root o
 #! /bin/sh
 
 set -x
-export DATABASE_URL=postgresql://localhost:28818/pg_search
+export DATABASE_URL=postgresql://$(whoami)@localhost:28818/pg_search
 export RUST_BACKTRACE=1
 cargo pgrx stop --package pg_search
 cargo pgrx install --package pg_search --pg-config ~/.pgrx/18.1/pgrx-install/bin/pg_config
@@ -46,7 +46,7 @@ and install the `pg_search` extension files into that PostgreSQL instance instea
 #! /bin/sh
 
 set -x
-export DATABASE_URL=postgresql://localhost:5432/pg_search
+export DATABASE_URL=postgresql://$(whoami)@localhost:5432/pg_search
 export RUST_BACKTRACE=1
 
 createdb pg_search || true

--- a/tests/src/fixtures/db.rs
+++ b/tests/src/fixtures/db.rs
@@ -22,7 +22,8 @@ use async_std::task::block_on;
 use bytes::Bytes;
 use rand::Rng;
 use sqlx::{
-    ConnectOptions, Connection, Decode, Error, Executor, FromRow, PgConnection, Postgres, Type,
+    AssertSqlSafe, ConnectOptions, Connection, Decode, Error, Executor, FromRow, PgConnection,
+    Postgres, Type,
     postgres::PgRow,
     testing::{TestArgs, TestContext, TestSupport},
 };
@@ -105,13 +106,13 @@ where
     #[allow(async_fn_in_trait)]
     async fn execute_async(self, connection: &mut PgConnection) {
         connection
-            .execute(self.as_ref())
+            .execute(AssertSqlSafe(self.as_ref()))
             .await
             .expect("query execution should succeed");
     }
 
     fn execute_result(self, connection: &mut PgConnection) -> Result<(), sqlx::Error> {
-        block_on(async { connection.execute(self.as_ref()).await })?;
+        block_on(async { connection.execute(AssertSqlSafe(self.as_ref())).await })?;
         Ok(())
     }
 
@@ -120,7 +121,7 @@ where
         T: for<'r> FromRow<'r, <Postgres as sqlx::Database>::Row> + Send + Unpin,
     {
         block_on(async {
-            sqlx::query_as::<_, T>(self.as_ref())
+            sqlx::query_as::<_, T>(AssertSqlSafe(self.as_ref()))
                 .fetch_all(connection)
                 .await
                 .unwrap_or_else(|e| panic!("{e}:  error in query '{}'", self.as_ref()))
@@ -139,7 +140,7 @@ where
     {
         for attempt in 0..retries {
             match block_on(async {
-                sqlx::query_as::<_, T>(self.as_ref())
+                sqlx::query_as::<_, T>(AssertSqlSafe(self.as_ref()))
                     .fetch_all(&mut *connection)
                     .await
                     .map_err(anyhow::Error::from)
@@ -162,7 +163,7 @@ where
 
     fn fetch_dynamic(self, connection: &mut PgConnection) -> Vec<PgRow> {
         block_on(async {
-            sqlx::query(self.as_ref())
+            sqlx::query(AssertSqlSafe(self.as_ref()))
                 .fetch_all(connection)
                 .await
                 .unwrap_or_else(|e| panic!("{e}:  error in query '{}'", self.as_ref()))
@@ -174,7 +175,7 @@ where
         T: Type<Postgres> + for<'a> Decode<'a, sqlx::Postgres> + Send + Unpin,
     {
         block_on(async {
-            sqlx::query_scalar(self.as_ref())
+            sqlx::query_scalar(AssertSqlSafe(self.as_ref()))
                 .fetch_all(connection)
                 .await
                 .unwrap_or_else(|e| panic!("{e}:  error in query '{}'", self.as_ref()))
@@ -186,7 +187,7 @@ where
         T: for<'r> FromRow<'r, <Postgres as sqlx::Database>::Row> + Send + Unpin,
     {
         block_on(async {
-            sqlx::query_as::<_, T>(self.as_ref())
+            sqlx::query_as::<_, T>(AssertSqlSafe(self.as_ref()))
                 .fetch_one(connection)
                 .await
                 .unwrap_or_else(|e| panic!("{e}:  error in query '{}'", self.as_ref()))
@@ -198,7 +199,7 @@ where
         T: for<'r> FromRow<'r, <Postgres as sqlx::Database>::Row> + Send + Unpin,
     {
         block_on(async {
-            sqlx::query_as::<_, T>(self.as_ref())
+            sqlx::query_as::<_, T>(AssertSqlSafe(self.as_ref()))
                 .fetch_all(connection)
                 .await
         })

--- a/tests/src/fixtures/mod.rs
+++ b/tests/src/fixtures/mod.rs
@@ -37,6 +37,19 @@ pub fn database() -> Db {
     block_on(async { Db::new().await })
 }
 
+/// Render a database error the way `sqlx::Error`'s `Display` did before 0.9.
+///
+/// sqlx 0.9 appends the Postgres source line that raised the error, so
+/// `err.to_string()` now reads `...does not exist at line 248`. That line number is a
+/// position in *our* source and moves whenever the extension's code moves, which would
+/// make every assertion on an error message a tripwire. Assert on this instead.
+pub fn db_error_message(err: &sqlx::Error) -> String {
+    match err.as_database_error() {
+        Some(db_err) => format!("error returned from database: {}", db_err.message()),
+        None => err.to_string(),
+    }
+}
+
 pub fn pg_major_version(conn: &mut PgConnection) -> usize {
     r#"select (regexp_match(version(), 'PostgreSQL (\d+)'))[1]::int;"#
         .fetch_one::<(i32,)>(conn)

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -1402,7 +1402,7 @@ fn alias_cannot_be_key_field(mut conn: PgConnection) {
 
     assert!(result.is_err());
     assert_eq!(
-        result.unwrap_err().to_string(),
+        db_error_message(&result.unwrap_err()),
         "error returned from database: cannot override BM25 configuration for key_field 'id', you must use an aliased field name and 'column' configuration key"
     );
 
@@ -1632,7 +1632,7 @@ fn cant_name_a_field_ctid(mut conn: PgConnection) {
 
     assert!(result.is_err());
     assert_eq!(
-        result.unwrap_err().to_string(),
+        db_error_message(&result.unwrap_err()),
         "error returned from database: the name `ctid` is reserved by pg_search"
     );
 }
@@ -1685,7 +1685,7 @@ fn missing_source_column(mut conn: PgConnection) {
 
     assert!(result.is_err());
     assert_eq!(
-        result.unwrap_err().to_string(),
+        db_error_message(&result.unwrap_err()),
         "error returned from database: the column `nonexistent_column` referenced by the field configuration for 'alias' does not exist"
     );
 }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -472,7 +472,7 @@ fn leaky_file_handles(mut conn: PgConnection) {
     assert!(result.is_err());
     assert_eq!(
         "error returned from database: error! 12 = 12",
-        &format!("{}", result.err().unwrap())
+        db_error_message(&result.err().unwrap())
     );
 
     fn tantivy_files_still_open(pid: i32) -> bool {

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -40,7 +40,7 @@ fn invalid_create_index(mut conn: PgConnection) {
     {
         Ok(_) => panic!("should fail with no key_field"),
         Err(err) => assert_eq!(
-            err.to_string(),
+            db_error_message(&err),
             "error returned from database: index should have a `WITH (key_field='...')` option"
         ),
     };
@@ -395,7 +395,7 @@ fn null_key_field_build(mut conn: PgConnection) {
     {
         Ok(_) => panic!("should fail with null key_field"),
         Err(err) => assert_eq!(
-            err.to_string(),
+            db_error_message(&err),
             "error returned from database: key_field column 'id' cannot be NULL"
         ),
     };
@@ -415,7 +415,7 @@ fn null_key_field_insert(mut conn: PgConnection) {
     {
         Ok(_) => panic!("should fail with null key_field"),
         Err(err) => assert_eq!(
-            err.to_string(),
+            db_error_message(&err),
             "error returned from database: key_field column 'id' cannot be NULL"
         ),
     };

--- a/tests/tests/mpp_cancel.rs
+++ b/tests/tests/mpp_cancel.rs
@@ -23,7 +23,7 @@
 
 use anyhow::Result;
 use rstest::*;
-use sqlx::{Executor, PgConnection};
+use sqlx::{AssertSqlSafe, Executor, PgConnection};
 use std::time::{Duration, Instant};
 use tests::fixtures::*;
 use tokio::time::sleep;
@@ -117,9 +117,11 @@ const VICTIM_LOOP_TIMEOUT: Duration = Duration::from_secs(30);
 
 async fn assert_query_plans_as_mpp(conn: &mut PgConnection) -> Result<()> {
     conn.execute(MPP_GUCS).await?;
-    let rows: Vec<(String,)> = sqlx::query_as(&format!("EXPLAIN (COSTS OFF, VERBOSE) {MPP_QUERY}"))
-        .fetch_all(&mut *conn)
-        .await?;
+    let rows: Vec<(String,)> = sqlx::query_as(AssertSqlSafe(format!(
+        "EXPLAIN (COSTS OFF, VERBOSE) {MPP_QUERY}"
+    )))
+    .fetch_all(&mut *conn)
+    .await?;
     let explain = rows
         .into_iter()
         .map(|(line,)| line)
@@ -155,7 +157,7 @@ async fn signal_running_mpp_backend(
         if let Some(pid) = pid {
             // Let execution get well inside the MPP join (senders live) before signalling.
             sleep(SIGNAL_DELAY).await;
-            sqlx::query(&format!("SELECT {signal_fn}($1)"))
+            sqlx::query(AssertSqlSafe(format!("SELECT {signal_fn}($1)")))
                 .bind(pid)
                 .execute(&mut *killer)
                 .await?;
@@ -172,7 +174,9 @@ async fn signal_running_mpp_backend(
 /// the backend busy so the killer has a wide window to land the signal mid-query.
 async fn run_until_signalled(mut victim: PgConnection, app_name: String) -> Result<()> {
     if victim
-        .execute(format!("SET application_name = '{app_name}';").as_str())
+        .execute(AssertSqlSafe(format!(
+            "SET application_name = '{app_name}';"
+        )))
         .await
         .is_err()
     {

--- a/tests/tests/parallel.rs
+++ b/tests/tests/parallel.rs
@@ -23,7 +23,7 @@ use futures::future::join_all;
 use pretty_assertions::assert_eq;
 use rand::Rng;
 use rstest::*;
-use sqlx::Row;
+use sqlx::{AssertSqlSafe, Row};
 use tests::fixtures::*;
 use tokio::join;
 use tokio::sync::Barrier;
@@ -424,7 +424,7 @@ async fn test_parallel_scan_with_segments_exceeding_target(database: Db) -> Resu
                 "INSERT INTO test (column_a, column_b) VALUES ('{}', true)",
                 i
             );
-            let _ = sqlx::query(&q).execute(&mut writer).await;
+            let _ = sqlx::query(AssertSqlSafe(q)).execute(&mut writer).await;
             i += 1;
         }
     });

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -472,7 +472,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
     {
         Err(err) => {
             assert_eq!(
-                err.to_string(),
+                db_error_message(&err),
                 "error returned from database: more_like_this must be called with either key_value or document"
             )
         }
@@ -533,7 +533,7 @@ fn more_like_this_empty(mut conn: PgConnection) {
     {
         Err(err) => {
             assert_eq!(
-                err.to_string(),
+                db_error_message(&err),
                 "error returned from database: more_like_this must be called with either key_value or document"
             )
         }

--- a/tests/tests/query_json.rs
+++ b/tests/tests/query_json.rs
@@ -485,7 +485,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
     {
         Err(err) => {
             assert_eq!(
-                err.to_string(),
+                db_error_message(&err),
                 "error returned from database: more_like_this must be called with either key_value or document"
             )
         }
@@ -504,7 +504,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
     {
         Err(err) => {
             assert_eq!(
-                err.to_string(),
+                db_error_message(&err),
                 "error returned from database: more_like_this must be called with either key_value or document"
             )
         }
@@ -569,7 +569,7 @@ fn more_like_this_empty(mut conn: PgConnection) {
     {
         Err(err) => {
             assert_eq!(
-                err.to_string(),
+                db_error_message(&err),
                 "error returned from database: more_like_this must be called with either key_value or document"
             )
         }
@@ -1237,7 +1237,7 @@ fn parse_error(mut conn: PgConnection) {
 
     match result {
         Err(err) => assert_eq!(
-            err.to_string(),
+            db_error_message(&err),
             r#"error returned from database: error parsing search query input json at ".": data did not match any variant of untagged enum SearchQueryInput"#
         ),
         _ => {

--- a/tests/tests/range_term.rs
+++ b/tests/tests/range_term.rs
@@ -22,8 +22,8 @@ use sqlx::postgres::types::PgRange;
 use sqlx::types::time::{Date, OffsetDateTime, PrimitiveDateTime};
 use std::fmt::{Debug, Display};
 use std::ops::Bound;
+use strum::EnumIter;
 use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
 use tests::fixtures::*;
 use time::macros::{date, datetime};
 

--- a/tests/tests/replication.rs
+++ b/tests/tests/replication.rs
@@ -64,6 +64,14 @@ fn get_free_port() -> u16 {
     }
 }
 
+// Superuser created by `initdb` for every ephemeral instance.
+//
+// This is pinned rather than left to `initdb`'s default (the OS user) because sqlx
+// resolves an omitted username via `whoami`, which reports `anonymous` when neither
+// `USER` nor `LOGNAME` is set — as is the case in our CI containers. Naming the role on
+// both sides keeps the tests independent of the ambient environment.
+const SUPERUSER: &str = "postgres";
+
 // Struct to manage an ephemeral PostgreSQL instance
 struct EphemeralPostgres {
     pub tempdir_path: String,
@@ -175,7 +183,7 @@ impl EphemeralPostgres {
         let tempdir_path = tempdir.keep();
 
         // Initialize PostgreSQL data directory
-        run_cmd!($init_db_path -D $tempdir_path &> /dev/null)
+        run_cmd!($init_db_path -D $tempdir_path --username $SUPERUSER &> /dev/null)
             .expect("Failed to initialize Postgres data directory");
 
         Self::new_from_initialized(tempdir_path.as_path(), postgresql_conf, pg_hba_conf)
@@ -184,8 +192,8 @@ impl EphemeralPostgres {
     // Method to establish a connection to the PostgreSQL instance
     async fn connection(&self) -> Result<PgConnection> {
         Ok(PgConnection::connect(&format!(
-            "postgresql://{}:{}/{}",
-            self.host, self.port, self.dbname
+            "postgresql://{}@{}:{}/{}",
+            SUPERUSER, self.host, self.port, self.dbname
         ))
         .await?)
     }
@@ -256,9 +264,9 @@ async fn test_logical_replication() -> Result<()> {
     "CREATE PUBLICATION mock_items_pub FOR TABLE mock_items".execute(&mut source_conn);
     format!(
         "CREATE SUBSCRIPTION mock_items_sub
-         CONNECTION 'host={} port={} dbname={}'
+         CONNECTION 'host={} port={} dbname={} user={}'
          PUBLICATION mock_items_pub;",
-        source_postgres.host, source_postgres.port, source_postgres.dbname
+        source_postgres.host, source_postgres.port, source_postgres.dbname, SUPERUSER
     )
     .execute(&mut target_conn);
 
@@ -754,8 +762,8 @@ async fn test_wal_streaming_replication_with_pg_search() -> Result<()> {
 
     // The FATAL during recovery should also have brought the standby down: reconnects fail.
     let reconnect = PgConnection::connect(&format!(
-        "postgresql://{}:{}/{}",
-        standby_postgres.host, standby_postgres.port, standby_postgres.dbname
+        "postgresql://{}@{}:{}/{}",
+        SUPERUSER, standby_postgres.host, standby_postgres.port, standby_postgres.dbname
     ))
     .await;
     assert!(


### PR DESCRIPTION
Upgrading `pgvector`, which we now use, required upgrading `sqlx` as well. This PR fixes some missing use of a username when using `sqlx`, which no longer works on `sqlx 0.9.0`.

This is part of an effort to upgrade a variety of our dependencies