### PR TITLE
test: Run the qgen property tests under Antithesis fault injection

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -403,11 +403,9 @@ jobs:
       # antithesis.duration is in minutes, 360 minutes = 6 hours
       # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
       # antithesis.source ensures Community and Enteprise have separate histories
-      # custom.container_faults_{stop,kill}_exclusion_patterns exempts containers from stop/kill faults for two reasons:
-      #   - infra ParadeDB doesn't develop, always exempt: the cloudnative-pg operator and
-      #     logical-replication-publisher (a vanilla Postgres container)
-      #   - the paradedb pod(s) under proptests: proptests is a differential-correctness oracle with no reconnect
-      #     resilience, so a stopped/killed paradedb there is spurious query-failure noise rather than exercised recovery
+      # custom.container_faults_{stop,kill}_exclusion_patterns exempts infra ParadeDB doesn't
+      # develop: the cloudnative-pg operator and logical-replication-publisher (a vanilla
+      # Postgres container).
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.12
         with:
@@ -425,8 +423,8 @@ jobs:
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=${{ env.REPO_NAME }}
             custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }},logical-replication-publisher
-            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
-            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
+            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},cloudnative-pg,logical-replication-publisher
+            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},cloudnative-pg,logical-replication-publisher
 
   # Ping Slack if any of the nightly (scheduled) jobs failed. Scheduled runs only execute on
   # paradedb-enterprise (see the `if` on `setup`), so this notification only fires there.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "linkme",
  "once_cell",
  "rand 0.8.7",
+ "rand_core 0.10.1",
  "rustc_version_runtime",
  "serde",
  "serde_json",
