### PR TITLE
perf: link Linux builds with LLD

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,13 @@
 # on macOS, PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
+
+# pg_search links datafusion, arrow and tantivy into a single cdylib. GNU ld is the
+# slowest and most memory-hungry step of that build, and the coverage-instrumented CI
+# builds pass `--no-gc-sections`, so nothing is discarded and the link is at its worst.
+# LLD does the same job in a fraction of the time and memory.
+#
+# This requires `lld` on the PATH for every Linux build -- CI, the release containers,
+# nix, and local development. See CONTRIBUTING.md.
+[target.'cfg(target_os="linux")']
+rustflags = ["-Clink-arg=-fuse-ld=lld"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,12 +2,6 @@
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
 
-# pg_search links datafusion, arrow and tantivy into a single cdylib. GNU ld is the
-# slowest and most memory-hungry step of that build, and the coverage-instrumented CI
-# builds pass `--no-gc-sections`, so nothing is discarded and the link is at its worst.
-# LLD does the same job in a fraction of the time and memory.
-#
-# This requires `lld` on the PATH for every Linux build -- CI, the release containers,
-# nix, and local development. See CONTRIBUTING.md.
+# LLD is equivalent to GNU ld, but uses a fraction of the time and memory.
 [target.'cfg(target_os="linux")']
 rustflags = ["-Clink-arg=-fuse-ld=lld"]

--- a/.github/actions/setup-benchmark-cluster/action.yml
+++ b/.github/actions/setup-benchmark-cluster/action.yml
@@ -33,7 +33,7 @@ runs:
       run: |
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        sudo apt-get update && sudo apt-get install -y libopenblas-dev postgresql-${{ inputs.pg_version }} postgresql-server-dev-${{ inputs.pg_version }} postgresql-${{ inputs.pg_version }}-pgvector
+        sudo apt-get update && sudo apt-get install -y lld libopenblas-dev postgresql-${{ inputs.pg_version }} postgresql-server-dev-${{ inputs.pg_version }} postgresql-${{ inputs.pg_version }}-pgvector
         echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> $GITHUB_PATH
 
     # Separate prefix-key from debug workflows - benchmarks compile with --release.

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Install required system tools
         run: |
-          sudo apt-get update && sudo apt-get install -y lsof fontconfig pkg-config libfontconfig1-dev libopenblas-dev
+          sudo apt-get update && sudo apt-get install -y lsof fontconfig pkg-config libfontconfig1-dev libopenblas-dev lld
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libopenblas-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y lld libfontconfig1-dev libopenblas-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.guard.outputs.build == 'true'
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base lld
 
       - name: Checkout Git Repository
         if: steps.guard.outputs.build == 'true'

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -186,7 +186,7 @@ jobs:
           echo "Detected RHEL Version: $RHEL_VERSION for image: ${{ matrix.image }}"
 
           # Install dependencies
-          dnf install -y sudo wget git ca-certificates gcc llvm llvm-libs llvm-devel pkgconf-pkg-config openssl-devel jq rpm-build clang clang-devel gettext
+          dnf install -y sudo wget git ca-certificates gcc llvm llvm-libs llvm-devel pkgconf-pkg-config openssl-devel jq rpm-build clang clang-devel gettext lld
 
           # Add Oracle Linux ${RHEL_VERSION} repositories to enable epel-release
           sudo tee /etc/yum.repos.d/oracle-linux-ol${RHEL_VERSION}.repo > /dev/null <<EOF

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }} libopenblas-dev
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }} libopenblas-dev lld
           echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -196,7 +196,7 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base lld
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-dst-crate.yml
+++ b/.github/workflows/test-dst-crate.yml
@@ -40,6 +40,11 @@ jobs:
           cache: false
           rustflags: "" # Use .cargo/config.toml target-cpu flags
 
+      # .cargo/config.toml links Linux builds with LLD. The GitHub-hosted image
+      # currently ships it, but install it explicitly rather than depend on that.
+      - name: Install LLD
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lld
+
       # With `enabled` off the DST crate compiles to nothing — this is what pg_search ships,
       # and it is the half the workspace-wide runs in lint-rust never see, since stressgres
       # pins `enabled` and feature unification turns it on for the whole workspace.

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install System Dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libsecret-1-dev libopenblas-dev
+          sudo apt-get update && sudo apt-get install -y libsecret-1-dev libopenblas-dev lld
 
       - name: Install .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev lld
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install pg-schema-diff and its Required Dependencies
         run: |
-          sudo apt install clang llvm diffutils
+          sudo apt install clang lld llvm diffutils
           cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --debug --force
 
       - name: Install pgrx

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install required system tools
         run: |
-          sudo apt-get update && sudo apt-get install -y lsof libopenblas-dev
+          sudo apt-get update && sudo apt-get install -y lsof libopenblas-dev lld
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install required system tools
         run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            lsof build-essential clang flex bison pkg-config ca-certificates git \
+            lsof build-essential clang lld flex bison pkg-config ca-certificates git \
             libreadline-dev zlib1g-dev libssl-dev libkrb5-dev liblz4-dev libzstd-dev \
             libcurl4-openssl-dev libopenblas-dev
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -4,6 +4,7 @@
   cargo-pgrx,
   fetchurl,
   lib,
+  lld,
   nix-update-script,
   pkg-config,
   postgresql,
@@ -89,7 +90,9 @@ buildPgrxExtension (finalAttrs: {
     "pg_search"
   ];
 
+  # .cargo/config.toml links Linux builds with LLD.
   nativeBuildInputs = [
+    lld
     pkg-config
   ];
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -18,14 +18,14 @@ rustup install stable
 
 ### pgrx
 
-The `cargo-pgrx` version must match the `pgrx` dependency declared in [`pg_search/Cargo.toml`](Cargo.toml). On Linux, `pgrx` also requires `libclang`:
+The `cargo-pgrx` version must match the `pgrx` dependency declared in [`pg_search/Cargo.toml`](Cargo.toml). On Linux, `pgrx` also requires `libclang`, and [`.cargo/config.toml`](../.cargo/config.toml) links Linux builds with `lld`:
 
 ```bash
 # Ubuntu
-sudo apt install libclang-dev
+sudo apt install libclang-dev lld
 
 # Arch Linux
-sudo pacman -S extra/clang
+sudo pacman -S extra/clang extra/lld
 ```
 
 Then install `cargo-pgrx` and let it bootstrap a managed PostgreSQL installation under `~/.pgrx/`:


### PR DESCRIPTION
## What

This PR swaps Linux linking from GNU ld over to LLD. It is faster and less memory hungry.

## Measurement

pg_search links datafusion, arrow and tantivy into one cdylib, so the link is large. I captured the exact `cc` argv rustc invokes for `libpg_search.so` and replayed it under each linker, so this is the real link rather than a full rebuild with the delta inferred out of it.

linux/arm64, 8 cores, matching the CI runner shape. Debug cdylib, three runs each:

| linker | run 1 | run 2 | run 3 | peak RSS |
|---|---|---|---|---|
| GNU ld | 40.3s | 31.3s | 37.7s | 3.78 GB |
| LLD | 10.5s | 10.8s | 9.5s | 3.50 GB |

**~3.5x faster, roughly 26s back per link.** Every job that runs `cargo pgrx install` pays this, and the coverage jobs pay it more than once. Peak memory usage is ~7% lower.

## Correctness

Both linkers export an identical set of **1639** dynamic symbols, and both emit `Pg_magic_func`, so pgrx's `--version-script` and `--no-undefined-version` are honoured the same way by each. LLD's output is ~2% larger (813 MB vs 796 MB, debug).