### PR TITLE
fix(mpp): multiplex tasks after short worker launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-08-041610#57dd67ec2f14296c16c864edb367f46f557d3668"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=d33959fdd6e65df6daee4e72d1482194b8190798#d33959fdd6e65df6daee4e72d1482194b8190798"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5729,7 +5729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=d33959fdd6e65df6daee4e72d1482194b8190798#d33959fdd6e65df6daee4e72d1482194b8190798"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-08-100736#91667bfc003a3118abdec2b2c4358f93ca564b08"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5729,7 +5729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-9ZzRKnP/OrJaC1DjID7/5voENxeG2X5l0k2sp3EHFDY=";
+  cargoHash = "sha256-iiUCiUUQ84uA1SOhgpFKhVeR7UcLhKgulPBrfnZgDnk=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-iiUCiUUQ84uA1SOhgpFKhVeR7UcLhKgulPBrfnZgDnk=";
+  cargoHash = "sha256-X1KvUV/Ei4NbjwTWsnuwP0zMUJhJyTLpjx2Nw3s8Mlc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -92,7 +92,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-08-041610", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "d33959fdd6e65df6daee4e72d1482194b8190798", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -92,7 +92,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "d33959fdd6e65df6daee4e72d1482194b8190798", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-08-100736", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1575,8 +1575,9 @@ impl AggregateScan {
             };
             let plan_us = t_plan.elapsed().as_micros() as u64;
 