@@ -5069,7 +5070,7 @@ dependencies = [
  "pgrx",
  "pgrx-tests",
  "postcard",
- "proptest",
+ "proptest 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost",
  "rand 0.10.2",
  "regex",
@@ -5674,7 +5675,26 @@ dependencies = [
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
- "rand_xorshift",
+ "rand_xorshift 0.4.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "git+https://github.com/antithesishq/proptest?rev=6061eb48d67ff76f882e709677308816d5791ce7#6061eb48d67ff76f882e709677308816d5791ce7"
+dependencies = [
+ "antithesis_sdk",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_xorshift 0.5.0",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
@@ -5894,6 +5914,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5934,6 +5964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60aa6af80be32871323012e02e6e65f8a7cc7890931ae421d217ad8fe0df2ccf"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7289,13 +7328,14 @@ dependencies = [
  "chrono",
  "cmd_lib",
  "dotenvy",
+ "dst",
  "env_logger",
  "futures",
  "lockfree-object-pool",
  "num-traits",
  "pgvector",
  "pretty_assertions",
- "proptest",
+ "proptest 1.11.0 (git+https://github.com/antithesishq/proptest?rev=6061eb48d67ff76f882e709677308816d5791ce7)",
  "proptest-derive",
  "rand 0.10.2",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,16 @@ inherits = "release"
 debug = true
 debug-assertions = false
 
-# DST build profile — `dev`-like (debug assertions on) but isolated so it can be tuned
-# without affecting `dev`.
+# DST profile: opt-level 2 (unoptimized paradedb execution dominates qgen case time otherwise) but
+# fully debuggable -- DWARF, debug assertions and overflow checks on (the dst invariants need
+# them). LTO off: it mangles frames, and with sancov's codegen-units=1 it exhausts rustc memory.
 [profile.dst]
-inherits = "dev"
+inherits = "release"
+opt-level = 2
+lto = "off"
+debug = true
+debug-assertions = true
+overflow-checks = true
 
 [workspace.dependencies]
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "15cfa80854c21955e3994a5910e12e36c90a5983", features = [

--- a/docker/Dockerfile.config.proptests
+++ b/docker/Dockerfile.config.proptests
@@ -6,3 +6,4 @@ FROM scratch
 COPY docker/manifests/cnpg.yaml /manifests/
 COPY docker/manifests/antithesis-paradedb.yaml /manifests/
 COPY docker/manifests/antithesis-proptests.yaml /manifests/
+COPY docker/manifests/antithesis-bootstrap-gate.yaml /manifests/

--- a/docker/Dockerfile.config.stressgres
+++ b/docker/Dockerfile.config.stressgres
@@ -6,3 +6,4 @@ FROM scratch
 COPY docker/manifests/cnpg.yaml /manifests/
 COPY docker/manifests/antithesis-paradedb.yaml /manifests/
 COPY docker/manifests/antithesis-stressgres.yaml /manifests/
+COPY docker/manifests/antithesis-bootstrap-gate.yaml /manifests/

--- a/docker/Dockerfile.proptests
+++ b/docker/Dockerfile.proptests
@@ -13,7 +13,8 @@ FROM rust:1.97-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build and runtime dependencies. `jq` is used during build to extract
-# the test binary path from cargo's JSON output.
+# the test binary path from cargo's JSON output; `curl` is needed by the
+# antithesis-instrumentation build script, which `--features dst` pulls in.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     lld \
@@ -21,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     libssl-dev \
     ca-certificates \
+    curl \
     postgresql-client \
     libpq5 \
     jq \
@@ -55,7 +57,7 @@ ENV PGCLIENTENCODING=UTF8
 RUN cargo fetch --manifest-path /home/app/Cargo.toml && \
     cargo test --offline --release --no-run \
         --manifest-path /home/app/Cargo.toml \
-        -p tests --test qgen \
+        -p tests --test qgen --features dst \
         --message-format=json > /tmp/build.json && \
     QGEN_BIN=$(jq -r 'select(.profile.test == true and .target.name == "qgen") | .executable' /tmp/build.json | tail -n 1) && \
     test -x "$QGEN_BIN" && \

--- a/docker/manifests/antithesis-bootstrap-gate.yaml
+++ b/docker/manifests/antithesis-bootstrap-gate.yaml
@@ -1,0 +1,31 @@
+# Holds the Antithesis bootstrap phase open until the ParadeDB cluster accepts connections.
+# Fault injection starts when `kapp deploy` succeeds, and kapp has no wait rule for CNPG's
+# `Cluster` CRD -- it treats the cluster as done at resource creation, so faults would land while
+# initdb is still running. kapp does wait for a Job, so this Job extends the fault-free phase over
+# cluster initialization. (A custom `setup_complete` cannot: the earliest ready signal wins.)
+# https://antithesis.com/docs/getting_started/setup_guide/setup_k8s/#optional-add-a-ready-signal-for-fuzzing
+# Reuses `postgres:18` so no per-commit image patching is needed.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bootstrap-gate
+  namespace: default
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: bootstrap-gate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: wait-for-paradedb
+          image: docker.io/postgres:18
+          command: ["/bin/bash", "-c"]
+          # pg_isready needs no credentials and returns 0 only after initdb + post-init SQL.
+          # The timeout turns a broken cluster into a failed deploy instead of a hung run.
+          args:
+            - |
+              set -Eeuo pipefail
+              timeout 600 bash -c 'until pg_isready -q -h paradedb-rw -p 5432 -U postgres -d paradedb; do sleep 2; done'
+              echo "bootstrap-gate: paradedb-rw is accepting connections"

--- a/dst/src/lib.rs
+++ b/dst/src/lib.rs
@@ -58,6 +58,37 @@ pub fn init() {
 #[cfg(not(feature = "enabled"))]
 pub fn init() {}
 
+/// Whether a Postgres SQLSTATE means the connection is gone and reconnecting is the right
+/// response: class 08 (connection exception), operator/crash shutdown, "cannot connect now"
+/// (server starting up or shutting down), and idle-session timeout. Shared by the stressgres and
+/// qgen workloads so their transient-fault classifications cannot drift. (stressgres additionally
+/// keeps a stringified-needle fallback in `fault_tolerance::TRANSIENT_ERROR_NEEDLES`, which must
+/// mirror this list.)
+pub fn is_connection_lost_sqlstate(code: &str) -> bool {
+    code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05")
+}
+
+#[cfg(test)]
+mod sqlstate_tests {
+    use super::is_connection_lost_sqlstate;
+
+    #[test]
+    fn connection_class_and_shutdown_codes_are_lost() {
+        for code in [
+            "08000", "08006", "08P01", "57P01", "57P02", "57P03", "57P05",
+        ] {
+            assert!(is_connection_lost_sqlstate(code), "{code}");
+        }
+    }
+
+    #[test]
+    fn query_and_data_errors_are_not_lost() {
+        for code in ["57014", "40001", "40P01", "23505", "42601", ""] {
+            assert!(!is_connection_lost_sqlstate(code), "{code}");
+        }
+    }
+}
+
 // The leading `debug_assert` / `type_only` keyword selects the SDK-off lowering (see crate docs).
 // `$d` is bound to `$` so a generated macro can name its own metavariables (the escape for a macro
 // that defines a macro).

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -111,7 +111,7 @@ impl GraceWindow {
 /// Substrings that identify a transient connectivity failure when all we have is a
 /// stringified error (e.g. one already flattened by `format_postgres_error`).
 ///
-/// The `(sqlstate: ...` needles must mirror the connection-class codes in
+/// The `(sqlstate: ...` needles must mirror [`dst::is_connection_lost_sqlstate`] via
 /// [`is_transient_connection_error`]; this is the fallback for errors that have lost
 /// their structured `postgres::Error`, so keep the two lists in sync.
 const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
@@ -157,13 +157,7 @@ fn message_looks_transient(msg: &str) -> bool {
 /// SQLSTATE and no `is_closed()` signal, so needle matching alone would miss it).
 fn is_transient_connection_error(e: &postgres::Error) -> bool {
     match e.as_db_error() {
-        Some(db) => {
-            let code = db.code().code();
-            // Class 08 = connection exception; 57P0x = operator/crash shutdown,
-            // "cannot connect now" (server starting up / shutting down), and idle-session
-            // timeout — all cases where the connection is gone and reconnecting is right.
-            code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05")
-        }
+        Some(db) => dst::is_connection_lost_sqlstate(db.code().code()),
         // Client-side/transport failure: no answer from the server, so it never got
         // far enough to be a logical bug. Treat it as transient.
         None => true,

--- a/stressgres/suites/antithesis/helper_suite_setup.sh
+++ b/stressgres/suites/antithesis/helper_suite_setup.sh
@@ -66,10 +66,8 @@ setup() {
     *) echo "unknown topology: ${topology}" >&2; exit 1 ;;
   esac
 
-  echo ""
-  echo "Waiting 60s for the ParadeDB cluster to initialize..."
-  sleep 60
-
+  # antithesis-bootstrap-gate.yaml holds the fault-free bootstrap phase open until paradedb-rw
+  # accepts connections, so no fixed wait is needed here.
   echo ""
   echo "Building schema for ${toml}..."
   "${STRESSGRES}" headless "${path}" --setup-only --reconnect-grace 200000

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,8 +11,15 @@ workspace = true
 [lib]
 crate-type = ["rlib"]
 
+[features]
+# Antithesis build (docker/Dockerfile.proptests): proptest draws entropy from the SDK and the dst
+# assert macros go live. Off for normal `cargo test`.
+dst = ["proptest/antithesis", "dst/enabled"]
+
 [dependencies]
 approx = "0.5.1"
+# Antithesis hooks; the macros are type-checked no-ops until `dst/enabled`.
+dst = { path = "../dst" }
 anyhow = "1.0.102"
 async-std = { version = "1.13.2", features = ["attributes"] }
 bigdecimal = { version = "0.4.10", features = ["serde"] }
@@ -50,6 +57,8 @@ tokio = { version = "1.52.1", features = [
 ] }
 uuid = "1.23.1"
 num-traits = "0.2.19"
-proptest = "1.11.0"
+# Fork adds RngAlgorithm::Antithesis (crate version still 1.11.0).
+proptest = { git = "https://github.com/antithesishq/proptest", rev = "6061eb48d67ff76f882e709677308816d5791ce7" }
+# Stays on crates.io: the antithesis feature does not touch the derive crate.
 proptest-derive = "0.8.0"
 env_logger = "0.11.10"

--- a/tests/antithesis/anytime_recovery_liveness.sh
+++ b/tests/antithesis/anytime_recovery_liveness.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Antithesis "anytime" command: heal every fault, then require that the driver running alongside
+# makes progress before faults resume. "The database was provably reachable and the workload still
+# made no progress" is a failure no fault schedule can fake; the rationale lives in
+# tests/src/fixtures/fault_grace.rs. Mirrors stressgres/suites/antithesis/anytime_recovery_liveness.sh.
+
+set -Eeuo pipefail
+
+# The poke channel, shared via the proptests container's filesystem. The driver is launched with
+# this same path in PARADEDB_QGEN_RECONNECT_GRACE_FILE.
+GRACE_FILE=/tmp/qgen-reconnect-grace
+LOCK_FILE=/tmp/qgen-recovery-liveness.lock
+
+# RECOVER < QUIET so the window is judged before faults resume, and QUIET must comfortably exceed
+# the 60s statement_timeout or slow-query detection never fires. 90s of recovery allows a few
+# attempts past sqlx's 30s pool-acquire timeout.
+QUIET_SECONDS="${QGEN_LIVENESS_QUIET_SECONDS:-120}"
+RECOVER_SECONDS="${QGEN_LIVENESS_RECOVER_SECONDS:-90}"
+
+# Minimum chaos between pauses; without it back-to-back pauses would suppress the faults this
+# test exists to inject.
+COOLDOWN_SECONDS="${QGEN_LIVENESS_COOLDOWN_SECONDS:-300}"
+COOLDOWN_FILE=/tmp/qgen-recovery-liveness.last
+
+# Fire on a small fraction of invocations so most of the run is spent under chaos.
+TRIGGER_PERCENT="${QGEN_LIVENESS_TRIGGER_PERCENT:-10}"
+sample=$(od -An -N2 -tu2 < /dev/urandom | tr -d '[:space:]')
+(( sample % 100 < TRIGGER_PERCENT )) || exit 0
+
+# Overlapping pokes would race: the first to finish would restore the baseline while the second is
+# still counting down, silently disarming the check. Check for flock(1) separately from taking the
+# lock, because a missing binary exits 127, which `|| exit 0` would misreport as "another instance
+# holds the lock" and skip every check for the whole run.
+if ! command -v flock >/dev/null 2>&1; then
+  echo "qgen recovery liveness: flock(1) not found, refusing to run without single-flight" >&2
+  exit 1
+fi
+exec 9>"${LOCK_FILE}"
+flock -n 9 || exit 0
+
+# Enforce the cooldown under the lock, so two invocations cannot both pass. Clock faults make the
+# arithmetic inexact, and that is fine: overshoot means more chaos, and a backwards jump goes
+# negative, firing early rather than never.
+last=$(stat -c %Y "${COOLDOWN_FILE}" 2>/dev/null || echo 0)
+now=$(date +%s)
+elapsed=$(( now - last ))
+if (( elapsed >= 0 && elapsed < COOLDOWN_SECONDS )); then
+  echo "qgen recovery liveness: ${elapsed}s since the last pause, under the ${COOLDOWN_SECONDS}s cooldown; leaving faults alone"
+  exit 0
+fi
+touch "${COOLDOWN_FILE}"
+
+# Atomic rename so a reader never sees a half-written declaration. Format:
+# '<unpause_epoch_ms> <window_ms>' (parsed by fault_grace.rs; the deadline makes a stranded file
+# self-voiding). Removing the file restores retry-forever.
+poke() {
+  printf '%s %s' "$1" "$2" > "${GRACE_FILE}.tmp"
+  mv "${GRACE_FILE}.tmp" "${GRACE_FILE}"
+}
+restore() { rm -f "${GRACE_FILE}" "${GRACE_FILE}.tmp"; }
+
+# Restore on every exit path (normal, set -e, SIGTERM), or the next fault is judged against a
+# stale window. SIGKILL would strand it, but this container is in the fault exclusion patterns.
+trap restore EXIT
+
+echo "qgen recovery liveness: pausing faults for ${QUIET_SECONDS}s; qgen must finish a case within ${RECOVER_SECONDS}s"
+"${ANTITHESIS_STOP_FAULTS}" "${QUIET_SECONDS}"
+
+UNPAUSE_AT_MS=$(( ($(date +%s) + QUIET_SECONDS) * 1000 ))
+poke "${UNPAUSE_AT_MS}" "$(( RECOVER_SECONDS * 1000 ))"
+sleep "${RECOVER_SECONDS}"
+restore
+
+echo "qgen recovery liveness: qgen survived the quiet period"
+
+# Exit 0 either way: the assertion belongs to the driver, whose failing case carries the repro.
+exit 0

--- a/tests/antithesis/singleton_driver_property-tests.sh
+++ b/tests/antithesis/singleton_driver_property-tests.sh
@@ -14,6 +14,7 @@ set -Eeuo pipefail
 
 export DATABASE_URL="postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"
 export PARADEDB_FORCE_PARALLEL=1
+# Hang detector for pathologically slow generated queries (issue #2733), not a fault-tolerance knob.
 export PARADEDB_QGEN_STATEMENT_TIMEOUT_MS="${PARADEDB_QGEN_STATEMENT_TIMEOUT_MS:-60000}"
 export PROPTEST_CASES="${PROPTEST_CASES:-128}"
 # Disable proptest's source-relative regression file persistence: the qgen
@@ -21,10 +22,8 @@ export PROPTEST_CASES="${PROPTEST_CASES:-128}"
 # otherwise spams a warning on every iteration.
 export PROPTEST_DISABLE_FAILURE_PERSISTENCE=1
 export RUST_BACKTRACE=1
-
-echo ""
-echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
-sleep 60
+# Poke channel for the recovery-liveness command; see tests/antithesis/anytime_recovery_liveness.sh.
+export PARADEDB_QGEN_RECONNECT_GRACE_FILE=/tmp/qgen-reconnect-grace
 
 echo ""
 echo "Starting qgen property tests..."

--- a/tests/src/fixtures/db.rs
+++ b/tests/src/fixtures/db.rs
@@ -29,6 +29,32 @@ use sqlx::{
 };
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+fn lost_connection(e: &Error) -> bool {
+    use crate::fixtures::fault_grace::{TransientKind, classify_transient};
+    classify_transient(e) == Some(TransientKind::ConnectionLost)
+}
+
+/// Awaits `$op`, retrying lost connections per [`crate::fixtures::fault_grace::FaultRetry`].
+/// Panics on any other error. The async twin of `fault_grace::retry_transient`, without a pool.
+macro_rules! tolerate_transient_setup {
+    ($what:literal, $op:expr) => {{
+        let mut retry = crate::fixtures::fault_grace::FaultRetry::default();
+        loop {
+            match $op.await {
+                Ok(value) => break value,
+                Err(err) => {
+                    if !lost_connection(&err) {
+                        panic!(concat!($what, ": {:#?}"), err);
+                    }
+                    if let Err(reason) = retry.record($what, &err) {
+                        panic!("{}", reason);
+                    }
+                }
+            }
+        }
+    }};
+}
+
 pub struct Db {
     context: TestContext<Postgres>,
 }
@@ -57,19 +83,19 @@ impl Db {
                 });
 
         let args = TestArgs::new(Box::leak(path.into_boxed_str()));
-        let context = Postgres::test_context(&args)
-            .await
-            .unwrap_or_else(|err| panic!("could not create test database: {err:#?}"));
+        let context = tolerate_transient_setup!(
+            "could not create test database",
+            Postgres::test_context(&args)
+        );
 
         Self { context }
     }
 
     pub async fn connection(&self) -> PgConnection {
-        self.context
-            .connect_opts
-            .connect()
-            .await
-            .unwrap_or_else(|err| panic!("failed to connect to test database: {err:#?}"))
+        tolerate_transient_setup!(
+            "failed to connect to test database",
+            self.context.connect_opts.connect()
+        )
     }
 }
 
@@ -170,6 +196,18 @@ where
         })
     }
 
+    /// Like [`Query::fetch_dynamic`], but surfaces the `sqlx::Error` instead of panicking.
+    fn fetch_dynamic_result(
+        self,
+        connection: &mut PgConnection,
+    ) -> Result<Vec<PgRow>, sqlx::Error> {
+        block_on(async {
+            sqlx::query(AssertSqlSafe(self.as_ref()))
+                .fetch_all(connection)
+                .await
+        })
+    }
+
     fn fetch_scalar<T>(self, connection: &mut PgConnection) -> Vec<T>
     where
         T: Type<Postgres> + for<'a> Decode<'a, sqlx::Postgres> + Send + Unpin,
@@ -191,6 +229,18 @@ where
                 .fetch_one(connection)
                 .await
                 .unwrap_or_else(|e| panic!("{e}:  error in query '{}'", self.as_ref()))
+        })
+    }
+
+    /// Like [`Query::fetch_one`], but surfaces the `sqlx::Error` instead of panicking.
+    fn fetch_one_result<T>(self, connection: &mut PgConnection) -> Result<T, sqlx::Error>
+    where
+        T: for<'r> FromRow<'r, <Postgres as sqlx::Database>::Row> + Send + Unpin,
+    {
+        block_on(async {
+            sqlx::query_as::<_, T>(AssertSqlSafe(self.as_ref()))
+                .fetch_one(connection)
+                .await
         })
     }
 

