### PR TITLE
chore: refresh the pg_search tagline away from BM25

### DIFF
--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -321,7 +321,7 @@ jobs:
           Name:           pg_search_${{ matrix.pg_version }}
           Version:        ${{ steps.version.outputs.tag_version }}
           Release:        1%{?dist}
-          Summary:        Full-text search for PostgreSQL using BM25
+          Summary:        One Postgres for your application data, full-text search, vector retrieval, and aggregations
           License:        GNU Affero General Public License v3.0
           URL:            ${{ github.server_url }}/${{ github.repository }}
 
@@ -331,9 +331,9 @@ jobs:
           Requires:       openblas
 
           %description
-          pg_search is a Postgres extension that enables full-text search over
-          PostgreSQL tables using the BM25 algorithm. It is built on top of Tantivy,
-          the Rust-based alternative to Apache Lucene, using pgrx.
+          pg_search is a Postgres extension that brings full-text search, vector
+          retrieval, and aggregations to PostgreSQL tables. It is built on top of
+          Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.
 
           %install
           %{__rm} -rf %{buildroot}

--- a/META.json.in
+++ b/META.json.in
@@ -2,7 +2,7 @@
 {
    "name": "pg_search",
    "abstract": "@CRATE_DESC@",
-   "description": "ParadeDB pg_search is a Postgres extension that enables fast full-text, faceted and hybrid search over Postgres tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
+   "description": "ParadeDB pg_search is a Postgres extension that brings fast full-text search, vector retrieval, and aggregations to Postgres tables. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
    "version": "@CRATE_VERSION@",
    "maintainer": [
       "ParadeDB <support@paradedb.com>"
@@ -10,7 +10,7 @@
    "license": "agpl_3",
    "provides": {
       "pg_search": {
-         "abstract": "Postgres for Search and Analytics",
+         "abstract": "Search without a second system",
          "file": "pg_search/src/lib.rs",
          "docfile": "pg_search/README.md",
          "version": "@CRATE_VERSION@"

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "pg_search: full-text search for PostgreSQL using BM25";
+  description = "pg_search: one Postgres for your application data, full-text search, vector retrieval, and aggregations";
 
   # Flake inputs
   # To update all inputs: nix flake update

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_search"
-description = "Full text search for PostgreSQL using BM25"
+description = "One Postgres for your application data, full-text search, vector retrieval, and aggregations"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/pg_search/pg_search.control
+++ b/pg_search/pg_search.control
@@ -1,4 +1,4 @@
-comment = 'pg_search: Full text search for PostgreSQL using BM25'
+comment = 'pg_search: One Postgres for your application data, full-text search, vector retrieval, and aggregations'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_search'
 relocatable = false


### PR DESCRIPTION
This was missed in the rebrand