-            // On a launch fallback (nothing to distribute, short launch) no workers remain and
-            // the `DistributedExec` shape has no mesh to read from, so replan serially below.
+            // On a launch fallback (nothing to distribute, or too few attached workers) no workers
+            // remain and the `DistributedExec` shape has no mesh to read from, so replan serially
+            // below.
             let leader = match &mpp_plan_bytes {
                 Some(bytes) => Self::launch_mpp(state, &physical_plan, bytes.len()),
                 None => None,

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -15,7 +15,7 @@ ProjectionExec
         PgSearchScan (files)          ← lazy scan, deferred columns, receives dynamic filters
 ```
 
-When parallel execution is enabled in PostgreSQL, JoinScan exclusively relies on Massively Parallel Processing (MPP) via `datafusion-distributed` to parallelize queries. DataFusion's in-process multithreading is completely bypassed because PostgreSQL has already launched independent parallel worker processes. Instead, the above physical plan is intercepted by the `DistributedPlanner` and sliced into network stages (`DistributedExec`), mapping distributed tasks 1:1 with PostgreSQL workers.
+When a viable PostgreSQL parallel launch is available, JoinScan uses Massively Parallel Processing (MPP) via `datafusion-distributed` to parallelize queries. DataFusion's in-process multithreading is bypassed because PostgreSQL has already launched independent parallel worker processes. For a viable MPP launch, `DistributedPlanner` slices the physical plan into network stages (`DistributedExec`); logical tasks are assigned round-robin across the workers that attached, so one worker may host multiple tasks.
 
 [`SegmentedTopKExec`][topk-exec] publishes dynamic filter thresholds that are pushed down through the join to the probe-side scan, pruning rows at the scanner level. It also performs the final materialized sort and LIMIT, so `TantivyLookupExec` only decodes K rows (not K×segments).
 
@@ -43,7 +43,7 @@ The planner hook builds a [`JoinCSClause`][joincsc] — a serializable IR captur
 3. **[`RangeCoPartitionedJoinRule`](range_partitioning_rule.rs)** — flips a `CollectLeft` inner hash join to `Partitioned` mode when both sides declare compatible `Partitioning::Range` layouts, so MPP joins partition pairs task-locally instead of broadcasting the build side
 4. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)` and transfers ownership of its already pushed-down `DynamicFilterPhysicalExpr` into the injected node, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
 
-If `max_parallel_workers_per_gather > 0` and PostgreSQL has planned parallel execution, `DistributedPlanner` converts the finalized physical plan into an MPP execution tree (`DistributedExec`), slicing it into isolated tasks.
+When MPP is eligible, `DistributedPlanner` builds an MPP execution tree (`DistributedExec`), slicing it into isolated tasks. Plans with fewer than two producer tasks, or launches with fewer than two attached workers, run serially.
 
 ### 4. Deferred Columns
 
@@ -65,11 +65,11 @@ After all input is consumed, `SegmentedTopKExec` materializes sort column values
 
 JoinScan does not use DataFusion's standard in-process multithreading. Since PostgreSQL already coordinates execution across independent backend processes via the `Gather` node, relying on thread-level parallelism inside a Postgres worker would result in `Workers * Threads` explosions, and Postgres does not support interacting with its APIs anywhere but on the `main` thread.
 
-Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizing joins. We map PostgreSQL parallel workers to distributed tasks based on segment count:
+Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizing joins. It assigns logical tasks across PostgreSQL parallel workers based on segment count:
 
 1. **Partition Output Definition**: Because index segments are checked out atomically from shared memory, [`PgSearchScanPlan`][scan-plan] natively partitions its output by the number of segments. In [`table_provider.rs`](../../scan/table_provider.rs), we formally expose the scan's output partition count as `min(segment_count, target_partitions)`. When the `RangePartitioningRule` has injected a range sample, the scan instead declares `Partitioning::Range` with the sample's split points, which lets DataFusion treat the two sides of a join as co-partitioned.
 2. **Task Estimation**: During MPP planning, [`PgSearchScanTaskEstimator`](../../../scan/execution_plan.rs) intercepts the leaf nodes and requests exactly this `partition_count` number of tasks.
-3. **Execution Routing**: This routes large multi-segment tables to scale out across all available PostgreSQL parallel workers, where each parallel worker uses `ParallelScanState` to lazily claim segments. Conversely, tables with a single segment evaluate to exactly 1 task; `datafusion-distributed` detects the absence of parallel work, avoids MPP planning overhead entirely, and falls back to running the query via local serial execution on a single worker.
+3. **Execution Routing**: For a viable MPP launch, tasks are assigned round-robin across the workers PostgreSQL attached, and each worker uses `ParallelScanState` to lazily claim segments. A one-task plan does not launch MPP workers and runs serially.
 
 ## Key Files
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1360,8 +1360,9 @@ impl CustomScan for JoinScan {
                 let plan = build_plan(&plan_ctx);
                 launch_us.plan_us = t_plan.elapsed().as_micros() as u64;
 
-                // On a launch fallback (nothing to distribute, short launch) no workers remain
-                // and the `DistributedExec` shape has no mesh to read from, so replan serially.
+                // On a launch fallback (nothing to distribute, or too few attached workers) no
+                // workers remain and the `DistributedExec` shape has no mesh to read from, so
+                // replan serially.
                 let (ctx, plan) = match mpp_plan_bytes {
                     Some(bytes) => match Self::launch_mpp(state, &plan, bytes.len()) {
                         Some(leader) => {

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -216,27 +216,49 @@ mod tests {
     use super::*;
 
     #[test]
-    fn assigns_multiple_stage_tasks_to_one_proc_after_short_launch() {
-        let mut assignments = Vec::new();
-        push_owned_tasks(
-            &mut assignments,
-            7,
-            5,
-            &FragmentRouting::Coalesce { dest_proc: 0 },
-            1,
-            3,
-        );
+    fn assigns_every_logical_task_once_after_short_launch() {
+        let routing = FragmentRouting::Coalesce { dest_proc: 0 };
+        let assigned_by_proc = (1..=3)
+            .map(|proc_idx| {
+                let mut assignments = Vec::new();
+                push_owned_tasks(&mut assignments, 7, 5, &routing, proc_idx, 3);
+                assignments
+            })
+            .collect::<Vec<_>>();
 
         assert_eq!(
-            assignments
+            assigned_by_proc[0]
                 .iter()
                 .map(|assignment| assignment.task_idx)
                 .collect::<Vec<_>>(),
             vec![0, 3]
         );
-        assert!(
-            assignments
+        assert_eq!(
+            assigned_by_proc[1]
                 .iter()
+                .map(|assignment| assignment.task_idx)
+                .collect::<Vec<_>>(),
+            vec![1, 4]
+        );
+        assert_eq!(
+            assigned_by_proc[2]
+                .iter()
+                .map(|assignment| assignment.task_idx)
+                .collect::<Vec<_>>(),
+            vec![2]
+        );
+
+        let mut all_tasks = assigned_by_proc
+            .iter()
+            .flatten()
+            .map(|assignment| assignment.task_idx)
+            .collect::<Vec<_>>();
+        all_tasks.sort_unstable();
+        assert_eq!(all_tasks, vec![0, 1, 2, 3, 4]);
+        assert!(
+            assigned_by_proc
+                .iter()
+                .flatten()
                 .all(|assignment| assignment.task_count == 5)
         );
     }

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -119,10 +119,9 @@ fn unframe_dispatch_payload(body: &[u8]) -> Result<&[u8]> {
 /// leader's [`crate::postgres::customscan::mpp::glue::StagePlanDispatchSource`] as it dispatches.
 pub fn dispatch_payload_from_stages(
     stages: &[DiscoveredStage],
-    n_workers: u32,
     capacity: usize,
 ) -> Result<Vec<u8>> {
-    let entries = classify_stages(stages, n_workers)?;
+    let entries = classify_stages(stages)?;
     let dispatched: Vec<DispatchedStage> = entries
         .into_iter()
         .map(|stage| DispatchedStage {
@@ -210,4 +209,35 @@ pub fn fragments_for_worker(
     let session = build_mpp_session_context(seed, Some(mesh));
     let fragments = expand_to_assignments(body, this_proc, n_workers)?;
     Ok((fragments, session))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assigns_multiple_stage_tasks_to_one_proc_after_short_launch() {
+        let mut assignments = Vec::new();
+        push_owned_tasks(
+            &mut assignments,
+            7,
+            5,
+            &FragmentRouting::Coalesce { dest_proc: 0 },
+            1,
+            3,
+        );
+
+        assert_eq!(
+            assignments
+                .iter()
+                .map(|assignment| assignment.task_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 3]
+        );
+        assert!(
+            assignments
+                .iter()
+                .all(|assignment| assignment.task_count == 5)
+        );
+    }
 }

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -151,9 +151,18 @@ fn push_owned_tasks(
     routing: &FragmentRouting,
     this_proc: u32,
     n_workers: u32,
-) {
-    for task_idx in 0..task_count {
-        if proc_for_task(n_workers, task_idx as u32) == this_proc {
+) -> Result<()> {
+    let Some(last_task_idx) = task_count.checked_sub(1) else {
+        return Ok(());
+    };
+    let last_task_idx = u32::try_from(last_task_idx).map_err(|_| {
+        DataFusionError::Internal(format!(
+            "mpp dispatch: task_count {task_count} exceeds transport u32 task IDs \
+             (stage_id={stage_num})"
+        ))
+    })?;
+    for task_idx in 0..=last_task_idx {
+        if proc_for_task(n_workers, task_idx) == this_proc {
             out.push(FragmentAssignment {
                 stage_id: stage_num,
                 task_idx,
@@ -162,6 +171,7 @@ fn push_owned_tasks(
             });
         }
     }
+    Ok(())
 }
 
 /// Expand the dispatch blob body into this worker's fragment assignments: the `(stage, task)`
@@ -182,7 +192,7 @@ fn expand_to_assignments(
             &stage.routing,
             this_proc,
             n_workers,
-        );
+        )?;
     }
     Ok(out)
 }
@@ -221,7 +231,7 @@ mod tests {
         let assigned_by_proc = (1..=3)
             .map(|proc_idx| {
                 let mut assignments = Vec::new();
-                push_owned_tasks(&mut assignments, 7, 5, &routing, proc_idx, 3);
+                push_owned_tasks(&mut assignments, 7, 5, &routing, proc_idx, 3).unwrap();
                 assignments
             })
             .collect::<Vec<_>>();
@@ -261,5 +271,23 @@ mod tests {
                 .flatten()
                 .all(|assignment| assignment.task_count == 5)
         );
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn rejects_task_counts_that_exceed_transport_task_ids() {
+        let mut assignments = Vec::new();
+        let err = push_owned_tasks(
+            &mut assignments,
+            7,
+            (u32::MAX as usize) + 2,
+            &FragmentRouting::Coalesce { dest_proc: 0 },
+            1,
+            1,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("exceeds transport u32 task IDs"));
+        assert!(assignments.is_empty());
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -107,14 +107,6 @@ pub(crate) fn build_mpp_session_context(
         Some(m) => m.n_workers() as usize,
         None => producer_worker_cap() as usize,
     };
-    build_mpp_session_context_with_worker_count(seed, mesh, n_workers)
-}
-
-fn build_mpp_session_context_with_worker_count(
-    seed: SessionContext,
-    mesh: Option<Arc<MppMesh>>,
-    n_workers: usize,
-) -> SessionContext {
     assert!(
         n_workers >= 2,
         "MPP session contexts require at least two producer workers"
@@ -126,9 +118,7 @@ fn build_mpp_session_context_with_worker_count(
     //      `_distribute_plan` elides every shuffle.
     //   3. distributed_broadcast_joins(true): otherwise CollectLeft HashJoins cap their
     //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
-    let cfg = seed
-        .copied_config()
-        .with_target_partitions(n_workers.max(2));
+    let cfg = seed.copied_config().with_target_partitions(n_workers);
 
     // Start from the seed's existing state so the customscan's query planner
     // (`PgSearchQueryPlanner`), optimizer rules, and registered extensions all carry over.
@@ -381,14 +371,10 @@ pub(crate) fn run_mpp_worker(
         let collected = runtime.block_on(async {
             let mut frames = Vec::with_capacity(fragments.len());
             for fragment in &fragments {
-                let task_idx = u32::try_from(fragment.task_idx).map_err(|_| {
-                    datafusion::common::DataFusionError::Internal(format!(
-                        "mpp worker: task_idx {} exceeds transport u32 (stage_id={})",
-                        fragment.task_idx, fragment.stage_id,
-                    ))
-                })?;
-                frames
-                    .push(take_set_plan_draining(worker_mesh, fragment.stage_id, task_idx).await?);
+                frames.push(
+                    take_set_plan_draining(worker_mesh, fragment.stage_id, fragment.task_idx)
+                        .await?,
+                );
             }
             Ok::<_, datafusion::common::DataFusionError>(frames)
         });
@@ -453,15 +439,9 @@ pub(crate) fn run_mpp_worker(
     let mesh_for_block = Arc::clone(worker_mesh);
     let result = runtime.block_on(async move {
         let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
-        let mut executed_fragments: Vec<(u32, usize, usize, Arc<dyn ExecutionPlan>)> =
+        let mut executed_fragments: Vec<(u32, u32, usize, Arc<dyn ExecutionPlan>)> =
             Vec::with_capacity(fragments.len());
         for (fragment, frag_plan) in fragments.iter().zip(&plans) {
-            let task_idx = u32::try_from(fragment.task_idx).map_err(|_| {
-                datafusion::common::DataFusionError::Internal(format!(
-                    "mpp worker dispatch: task_idx {} exceeds transport u32 (stage_id={})",
-                    fragment.task_idx, fragment.stage_id,
-                ))
-            })?;
             let n_out = frag_plan
                 .properties()
                 .output_partitioning()
@@ -522,7 +502,7 @@ pub(crate) fn run_mpp_worker(
                 // pattern where every peer is blocked sending to a full peer.
                 per_partition_sinks.push(Box::new(MppPartitionSink::new(
                     base.clone_with_header(MppFrameHeader::batch(
-                        MppDataStreamKey::new(fragment.stage_id, task_idx, q_u32),
+                        MppDataStreamKey::new(fragment.stage_id, fragment.task_idx, q_u32),
                         mesh_for_block.this_proc,
                     ))
                     .with_cooperative_drain(
@@ -538,7 +518,7 @@ pub(crate) fn run_mpp_worker(
                 .config()
                 .clone()
                 .with_extension(Arc::new(DistributedTaskContext {
-                    task_index: fragment.task_idx,
+                    task_index: fragment.task_idx as usize,
                     task_count: fragment.task_count,
                 }));
             let memory_pool =
@@ -565,7 +545,7 @@ pub(crate) fn run_mpp_worker(
             futures.push(Box::pin(dispatch_fragment_requests(
                 Arc::clone(&mesh_for_block),
                 fragment.stage_id,
-                fragment.task_idx as u32,
+                fragment.task_idx,
                 per_partition_sinks,
                 plan,
                 task_ctx,
@@ -619,16 +599,10 @@ pub(crate) fn run_mpp_worker(
         // metrics path; the bounded send drops the frame if the leader already went away.
         if let Some(base) = metrics_sender_base {
             for (stage_id, task_idx, task_count, plan) in &executed_fragments {
-                let frame = collect_task_metrics(plan, *task_idx, *task_count);
-                let task_idx = u32::try_from(*task_idx).map_err(|_| {
-                    datafusion::common::DataFusionError::Internal(format!(
-                        "mpp worker metrics: task_idx {task_idx} exceeds transport u32 \
-                         (stage_id={stage_id})"
-                    ))
-                })?;
+                let frame = collect_task_metrics(plan, *task_idx as usize, *task_count);
                 let sender = base.clone_with_header(MppFrameHeader::task_metrics(
                     *stage_id,
-                    task_idx,
+                    *task_idx,
                     this_proc,
                 ));
                 let _ = sender.send_task_metrics_best_effort(&frame).await;

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -47,8 +47,9 @@ use crate::postgres::customscan::datafusion::memory::{build_runtime_env, create_
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::PartitionSink;
 use datafusion_distributed::shm::{
-    CooperativeDrainSet, InProcessWorkerResolver, MppFrameHeader, MppMesh, MppPartitionSink,
-    ShmChannelResolver, WorkerSession, collect_task_metrics, proc_for_task, run_worker_fragment,
+    CooperativeDrainSet, InProcessWorkerResolver, MppDataStreamKey, MppFrameHeader, MppMesh,
+    MppPartitionSink, ShmChannelResolver, WorkerSession, collect_task_metrics, proc_for_task,
+    run_worker_fragment,
 };
 use datafusion_proto::physical_plan::DeduplicatingProtoConverter;
 
@@ -106,6 +107,18 @@ pub(crate) fn build_mpp_session_context(
         Some(m) => m.n_workers() as usize,
         None => producer_worker_cap() as usize,
     };
+    build_mpp_session_context_with_worker_count(seed, mesh, n_workers)
+}
+
+fn build_mpp_session_context_with_worker_count(
+    seed: SessionContext,
+    mesh: Option<Arc<MppMesh>>,
+    n_workers: usize,
+) -> SessionContext {
+    assert!(
+        n_workers >= 2,
+        "MPP session contexts require at least two producer workers"
+    );
     // Three knobs that have to be set for the planner to actually emit `NetworkShuffleExec`:
     //   1. target_partitions(N): without it, EnforceDistribution skips every
     //      RepartitionExec so the annotator never sees a Shuffle.
@@ -368,14 +381,14 @@ pub(crate) fn run_mpp_worker(
         let collected = runtime.block_on(async {
             let mut frames = Vec::with_capacity(fragments.len());
             for fragment in &fragments {
-                frames.push(
-                    take_set_plan_draining(
-                        worker_mesh,
-                        fragment.stage_id,
-                        fragment.task_idx as u32,
-                    )
-                    .await?,
-                );
+                let task_idx = u32::try_from(fragment.task_idx).map_err(|_| {
+                    datafusion::common::DataFusionError::Internal(format!(
+                        "mpp worker: task_idx {} exceeds transport u32 (stage_id={})",
+                        fragment.task_idx, fragment.stage_id,
+                    ))
+                })?;
+                frames
+                    .push(take_set_plan_draining(worker_mesh, fragment.stage_id, task_idx).await?);
             }
             Ok::<_, datafusion::common::DataFusionError>(frames)
         });
@@ -443,6 +456,12 @@ pub(crate) fn run_mpp_worker(
         let mut executed_fragments: Vec<(u32, usize, usize, Arc<dyn ExecutionPlan>)> =
             Vec::with_capacity(fragments.len());
         for (fragment, frag_plan) in fragments.iter().zip(&plans) {
+            let task_idx = u32::try_from(fragment.task_idx).map_err(|_| {
+                datafusion::common::DataFusionError::Internal(format!(
+                    "mpp worker dispatch: task_idx {} exceeds transport u32 (stage_id={})",
+                    fragment.task_idx, fragment.stage_id,
+                ))
+            })?;
             let n_out = frag_plan
                 .properties()
                 .output_partitioning()
@@ -484,7 +503,13 @@ pub(crate) fn run_mpp_worker(
                         )));
                     }
                 };
-                let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
+                let q_u32 = u32::try_from(q).map_err(|_| {
+                    datafusion::common::DataFusionError::Internal(format!(
+                        "mpp worker dispatch: output partition {q} exceeds transport u32 \
+                         (stage_id={} task_idx={})",
+                        fragment.stage_id, fragment.task_idx,
+                    ))
+                })?;
                 crate::mpp_log!(
                     "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
                      task_idx={}) partition={q} → dest_proc={dest_proc}",
@@ -497,8 +522,7 @@ pub(crate) fn run_mpp_worker(
                 // pattern where every peer is blocked sending to a full peer.
                 per_partition_sinks.push(Box::new(MppPartitionSink::new(
                     base.clone_with_header(MppFrameHeader::batch(
-                        fragment.stage_id,
-                        q_u32,
+                        MppDataStreamKey::new(fragment.stage_id, task_idx, q_u32),
                         mesh_for_block.this_proc,
                     ))
                     .with_cooperative_drain(
@@ -596,9 +620,15 @@ pub(crate) fn run_mpp_worker(
         if let Some(base) = metrics_sender_base {
             for (stage_id, task_idx, task_count, plan) in &executed_fragments {
                 let frame = collect_task_metrics(plan, *task_idx, *task_count);
+                let task_idx = u32::try_from(*task_idx).map_err(|_| {
+                    datafusion::common::DataFusionError::Internal(format!(
+                        "mpp worker metrics: task_idx {task_idx} exceeds transport u32 \
+                         (stage_id={stage_id})"
+                    ))
+                })?;
                 let sender = base.clone_with_header(MppFrameHeader::task_metrics(
                     *stage_id,
-                    *task_idx as u32,
+                    task_idx,
                     this_proc,
                 ));
                 let _ = sender.send_task_metrics_best_effort(&frame).await;

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -72,7 +72,8 @@ pub(super) fn mpp_queue_size() -> usize {
 /// Total DSM bytes the leader will need for the mesh header, the worker plan, and one MPSC
 /// inbox per process. `n_procs` is the total proc count (leader + launched producers) the
 /// plan-first launch computed from the physical plan — the mesh grows as `n_procs²`, so this
-/// is sized from the plan's needs, not the GUC ceiling (#5667).
+/// is sized from the plan's needs, not the GUC ceiling (#5667). A short launch may initialize a
+/// narrower logical mesh in this allocation, but never a wider one.
 pub fn estimate_dsm_size(n_procs: u32, plan_bytes_len: usize) -> Result<usize, String> {
     shm::dsm_region_bytes(n_procs, mpp_queue_size(), plan_bytes_len).map_err(|e| e.to_string())
 }
@@ -167,8 +168,9 @@ unsafe fn self_receiver_token() -> u64 {
 /// # Safety
 /// - `coordinate` must be the MPP region pointer (a `ParallelState` byte blob the leader owns).
 /// - `n_procs` is the total mesh participant count including the leader: 1 (leader, proc 0)
-///   plus the launched producer workers. It must equal the count passed to
-///   [`estimate_dsm_size`] for this region, or the ring mesh won't fit.
+///   plus the launched producer workers. It must not exceed the count passed to
+///   [`estimate_dsm_size`] for this region. A short launch may use fewer processes than the
+///   preallocated region was sized for.
 /// - `plan_bytes` must have the same length passed to [`estimate_dsm_size`]
 ///   so the leader doesn't overrun the region.
 pub unsafe fn leader_setup(
@@ -253,6 +255,39 @@ mod tests {
 
     impl Wakeup for NoopWakeup {
         fn wake(&self, _token: u64) {}
+    }
+
+    #[test]
+    fn mesh_can_use_fewer_processes_than_its_reserved_region() {
+        // `launch_mpp` must allocate DSM before PostgreSQL tells it how many workers actually
+        // attached. Pin the transport contract that lets a short launch initialize its smaller
+        // logical mesh in the region reserved for the requested width.
+        let requested_procs = 6;
+        let launched_procs = 4;
+        let plan = [0_u8; 64];
+        let region_bytes = shm::dsm_region_bytes(requested_procs, 64 * 1024, plan.len()).unwrap();
+        let mut region = vec![0_u64; region_bytes.div_ceil(std::mem::size_of::<u64>())];
+
+        let attach = unsafe {
+            shm::leader_setup(
+                region.as_mut_ptr().cast(),
+                launched_procs,
+                64 * 1024,
+                &plan,
+                Arc::new(NoopWakeup),
+                1,
+                Arc::new(NoInterrupt),
+                true,
+            )
+            .unwrap()
+        };
+
+        assert_eq!(attach.outbound_senders().len(), launched_procs as usize);
+        assert!(attach.outbound_senders()[0].is_none());
+        assert_eq!(
+            attach.outbound_senders().iter().flatten().count(),
+            (launched_procs - 1) as usize
+        );
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -19,8 +19,9 @@
 //!
 //! The leader spawns its producer workers itself through `parallel_worker::builder`
 //! (`CreateParallelContext` + `LaunchParallelWorkers`), the same path index builds and the
-//! parallel aggregate use. The leader picks the worker count, so a short launch becomes a clean
-//! serial fallback instead of the hang it used to be when PG's Gather decided the count.
+//! parallel aggregate use. The leader picks the requested worker count; if PostgreSQL attaches
+//! fewer (but still at least two), tasks safely multiplex onto the attached workers instead of
+//! falling back to serial execution.
 //!
 //! The MPP DSM region rides as builder `ParallelState` entries instead of a hand-laid coordinate:
 //! a reserve-only region for the ring mesh (`shm::dsm_region_bytes`), a zeroed byte blob for the
@@ -30,13 +31,15 @@
 //! The launch is plan-first (#5667), mirroring core PG's parallel-query order (plan →
 //! size-by-walking-the-plan → create DSM → bind pointers → launch): the caller builds the
 //! distributed physical plan with `producer_worker_cap()` (PG's parallelism GUCs) as the
-//! planner's ceiling, then [`launch_mpp_join`] / [`launch_mpp_aggregate`] walk the finished plan to learn
-//! the largest producer-stage task count, size the mesh and spawn exactly
+//! planner's ceiling, then [`launch_mpp_join`] / [`launch_mpp_aggregate`] walk the finished plan
+//! to learn the largest producer-stage task count, size the mesh and spawn exactly
 //! `clamp(max_tasks, 2, cap)` producers, stamp the shared scan state into the plan
 //! ([`crate::scan::execution_plan::stamp_parallel_state`]), and dispatch. A plan with no
 //! producer stages spawns nothing at all. One plan serves both dispatch and the leader's own
 //! execution; the go flag holds spawned workers off the mesh until the rings and dispatch
-//! payload are initialized, and aborts them on a short launch (#5061).
+//! payload are initialized. If PostgreSQL attaches fewer workers, neither the plan nor the
+//! payload changes — the leader just initializes a narrower mesh inside the region it already
+//! reserved, and the plan's tasks multiplex onto the attached producers.
 
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -71,8 +74,8 @@ const MESH_IDX: usize = 0;
 const SCAN_IDX: usize = 1;
 const GO_IDX: usize = 2;
 
-/// Go-flag states. The leader sets `RUN` once the full producer set launched and the rings are
-/// initialized, or `ABORT` on a short launch so the spare workers exit before touching the mesh.
+/// Go-flag states. The leader sets `RUN` once the mesh is initialized, or `ABORT` if too few
+/// workers attached for an MPP mesh.
 const GO_WAIT: u32 = 0;
 const GO_RUN: u32 = 1;
 const GO_ABORT: u32 = 2;
@@ -109,7 +112,8 @@ unsafe fn go_flag(sm: &ParallelStateManager) -> &'static AtomicU32 {
 }
 
 /// AggregateScan worker entry point. PG resolves this symbol by name (passed to
-/// `ParallelProcessBuilder::build`), so the name must match the string in [`launch_mpp_aggregate`].
+/// `ParallelProcessBuilder::build`), so the name must match the string in
+/// [`launch_mpp_aggregate`].
 #[unsafe(no_mangle)]
 #[pgrx::pg_guard]
 pub unsafe extern "C-unwind" fn mpp_launched_worker_agg(
@@ -149,7 +153,8 @@ fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> Se
         check_for_interrupts!();
         match go.load(Ordering::Acquire) {
             GO_RUN => break,
-            // Short launch: the leader ran the query serially. Exit before touching the mesh.
+            // Too few workers attached for MPP: the leader runs serially. Exit before touching
+            // the mesh. A short-but-viable launch instead reaches GO_RUN and multiplexes tasks.
             GO_ABORT => return,
             _ if spins < 1000 => {
                 spins += 1;
@@ -259,10 +264,10 @@ impl MppLifecycle {
 /// Plan-first MPP launch (#5667): size the worker pool from the finished physical plan, build
 /// the DSM, stamp the shared scan state into the plan, spawn exactly the needed producers, and
 /// dispatch. `None` means run serially — the plan has nothing to distribute, the DSM couldn't
-/// be built, or the machine couldn't give us the full producer set. Nothing is forked on the
-/// nothing-to-distribute path. `None` covers only environmental shortfalls; a `pgrx::error!`
-/// means an invariant breach or a failure past mesh commitment, where a silent serial
-/// fallback would hide a real bug.
+/// be built, or the machine could not attach the minimum two producers needed for an MPP mesh.
+/// Nothing is forked on the nothing-to-distribute path. `None` covers only environmental
+/// shortfalls; a `pgrx::error!` means an invariant breach or a failure past mesh commitment,
+/// where a silent serial fallback would hide a real bug.
 fn launch_mpp(
     physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
     plan_bytes_len: usize,
@@ -333,11 +338,12 @@ fn launch_mpp(
     crate::mpp_log!("launch: spawning {producer_count} producers");
     let attach = launcher.launch()?;
 
-    // Derive the per-stage subplans from the plan the leader itself will execute. A failure
-    // here is a hard error: a serialization gap is a codec bug, and the parked workers die
-    // with the transaction.
+    // Derive the per-stage subplans from the plan the leader itself will execute. Built before
+    // `wait_for_attach` so serialization overlaps worker attachment (#5756). A failure here is
+    // a hard error: a serialization gap is a codec bug, and the parked workers die with the
+    // transaction.
     let t_payload = std::time::Instant::now();
-    let payload = match dispatch_payload_from_stages(&stages, producer_count, payload_capacity) {
+    let payload = match dispatch_payload_from_stages(&stages, payload_capacity) {
         Ok(p) => p,
         Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
     };
@@ -351,16 +357,27 @@ fn launch_mpp(
 
     let go = unsafe { go_flag(finish.state_manager()) };
 
-    if launched < producer_count {
-        // #5061: the machine couldn't give us the full producer set. The launched workers are
-        // still on the go flag with no rings attached; release them and run serially. No
-        // `leader_setup` ran, so there are no DSM-backed senders to outlive the mapping.
+    if launched < MIN_TOTAL_WORKER_COUNT - 1 {
+        // The machine could not give us the minimum two producers required for the MPP mesh.
+        // The launched workers are still on the go flag with no rings attached; release them
+        // and run serially. No `leader_setup` ran, so there are no DSM-backed senders to
+        // outlive the mapping.
         go.store(GO_ABORT, Ordering::Release);
         finish.wait_for_finish();
         pgrx::warning!(
             "mpp: launched {launched} of {producer_count} requested workers; running serially"
         );
         return None;
+    }
+
+    // PostgreSQL may attach fewer workers than requested. The plan, its task counts, and the
+    // payload all stand: `proc_for_task(launched, task_idx)` assigns tasks to the attached
+    // workers when each worker expands the blob, and the task-aware transport keeps same-worker
+    // streams apart.
+    if launched != producer_count {
+        crate::mpp_log!(
+            "launch: {launched} of {producer_count} producers attached; multiplexing original task plan"
+        );
     }
 
     // Bind the shared scan state into the plan the leader will execute. Must stay below the
@@ -376,7 +393,7 @@ fn launch_mpp(
         _ => pgrx::error!("mpp: mesh region missing"),
     };
     let t_setup = std::time::Instant::now();
-    let mut leader = match unsafe { leader_setup(mesh_ptr, producer_count + 1, payload) } {
+    let mut leader = match unsafe { leader_setup(mesh_ptr, launched + 1, payload) } {
         Ok(l) => l,
         Err(e) => pgrx::error!("mpp: leader_setup failed: {e}"),
     };

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -424,6 +424,10 @@ fn launch_mpp(
         Ok(Some(s)) => s.as_mut_ptr() as *mut c_void,
         _ => pgrx::error!("mpp: mesh region missing"),
     };
+    // The narrow mesh depends on attached workers occupying `ParallelWorkerNumber`
+    // 0..launched-1 with no holes: PostgreSQL stops registering after the first failure,
+    // and `wait_for_attach` reports a worker that dies before attaching. Each worker maps
+    // its number to `proc_idx = worker_number + 1`, so every attached worker is in this mesh.
     let t_setup = std::time::Instant::now();
     let mut leader = match unsafe { leader_setup(mesh_ptr, launched + 1, payload) } {
         Ok(l) => l,

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -95,6 +95,34 @@ struct MppParallelProcess {
     go: u32,
 }
 
+/// The only launch outcomes that preserve the MPP mesh invariant.
+///
+/// PostgreSQL can attach fewer workers than requested, but the mesh needs at least two
+/// producers. More workers than requested would contradict the DSM allocation made for this
+/// launch and must not be treated as a valid width.
+#[derive(Debug, PartialEq, Eq)]
+enum MppAttachOutcome {
+    SerialFallback,
+    Parallel,
+}
+
+fn mpp_attach_outcome(
+    requested_producers: u32,
+    attached_producers: u32,
+) -> Result<MppAttachOutcome, String> {
+    if attached_producers > requested_producers {
+        return Err(format!(
+            "mpp: {attached_producers} workers attached after requesting {requested_producers}"
+        ));
+    }
+
+    if attached_producers < MIN_TOTAL_WORKER_COUNT - 1 {
+        Ok(MppAttachOutcome::SerialFallback)
+    } else {
+        Ok(MppAttachOutcome::Parallel)
+    }
+}
+
 impl ParallelProcess for MppParallelProcess {
     fn state_values(&self) -> Vec<&dyn ParallelState> {
         vec![&self.mesh_region, &self.scan_state, &self.go]
@@ -357,17 +385,21 @@ fn launch_mpp(
 
     let go = unsafe { go_flag(finish.state_manager()) };
 
-    if launched < MIN_TOTAL_WORKER_COUNT - 1 {
-        // The machine could not give us the minimum two producers required for the MPP mesh.
-        // The launched workers are still on the go flag with no rings attached; release them
-        // and run serially. No `leader_setup` ran, so there are no DSM-backed senders to
-        // outlive the mapping.
-        go.store(GO_ABORT, Ordering::Release);
-        finish.wait_for_finish();
-        pgrx::warning!(
-            "mpp: launched {launched} of {producer_count} requested workers; running serially"
-        );
-        return None;
+    match mpp_attach_outcome(producer_count, launched) {
+        Ok(MppAttachOutcome::SerialFallback) => {
+            // The machine could not give us the minimum two producers required for the MPP mesh.
+            // The launched workers are still on the go flag with no rings attached; release them
+            // and run serially. No `leader_setup` ran, so there are no DSM-backed senders to
+            // outlive the mapping.
+            go.store(GO_ABORT, Ordering::Release);
+            finish.wait_for_finish();
+            pgrx::warning!(
+                "mpp: launched {launched} of {producer_count} requested workers; running serially"
+            );
+            return None;
+        }
+        Ok(MppAttachOutcome::Parallel) => {}
+        Err(e) => pgrx::error!("{e}"),
     }
 
     // PostgreSQL may attach fewer workers than requested. The plan, its task counts, and the
@@ -427,4 +459,25 @@ pub fn launch_mpp_join(
     args: ParallelScanArgs,
 ) -> Option<MppLeaderState> {
     launch_mpp(physical, plan_bytes_len, args, "mpp_launched_worker_join")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_launch_uses_the_attached_width_when_the_mesh_is_viable() {
+        assert_eq!(
+            mpp_attach_outcome(5, 0),
+            Ok(MppAttachOutcome::SerialFallback)
+        );
+        assert_eq!(
+            mpp_attach_outcome(5, 1),
+            Ok(MppAttachOutcome::SerialFallback)
+        );
+        assert_eq!(mpp_attach_outcome(5, 2), Ok(MppAttachOutcome::Parallel));
+        assert_eq!(mpp_attach_outcome(5, 3), Ok(MppAttachOutcome::Parallel));
+        assert_eq!(mpp_attach_outcome(5, 5), Ok(MppAttachOutcome::Parallel));
+        assert!(mpp_attach_outcome(5, 6).is_err());
+    }
 }

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -21,7 +21,7 @@
 //!
 //! [`collect_stages`] walks the distributed physical plan and visits every
 //! [`datafusion_distributed::NetworkBoundary`]; [`classify_stages`] turns each into one
-//! [`StageEntry`] (`input_stage.num`, `task_count`, `routing`) once the worker count is known.
+//! [`StageEntry`] (`input_stage.num`, `task_count`, `routing`) from the unchanged physical plan.
 //! The stage plans travel separately, serialized by the coordinator's dispatch; each worker later
 //! expands a stage into one [`FragmentAssignment`] per `task_idx` it owns under `proc_for_task`.
 //!
@@ -47,10 +47,13 @@ use std::sync::Arc;
 
 use datafusion::common::DataFusionError;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::shm::proc_for_task;
 use datafusion_distributed::{
     NetworkBoundaryExt, NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec,
 };
+
+/// Proc 0 is the leader. Task 0 always belongs to the first producer proc, independent of how
+/// many producers PostgreSQL actually attached.
+const FIRST_WORKER_PROC: u32 = 1;
 
 /// One worker fragment to run for `this_proc`. The fragment is one task of a
 /// producer stage; the dispatcher runs `plan` with the matching
@@ -78,9 +81,8 @@ pub enum FragmentRouting {
     /// output partition, so the crate's `route_partition` does not describe it;
     /// the dispatcher sends every partition to `dest_proc`.
     Coalesce {
-        /// Destination proc index. `0` for the leader (top-level gather), or a
-        /// `proc_for_task(n_workers, 0)` lookup for a nested coalesce that lands
-        /// on a single consumer task.
+        /// Destination proc index. `0` for the leader (top-level gather), or
+        /// [`FIRST_WORKER_PROC`] for a nested coalesce that lands on consumer task 0.
         dest_proc: u32,
     },
     /// Hash-partitioned mesh ([`NetworkShuffleExec`] / [`NetworkBroadcastExec`]). Output
@@ -168,18 +170,18 @@ pub(crate) fn max_producer_task_count(stages: &[DiscoveredStage]) -> usize {
         .unwrap_or(0)
 }
 
-/// Classify each discovered stage's routing, once the worker count is known. The leader runs this
-/// (replacing the worker-side re-plan) to derive routing from the boundary type. Not filtered by
-/// proc; the blob is shared and each worker selects its own `(stage, task)` slots.
+/// Classify each discovered stage's routing from the physical-plan boundary type. The routing blob
+/// contains task IDs, not worker ownership, so it remains valid when PostgreSQL attaches fewer
+/// workers than requested. Not filtered by proc; each worker later selects its own `(stage, task)`
+/// slots with the actual attached-worker count.
 pub(crate) fn classify_stages(
     stages: &[DiscoveredStage],
-    n_workers: u32,
 ) -> Result<Vec<StageEntry>, DataFusionError> {
     let mut out = Vec::new();
     for stage in stages {
         // Classified before the `dispatchable` check so an unroutable shape is rejected whether or
         // not it carries a local plan.
-        let routing = classify_routing(stage, n_workers)?;
+        let routing = classify_routing(stage)?;
         if stage.dispatchable {
             out.push(StageEntry {
                 stage_num: stage.stage_num,
@@ -191,10 +193,7 @@ pub(crate) fn classify_stages(
     Ok(out)
 }
 
-fn classify_routing(
-    discovered: &DiscoveredStage,
-    n_workers: u32,
-) -> Result<FragmentRouting, DataFusionError> {
+fn classify_routing(discovered: &DiscoveredStage) -> Result<FragmentRouting, DataFusionError> {
     let plan = &discovered.boundary;
     let stage_id = discovered.stage_num;
     let nested = discovered.nested;
@@ -229,11 +228,9 @@ fn classify_routing(
         // top-level (`nested == false`) routes to the leader.
         let routing = if plan.is::<NetworkCoalesceExec>() {
             if nested {
-                // Nested NetworkCoalesceExec: consumer is a single task in the parent stage. The
-                // receive math collapses to task 0 of the parent group, so the destination proc
-                // is `proc_for_task(n_workers, 0)`.
+                // Nested NetworkCoalesceExec: consumer is task 0 of the parent stage.
                 FragmentRouting::Coalesce {
-                    dest_proc: proc_for_task(n_workers, 0),
+                    dest_proc: FIRST_WORKER_PROC,
                 }
             } else {
                 // Top-level NetworkCoalesceExec (gather to leader): consumer is leader proc 0.
@@ -286,7 +283,7 @@ mod tests {
     fn boundary_free_plan_yields_no_stages() {
         let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
-        let out = classify_stages(&collect_stages(&plan), 3).unwrap();
+        let out = classify_stages(&collect_stages(&plan)).unwrap();
         assert!(out.is_empty());
     }
 
@@ -320,6 +317,18 @@ mod tests {
                 assert_eq!(consumer_task, vec![0, 0, 1]);
             }
             _ => panic!("expected Hashed"),
+        }
+    }
+
+    #[test]
+    fn nested_coalesce_destination_is_width_independent() {
+        // This invariant is why the dispatch payload can be built while workers attach and reused
+        // unchanged after a viable short launch.
+        for worker_count in 1..=8 {
+            assert_eq!(
+                datafusion_distributed::shm::proc_for_task(worker_count, 0),
+                FIRST_WORKER_PROC
+            );
         }
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -65,8 +65,8 @@ pub struct FragmentAssignment {
     /// belongs to. Frames the fragment emits carry this in the
     /// `MppFrameHeader::stage_id` field.
     pub stage_id: u32,
-    /// Task index within the stage (0..task_count).
-    pub task_idx: usize,
+    /// Task index within the stage (0..task_count), validated for the shared-memory transport.
+    pub task_idx: u32,
     /// Total task count for this stage (= `input_stage.tasks.len()`).
     pub task_count: usize,
     /// How to route each output partition to a destination proc.
@@ -125,8 +125,8 @@ pub(crate) struct DiscoveredStage {
 
 /// Every producer stage, once per boundary. The launch walks before forking and hands the result
 /// to both [`max_producer_task_count`] and [`classify_stages`], so the two cannot disagree about
-/// which stages exist (#5667). Routing is not derived here: it needs the worker count that sizing
-/// produces.
+/// which stages exist (#5667). [`classify_stages`] derives logical task routing from this list;
+/// worker ownership remains deferred until each worker applies the actual attached width.
 pub(crate) fn collect_stages(root: &Arc<dyn ExecutionPlan>) -> Vec<DiscoveredStage> {
     let mut out = Vec::new();
     walk_stages(root, /* nested = */ false, &mut out);
@@ -278,6 +278,7 @@ mod tests {
     use super::*;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion_distributed::shm::proc_for_task;
 
     #[test]
     fn boundary_free_plan_yields_no_stages() {
@@ -325,10 +326,7 @@ mod tests {
         // This invariant is why the dispatch payload can be built while workers attach and reused
         // unchanged after a viable short launch.
         for worker_count in 1..=8 {
-            assert_eq!(
-                datafusion_distributed::shm::proc_for_task(worker_count, 0),
-                FIRST_WORKER_PROC
-            );
+            assert_eq!(proc_for_task(worker_count, 0), FIRST_WORKER_PROC);
         }
     }
 }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -1218,10 +1218,8 @@ impl<T: Stream<Item = Result<RecordBatch>>> RecordBatchStream for UnsafeSendStre
 
 /// Caps a `PgSearchScanPlan`'s stage at its `partition_count` tasks.
 ///
-/// This correctly maps PostgreSQL parallel workers to tasks, ensuring that tables with 1 segment
-/// do not force MPP planning and fall back to local serial execution (under `Shared` partitioning),
-/// whereas large tables or tables utilizing `Range` partitioning scale out efficiently across
-/// available workers.
+/// This preserves useful scan parallelism: a single-segment scan has one task, while larger or
+/// range-partitioned scans expose their partitions to the distributed planner.
 pub(crate) fn pg_search_scan_desired_task_count(
     ev: DesiredTaskCountEvent,
 ) -> Option<datafusion::error::Result<DesiredTaskCountEventResponse>> {

--- a/pg_search/tests/pg_regress/expected/issue_5747.out
+++ b/pg_search/tests/pg_regress/expected/issue_5747.out
@@ -2,7 +2,7 @@
 --
 -- The trigger is a join between two BM25-indexed tables whose indexes have
 -- DIFFERENT physical segment counts. Equal segment counts do not reproduce it.
--- It requires MPP to be enabled (max_parallel_workers_per_gather > 0).
+-- It requires an MPP-eligible worker configuration.
 --
 -- To get the asymmetry deterministically without needing much data:
 --   * pc_big   uses mutable_segment_rows='0', so every INSERT lands in its own

--- a/pg_search/tests/pg_regress/sql/issue_5747.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5747.sql
@@ -2,7 +2,7 @@
 --
 -- The trigger is a join between two BM25-indexed tables whose indexes have
 -- DIFFERENT physical segment counts. Equal segment counts do not reproduce it.
--- It requires MPP to be enabled (max_parallel_workers_per_gather > 0).
+-- It requires an MPP-eligible worker configuration.
 --
 -- To get the asymmetry deterministically without needing much data:
 --   * pc_big   uses mutable_segment_rows='0', so every INSERT lands in its own


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5781
- Closes #5882

## What

When PostgreSQL launches fewer MPP workers than requested, keep the existing distributed plan and run its tasks across the workers that actually attached.

This PR depends on [paradedb/datafusion-distributed#57](https://github.com/paradedb/datafusion-distributed/pull/57), which makes the shared-memory stream key task-aware.

## Example

A stage has 5 tasks, but PostgreSQL launches 3 workers:

```text
before:
  launched 3 of the 5 requested workers
  -> abort the workers, run the whole query serially

now:
  worker 1: tasks 0, 3
  worker 2: tasks 1, 4
  worker 3: task 2
```

Co-locating tasks was not previously possible: the shared-memory stream key did not include the task, so task 0's EOF would close task 3's stream. Each task now has its own stream identity:

```text
(sender worker, stage, task, partition)
```

## Why this is safe

The physical plan still has 5 tasks. We do not change its stages, partitions, or routing after worker launch.

We only:

1. Use the number of workers PostgreSQL actually launched to initialize the mesh.
2. Assign existing tasks round-robin to those workers.
3. Include `task_idx` in all data-plane stream operations: batches, EOF, cancellation, chunks, reassembly, and receiver lookup.

## Review guide

- DFD #57: verifies task identity is propagated through the shared-memory transport.
- `worker_fragments.rs` / `dispatch.rs`: assigns multiple tasks to one worker.
- `exec_worker.rs`: stamps outgoing frames with `task_idx`.
- `launch.rs`: retains the original plan on a viable short launch instead of rebuilding it.

## Tests

- Focused ParadeDB MPP unit tests: 9 passed.
- DFD focused transport tests: 43 passed, 2 ignored.
- DFD in-process shared-memory tests: 5 passed, including a 5-logical-task / 3-worker hash-shuffle E2E test.

## Intentional PostgreSQL E2E coverage gap — @mdashti

The remaining end-to-end scenario is to make PostgreSQL request 5 MPP workers while only 3 attach, then verify the query result and the 5-to-3 task mapping in the real extension process.

It is intentionally not added to the normal Rust integration suite. Reproducing it requires a second PostgreSQL connection to hold two parallel-worker slots. Those slots are global to the PostgreSQL server, while the existing integration tests share that server and run concurrently. Adding this test to the ordinary suite would make unrelated tests nondeterministically receive fewer parallel workers.

To add it safely, it needs an ignored standalone test target and an explicit single-threaded CI invocation immediately after PostgreSQL starts and before the shared integration suite runs. This PR does not change CI for that isolated test yet; DFD #57 provides deterministic in-process 5-task / 3-worker data-plane E2E coverage in the meantime.

## Dependency

This branch pins DFD commit `9b4f45be3c2b0f7139c6ca8e8eac1df4a38d7743`, which contains the task-aware shared-memory transport and its multiplexed-shuffle E2E coverage. After DFD #57 merges, replace it with the corresponding snapshot tag.