--- a/tests/src/fixtures/fault_grace.rs
+++ b/tests/src/fixtures/fault_grace.rs
@@ -1,0 +1,429 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Fault tolerance for qgen under Antithesis.
+//!
+//! Retries are unbounded by default: any finite window is one the fault injector can outlast, so
+//! a transient fault must never fail the run on its own. Liveness is asserted from the outside —
+//! the `anytime_recovery_liveness` command heals every fault, then writes a poke file declaring
+//! when faults resume and how quickly qgen must make progress. Only while that declaration is in
+//! force can failing to make progress fail the run, which no fault schedule can fake.
+//!
+//! The unpause deadline also makes a server-side `statement_timeout` (57014) attributable:
+//! Antithesis pauses threads, so any fixed timeout can be exceeded while faults are active. Only
+//! when an attempt ran start to finish inside one declared pause is "the query could not finish
+//! in time on a healthy database" a real finding.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use lockfree_object_pool::MutexObjectPool;
+use sqlx::PgConnection;
+
+/// What kind of fault-induced failure occurred.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransientKind {
+    /// The connection died. Retrying works once the fault heals, on a fresh connection.
+    ConnectionLost,
+    /// The server cancelled the statement: the database answered, on a still-usable connection.
+    QueryCanceled,
+}
+
+/// Classify an error as fault-induced. Connection-level errors are ridden out by reconnecting; a
+/// server-side `statement_timeout` (57014) is meaningful only relative to the fault schedule.
+/// Serialization failures and deadlocks are excluded: with one instance and one session per test
+/// they would be real findings. Always `None` under a plain `cargo test`, which keeps every error
+/// a hard failure.
+pub fn classify_transient(e: &sqlx::Error) -> Option<TransientKind> {
+    if !cfg!(feature = "dst") {
+        return None;
+    }
+    match e {
+        sqlx::Error::Io(_)
+        | sqlx::Error::Protocol(_)
+        | sqlx::Error::WorkerCrashed
+        | sqlx::Error::PoolClosed
+        | sqlx::Error::PoolTimedOut => Some(TransientKind::ConnectionLost),
+        sqlx::Error::Database(db) => {
+            let code = db.code().unwrap_or_default();
+            if dst::is_connection_lost_sqlstate(&code) {
+                Some(TransientKind::ConnectionLost)
+            } else if code == "57014" {
+                Some(TransientKind::QueryCanceled)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+/// A declared fault pause, parsed from the poke file: `<unpause_epoch_ms> <window_ms>`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Pause {
+    /// When faults resume (epoch ms). `u64::MAX` for the env-var baseline, which never expires.
+    unpause_at_ms: u64,
+    /// How quickly qgen must make progress while the pause is in force.
+    window: Duration,
+}
+
+/// Where pause declarations come from: `PARADEDB_QGEN_RECONNECT_GRACE_FILE` (the poke channel)
+/// and `PARADEDB_QGEN_RECONNECT_GRACE_MS` (local-testing baseline, ignored if the file is set).
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PauseSource {
+    file: Option<PathBuf>,
+    baseline: Option<Duration>,
+}
+
+impl PauseSource {
+    fn from_env() -> Self {
+        Self {
+            file: std::env::var("PARADEDB_QGEN_RECONNECT_GRACE_FILE")
+                .ok()
+                .filter(|p| !p.is_empty())
+                .map(PathBuf::from),
+            baseline: std::env::var("PARADEDB_QGEN_RECONNECT_GRACE_MS")
+                .ok()
+                .and_then(|ms| ms.trim().parse::<u64>().ok())
+                .map(Duration::from_millis),
+        }
+    }
+
+    /// The pause in force right now, if any. Re-read on every use. A missing, malformed, or
+    /// expired file is no pause: a supervisor that has not run, a half-written file, or a file
+    /// stranded by a killed supervisor must not be able to fail the run.
+    fn current(&self) -> Option<Pause> {
+        if let Some(file) = self.file.as_ref() {
+            let contents = std::fs::read_to_string(file).ok()?;
+            let pause = Self::parse(&contents).or_else(|| {
+                eprintln!(
+                    "qgen: ignoring malformed grace file {}: {:?}",
+                    file.display(),
+                    contents.trim()
+                );
+                None
+            })?;
+            return (now_ms() < pause.unpause_at_ms).then_some(pause);
+        }
+        self.baseline.map(|window| Pause {
+            unpause_at_ms: u64::MAX,
+            window,
+        })
+    }
+
+    fn parse(contents: &str) -> Option<Pause> {
+        let mut fields = contents.split_whitespace();
+        let unpause_at_ms = fields.next()?.parse::<u64>().ok()?;
+        let window = Duration::from_millis(fields.next()?.parse::<u64>().ok()?);
+        fields.next().is_none().then_some(Pause {
+            unpause_at_ms,
+            window,
+        })
+    }
+}
+
+pub(crate) fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn pause_source() -> &'static PauseSource {
+    static SOURCE: OnceLock<PauseSource> = OnceLock::new();
+    SOURCE.get_or_init(PauseSource::from_env)
+}
+
+/// The pause state when an attempt began. A statement timeout is a finding only if the whole
+/// attempt ran inside one declared pause; two pokes never share a deadline, so "same deadline at
+/// start and at failure" pins the attempt inside a single episode. Anything else — faults active,
+/// faults resumed mid-attempt, the attempt spanning two pauses — may have been slowed by faults
+/// and must be retried instead.
+struct PauseWitness(Option<Pause>);
+
+impl PauseWitness {
+    fn take(source: &PauseSource) -> Self {
+        Self(source.current())
+    }
+
+    fn still_paused(&self, source: &PauseSource) -> bool {
+        match (self.0, source.current()) {
+            (Some(at_start), Some(now)) => at_start.unpause_at_ms == now.unpause_at_ms,
+            _ => false,
+        }
+    }
+}
+
+/// Why [`retry_transient`] gave up.
+pub enum RetryError {
+    /// The statement timed out while faults were paused for the whole attempt: the query cannot
+    /// finish inside `statement_timeout` on a healthy database.
+    TimedOutUnderPause(sqlx::Error),
+    /// A pause's recovery window elapsed without progress: a liveness failure.
+    GraceExpired(String),
+}
+
+/// One attempt of a retryable operation: either it resolved (the resolution may itself be a hard
+/// failure — that is the caller's business), or it hit a classified transient fault.
+pub enum Attempt<T> {
+    Done(T),
+    Transient(TransientKind, sqlx::Error),
+}
+
+/// Adapts a raw SQL result into an [`Attempt`]: transient errors retry, everything else — success
+/// or hard error — resolves to the caller.
+pub fn sql_attempt<T>(result: Result<T, sqlx::Error>) -> Attempt<Result<T, sqlx::Error>> {
+    match result {
+        Ok(value) => Attempt::Done(Ok(value)),
+        Err(e) => match classify_transient(&e) {
+            Some(kind) => Attempt::Transient(kind, e),
+            None => Attempt::Done(Err(e)),
+        },
+    }
+}
+
+/// Runs `op` against pooled connections, retrying transient faults until it resolves.
+///
+/// A lost connection is never returned to the pool (the next `pull` builds a live one); a
+/// cancelled statement keeps its connection, which is still usable. Retries are bounded only
+/// while a pause is declared — see the module doc.
+pub fn retry_transient<T>(
+    pool: &MutexObjectPool<PgConnection>,
+    what: &str,
+    mut op: impl FnMut(&mut PgConnection) -> Attempt<T>,
+) -> Result<T, RetryError> {
+    let mut retry = FaultRetry::default();
+    loop {
+        let witness = PauseWitness::take(pause_source());
+        let mut conn = pool.pull();
+        let attempt = op(&mut conn);
+        observe_schedule();
+        let (kind, err) = match attempt {
+            Attempt::Done(value) => return Ok(value),
+            Attempt::Transient(kind, err) => (kind, err),
+        };
+        match kind {
+            TransientKind::ConnectionLost => {
+                // The peer is gone; leak the connection rather than let `Drop` return it to the
+                // pool, where a later `pull` would hand it back out.
+                std::mem::forget(conn);
+            }
+            TransientKind::QueryCanceled => {
+                if witness.still_paused(pause_source()) {
+                    return Err(RetryError::TimedOutUnderPause(err));
+                }
+            }
+        }
+        if let Err(reason) = retry.record(what, &err) {
+            return Err(RetryError::GraceExpired(reason));
+        }
+    }
+}
+
+/// Counters describing the fault schedule this timeline actually experienced, so its shape can be
+/// asserted rather than trusted.
+static LAST_PAUSED: AtomicBool = AtomicBool::new(false);
+static QUIET_PERIODS_COMPLETED: AtomicUsize = AtomicUsize::new(0);
+static FAULTS_BEFORE_ANY_QUIET: AtomicUsize = AtomicUsize::new(0);
+
+/// Samples the pause state after every attempt — not just failing ones, since a fault-free window
+/// is exactly when nothing fails — and asserts the schedule alternates: faults, a quiet window,
+/// faults again.
+fn observe_schedule() {
+    let paused = pause_source().current().is_some();
+    let was_paused = LAST_PAUSED.swap(paused, Ordering::Relaxed);
+
+    if paused && !was_paused {
+        dst::assert_reachable!("qgen: the recovery-liveness command paused faults");
+    }
+    if !paused && was_paused {
+        QUIET_PERIODS_COMPLETED.fetch_add(1, Ordering::Relaxed);
+        dst::assert_reachable!("qgen: returned to unbounded retry after a fault-free window");
+    }
+
+    // Faults must not be paused everywhere: some case has to complete under uninterrupted chaos.
+    dst::assert_sometimes!(
+        QUIET_PERIODS_COMPLETED.load(Ordering::Relaxed) == 0
+            && FAULTS_BEFORE_ANY_QUIET.load(Ordering::Relaxed) > 0,
+        "qgen: a case completed while faults had never been paused",
+        &serde_json::json!({})
+    );
+}
+
+fn note_fault() {
+    if QUIET_PERIODS_COMPLETED.load(Ordering::Relaxed) == 0 {
+        FAULTS_BEFORE_ANY_QUIET.fetch_add(1, Ordering::Relaxed);
+    } else if FAULTS_BEFORE_ANY_QUIET.load(Ordering::Relaxed) > 0 {
+        dst::assert_reachable!("qgen: faults resumed after surviving a fault-free window");
+    }
+}
+
+/// Tracks one continuous transient fault against the declared pause. The pause state is re-read
+/// on every failure and the clock restarts whenever it changes, so a poke landing mid-fault
+/// starts a fresh recovery window: it asks "can you recover within the window from *now*".
+#[derive(Default)]
+pub(crate) struct FaultRetry {
+    down_since: Option<std::time::Instant>,
+    last_pause: Option<Option<Pause>>,
+    backoff: Option<Duration>,
+}
+
+impl FaultRetry {
+    /// Records a transient failure of `what`, then sleeps so the caller can retry. Returns `Err`
+    /// only once a declared pause's window has elapsed continuously — i.e. only while faults are
+    /// healed.
+    pub(crate) fn record(&mut self, what: &str, err: &dyn std::fmt::Display) -> Result<(), String> {
+        let pause = pause_source().current();
+        note_fault();
+
+        // A poke landing mid-fault is the only path where the liveness check can actually fail;
+        // assert it happens at all.
+        dst::assert_sometimes!(
+            self.last_pause
+                .is_some_and(|last| pause_narrowed(last, pause)),
+            "qgen: a recovery poke narrowed the grace window during an active database fault",
+            &serde_json::json!({})
+        );
+
+        if self.last_pause != Some(pause) {
+            self.down_since = None;
+            self.backoff = None;
+        }
+        self.last_pause = Some(pause);
+
+        let down_since = *self.down_since.get_or_insert_with(std::time::Instant::now);
+        if let Some(pause) = pause
+            && down_since.elapsed() >= pause.window
+        {
+            return Err(format!(
+                "{what}: no progress for {:?}, past the {:?} grace window \
+                 (faults were healed, so this is a liveness failure): {err}",
+                down_since.elapsed(),
+                pause.window
+            ));
+        }
+
+        dst::assert_reachable!("qgen: retried a transient database fault");
+        eprintln!("{what}: transient database fault, retrying: {err}");
+        let backoff = self.backoff.unwrap_or(INITIAL_BACKOFF);
+        std::thread::sleep(backoff);
+        self.backoff = Some((backoff * 2).min(MAX_BACKOFF));
+        Ok(())
+    }
+}
+
+/// Whether `now` is a strictly tighter constraint than `last`. No pause is the loosest there is.
+fn pause_narrowed(last: Option<Pause>, now: Option<Pause>) -> bool {
+    match (last, now) {
+        (None, Some(_)) => true,
+        (Some(last), Some(now)) => now.window < last.window,
+        (_, None) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file_source(path: PathBuf) -> PauseSource {
+        PauseSource {
+            file: Some(path),
+            baseline: None,
+        }
+    }
+
+    #[test]
+    fn absent_file_means_no_pause() {
+        let s = file_source(PathBuf::from("/nonexistent/qgen-grace"));
+        assert_eq!(s.current(), None);
+    }
+
+    #[test]
+    fn no_file_and_no_baseline_is_unbounded() {
+        assert_eq!(PauseSource::default().current(), None);
+    }
+
+    #[test]
+    fn baseline_is_a_pause_that_never_expires() {
+        let s = PauseSource {
+            file: None,
+            baseline: Some(Duration::from_secs(7)),
+        };
+        let p = s.current().unwrap();
+        assert_eq!(p.window, Duration::from_secs(7));
+        assert_eq!(p.unpause_at_ms, u64::MAX);
+    }
+
+    #[test]
+    fn file_declares_deadline_and_window() {
+        let path = std::env::temp_dir().join("qgen-grace-test-valid");
+        let future = now_ms() + 60_000;
+        std::fs::write(&path, format!("{future} 1500\n")).unwrap();
+        let p = file_source(path.clone()).current().unwrap();
+        assert_eq!(p.unpause_at_ms, future);
+        assert_eq!(p.window, Duration::from_millis(1500));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn expired_file_is_no_pause() {
+        let path = std::env::temp_dir().join("qgen-grace-test-expired");
+        std::fs::write(&path, format!("{} 1500\n", now_ms().saturating_sub(1))).unwrap();
+        assert_eq!(file_source(path.clone()).current(), None);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn malformed_file_is_no_pause() {
+        let path = std::env::temp_dir().join("qgen-grace-test-malformed");
+        for junk in ["not-a-number", "12345", "1 2 3"] {
+            std::fs::write(&path, junk).unwrap();
+            assert_eq!(file_source(path.clone()).current(), None, "junk: {junk}");
+        }
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn timeout_after_unpause_is_not_attributed() {
+        // An attempt starts inside a pause, but its statement timeout fires after faults resume.
+        let path = std::env::temp_dir().join("qgen-grace-test-mid-attempt");
+        std::fs::write(&path, format!("{} 120000\n", now_ms() + 60_000)).unwrap();
+        let source = file_source(path.clone());
+        let witness = PauseWitness::take(&source);
+        assert!(witness.0.is_some(), "attempt started under a pause");
+        std::fs::write(&path, format!("{} 120000\n", now_ms().saturating_sub(1))).unwrap();
+        assert!(!witness.still_paused(&source));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn timeout_spanning_two_pauses_is_not_attributed() {
+        // An attempt that starts in pause A and fails in pause B was exposed to faults in between.
+        let path = std::env::temp_dir().join("qgen-grace-test-two-pokes");
+        let source = file_source(path.clone());
+        std::fs::write(&path, format!("{} 120000\n", now_ms() + 60_000)).unwrap();
+        let witness = PauseWitness::take(&source);
+        std::fs::write(&path, format!("{} 120000\n", now_ms() + 90_000)).unwrap();
+        assert!(!witness.still_paused(&source));
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/tests/src/fixtures/mod.rs
+++ b/tests/src/fixtures/mod.rs
@@ -19,6 +19,7 @@
 #![allow(unused_imports)]
 
 pub mod db;
+pub mod fault_grace;
 pub mod querygen;
 pub mod tables;
 pub mod utils;
@@ -26,14 +27,23 @@ pub mod utils;
 use async_std::task::block_on;
 use rstest::*;
 use sqlx::{self, PgConnection};
+use std::sync::Once;
 
 pub use crate::fixtures::db::*;
 pub use crate::fixtures::tables::*;
+
+/// Register the DST assertion catalog once, before any test work -- registered lazily, a
+/// run whose cases all fail during setup would report no properties. No-op unless `dst/enabled`.
+pub fn ensure_dst_init() {
+    static INIT: Once = Once::new();
+    INIT.call_once(dst::init);
+}
 
 #[fixture]
 pub fn database() -> Db {
     let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
         .try_init();
+    ensure_dst_init();
     block_on(async { Db::new().await })
 }
 

--- a/tests/src/fixtures/querygen/mod.rs
+++ b/tests/src/fixtures/querygen/mod.rs
@@ -26,8 +26,10 @@ pub mod wheregen;
 use std::fmt::{Debug, Write};
 use std::num::NonZeroUsize;
 use std::sync::OnceLock;
+use std::time::Instant;
 
 use futures::executor::block_on;
+use lockfree_object_pool::MutexObjectPool;
 use proptest::prelude::*;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -35,6 +37,7 @@ use sqlx::{Connection, PgConnection};
 
 use crate::fixtures::ConnExt;
 use crate::fixtures::db::Query;
+use crate::fixtures::fault_grace::{TransientKind, classify_transient};
 use joingen::{JoinExpr, JoinType};
 use opexprgen::{ArrayQuantifier, Operator};
 use wheregen::Expr;
@@ -141,15 +144,53 @@ impl Column {
     }
 }
 
+/// Builds the schema every generator queries against and returns the SQL as a reproduction
+/// script, retrying transient faults per [`crate::fixtures::fault_grace`] (under a plain
+/// `cargo test` the first error panics). Each attempt runs in one transaction so a connection
+/// killed midway rolls back cleanly and the retry starts from scratch (`CREATE TABLE` has no
+/// `IF NOT EXISTS`). `BEGIN`/`COMMIT` are kept out of the returned script, which is replayed
+/// statement by statement.
 pub fn generated_queries_setup(
-    conn: &mut PgConnection,
+    pool: &MutexObjectPool<PgConnection>,
     tables: &[(&str, usize)],
     columns_def: &[Column],
 ) -> String {
-    "CREATE EXTENSION IF NOT EXISTS vector;".execute(conn);
-    "CREATE EXTENSION IF NOT EXISTS pg_search;".execute(conn);
-    "SET log_error_verbosity TO VERBOSE;".execute(conn);
-    "SET log_min_duration_statement TO 1000;".execute(conn);
+    use crate::fixtures::fault_grace::{RetryError, sql_attempt};
+    let attempt = |conn: &mut PgConnection| -> Result<String, sqlx::Error> {
+        "BEGIN;".execute_result(conn)?;
+        match generated_queries_setup_inner(conn, tables, columns_def) {
+            Ok(setup_sql) => {
+                "COMMIT;".execute_result(conn)?;
+                Ok(setup_sql)
+            }
+            Err(err) => {
+                // Best effort: if the connection is already gone the server rolls back on its own.
+                let _ = "ROLLBACK;".execute_result(conn);
+                Err(err)
+            }
+        }
+    };
+    match crate::fixtures::fault_grace::retry_transient(pool, "generated queries setup", |conn| {
+        sql_attempt(attempt(conn))
+    }) {
+        Ok(Ok(setup_sql)) => setup_sql,
+        Ok(Err(e)) => panic!("generated queries setup should succeed: {e:#?}"),
+        Err(RetryError::TimedOutUnderPause(e)) => {
+            panic!("generated queries setup timed out while faults were paused: {e}")
+        }
+        Err(RetryError::GraceExpired(reason)) => panic!("{reason}"),
+    }
+}
+
+fn generated_queries_setup_inner(
+    conn: &mut PgConnection,
+    tables: &[(&str, usize)],
+    columns_def: &[Column],
+) -> Result<String, sqlx::Error> {
+    "CREATE EXTENSION IF NOT EXISTS vector;".execute_result(conn)?;
+    "CREATE EXTENSION IF NOT EXISTS pg_search;".execute_result(conn)?;
+    "SET log_error_verbosity TO VERBOSE;".execute_result(conn)?;
+    "SET log_min_duration_statement TO 1000;".execute_result(conn)?;
 
     let qgen_seed = qgen_seed().unwrap_or_else(|| rand::rng().random::<u64>());
     let mut rng = StdRng::seed_from_u64(qgen_seed);
@@ -157,7 +198,7 @@ pub fn generated_queries_setup(
     let bulk_inserts = pick_bulk_inserts(&mut rng);
 
     let seed_sql = format!("SET seed TO {pg_seed};\n");
-    seed_sql.as_str().execute(conn);
+    seed_sql.as_str().execute_result(conn)?;
 
     let mut setup_sql = seed_sql;
     setup_sql.push_str(&format!("-- PARADEDB_QGEN_SEED: {qgen_seed}\n"));
@@ -328,7 +369,7 @@ ANALYZE {tname};
                 .join("\n")
         );
 
-        (&sql).execute(conn);
+        (&sql).execute_result(conn)?;
         setup_sql.push_str(&sql);
     }
 
@@ -336,11 +377,11 @@ ANALYZE {tname};
     // more interesting.
     for (tname, _) in tables {
         let sql = format!("DELETE FROM {tname} WHERE random() < 0.01;\n");
-        sql.as_str().execute(conn);
+        sql.as_str().execute_result(conn)?;
         setup_sql.push_str(&sql);
     }
 
-    setup_sql
+    Ok(setup_sql)
 }
 
 ///
@@ -424,7 +465,7 @@ const SINGLE_BULK_INSERT: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 
 /// Reads `PARADEDB_QGEN_SEED`, the optional u64 that pins both the Postgres
 /// `SET seed` value and the bulk-insert chunk-count roll. Unset means
-/// `generated_queries_setup` picks one fresh per call. Either way the seed
+/// `generated_queries_setup_result` picks one fresh per call. Either way the seed
 /// used lands in the reproduction script, so a failing run can be replayed
 /// with `PARADEDB_QGEN_SEED=<n> PROPTEST_RNG_SEED=<m> cargo test ...`.
 fn qgen_seed() -> Option<u64> {
@@ -440,7 +481,7 @@ fn qgen_seed() -> Option<u64> {
 ///
 /// Honors `PARADEDB_QGEN_SEGMENTATION=single|multi|random` first, then falls
 /// back to a coin flip on the supplied RNG. One call per
-/// `generated_queries_setup`; every table built in the same call gets the
+/// `generated_queries_setup_result`; every table built in the same call gets the
 /// same count, different `#[test]` functions roll independently.
 fn pick_bulk_inserts(rng: &mut impl RngExt) -> NonZeroUsize {
     let mode = std::env::var("PARADEDB_QGEN_SEGMENTATION")
@@ -615,8 +656,199 @@ impl PgGucs {
     }
 }
 
-/// Run the given pg and bm25 queries on the given connection, and compare their results when run
-/// with the given GUCs.
+/// Fully-resolved outcome of a single qgen comparison case: good, transient, or bad.
+pub enum CaseOutcome {
+    /// Good: PostgreSQL and ParadeDB produced identical results.
+    Match,
+    /// Transient: a query hit a classified fault-induced error. Ride it out by retrying (see
+    /// [`crate::fixtures::fault_grace::retry_transient`]); never a verdict.
+    Transient(TransientKind, sqlx::Error),
+    /// Bad: a result mismatch, a panic during comparison, or a hard SQL error. Carries a
+    /// `TestCaseError` with the reproduction script embedded.
+    Failure(TestCaseError),
+}
+
+impl CaseOutcome {
+    pub fn into_test_result(self) -> Result<(), TestCaseError> {
+        match self {
+            CaseOutcome::Match => Ok(()),
+            CaseOutcome::Failure(e) => Err(e),
+            // Unreachable through the retrying path, and a plain `cargo test` never classifies
+            // anything transient; kept total for direct `compare_outcome` callers.
+            CaseOutcome::Transient(_, e) => Err(TestCaseError::fail(format!(
+                "{e}: transient database fault"
+            ))),
+        }
+    }
+}
+
+/// Run one generated case on `conn`: execute `pg_query` (custom scan off, the known-correct
+/// baseline) and `bm25_query` (with `gucs`), then compare their results.
+pub fn compare_outcome<R, F>(
+    pg_query: &str,
+    bm25_query: &str,
+    gucs: &PgGucs,
+    conn: &mut PgConnection,
+    setup_sql: &str,
+    run_query: F,
+) -> CaseOutcome
+where
+    R: Eq + Debug,
+    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+{
+    // A panic (vs a returned sqlx::Error) still becomes a Failure, so it trips the oracle and
+    // carries a repro script instead of aborting the driver.
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        compare_outcome_inner(pg_query, bm25_query, gucs, conn, setup_sql, run_query)
+    }));
+    match outcome {
+        Ok(o) => o,
+        Err(panic) => {
+            let msg = if let Some(s) = panic.downcast_ref::<&str>() {
+                format!("Panic: {s}")
+            } else if let Some(s) = panic.downcast_ref::<String>() {
+                format!("Panic: {s}")
+            } else {
+                "Panic occurred".to_string()
+            };
+            CaseOutcome::Failure(handle_compare_error(
+                TestCaseError::fail(msg),
+                pg_query,
+                bm25_query,
+                gucs,
+                setup_sql,
+            ))
+        }
+    }
+}
+
+/// Runs one case, retrying transient faults until it completes, so every case in the proptest
+/// budget ends in a real verdict. Bounding and liveness are [`crate::fixtures::fault_grace`]'s
+/// job. Takes the pool because a fault usually kills the connection in use.
+pub fn compare_outcome_retrying<R, F>(
+    pg_query: &str,
+    bm25_query: &str,
+    gucs: &PgGucs,
+    pool: &MutexObjectPool<PgConnection>,
+    setup_sql: &str,
+    run_query: F,
+) -> CaseOutcome
+where
+    R: Eq + Debug,
+    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+{
+    use crate::fixtures::fault_grace::{Attempt, RetryError};
+    let fail = |msg: String| {
+        CaseOutcome::Failure(handle_compare_error(
+            TestCaseError::fail(msg),
+            pg_query,
+            bm25_query,
+            gucs,
+            setup_sql,
+        ))
+    };
+    let outcome = crate::fixtures::fault_grace::retry_transient(pool, "qgen case", |conn| {
+        match compare_outcome(pg_query, bm25_query, gucs, conn, setup_sql, &run_query) {
+            CaseOutcome::Transient(kind, e) => Attempt::Transient(kind, e),
+            verdict => Attempt::Done(verdict),
+        }
+    });
+    match outcome {
+        Ok(o) => o,
+        Err(RetryError::TimedOutUnderPause(e)) => fail(format!(
+            "statement timed out while faults were paused for the whole attempt \
+             (the query cannot finish inside statement_timeout on a healthy database): {e}"
+        )),
+        Err(RetryError::GraceExpired(reason)) => fail(reason),
+    }
+}
+
+fn compare_outcome_inner<R, F>(
+    pg_query: &str,
+    bm25_query: &str,
+    gucs: &PgGucs,
+    conn: &mut PgConnection,
+    setup_sql: &str,
+    run_query: F,
+) -> CaseOutcome
+where
+    R: Eq + Debug,
+    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+{
+    let mut queries = || -> Result<(R, R), sqlx::Error> {
+        // The pg query runs with the paradedb custom scan off, so we compare against Postgres'
+        // known-correct plan rather than our own pushdown.
+        PgGucs::pg_search_disabled()
+            .set()
+            .execute_result(conn)
+            .and_then(|()| conn.deallocate_all())?;
+        let pg_result = run_query(pg_query, conn)?;
+
+        gucs.set()
+            .execute_result(conn)
+            .and_then(|()| conn.deallocate_all())?;
+        let bm25_result = run_query(bm25_query, conn)?;
+        Ok((pg_result, bm25_result))
+    };
+    let (pg_result, bm25_result) = match queries() {
+        Ok(results) => results,
+        Err(e) => match classify_transient(&e) {
+            Some(kind) => return CaseOutcome::Transient(kind, e),
+            None => {
+                return CaseOutcome::Failure(handle_compare_error(
+                    TestCaseError::fail(format!("{e}: error in query execution")),
+                    pg_query,
+                    bm25_query,
+                    gucs,
+                    setup_sql,
+                ));
+            }
+        },
+    };
+    match assert_results_match(&pg_result, &bm25_result, pg_query, bm25_query, gucs, conn) {
+        Ok(()) => CaseOutcome::Match,
+        Err(e) => CaseOutcome::Failure(handle_compare_error(
+            e, pg_query, bm25_query, gucs, setup_sql,
+        )),
+    }
+}
+
+/// Assert the two result sets are equal, attaching the ParadeDB plan to the failure message. The
+/// EXPLAIN is built lazily inside the assert message so it runs only on mismatch, and best-effort
+/// so a fault while composing it cannot itself panic.
+fn assert_results_match<R>(
+    pg_result: &R,
+    bm25_result: &R,
+    pg_query: &str,
+    bm25_query: &str,
+    gucs: &PgGucs,
+    conn: &mut PgConnection,
+) -> Result<(), TestCaseError>
+where
+    R: Eq + Debug,
+{
+    prop_assert_eq!(
+        pg_result,
+        bm25_result,
+        "\ngucs={:?}\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
+        gucs,
+        pg_query,
+        bm25_query,
+        format!("EXPLAIN {bm25_query}")
+            .fetch_result::<(String,)>(conn)
+            .map(|rows| rows
+                .into_iter()
+                .map(|(s,)| s)
+                .collect::<Vec<_>>()
+                .join("\n"))
+            .unwrap_or_else(|e| format!("<EXPLAIN unavailable: {e}>"))
+    );
+    Ok(())
+}
+
+/// Panic-based comparison kept for the non-Antithesis generator tests (`json_pushdown`,
+/// `scalar_array_pushdown`), whose `run_query` closures panic on DB errors. Thin wrapper over
+/// [`compare_outcome`].
 pub fn compare<R, F>(
     pg_query: &str,
     bm25_query: &str,
@@ -629,75 +861,25 @@ where
     R: Eq + Debug,
     F: Fn(&str, &mut PgConnection) -> R,
 {
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        inner_compare(pg_query, bm25_query, gucs, conn, run_query)
-    }));
-
-    let inner_result = match result {
-        Ok(r) => r,
-        Err(e) => {
-            let msg = if let Some(s) = e.downcast_ref::<&str>() {
-                format!("Panic: {}", s)
-            } else if let Some(s) = e.downcast_ref::<String>() {
-                format!("Panic: {}", s)
-            } else {
-                "Panic occurred".to_string()
-            };
-            Err(TestCaseError::fail(msg))
-        }
-    };
-
-    match inner_result {
-        Ok(()) => Ok(()),
-        Err(e) => Err(handle_compare_error(
-            e, pg_query, bm25_query, gucs, setup_sql,
-        )),
-    }
-}
-
-fn inner_compare<R, F>(
-    pg_query: &str,
-    bm25_query: &str,
-    gucs: &PgGucs,
-    conn: &mut PgConnection,
-    run_query: F,
-) -> Result<(), TestCaseError>
-where
-    R: Eq + Debug,
-    F: Fn(&str, &mut PgConnection) -> R,
-{
-    // the postgres query is always run with the paradedb custom scan turned off
-    // this ensures we get the actual, known-to-be-correct result from Postgres'
-    // plan, and not from ours where we did some kind of pushdown
-    PgGucs::pg_search_disabled().set().execute(conn);
-
-    conn.deallocate_all()?;
-
-    let pg_result = run_query(pg_query, conn);
-
-    // and for the "bm25" query, we run it with the given GUCs set.
-    gucs.set().execute(conn);
-
-    conn.deallocate_all()?;
-
-    let bm25_result = run_query(bm25_query, conn);
-
-    prop_assert_eq!(
-        &pg_result,
-        &bm25_result,
-        "\ngucs={:?}\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
-        gucs,
+    match compare_outcome(
         pg_query,
         bm25_query,
-        format!("EXPLAIN {bm25_query}")
-            .fetch::<(String,)>(conn)
-            .into_iter()
-            .map(|(s,)| s)
-            .collect::<Vec<_>>()
-            .join("\n")
-    );
-
-    Ok(())
+        gucs,
+        conn,
+        setup_sql,
+        |query, conn| Ok::<R, sqlx::Error>(run_query(query, conn)),
+    ) {
+        // run_query panics on DB errors here, so a `Transient` means the GUC set failed (and a
+        // plain `cargo test` never classifies anything transient anyway).
+        CaseOutcome::Transient(_, e) => Err(handle_compare_error(
+            TestCaseError::fail(format!("{e}: error in query execution")),
+            pg_query,
+            bm25_query,
+            gucs,
+            setup_sql,
+        )),
+        verdict => verdict.into_test_result(),
+    }
 }
 
 /// Helper function to handle comparison errors and generate reproduction scripts
@@ -725,7 +907,7 @@ pub fn handle_compare_error(
         .unwrap_or_else(|| {
             panic!(
                 "qgen seed marker missing from setup_sql; \
-                 `generated_queries_setup` must emit `-- PARADEDB_QGEN_SEED: <n>`"
+                 `generated_queries_setup_result` must emit `-- PARADEDB_QGEN_SEED: <n>`"
             )
         });
     let proptest_seed = std::env::var("PROPTEST_RNG_SEED")
@@ -753,7 +935,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 -- Set GUCs to match the failing test case
 {gucs_sql}
 --
--- BM25 query:
+-- ParadeDB query:
 {bm25_query};
 --
 -- ==== END REPRODUCTION SCRIPT ====
@@ -781,7 +963,7 @@ Original error:
         if failure_type == "QUERY EXECUTION FAILURE" {
             "Query execution failed"
         } else {
-            "Results differ between PostgreSQL and BM25"
+            "Results differ between PostgreSQL and ParadeDB"
         }
     ))
 }

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -23,7 +23,7 @@ use tests::fixtures::querygen::pagegen::arb_paging_exprs;
 use tests::fixtures::querygen::wheregen::Expr as WhereExpr;
 use tests::fixtures::querygen::wheregen::arb_wheres;
 use tests::fixtures::querygen::{
-    Column, PgGucs, arb_joins_and_wheres, compare, generated_queries_setup,
+    Column, PgGucs, arb_joins_and_wheres, compare_outcome_retrying, generated_queries_setup,
 };
 
 use tests::fixtures::*;
@@ -34,6 +34,54 @@ use proptest::prelude::*;
 use rstest::*;
 use serde_json::Value;
 use sqlx::{PgConnection, Row};
+
+/// Proptest configuration shared by every generator test in this file. Under `dst`, proptest
+/// draws its randomness from the Antithesis SDK, so the platform controls and branches the
+/// entropy stream; otherwise this is just `Config::default()`.
+fn qgen_proptest_config() -> proptest::test_runner::Config {
+    #[allow(unused_mut)]
+    let mut config = proptest::test_runner::Config::default();
+    #[cfg(feature = "dst")]
+    {
+        config.rng_algorithm = proptest::test_runner::RngAlgorithm::Antithesis;
+        // No shrinking: Antithesis controls the entropy stream and fault schedule, so a replay
+        // sees a different history and the minimized input is meaningless.
+        config.max_shrink_iters = 0;
+    }
+    config
+}
+
+/// Report one case outcome as a per-test Antithesis property, then collapse it to a proptest
+/// result. The single `Always` assertion doubles as a reachability check: cataloged, it fails as
+/// unreached if the generator never produces a case. No-op under a plain `cargo test`.
+macro_rules! qgen_oracle {
+    ($prop:literal, $outcome:expr) => {{
+        let outcome = $outcome;
+        ensure_dst_init();
+        match &outcome {
+            tests::fixtures::querygen::CaseOutcome::Match => {
+                dst::assert_always!(true, $prop, &serde_json::json!({}));
+            }
+            tests::fixtures::querygen::CaseOutcome::Failure(e) => {
+                dst::assert_always!(
+                    false,
+                    $prop,
+                    &serde_json::json!({ "detail": e.to_string() })
+                );
+            }
+            // compare_outcome_retrying resolves every Transient by retrying, so this arm is
+            // defensive.
+            tests::fixtures::querygen::CaseOutcome::Transient(_, e) => {
+                dst::assert_always!(
+                    false,
+                    $prop,
+                    &serde_json::json!({ "detail": e.to_string() })
+                );
+            }
+        }
+        outcome.into_test_result()
+    }};
+}
 
 const COLUMNS: &[Column] = &[
     Column::new("id", "SERIAL8", "'4'")
@@ -208,9 +256,9 @@ async fn generated_joins_small(database: Db) {
         .iter()
         .map(|(table, _)| table)
         .collect::<Vec<_>>();
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         (join, where_expr) in arb_joins_and_wheres(
             any::<JoinType>(),
             tables,
@@ -222,14 +270,14 @@ async fn generated_joins_small(database: Db) {
 
         let from = format!("SELECT COUNT(*) {join_clause} ");
 
-        compare(
+        qgen_oracle!("qgen: generated_joins_small - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &format!("{from} WHERE {}", where_expr.to_sql(" = ")),
             &format!("{from} WHERE {}", where_expr.to_sql("@@@")),
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
-            |query, conn| query.fetch_one::<(i64,)>(conn).0,
-        )?;
+            |query, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
+        ))?;
     });
 }
 
@@ -254,9 +302,9 @@ async fn generated_joins_large_limit(database: Db) {
         .iter()
         .map(|(table, _)| table)
         .collect::<Vec<_>>();
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         (join, where_expr) in arb_joins_and_wheres(
             Just(JoinType::Inner),
             tables,
@@ -277,14 +325,17 @@ async fn generated_joins_large_limit(database: Db) {
 
         let from = format!("SELECT {target_list} {join_clause} ");
 
-        compare(
+        // This test is #[ignore]d, so it never runs. Emit no Antithesis property for it: a cataloged
+        // `Always` that is never reached would otherwise show as a permanently-failing property.
+        compare_outcome_retrying(
             &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql(" = ")),
             &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql("@@@")),
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
-            |query, conn| query.fetch_dynamic(conn).len(),
-        )?;
+            |query, conn| Ok(query.fetch_dynamic_result(conn)?.len()),
+        )
+        .into_test_result()?;
     });
 }
 
