### PR TITLE
ci: ship macOS 26 (Tahoe) binaries and drop macOS 14 (Sonoma)

### DIFF
--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -35,21 +35,8 @@ jobs:
     strategy:
       matrix:
         include:
-          # macOS 14 and 15 are arm-only (M1)
+          # The macos-15 and macos-26 runners are arm-only (M1)
           # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-          # macOS 14 (Sonoma)
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 15
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 16
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 17
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 18
           # macOS 15 (Sequoia)
           - name: macOS 15 (Sequoia)
             runner: macos-15
@@ -62,6 +49,19 @@ jobs:
             pg_version: 17
           - name: macOS 15 (Sequoia)
             runner: macos-15
+            pg_version: 18
+          # macOS 26 (Tahoe)
+          - name: macOS 26 (Tahoe)
+            runner: macos-26
+            pg_version: 15
+          - name: macOS 26 (Tahoe)
+            runner: macos-26
+            pg_version: 16
+          - name: macOS 26 (Tahoe)
+            runner: macos-26
+            pg_version: 17
+          - name: macOS 26 (Tahoe)
+            runner: macos-26
             pg_version: 18
 
     steps:
@@ -105,8 +105,8 @@ jobs:
 
           OS_VERSION=$(sw_vers -productVersion)
           case $OS_VERSION in
+              26.*) OS_NAME="tahoe" ;;
               15.*) OS_NAME="sequoia" ;;
-              14.*) OS_NAME="sonoma" ;;
               *) exit 1 ;;
           esac
           echo "OS Version: $OS_NAME"

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   publish-pg_search-postgresapp:
     name: Publish pg_search for Postgres.app (PostgreSQL ${{ matrix.pg_version }}, arm64)
-    runs-on: macos-15
+    runs-on: macos-26
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
       matrix:

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -29,8 +29,8 @@ instructions](https://github.com/pgvector/pgvector?tab=readme-ov-file#installati
 ParadeDB provides prebuilt binaries of our extension for Postgres 15+ on:
 
 - Debian 12 (Bookworm) and 13 (Trixie)
-- Ubuntu 22.04 (Jammy) and 24.04 (Noble)
-- macOS 14 (Sonoma) and 15 (Sequoia)
+- Ubuntu 24.04 (Noble) and 26.04 (Resolute)
+- macOS 15 (Sequoia) and 26 (Tahoe)
 - macOS via [Postgres.app](https://postgresapp.com/extensions/) (PostgreSQL 18)
 - Red Hat Enterprise Linux 9 and 10
 
@@ -47,15 +47,15 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 <CodeGroup>
 
-```bash Ubuntu 24.04
+```bash Ubuntu 26.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-resolute_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
-```bash Ubuntu 22.04
+```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
@@ -83,15 +83,15 @@ curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_searc
 sudo dnf install -y /tmp/*.rpm
 ```
 
-```bash macOS 15 (Sequoia)
+```bash macOS 26 (Tahoe)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search@18--0.25.0.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search@18--0.25.0.arm64_tahoe.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
-```bash macOS 14 (Sonoma)
+```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search@18--0.25.0.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search@18--0.25.0.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 


### PR DESCRIPTION
## What

We forgot to upgrade to Tahoe for macOS binaries. It was requested by a user last week.

This adds `macos-26` to the pg_search macOS publish matrix and drops the `macos-14` (Sonoma) rows, keeping us on the latest two macOS versions.

There was also some missing documentation from having upgraded to shipping Ubuntu 26.04. This is now fixed.
