### PR TITLE
fix(mpp): replan after a short worker launch

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -876,11 +876,15 @@ impl AggregateScan {
     /// sizes the producer pool from the plan's widest stage, builds the DSM, and spawns exactly
     /// the needed workers. `None` means run serially — the plan had nothing to distribute (no
     /// workers were forked at all) or the launch fell back.
-    fn launch_mpp(
+    fn launch_mpp<R, F>(
         state: &mut CustomScanStateWrapper<Self>,
         physical: &Arc<dyn ExecutionPlan>,
         plan_bytes_len: usize,
-    ) -> Option<crate::postgres::customscan::mpp::glue::MppLeaderState> {
+        replan_for_attached_workers: F,
+    ) -> Option<crate::postgres::customscan::mpp::launch::MppLaunch<R>>
+    where
+        F: FnOnce(u32) -> (Arc<dyn ExecutionPlan>, R),
+    {
         // Manifests were captured in `stash_mpp_plan_bytes` (begin); `ensure`
         // is idempotent.
         Self::ensure_source_manifests(state);
@@ -897,10 +901,12 @@ impl AggregateScan {
             with_aggregates: false,
         };
 
-        crate::postgres::customscan::mpp::launch::launch_mpp_aggregate(
+        crate::postgres::customscan::mpp::launch::launch_mpp(
             physical,
             plan_bytes_len,
             args,
+            crate::postgres::customscan::mpp::launch::MppWorkerKind::Aggregate,
+            replan_for_attached_workers,
         )
     }
 
@@ -1549,10 +1555,73 @@ impl AggregateScan {
             };
             let plan_us = t_plan.elapsed().as_micros() as u64;
 
+            // Keep the logical-plan inputs independent of `state` while launch_mpp borrows the
+            // source manifests. A short PostgreSQL launch rebuilds at the attached width, and
+            // returns the rebuilt GROUP BY projection mapping with that physical plan.
+            let replan_inputs = {
+                let df_state = state
+                    .custom_state()
+                    .datafusion_state
+                    .as_ref()
+                    .expect("DataFusion state must be initialized");
+                (
+                    df_state.plan.clone(),
+                    df_state.targetlist.clone(),
+                    df_state.topk.clone(),
+                    df_state.join_level_predicates.clone(),
+                    df_state.custom_exprs,
+                    df_state.custom_scan_tlist,
+                    df_state.having_filter.clone(),
+                )
+            };
+
             // On a launch fallback (nothing to distribute, short launch) no workers remain and
             // the `DistributedExec` shape has no mesh to read from, so replan serially below.
-            let leader = match &mpp_plan_bytes {
-                Some(bytes) => Self::launch_mpp(state, &physical_plan, bytes.len()),
+            let launched = match &mpp_plan_bytes {
+                Some(bytes) => {
+                    Self::launch_mpp(state, &physical_plan, bytes.len(), |worker_count| {
+                        let (
+                            plan,
+                            targetlist,
+                            topk,
+                            join_level_predicates,
+                            custom_exprs,
+                            custom_scan_tlist,
+                            having_filter,
+                        ) = replan_inputs;
+                        let replan_ctx = crate::postgres::customscan::mpp::exec_worker::
+                            build_mpp_session_context_for_worker_count(
+                                create_aggregate_session_context(),
+                                worker_count as usize,
+                            );
+                        let rebuilt = runtime.block_on(async {
+                            let (logical, group_df_indices) = build_join_aggregate_plan(
+                                &plan,
+                                &targetlist,
+                                topk.as_ref(),
+                                &join_level_predicates,
+                                custom_exprs,
+                                custom_scan_tlist,
+                                having_filter.as_ref(),
+                                &replan_ctx,
+                                runtime_expr_context,
+                                runtime_planstate,
+                                true,
+                            )
+                            .await?;
+                            Ok::<_, datafusion::common::DataFusionError>((
+                                build_physical_plan(&replan_ctx, logical).await?,
+                                group_df_indices,
+                            ))
+                        });
+                        match rebuilt {
+                            Ok(result) => result,
+                            Err(e) => pgrx::error!(
+                                "Failed to rebuild DataFusion aggregate plan after short MPP launch: {e}"
+                            ),
+                        }
+                    })
+                }
                 None => None,
             };
 
@@ -1562,8 +1631,12 @@ impl AggregateScan {
                 .as_mut()
                 .expect("DataFusion state must be initialized");
             let (ctx, physical_plan) = if is_mpp {
-                match leader {
-                    Some(leader) => {
+                match launched {
+                    Some(launched) => {
+                        let leader = launched.leader;
+                        if let Some(group_df_indices) = launched.replan_result {
+                            df_state.group_df_indices = group_df_indices;
+                        }
                         let source =
                             crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
                         let exec_ctx =
@@ -1573,7 +1646,7 @@ impl AggregateScan {
                         timing.plan_us = plan_us;
                         df_state.launch_timing = Some(timing);
                         df_state.mpp = MppLifecycle::Launched(leader);
-                        (exec_ctx, physical_plan)
+                        (exec_ctx, launched.physical)
                     }
                     None => {
                         let serial_ctx = create_aggregate_session_context();

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -871,7 +871,8 @@ impl JoinScan {
         state: &mut CustomScanStateWrapper<Self>,
         physical: &Arc<dyn ExecutionPlan>,
         plan_bytes_len: usize,
-    ) -> Option<crate::postgres::customscan::mpp::glue::MppLeaderState> {
+        replan_for_attached_workers: impl FnOnce(u32) -> Arc<dyn ExecutionPlan>,
+    ) -> Option<crate::postgres::customscan::mpp::launch::MppLaunch<()>> {
         Self::ensure_source_manifests(state);
         let all_sources: Vec<&[tantivy::SegmentReader]> = state
             .custom_state()
@@ -884,7 +885,13 @@ impl JoinScan {
             query: vec![],
             with_aggregates: false,
         };
-        crate::postgres::customscan::mpp::launch::launch_mpp_join(physical, plan_bytes_len, args)
+        crate::postgres::customscan::mpp::launch::launch_mpp(
+            physical,
+            plan_bytes_len,
+            args,
+            crate::postgres::customscan::mpp::launch::MppWorkerKind::Join,
+            |worker_count| (replan_for_attached_workers(worker_count), ()),
+        )
     }
 }
 
@@ -1364,8 +1371,16 @@ impl CustomScan for JoinScan {
                 // On a launch fallback (nothing to distribute, short launch) no workers remain
                 // and the `DistributedExec` shape has no mesh to read from, so replan serially.
                 let (ctx, plan) = match mpp_plan_bytes {
-                    Some(bytes) => match Self::launch_mpp(state, &plan, bytes.len()) {
-                        Some(leader) => {
+                    Some(bytes) => match Self::launch_mpp(state, &plan, bytes.len(), |workers| {
+                        let replan_ctx = crate::postgres::customscan::mpp::exec_worker::
+                            build_mpp_session_context_for_worker_count(
+                                create_datafusion_session_context(SessionContextProfile::Join),
+                                workers as usize,
+                            );
+                        build_plan(&replan_ctx)
+                    }) {
+                        Some(launched) => {
+                            let leader = launched.leader;
                             let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
                             let exec_ctx =
                                 Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
@@ -1376,7 +1391,7 @@ impl CustomScan for JoinScan {
                             launch_us.leader_setup_us = leader.timing.leader_setup_us;
                             launch_us.workers = leader.timing.workers;
                             state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
-                            (exec_ctx, plan)
+                            (exec_ctx, launched.physical)
                         }
                         None => {
                             let serial_ctx =

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -110,6 +110,28 @@ pub(crate) fn build_mpp_session_context(
         Some(m) => m.n_workers() as usize,
         None => producer_worker_cap() as usize,
     };
+    build_mpp_session_context_with_worker_count(seed, mesh, n_workers)
+}
+
+/// Build an MPP session context for a known producer width before the mesh exists. This is used
+/// after PostgreSQL reports a short launch: the physical plan must be rebuilt at the attached
+/// width so it has no more producer tasks than mesh workers.
+pub(crate) fn build_mpp_session_context_for_worker_count(
+    seed: SessionContext,
+    n_workers: usize,
+) -> SessionContext {
+    build_mpp_session_context_with_worker_count(seed, None, n_workers)
+}
+
+fn build_mpp_session_context_with_worker_count(
+    seed: SessionContext,
+    mesh: Option<Arc<MppMesh>>,
+    n_workers: usize,
+) -> SessionContext {
+    assert!(
+        n_workers >= 2,
+        "MPP session contexts require at least two producer workers"
+    );
     // Three knobs that have to be set for the planner to actually emit `NetworkShuffleExec`:
     //   1. target_partitions(N): without it, EnforceDistribution skips every
     //      RepartitionExec so the annotator never sees a Shuffle.

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -73,7 +73,8 @@ pub(super) fn mpp_queue_size() -> usize {
 /// Total DSM bytes the leader will need for the mesh header, the worker plan, and one MPSC
 /// inbox per process. `n_procs` is the total proc count (leader + launched producers) the
 /// plan-first launch computed from the physical plan — the mesh grows as `n_procs²`, so this
-/// is sized from the plan's needs, not the GUC ceiling (#5667).
+/// is sized from the plan's needs, not the GUC ceiling (#5667). A short launch may initialize a
+/// narrower logical mesh in this allocation, but never a wider one.
 pub fn estimate_dsm_size(n_procs: u32, plan_bytes_len: usize) -> Result<usize, String> {
     shm::dsm_region_bytes(n_procs, mpp_queue_size(), plan_bytes_len).map_err(|e| e.to_string())
 }
@@ -198,8 +199,9 @@ unsafe fn self_receiver_token() -> u64 {
 /// # Safety
 /// - `coordinate` must be the MPP region pointer (a `ParallelState` byte blob the leader owns).
 /// - `n_procs` is the total mesh participant count including the leader: 1 (leader, proc 0)
-///   plus the launched producer workers. It must equal the count passed to
-///   [`estimate_dsm_size`] for this region, or the ring mesh won't fit.
+///   plus the launched producer workers. It must not exceed the count passed to
+///   [`estimate_dsm_size`] for this region. A short launch may use fewer processes than the
+///   preallocated region was sized for.
 /// - `plan_bytes` must have the same length passed to [`estimate_dsm_size`]
 ///   so the leader doesn't overrun the region.
 pub unsafe fn leader_setup(
@@ -337,6 +339,39 @@ mod tests {
 
     impl Wakeup for NoopWakeup {
         fn wake(&self, _token: u64) {}
+    }
+
+    #[test]
+    fn mesh_can_use_fewer_processes_than_its_reserved_region() {
+        // `launch_mpp` must allocate DSM before PostgreSQL tells it how many workers actually
+        // attached. Pin the transport contract that lets a short launch initialize its smaller
+        // logical mesh in the region reserved for the requested width.
+        let requested_procs = 6;
+        let launched_procs = 4;
+        let plan = [0_u8; 64];
+        let region_bytes = shm::dsm_region_bytes(requested_procs, 64 * 1024, plan.len()).unwrap();
+        let mut region = vec![0_u64; region_bytes.div_ceil(std::mem::size_of::<u64>())];
+
+        let attach = unsafe {
+            shm::leader_setup(
+                region.as_mut_ptr().cast(),
+                launched_procs,
+                64 * 1024,
+                &plan,
+                Arc::new(NoopWakeup),
+                1,
+                Arc::new(NoInterrupt),
+                true,
+            )
+            .unwrap()
+        };
+
+        assert_eq!(attach.outbound_senders.len(), launched_procs as usize);
+        assert!(attach.outbound_senders[0].is_none());
+        assert_eq!(
+            attach.outbound_senders.iter().flatten().count(),
+            (launched_procs - 1) as usize
+        );
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -30,13 +30,15 @@
 //! The launch is plan-first (#5667), mirroring core PG's parallel-query order (plan →
 //! size-by-walking-the-plan → create DSM → bind pointers → launch): the caller builds the
 //! distributed physical plan with `producer_worker_cap()` (PG's parallelism GUCs) as the
-//! planner's ceiling, then [`launch_mpp_join`] / [`launch_mpp_aggregate`] walk the finished plan to learn
+//! planner's ceiling, then [`launch_mpp`] walks the finished plan to learn
 //! the largest producer-stage task count, size the mesh and spawn exactly
 //! `clamp(max_tasks, 2, cap)` producers, stamp the shared scan state into the plan
 //! ([`crate::scan::execution_plan::stamp_parallel_state`]), and dispatch. A plan with no
 //! producer stages spawns nothing at all. One plan serves both dispatch and the leader's own
 //! execution; the go flag holds spawned workers off the mesh until the rings and dispatch
-//! payload are initialized, and aborts them on a short launch (#5061).
+//! payload are initialized. If PostgreSQL attaches fewer workers, the leader rebuilds the
+//! physical plan and routing payload at the attached width, then initializes a narrower logical
+//! mesh; the preallocated DSM remains large enough for it.
 
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -71,8 +73,8 @@ const MESH_IDX: usize = 0;
 const SCAN_IDX: usize = 1;
 const GO_IDX: usize = 2;
 
-/// Go-flag states. The leader sets `RUN` once the full producer set launched and the rings are
-/// initialized, or `ABORT` on a short launch so the spare workers exit before touching the mesh.
+/// Go-flag states. The leader sets `RUN` once the mesh is initialized, or `ABORT` if too few
+/// workers attached for an MPP mesh.
 const GO_WAIT: u32 = 0;
 const GO_RUN: u32 = 1;
 const GO_ABORT: u32 = 2;
@@ -215,6 +217,31 @@ pub enum MppLifecycle {
     Launched(MppLeaderState),
 }
 
+/// The custom scan shape selects the PostgreSQL worker entrypoint. Keeping this as an enum
+/// rather than passing symbol strings from scan implementations keeps the FFI boundary local.
+pub(crate) enum MppWorkerKind {
+    Aggregate,
+    Join,
+}
+
+impl MppWorkerKind {
+    const fn entrypoint(self) -> &'static str {
+        match self {
+            Self::Aggregate => "mpp_launched_worker_agg",
+            Self::Join => "mpp_launched_worker_join",
+        }
+    }
+}
+
+/// A committed MPP launch. A short PostgreSQL launch carries a physical plan rebuilt at the
+/// attached worker width; the caller must execute this plan rather than the provisional one used
+/// only to size and start the worker pool.
+pub struct MppLaunch<R> {
+    pub leader: MppLeaderState,
+    pub physical: std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    pub replan_result: Option<R>,
+}
+
 impl MppLifecycle {
     /// Consume the stashed plan bytes. Leaves `Inactive`, so a launch fallback reads as the
     /// serial path from then on.
@@ -261,19 +288,29 @@ impl MppLifecycle {
 /// Plan-first MPP launch (#5667): size the worker pool from the finished physical plan, build
 /// the DSM, stamp the shared scan state into the plan, spawn exactly the needed producers, and
 /// dispatch. `None` means run serially — the plan has nothing to distribute, the DSM couldn't
-/// be built, or the machine couldn't give us the full producer set. Nothing is forked on the
-/// nothing-to-distribute path. `None` covers only environmental shortfalls; a `pgrx::error!`
-/// means an invariant breach or a failure past mesh commitment, where a silent serial
-/// fallback would hide a real bug.
-fn launch_mpp(
+/// be built, or the machine could not attach the minimum two producers needed for an MPP mesh.
+/// Nothing is forked on the nothing-to-distribute path. `None` covers only environmental
+/// shortfalls; a `pgrx::error!` means an invariant breach or a failure past mesh commitment,
+/// where a silent serial fallback would hide a real bug.
+pub(crate) fn launch_mpp<R, F>(
     physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
     plan_bytes_len: usize,
     args: ParallelScanArgs,
-    worker_entrypoint: &'static str,
-) -> Option<MppLeaderState> {
+    worker_kind: MppWorkerKind,
+    replan_for_attached_workers: F,
+) -> Option<MppLaunch<R>>
+where
+    F: FnOnce(
+        u32,
+    ) -> (
+        std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+        R,
+    ),
+{
     let mut timing = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
 
-    let stages = collect_stages(physical);
+    let mut physical = std::sync::Arc::clone(physical);
+    let mut stages = collect_stages(&physical);
 
     // Task counts were capped by `target_partitions = cap` at plan time and reflect segment
     // counts (#5657). The producer floor keeps the mesh-width invariant; see
@@ -313,7 +350,7 @@ fn launch_mpp(
 
     let launcher = ParallelProcessBuilder::build(
         process,
-        worker_entrypoint,
+        worker_kind.entrypoint(),
         WorkerStyle::Query,
         producer_count as usize,
         MPP_MQ_SIZE,
@@ -339,10 +376,11 @@ fn launch_mpp(
     // here is a hard error: a serialization gap is a codec bug, and the parked workers die
     // with the transaction.
     let t_payload = std::time::Instant::now();
-    let payload = match dispatch_payload_from_stages(&stages, producer_count, payload_capacity) {
-        Ok(p) => p,
-        Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
-    };
+    let provisional_payload =
+        match dispatch_payload_from_stages(&stages, producer_count, payload_capacity) {
+            Ok(p) => p,
+            Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
+        };
     timing.payload_us = t_payload.elapsed().as_micros() as u64;
 
     let t_attach = std::time::Instant::now();
@@ -353,10 +391,11 @@ fn launch_mpp(
 
     let go = unsafe { go_flag(finish.state_manager()) };
 
-    if launched < producer_count {
-        // #5061: the machine couldn't give us the full producer set. The launched workers are
-        // still on the go flag with no rings attached; release them and run serially. No
-        // `leader_setup` ran, so there are no DSM-backed senders to outlive the mapping.
+    if launched < MIN_TOTAL_WORKER_COUNT - 1 {
+        // The machine could not give us the minimum two producers required for the MPP mesh.
+        // The launched workers are still on the go flag with no rings attached; release them
+        // and run serially. No `leader_setup` ran, so there are no DSM-backed senders to
+        // outlive the mapping.
         go.store(GO_ABORT, Ordering::Release);
         finish.wait_for_finish();
         pgrx::warning!(
@@ -365,11 +404,48 @@ fn launch_mpp(
         return None;
     }
 
+    // PostgreSQL may attach fewer workers than requested. Keep the common full-launch path from
+    // building a second payload: its routing payload was serialized while workers were attaching.
+    // On a short launch, task ownership and routing must use the actual worker count, so rebuild
+    // the physical plan and its dispatch payload. The DSM allocation remains large enough; the
+    // provisional buffer for the wider plan drops here.
+    let mut replan_result = None;
+    let payload = if launched == producer_count {
+        provisional_payload
+    } else {
+        crate::mpp_log!(
+            "launch: {launched} of {producer_count} producers attached; replanning at attached width"
+        );
+        // The original physical plan has `producer_count` tasks. The shm transport associates a
+        // task with one producer proc, so routing alone cannot safely fold those tasks onto fewer
+        // attached workers: their per-channel EOFs would interleave. Replan at `launched` first;
+        // the resulting physical stages and mesh now have the same width.
+        let (replanned, result) = replan_for_attached_workers(launched);
+        physical = replanned;
+        stages = collect_stages(&physical);
+        let replanned_max_tasks = max_producer_task_count(&stages);
+        if replanned_max_tasks < 2 || replanned_max_tasks > launched as usize {
+            pgrx::error!(
+                "mpp: short-launch replan produced {replanned_max_tasks} producer tasks for \
+                 {launched} attached workers"
+            );
+        }
+        replan_result = Some(result);
+
+        let t_payload = std::time::Instant::now();
+        let payload = match dispatch_payload_from_stages(&stages, launched, payload_capacity) {
+            Ok(p) => p,
+            Err(e) => pgrx::error!("mpp: dispatch payload rebuild failed: {e}"),
+        };
+        timing.payload_us += t_payload.elapsed().as_micros() as u64;
+        payload
+    };
+
     // Bind the shared scan state into the plan the leader will execute. Must stay below the
     // last serial-fallback `return None`: a stamped plan must never outlive its DSM, and the
     // fallback paths replan. Workers are unaffected — dispatch encodes are context-free and
     // each worker injects its own pointer at decode.
-    crate::scan::execution_plan::stamp_parallel_state(physical, scan_ptr);
+    crate::scan::execution_plan::stamp_parallel_state(&physical, scan_ptr);
 
     // Initialize the leader's rings now that we're committed to the parallel path. After launch on
     // purpose: the serial fallbacks above never create the DSM-backed control senders.
@@ -378,7 +454,7 @@ fn launch_mpp(
         _ => pgrx::error!("mpp: mesh region missing"),
     };
     let t_setup = std::time::Instant::now();
-    let mut leader = match unsafe { leader_setup(mesh_ptr, producer_count + 1, payload) } {
+    let mut leader = match unsafe { leader_setup(mesh_ptr, launched + 1, payload) } {
         Ok(l) => l,
         Err(e) => pgrx::error!("mpp: leader_setup failed: {e}"),
     };
@@ -393,23 +469,9 @@ fn launch_mpp(
     go.store(GO_RUN, Ordering::Release);
 
     leader.finish = Some(finish);
-    Some(leader)
-}
-
-/// AggregateScan launch entry: aggregate worker symbol.
-pub fn launch_mpp_aggregate(
-    physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    plan_bytes_len: usize,
-    args: ParallelScanArgs,
-) -> Option<MppLeaderState> {
-    launch_mpp(physical, plan_bytes_len, args, "mpp_launched_worker_agg")
-}
-
-/// JoinScan launch entry: join worker symbol.
-pub fn launch_mpp_join(
-    physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    plan_bytes_len: usize,
-    args: ParallelScanArgs,
-) -> Option<MppLeaderState> {
-    launch_mpp(physical, plan_bytes_len, args, "mpp_launched_worker_join")
+    Some(MppLaunch {
+        leader,
+        physical,
+        replan_result,
+    })
 }

--- a/tests/tests/mpp_short_launch.rs
+++ b/tests/tests/mpp_short_launch.rs
@@ -1,0 +1,292 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! PostgreSQL can attach fewer query workers than a custom scan requested when the shared worker
+//! pool is occupied. MPP must rebuild routing for that attached width and execute distributed,
+//! rather than fall back to `CooperativeExec`.
+
+use anyhow::Result;
+use rstest::*;
+use sqlx::{Executor, PgConnection};
+use std::time::{Duration, Instant};
+use tests::fixtures::*;
+use tokio::time::sleep;
+
+const REQUESTED_MPP_WORKERS: i64 = 5;
+const HELD_PG_WORKERS: i64 = 4;
+const HOLDER_APP: &str = "mpp_short_launch_holder";
+
+// Five separate inserts with the mutable segment disabled create five durable segments per
+// index. The target JoinScan therefore has a five-task producer stage, while the GUC cap asks
+// PostgreSQL for five MPP workers.
+const SETUP_SQL: &str = r#"
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
+
+CREATE TABLE mpp_sl_posts (
+    id bigserial PRIMARY KEY,
+    body text NOT NULL,
+    age int NOT NULL
+);
+CREATE TABLE mpp_sl_comments (
+    id bigserial PRIMARY KEY,
+    post_id bigint NOT NULL,
+    body text NOT NULL,
+    age int NOT NULL
+);
+
+CREATE INDEX mpp_sl_posts_idx ON mpp_sl_posts USING bm25 (id, body, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{"body":{"fast":true}}',
+    numeric_fields = '{"age":{"fast":true}}',
+    mutable_segment_rows = 1000,
+    layer_sizes = '10TB',
+    background_layer_sizes = '10TB'
+);
+CREATE INDEX mpp_sl_comments_idx ON mpp_sl_comments USING bm25 (id, post_id, body, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{"body":{"fast":true}}',
+    numeric_fields = '{"age":{"fast":true}}',
+    mutable_segment_rows = 1000,
+    layer_sizes = '10TB',
+    background_layer_sizes = '10TB'
+);
+
+SET paradedb.global_mutable_segment_rows = 0;
+"#;
+
+const MPP_GUCS: &str = r#"
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.enable_aggregate_custom_scan = on;
+SET max_parallel_workers = 8;
+SET max_parallel_workers_per_gather = 5;
+SET min_parallel_table_scan_size = 0;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+"#;
+
+const HOLDER_GUCS: &str = r#"
+SET paradedb.enable_custom_scan = off;
+SET max_parallel_workers = 8;
+SET max_parallel_workers_per_gather = 4;
+SET min_parallel_table_scan_size = 0;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+"#;
+
+// The large cross join keeps all four ordinary PostgreSQL parallel workers busy until the test
+// cancels this connection. The MPP query is much smaller, so it completes while the holder is
+// still active.
+const HOLDER_QUERY: &str = r#"
+SELECT sum(length(md5(p.body)))
+FROM mpp_sl_posts AS p
+CROSS JOIN generate_series(1, 20000) AS g
+"#;
+
+const TARGET_QUERY: &str = r#"
+SELECT p.id
+FROM mpp_sl_posts AS p
+JOIN mpp_sl_comments AS c ON c.post_id = p.id
+WHERE p.body @@@ 'code' AND c.body @@@ 'comment'
+ORDER BY p.id
+LIMIT 10
+"#;
+
+const AGGREGATE_QUERY: &str = r#"
+SELECT p.age, count(*)
+FROM mpp_sl_posts AS p
+JOIN mpp_sl_comments AS c ON c.age = p.age
+WHERE p.body @@@ 'code'
+GROUP BY p.age
+ORDER BY p.age
+"#;
+
+async fn setup(conn: &mut PgConnection) -> Result<()> {
+    conn.execute(SETUP_SQL).await?;
+    for batch in 0..5_i64 {
+        let post_first = batch * 1000 + 1;
+        sqlx::query(
+            "INSERT INTO mpp_sl_posts (body, age) \
+             SELECT CASE WHEN g % 3 = 0 THEN 'code example tutorial' ELSE 'ordinary discussion' END, g % 50 \
+             FROM generate_series($1, $2) AS g",
+        )
+        .bind(post_first)
+        .bind(post_first + 999)
+        .execute(&mut *conn)
+        .await?;
+        let comment_first = batch * 2000 + 1;
+        sqlx::query(
+            "INSERT INTO mpp_sl_comments (post_id, body, age) \
+             SELECT ((g - 1) % 5000) + 1, 'comment body', g % 50 \
+             FROM generate_series($1, $2) AS g",
+        )
+        .bind(comment_first)
+        .bind(comment_first + 1999)
+        .execute(&mut *conn)
+        .await?;
+    }
+    conn.execute(
+        "RESET paradedb.global_mutable_segment_rows; \
+         ANALYZE mpp_sl_posts; ANALYZE mpp_sl_comments;",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn run_holder(mut conn: PgConnection) -> Result<()> {
+    conn.execute(format!("SET application_name = '{HOLDER_APP}';").as_str())
+        .await?;
+    conn.execute(HOLDER_GUCS).await?;
+
+    // Cancellation is the expected completion path.
+    let _ = conn.execute(HOLDER_QUERY).await;
+    Ok(())
+}
+
+async fn wait_for_holder_workers(observer: &mut PgConnection) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let worker_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM pg_stat_activity \
+             WHERE application_name = $1 AND backend_type = 'parallel worker'",
+        )
+        .bind(HOLDER_APP)
+        .fetch_one(&mut *observer)
+        .await?;
+
+        if worker_count == HELD_PG_WORKERS {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "holder did not reserve {HELD_PG_WORKERS} PostgreSQL workers; observed {worker_count}"
+            );
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn cancel_holder(observer: &mut PgConnection) -> Result<()> {
+    let pid: Option<i32> = sqlx::query_scalar(
+        "SELECT pid FROM pg_stat_activity \
+         WHERE application_name = $1 AND backend_type = 'client backend'",
+    )
+    .bind(HOLDER_APP)
+    .fetch_optional(&mut *observer)
+    .await?;
+
+    if let Some(pid) = pid {
+        sqlx::query("SELECT pg_cancel_backend($1)")
+            .bind(pid)
+            .execute(&mut *observer)
+            .await?;
+    }
+    Ok(())
+}
+
+fn launched_workers(explain: &str) -> Option<i64> {
+    let prefix = "MPP Launch: workers=";
+    let suffix = explain.split(prefix).nth(1)?;
+    suffix
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .ok()
+}
+
+async fn assert_short_distributed_launch(conn: &mut PgConnection, query: &str) -> Result<String> {
+    let explain = sqlx::query_as::<_, (String,)>(&format!(
+        "EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF) {query}"
+    ))
+    .fetch_all(&mut *conn)
+    .await?
+    .into_iter()
+    .map(|(line,)| line)
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(
+        explain.contains("DistributedExec") && !explain.contains("CooperativeExec"),
+        "short launch must remain distributed:\n{explain}"
+    );
+    let launched = launched_workers(&explain)
+        .expect("short distributed launch must report its actual worker count");
+    assert!(
+        (2..REQUESTED_MPP_WORKERS).contains(&launched),
+        "expected a distributed short launch below {REQUESTED_MPP_WORKERS} workers, got {launched}:\n{explain}"
+    );
+    Ok(explain)
+}
+
+fn assert_aggregate_scan(explain: &str) {
+    assert!(
+        explain.contains("Custom Scan (ParadeDB Aggregate Scan)")
+            && explain.contains("Backend: DataFusion"),
+        "aggregate query must use AggregateScan:\n{explain}"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn mpp_short_launch_remains_distributed(database: Db) -> Result<()> {
+    let mut setup = database.connection().await;
+    self::setup(&mut setup).await?;
+
+    let holder = database.connection().await;
+    let holder_handle = tokio::spawn(run_holder(holder));
+
+    let mut observer = database.connection().await;
+    let test_result = async {
+        wait_for_holder_workers(&mut observer).await?;
+
+        let mut mpp = database.connection().await;
+        mpp.execute(MPP_GUCS).await?;
+        let explain = assert_short_distributed_launch(&mut mpp, TARGET_QUERY).await?;
+
+        let mpp_rows: Vec<(i64,)> = sqlx::query_as(TARGET_QUERY).fetch_all(&mut mpp).await?;
+
+        let mut serial = database.connection().await;
+        serial
+            .execute("SET max_parallel_workers_per_gather = 0;")
+            .await?;
+        let serial_rows: Vec<(i64,)> = sqlx::query_as(TARGET_QUERY).fetch_all(&mut serial).await?;
+        assert_eq!(
+            mpp_rows, serial_rows,
+            "short MPP launch changed query results; EXPLAIN ANALYZE:\n{explain}"
+        );
+
+        let aggregate_explain = assert_short_distributed_launch(&mut mpp, AGGREGATE_QUERY).await?;
+        assert_aggregate_scan(&aggregate_explain);
+        let aggregate_mpp_rows: Vec<(i32, i64)> =
+            sqlx::query_as(AGGREGATE_QUERY).fetch_all(&mut mpp).await?;
+        let aggregate_serial_rows: Vec<(i32, i64)> = sqlx::query_as(AGGREGATE_QUERY)
+            .fetch_all(&mut serial)
+            .await?;
+        assert_eq!(
+            aggregate_mpp_rows, aggregate_serial_rows,
+            "short MPP launch changed aggregate results; EXPLAIN ANALYZE:\n{aggregate_explain}"
+        );
+
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+
+    cancel_holder(&mut observer).await?;
+    holder_handle.await??;
+    test_result
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5781

## What

- Keep an MPP query distributed when PostgreSQL attaches fewer producers than requested, provided at least two attach.
- Rebuild the physical plan and its dispatch payload at the attached width, then initialize the logical mesh at that width.
- Preserve the full-launch fast path: building the provisional payload still overlaps worker attachment.
- Add an end-to-end forced-short-launch test for both JoinScan and the DataFusion AggregateScan.

## Why

#5756 derives the requested producer count from the widest physical-plan stage. PostgreSQL treats that value as a cap, not a guarantee. Before this change, a 3-of-5 launch aborted the parked producers and ran serially, despite three usable workers being attached.

We cannot safely assign multiple tasks from the same stage to each of fewer workers today. The shared-memory transport identifies an output stream by `(sender_proc, stage_id, partition)`; it has no `task_idx`. Two same-stage tasks on one producer may write to the same stream. The first task's EOF makes the receiver treat that stream as complete, so output from the second task cannot be represented safely by the current protocol. Different stages may share a producer because `stage_id` distinguishes their streams.

Supporting same-stage multiplexing needs either task identity in the transport stream, for example `(sender_proc, stage_id, task_idx, partition)`, or worker-side coordination that emits one EOF only after every assigned task for that stream completes.

## How

Code snapshot:

```text
old
  physical plan/tasks = 5
  -> reserve DSM for leader + 5 workers
  -> spawn 5; build provisional payload while they attach
  -> PostgreSQL attaches 3
  -> GO_ABORT
  -> serial replan / execution

new
  provisional physical plan/tasks = 5
  -> reserve DSM for leader + 5 workers
  -> spawn 5; build provisional payload while they attach
  -> PostgreSQL attaches 3
  -> rebuild physical stages/tasks at width 3
  -> discard the provisional 5-worker payload
  -> build a 3-worker payload and mesh in the existing DSM reservation
  -> GO_RUN
  -> execute the rebuilt distributed plan
```

The replan is physical only: the SQL and logical plan do not change. It regenerates stage task variants and routing so they agree with the attached mesh width. The original DSM allocation remains valid because it was sized for the requested upper bound.

## Tests

- `cargo fmt --check`
- `cargo check --package pg_search --features pg18`
- `cargo pgrx regress --package pg_search --auto pg18 mpp_worker_sizing`
- `DATABASE_URL=postgresql://localhost:28818/pg_search cargo test -p tests --test mpp_short_launch -- --test-threads=1`
  - Five durable index segments request five MPP workers while a regular PostgreSQL query holds four of eight worker slots.
  - Both JoinScan and the DataFusion AggregateScan must attach 2–4 workers (three locally), retain `DistributedExec`, and return the same rows as serial execution.