@@ -297,9 +348,9 @@ async fn generated_single_relation(database: Db) {
     );
 
     let table_name = "users";
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 10)], COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 10)], COLUMNS);
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         where_expr in arb_wheres(
             vec![table_name],
             COLUMNS,
@@ -307,18 +358,18 @@ async fn generated_single_relation(database: Db) {
         gucs in any::<PgGucs>(),
         target in prop_oneof![Just("COUNT(*)"), Just("id")],
     )| {
-        compare(
+        qgen_oracle!("qgen: generated_single_relation - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql(" = ")),
             &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql("@@@")),
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
             |query, conn| {
-                let mut rows = query.fetch::<(i64,)>(conn);
+                let mut rows = query.fetch_result::<(i64,)>(conn)?;
                 rows.sort();
-                rows
+                Ok(rows)
             }
-        )?;
+        ))?;
     });
 }
 
@@ -335,7 +386,7 @@ async fn generated_group_by_aggregates(database: Db) {
     );
 
     let table_name = "users";
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 50)], COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 50)], COLUMNS);
 
     // Columns that can be used for grouping (must have fast: true in index)
     let columns: Vec<_> = COLUMNS
@@ -346,7 +397,7 @@ async fn generated_group_by_aggregates(database: Db) {
 
     let grouping_columns: Vec<_> = columns.iter().map(|col| col.name).collect();
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         text_where_expr in arb_wheres(
             vec![table_name],
             &columns,
@@ -406,9 +457,10 @@ async fn generated_group_by_aggregates(database: Db) {
         );
 
         // Custom result comparator for GROUP BY results
-        let compare_results = |query: &str, conn: &mut PgConnection| -> Vec<String> {
+        let compare_results =
+            |query: &str, conn: &mut PgConnection| -> Result<Vec<String>, sqlx::Error> {
             // Fetch all rows as dynamic results and convert to string representation
-            let rows = query.fetch_dynamic(conn);
+            let rows = query.fetch_dynamic_result(conn)?;
             let string_rows: Vec<String> = rows
                 .into_iter()
                 .map(|row| {
@@ -436,10 +488,10 @@ async fn generated_group_by_aggregates(database: Db) {
                 })
                 .collect();
 
-            string_rows
+            Ok(string_rows)
         };
 
-        compare(&pg_query, &bm25_query, &gucs, &mut pool.pull(), &setup_sql, compare_results)?;
+        qgen_oracle!("qgen: generated_group_by_aggregates - ParadeDB result matches PostgreSQL", compare_outcome_retrying(&pg_query, &bm25_query, &gucs, &pool, &setup_sql, compare_results))?;
     });
 }
 
@@ -452,21 +504,21 @@ async fn generated_paging_small(database: Db) {
     );
 
     let table_name = "users";
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 1000)], COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 1000)], COLUMNS);
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         where_expr in arb_wheres(vec![table_name], &columns_named(vec!["name"])),
         paging_exprs in arb_paging_exprs(table_name, vec!["name", "color", "age", "quantity"], vec!["id", "uuid"]),
         gucs in any::<PgGucs>(),
     )| {
-        compare(
+        qgen_oracle!("qgen: generated_paging_small - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql(" = ")),
             &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql("@@@")),
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
-            |query, conn| query.fetch::<(i64,)>(conn),
-        )?;
+            |query, conn| query.fetch_result::<(i64,)>(conn),
+        ))?;
     });
 }
 
