### PR TITLE
chore: drop stale build config and stop `set -x` leaking into sourcing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,6 @@ target/
 # Ruff
 .ruff_cache/
 
-# pgvector
-pgvector/
-
 # Env files
 .env
 

--- a/META.json.in
+++ b/META.json.in
@@ -1,4 +1,3 @@
-
 {
    "name": "pg_search",
    "abstract": "@CRATE_DESC@",

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ install:
 package:
 	@cargo pgrx package --package pg_search --pg-config "$(PG_CONFIG)"
 
-META.json: META.json.in pg_search/Cargo.toml
+# DISTDESC comes from pg_search/Cargo.toml, DISTVERSION from the workspace Cargo.toml.
+META.json: META.json.in pg_search/Cargo.toml Cargo.toml
 	@sed -e "s/@CRATE_DESC@/$(DISTDESC)/g" -e "s/@CRATE_VERSION@/$(DISTVERSION)/g" $< > $@
 
 $(DISTNAME)-$(DISTVERSION).zip: META.json

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -110,6 +110,3 @@ superkmeans = { git = "https://github.com/paradedb/superkmeans-rs", package = "s
 pgrx-tests.workspace = true
 rstest = "0.25.0"
 proptest = "1.11.0"
-
-[package.metadata.cargo-machete]
-ignored = ["indexmap", "tantivy-common"]

--- a/scripts/pg_search_common.sh
+++ b/scripts/pg_search_common.sh
@@ -87,5 +87,5 @@ rm -rf /tmp/ephemeral_postgres_logs/*
 # Export the PG_CONFIG variable for use by sourcing scripts
 export PG_CONFIG="${HOME}/.pgrx/${PGVER}/pgrx-install/bin/pg_config"
 
-# Setup is done — stop echoing so the sourcing script's commands run quietly
+# Setup is done, stop echoing so the sourcing script's commands run quietly
 set +x

--- a/scripts/pg_search_common.sh
+++ b/scripts/pg_search_common.sh
@@ -61,7 +61,9 @@ BASEVER=$(echo "${PGVER}" | cut -f1 -d.)
 PORT=288${BASEVER}  # Port 2880 + major version (e.g., 28818 for version 18.1)
 FEATURE=pg${BASEVER}  # Feature flag (e.g., pg18)
 
-# Enable command echo for debugging
+# Enable command echo for debugging the setup steps below. It is disabled again
+# at the end of the script so it does not leak into the sourcing script's own
+# commands (psql, cargo test).
 set -x
 
 # Stop any existing pgrx server with this feature
@@ -84,3 +86,6 @@ rm -rf /tmp/ephemeral_postgres_logs/*
 
 # Export the PG_CONFIG variable for use by sourcing scripts
 export PG_CONFIG="${HOME}/.pgrx/${PGVER}/pgrx-install/bin/pg_config"
+
+# Setup is done — stop echoing so the sourcing script's commands run quietly
+set +x


### PR DESCRIPTION
Cleanup of a few small build/infra inconsistencies. No behavioural change to the extension.

- **`scripts/pg_search_common.sh`** turned on `set -x` for its setup steps but never turned it off. The script is *sourced*, so the trace leaked into the caller: `pg_search_run.sh`'s psql session and `pg_search_test.sh`'s `cargo test` both ran with echo on. Disabled again once setup finishes.
- **`pg_search/Cargo.toml`** — the cargo-machete `ignored` list named `indexmap` and `tantivy-common`, neither of which is a dependency any more. Section removed; `cargo machete` still passes clean locally. The equivalent list in `tokenizers/Cargo.toml` is still live (`strum`) and is untouched.
- **`META.json.in`** began with a blank line, which carried through the `sed` into the generated `META.json`.
- **`Makefile`** — `META.json`'s prerequisites listed `pg_search/Cargo.toml` but not the workspace `Cargo.toml`, which is where `DISTVERSION` is actually read from, so a version bump alone would not regenerate it.
- **`.gitignore`** still ignored `pgvector/`, which no longer exists in the tree.

## Verification

- `make META.json` regenerates, parses as valid JSON, and now starts at `{`.
- `bash -n` and `shellcheck` clean on all three scripts.
- `cargo machete` finds no unused dependencies.
- `cargo metadata` parses.

## Deliberately not included

Two items from the same audit were already fixed on `main` — `docker/README.md` now correctly says `libvoidstar` is injected at runtime, and the Rust toolchain pin is a single `rust-toolchain.toml` (1.97.1) with no hardcoded copies.

The audit also flagged the `Makefile` `PGRXV` regex as order-sensitive. It isn't: `^pgrx\s+=` cannot match `pgrx-tests`, so the first-match-wins `exit` is safe.

The remaining item — the `{15,16,17,18}` PG-major list hand-duplicated across workflow matrices, `docker/generate-dockerfiles.sh` and stressgres — is real but is a CI refactor touching the release path, not a config tidy. Left out of this PR deliberately; worth its own change if we want it.

https://claude.ai/code/session_01ESbGCQzXnRB8GrQ49FfBHf