@@ -484,20 +536,20 @@ async fn generated_paging_large(database: Db) {
     );
 
     let table_name = "users";
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 100000)], COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 100000)], COLUMNS);
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         paging_exprs in arb_paging_exprs(table_name, vec![], vec!["uuid"]),
         gucs in any::<PgGucs>(),
     )| {
-        compare(
+        qgen_oracle!("qgen: generated_paging_large - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &format!("SELECT uuid::text FROM {table_name} WHERE name  =  'bob' {paging_exprs}"),
             &format!("SELECT uuid::text FROM {table_name} WHERE name @@@ 'bob' {paging_exprs}"),
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
-            |query, conn| query.fetch::<(String,)>(conn),
-        )?;
+            |query, conn| query.fetch_result::<(String,)>(conn),
+        ))?;
     });
 }
 
@@ -512,12 +564,12 @@ async fn generated_subquery(database: Db) {
     let outer_table_name = "products";
     let inner_table_name = "orders";
     let setup_sql = generated_queries_setup(
-        &mut pool.pull(),
+        &pool,
         &[(outer_table_name, 10), (inner_table_name, 10)],
         COLUMNS,
     );
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         outer_where_expr in arb_wheres(
             vec![outer_table_name],
             COLUMNS,
@@ -556,14 +608,14 @@ async fn generated_subquery(database: Db) {
             outer_where_expr.to_sql("@@@"),
         );
 
-        compare(
+        qgen_oracle!("qgen: generated_subquery - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg,
             &bm25,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
-            |query, conn| query.fetch_one::<(i64,)>(conn),
-        )?;
+            |query, conn| query.fetch_one_result::<(i64,)>(conn),
+        ))?;
     });
 }
 
@@ -595,7 +647,7 @@ async fn generated_joinscan(database: Db) {
     // Three tables for 2-way and 3-way join testing
     let tables_and_sizes = [("users", 100), ("products", 100), ("orders", 100)];
     let all_tables: Vec<&str> = tables_and_sizes.iter().map(|(table, _)| *table).collect();
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
     // Text columns for BM25 WHERE clauses
     let text_columns = columns_named(vec!["name"]);
@@ -608,7 +660,7 @@ async fn generated_joinscan(database: Db) {
     // NumericBytes fast field projection is tested separately in fast_fields.rs.
     let numeric_columns = ["age"];
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         num_tables in 2..=3usize,
         // Outer table BM25 predicate (always present)
         outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
@@ -644,7 +696,7 @@ async fn generated_joinscan(database: Db) {
         let join_expr = {
             use proptest::strategy::ValueTree;
             use proptest::test_runner::TestRunner;
-            let mut runner = TestRunner::default();
+            let mut runner = TestRunner::new(qgen_proptest_config());
             join.new_tree(&mut runner).unwrap().current()
         };
 
@@ -727,29 +779,46 @@ async fn generated_joinscan(database: Db) {
             "{from} WHERE {bm25_where} ORDER BY {order_by} LIMIT {limit}"
         );
 
-        // Verify JoinScan was actually used
+        // Verify JoinScan was actually used, retrying transient faults like the case path.
         {
-            let conn = &mut pool.pull();
-            gucs.set().execute(conn);
-            let explain_query = format!("EXPLAIN (FORMAT JSON) {bm25_query}");
-            let (plan,): (Value,) = explain_query.fetch_one(conn);
-            let plan_str = format!("{plan:#?}");
+            use tests::fixtures::fault_grace::{RetryError, retry_transient, sql_attempt};
+            let plan = match retry_transient(&pool, "qgen joinscan plan check", |conn| {
+                sql_attempt(gucs.set().execute_result(conn).and_then(|()| {
+                    format!("EXPLAIN (FORMAT JSON) {bm25_query}").fetch_one_result::<(Value,)>(conn)
+                }))
+            }) {
+                Ok(Ok(plan)) => plan,
+                Ok(Err(e)) => {
+                    return Err(proptest::test_runner::TestCaseError::fail(format!(
+                        "{e}: EXPLAIN failed for '{bm25_query}'"
+                    )));
+                }
+                Err(RetryError::TimedOutUnderPause(e)) => {
+                    return Err(proptest::test_runner::TestCaseError::fail(format!(
+                        "EXPLAIN timed out while faults were paused, for '{bm25_query}': {e}"
+                    )));
+                }
+                Err(RetryError::GraceExpired(reason)) => {
+                    return Err(proptest::test_runner::TestCaseError::fail(reason));
+                }
+            };
+            let plan_str = format!("{:#?}", plan.0);
             prop_assert!(
                 plan_str.contains("ParadeDB Join Scan"),
                 "Query should use ParadeDB Join Scan but got plan: {plan_str}\nQuery: {bm25_query}",
             );
         }
 
-        compare(
+        qgen_oracle!("qgen: generated_joinscan - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg_query,
             &bm25_query,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
             |query, conn| {
-                "SET work_mem TO '16MB';".execute(conn);
+                "SET work_mem TO '16MB';".execute_result(conn)?;
                 // Use dynamic fetch since column count varies with HeapCondition
-                let rows = query.fetch_dynamic(conn);
+                let rows = query.fetch_dynamic_result(conn)?;
                 // Convert to sorted string representation for comparison
                 let mut row_strings: Vec<String> = rows
                     .into_iter()
@@ -761,9 +830,9 @@ async fn generated_joinscan(database: Db) {
                     })
                     .collect();
                 row_strings.sort();
-                row_strings
+                Ok(row_strings)
             },
-        )?;
+        ))?;
     });
 }
 
@@ -790,7 +859,7 @@ async fn generated_aggregate_join(database: Db) {
     // Three tables for 2-way and 3-way join testing
     let tables_and_sizes = [("users", 50), ("products", 50), ("orders", 50)];
     let all_tables: Vec<&str> = tables_and_sizes.iter().map(|(table, _)| *table).collect();
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
     // Text columns for BM25 WHERE clauses
     let text_columns = columns_named(vec!["name"]);
@@ -810,7 +879,7 @@ async fn generated_aggregate_join(database: Db) {
         format!("{}.metadata->'brand'", all_tables[0]),
     ]);
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         num_tables in 2..=3usize,
         // Outer table BM25 predicate
         outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
@@ -840,7 +909,7 @@ async fn generated_aggregate_join(database: Db) {
         let join_expr = {
             use proptest::strategy::ValueTree;
             use proptest::test_runner::TestRunner;
-            let mut runner = TestRunner::default();
+            let mut runner = TestRunner::new(qgen_proptest_config());
             join.new_tree(&mut runner).unwrap().current()
         };
 
@@ -868,14 +937,14 @@ async fn generated_aggregate_join(database: Db) {
         gucs.join_custom_scan = true;
         gucs.custom_scan = true;
 
-        compare(
+        qgen_oracle!("qgen: generated_aggregate_join - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg_query,
             &bm25_query,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
             |query, conn| {
-                let rows = query.fetch_dynamic(conn);
+                let rows = query.fetch_dynamic_result(conn)?;
                 let mut string_rows: Vec<String> = rows
                     .into_iter()
                     .map(|row| {
@@ -901,9 +970,9 @@ async fn generated_aggregate_join(database: Db) {
                     })
                     .collect();
                 string_rows.sort();
-                string_rows
+                Ok(string_rows)
             },
-        )?;
+        ))?;
     });
 }
 
@@ -920,7 +989,7 @@ async fn generated_aggregate_join_distinct(database: Db) {
 
     let tables_and_sizes = [("users", 50), ("products", 50), ("orders", 50)];
     let all_tables: Vec<&str> = tables_and_sizes.iter().map(|(table, _)| *table).collect();
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
     let text_columns = columns_named(vec!["name"]);
     let join_key_columns = vec!["id", "age"];
@@ -930,7 +999,7 @@ async fn generated_aggregate_join_distinct(database: Db) {
         .map(|col| col.name)
         .collect();
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         num_tables in 2..=3usize,
         outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
         group_by_expr in arb_group_by(
@@ -954,7 +1023,7 @@ async fn generated_aggregate_join_distinct(database: Db) {
         let join_expr = {
             use proptest::strategy::ValueTree;
             use proptest::test_runner::TestRunner;
-            let mut runner = TestRunner::default();
+            let mut runner = TestRunner::new(qgen_proptest_config());
             join.new_tree(&mut runner).unwrap().current()
         };
 
@@ -976,14 +1045,14 @@ async fn generated_aggregate_join_distinct(database: Db) {
         gucs.join_custom_scan = true;
         gucs.custom_scan = true;
 
-        compare(
+        qgen_oracle!("qgen: generated_aggregate_join_distinct - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg_query,
             &bm25_query,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
             |query, conn| {
-                let rows = query.fetch_dynamic(conn);
+                let rows = query.fetch_dynamic_result(conn)?;
                 let mut string_rows: Vec<String> = rows
                     .into_iter()
                     .map(|row| {
@@ -1009,9 +1078,9 @@ async fn generated_aggregate_join_distinct(database: Db) {
                     })
                     .collect();
                 string_rows.sort();
-                string_rows
+                Ok(string_rows)
             },
-        )?;
+        ))?;
     });
 }
 
@@ -1032,7 +1101,7 @@ async fn generated_group_by_stddev(database: Db) {
     );
 
     let table_name = "users";
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 50)], COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 50)], COLUMNS);
 
     // Columns that can be used for grouping (must have fast: true in index)
     let columns: Vec<_> = COLUMNS
@@ -1043,7 +1112,7 @@ async fn generated_group_by_stddev(database: Db) {
 
     let grouping_columns: Vec<_> = columns.iter().map(|col| col.name).collect();
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         text_where_expr in arb_wheres(
             vec![table_name],
             &columns,
@@ -1081,8 +1150,9 @@ async fn generated_group_by_stddev(database: Db) {
         );
 
         // Custom result comparator that rounds f64 values to 6 decimal places
-        let compare_results = |query: &str, conn: &mut PgConnection| -> Vec<String> {
-            let rows = query.fetch_dynamic(conn);
+        let compare_results =
+            |query: &str, conn: &mut PgConnection| -> Result<Vec<String>, sqlx::Error> {
+            let rows = query.fetch_dynamic_result(conn)?;
             let mut string_rows: Vec<String> = rows
                 .into_iter()
                 .map(|row| {
@@ -1113,10 +1183,10 @@ async fn generated_group_by_stddev(database: Db) {
 
             // Sort for consistent comparison
             string_rows.sort();
-            string_rows
+            Ok(string_rows)
         };
 
-        compare(&pg_query, &bm25_query, &gucs, &mut pool.pull(), &setup_sql, compare_results)?;
+        qgen_oracle!("qgen: generated_group_by_stddev - ParadeDB result matches PostgreSQL", compare_outcome_retrying(&pg_query, &bm25_query, &gucs, &pool, &setup_sql, compare_results))?;
     });
 }
 
@@ -1141,7 +1211,7 @@ async fn generated_join_aggregates(database: Db) {
     // Two tables for join testing, small sizes to keep tests fast
     let tables_and_sizes = [("users", 30), ("products", 30)];
     let all_tables: Vec<&str> = tables_and_sizes.iter().map(|(table, _)| *table).collect();
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
     // Text columns for BM25 WHERE clauses
     let text_columns = columns_named(vec!["name"]);
@@ -1154,7 +1224,7 @@ async fn generated_join_aggregates(database: Db) {
         .map(|col| format!("{}.{}", all_tables[0], col.name))
         .collect();
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         // Outer table BM25 predicate
         outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
         // GROUP BY + aggregates
@@ -1174,7 +1244,7 @@ async fn generated_join_aggregates(database: Db) {
         let join_expr = {
             use proptest::strategy::ValueTree;
             use proptest::test_runner::TestRunner;
-            let mut runner = TestRunner::default();
+            let mut runner = TestRunner::new(qgen_proptest_config());
             join.new_tree(&mut runner).unwrap().current()
         };
 
@@ -1202,14 +1272,14 @@ async fn generated_join_aggregates(database: Db) {
         gucs.join_custom_scan = true;
         gucs.custom_scan = true;
 
-        compare(
+        qgen_oracle!("qgen: generated_join_aggregates - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg_query,
             &bm25_query,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
             |query, conn| {
-                let rows = query.fetch_dynamic(conn);
+                let rows = query.fetch_dynamic_result(conn)?;
                 let mut string_rows: Vec<String> = rows
                     .into_iter()
                     .map(|row| {
@@ -1235,9 +1305,9 @@ async fn generated_join_aggregates(database: Db) {
                     })
                     .collect();
                 string_rows.sort();
-                string_rows
+                Ok(string_rows)
             },
-        )?;
+        ))?;
     });
 }
 
@@ -1257,7 +1327,7 @@ async fn generated_numeric_pushdown(database: Db) {
 
     let table_name = "users";
     // Use more rows to get better coverage of value ranges
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 100)], COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 100)], COLUMNS);
 
     // Numeric columns for testing - includes both Numeric64 and NumericBytes storage types
     let numeric_columns = columns_named(vec![
@@ -1269,7 +1339,7 @@ async fn generated_numeric_pushdown(database: Db) {
         "age",           // INTEGER - for comparison
     ]);
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         numeric_expr in arb_numeric_expr(vec![table_name], &numeric_columns),
         gucs in any::<PgGucs>(),
     )| {
@@ -1293,18 +1363,18 @@ async fn generated_numeric_pushdown(database: Db) {
             "SELECT id FROM {table_name} WHERE {bm25_predicate} AND {where_clause} ORDER BY id"
         );
 
-        compare(
+        qgen_oracle!("qgen: generated_numeric_pushdown - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg_query,
             &bm25_query,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
             |query, conn| {
-                let mut rows = query.fetch::<(i64,)>(conn);
+                let mut rows = query.fetch_result::<(i64,)>(conn)?;
                 rows.sort();
-                rows
+                Ok(rows)
             },
-        )?;
+        ))?;
     });
 }
 
@@ -1339,7 +1409,7 @@ async fn generated_joinscan_semi_like(database: Db) {
         ("orders", 40),
         ("logs", 1000),
     ];
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
     let all_tables = vec!["users", "products", "orders", "logs"];
     let join_key_columns = vec!["id", "age", "uuid"];
@@ -1347,7 +1417,7 @@ async fn generated_joinscan_semi_like(database: Db) {
         "alice", "bob", "cloe", "sally", "brandy", "brisket", "anchovy",
     ];
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         semi_join in arb_semi_joins(all_tables.clone(), join_key_columns.clone()),
         inner_term in proptest::sample::select(search_terms.clone()),
         is_anti_join in proptest::bool::ANY,
@@ -1444,14 +1514,14 @@ async fn generated_joinscan_semi_like(database: Db) {
         for join_custom_scan in [false, true] {
             gucs.join_custom_scan = join_custom_scan;
 
-            compare(
+            qgen_oracle!("qgen: generated_joinscan_semi_like - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
                 &pg_query,
                 &bm25_query,
                 &gucs,
-                &mut pool.pull(),
+                &pool,
                 &setup_sql,
-                |query, conn| query.fetch::<(i64, String)>(conn),
-            )?;
+                |query, conn| query.fetch_result::<(i64, String)>(conn),
+            ))?;
         }
     });
 }
@@ -1495,8 +1565,7 @@ async fn generated_numeric_precision(database: Db) {
             ),
     ];
 
-    let setup_sql =
-        generated_queries_setup(&mut pool.pull(), &[(table_name, 50)], precision_columns);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 50)], precision_columns);
 
     // High-precision test values that would be indistinguishable in f64
     let precision_test_values = vec![
@@ -1507,7 +1576,7 @@ async fn generated_numeric_precision(database: Db) {
         "999999999999999999",
     ];
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         test_value in proptest::sample::select(precision_test_values),
         gucs in any::<PgGucs>(),
     )| {
@@ -1522,14 +1591,14 @@ async fn generated_numeric_precision(database: Db) {
             "SELECT COUNT(*) FROM {table_name} WHERE name @@@ 'test' AND big_int = {test_value}"
         );
 
-        compare(
+        qgen_oracle!("qgen: generated_numeric_precision - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg_query,
             &bm25_query,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
-            |query, conn| query.fetch_one::<(i64,)>(conn).0,
-        )?;
+            |query, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
+        ))?;
     });
 }
 
@@ -1564,8 +1633,7 @@ async fn generated_numeric_range_precision(database: Db) {
             .random_generator_sql("(floor(random() * 100) + 123456789012345600)::numeric(18,0)"),
     ];
 
-    let setup_sql =
-        generated_queries_setup(&mut pool.pull(), &[(table_name, 100)], precision_columns);
+    let setup_sql = generated_queries_setup(&pool, &[(table_name, 100)], precision_columns);
 
     // Range boundaries that would collide in f64
     let range_bounds = vec![
@@ -1574,7 +1642,7 @@ async fn generated_numeric_range_precision(database: Db) {
         ("123456789012345690", "123456789012345700"),
     ];
 
-    proptest!(|(
+    proptest!(qgen_proptest_config(), |(
         (low, high) in proptest::sample::select(range_bounds),
         gucs in any::<PgGucs>(),
     )| {
@@ -1589,13 +1657,13 @@ async fn generated_numeric_range_precision(database: Db) {
             "SELECT COUNT(*) FROM {table_name} WHERE name @@@ 'test' AND big_int >= {low} AND big_int < {high}"
         );
 
-        compare(
+        qgen_oracle!("qgen: generated_numeric_range_precision - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
             &pg_query,
             &bm25_query,
             &gucs,
-            &mut pool.pull(),
+            &pool,
             &setup_sql,
-            |query, conn| query.fetch_one::<(i64,)>(conn).0,
-        )?;
+            |query, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
+        ))?;
     });
 }


### PR DESCRIPTION
This PR turns the qgen differential property tests into an Antithesis workload that survives database kill, stop, and network faults.

Each generated case now runs to a real verdict. A connection-level fault retries the case instead of skipping it, so a property's example count reflects only verified comparisons. A `statement_timeout` retries under active faults and fails the case only when faults are provably paused, because thread pausing can exceed any fixed timeout.

An anytime command periodically heals all faults and bounds retries through a poke file. This asserts that the workload recovers and makes progress when the environment is healthy, which no fault schedule can fake. Schedule-shape assertions verify that these pauses alternate with chaos instead of suppressing it.

The `dst` profile now builds with `opt-level = 2`, full debug info, and debug assertions.
The optimized build lets the full suite complete within a run while staying debuggable under gdb.

This PR also changes the proptest dependency to [this branch](https://github.com/antithesishq/proptest/tree/carlsverre/push-knnzyytykmox). The branch modifies proptest to draw randomness from Antithesis, which allows Antithesis to use coverage and behavioral guidance to control query generation.

These tests found #5810 