### PR TITLE
fix: Normalize and validate AggregateScan join predicates

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -686,8 +686,7 @@ struct PathRestrictInfo {
     /// path wrapper.
     wrapped_equi_keys: Vec<JoinKeyPair>,
     /// Cross-table residuals (transformed via `build_search_filter` after
-    /// plan_positions are assigned), together with the planner inventory that
-    /// exposed each one.
+    /// plan_positions are assigned), together with their planner identity.
     search_clauses: Vec<PathSearchClause>,
     /// Number of RestrictInfo entries we couldn't classify as equi-keys or
     /// @@@ predicates. Non-zero means unhandled quals that would be silently
@@ -720,7 +719,46 @@ enum RestrictInfoOrigin {
 #[derive(Clone, Copy, Debug)]
 struct PathSearchClause {
     clause: *mut pg_sys::Node,
+    // PG15 has no planner-assigned RestrictInfo identity.
+    #[cfg(feature = "pg15")]
     origin: RestrictInfoOrigin,
+    // PG16+ uses this serial to identify quals enforced within a Path.
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    rinfo_serial: i32,
+}
+
+enum PathSearchClauseOverlap {
+    Duplicate,
+    #[cfg(feature = "pg15")]
+    Ambiguous,
+}
+
+impl PathSearchClause {
+    unsafe fn overlap(&self, other: &Self) -> Option<PathSearchClauseOverlap> {
+        if std::ptr::eq(self.clause, other.clause) {
+            return Some(PathSearchClauseOverlap::Duplicate);
+        }
+
+        #[cfg(feature = "pg15")]
+        {
+            if self.origin == other.origin
+                || !pg_sys::equal(self.clause.cast(), other.clause.cast())
+            {
+                return None;
+            }
+
+            if pg_sys::contain_volatile_functions(other.clause) {
+                Some(PathSearchClauseOverlap::Ambiguous)
+            } else {
+                Some(PathSearchClauseOverlap::Duplicate)
+            }
+        }
+
+        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+        {
+            (self.rinfo_serial == other.rinfo_serial).then_some(PathSearchClauseOverlap::Duplicate)
+        }
+    }
 }
 
 impl PathRestrictInfo {
@@ -771,7 +809,8 @@ unsafe fn classify_path_restrictinfo(
     restrictinfo: *mut pg_sys::List,
     allow_unpushed_cross_table: bool,
     equi_key_source: EquiKeySource,
-    origin: RestrictInfoOrigin,
+    #[cfg(feature = "pg15")] origin: RestrictInfoOrigin,
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))] _origin: RestrictInfoOrigin,
     sources: &[JoinAggSource],
     search_op: pg_sys::Oid,
     info: &mut PathRestrictInfo,
@@ -846,28 +885,29 @@ unsafe fn classify_path_restrictinfo(
                 all_vars_are_fast_fields_for_agg(clause, sources)
             };
             if acceptable {
-                // Deduplicate structural copies only across the overlapping
-                // joinrestrictinfo and ppi_clauses inventories. Equal clauses
-                // within one inventory may be intentional repetitions.
-                let overlap = info.search_clauses.iter().find(|existing| {
-                    std::ptr::eq(existing.clause, clause)
-                        || (existing.origin != origin
-                            && pg_sys::equal(existing.clause.cast(), clause.cast()))
-                });
+                let candidate = PathSearchClause {
+                    clause,
+                    #[cfg(feature = "pg15")]
+                    origin,
+                    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+                    rinfo_serial: (*ri).rinfo_serial,
+                };
+                let overlap = info
+                    .search_clauses
+                    .iter()
+                    .find_map(|existing| existing.overlap(&candidate));
 
-                if let Some(existing) = overlap {
-                    // Without rinfo_serial on PG15, distinct volatile copies may
-                    // be one planner predicate or two intentional calls.
-                    if !std::ptr::eq(existing.clause, clause)
-                        && pg_sys::contain_volatile_functions(clause)
-                    {
+                match overlap {
+                    Some(PathSearchClauseOverlap::Duplicate) => continue,
+                    #[cfg(feature = "pg15")]
+                    Some(PathSearchClauseOverlap::Ambiguous) => {
                         info.unhandled += 1;
+                        continue;
                     }
-                    continue;
+                    None => {}
                 }
 
-                info.search_clauses
-                    .push(PathSearchClause { clause, origin });
+                info.search_clauses.push(candidate);
                 continue;
             }
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -689,13 +689,6 @@ struct PathRestrictInfo {
     /// Cross-table @@@ clause pointers (will be transformed via
     /// `build_search_filter` after plan_positions are assigned).
     search_clauses: Vec<*mut pg_sys::Node>,
-    /// Planner identity of every residual stored in `search_clauses`.
-    ///
-    /// The same RestrictInfo can be reachable from both joinrestrictinfo and a
-    /// parameterized base path's ppi_clauses, sometimes as different node
-    /// copies. `rinfo_serial` identifies that shared planner provenance without
-    /// collapsing two intentionally repeated, structurally equal SQL clauses.
-    search_clause_serials: crate::api::HashSet<i32>,
     /// Number of RestrictInfo entries we couldn't classify as equi-keys or
     /// @@@ predicates. Non-zero means unhandled quals that would be silently
     /// dropped - the caller should reject the DataFusion path.
@@ -751,7 +744,6 @@ unsafe fn analyze_join_path_restrictinfo(
         equi_keys: Vec::new(),
         wrapped_equi_keys: Vec::new(),
         search_clauses: Vec::new(),
-        search_clause_serials: Default::default(),
         unhandled: 0,
         coverage: PathPredicateCoverage::Complete,
     };
@@ -784,6 +776,17 @@ unsafe fn classify_path_restrictinfo(
         // candidate must decline instead of serializing a partially executable
         // filter.
         if contains_extern_param(clause) {
+            info.unhandled += 1;
+            continue;
+        }
+
+        // A volatile predicate cannot be lowered into the DataFusion join at
+        // all: DataFusion evaluates it at a different point and row count than
+        // PostgreSQL would, so even a single evaluation changes the answer.
+        // Declining here also makes the residual inventory below idempotent,
+        // which is what lets it deduplicate by structure on every supported
+        // version. Matches the volatility guards in BaseScan and JoinScan.
+        if pg_sys::contain_volatile_functions(clause) {
             info.unhandled += 1;
             continue;
         }
@@ -843,12 +846,17 @@ unsafe fn classify_path_restrictinfo(
                 all_vars_are_fast_fields_for_agg(clause, sources)
             };
             if acceptable {
-                // Deduplicate overlapping planner representations by
-                // RestrictInfo identity, not expression structure. Structural
-                // equality is not sufficient for volatile expressions, where
-                // two syntactically repeated conjuncts may require two
-                // evaluations even though they look identical.
-                if info.search_clause_serials.insert((*ri).rinfo_serial) {
+                // The same predicate is reachable from both joinrestrictinfo
+                // and a parameterized path's ppi_clauses, sometimes as separate
+                // node copies, so pointer identity is not enough. Compare by
+                // structure: the volatility guard above means every residual
+                // that reaches here is idempotent, so collapsing two equal
+                // conjuncts preserves the result set.
+                if !info
+                    .search_clauses
+                    .iter()
+                    .any(|&c| pg_sys::equal(c.cast(), clause.cast()))
+                {
                     info.search_clauses.push(clause);
                 }
                 continue;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -199,11 +199,13 @@ pub unsafe fn extract_join_tree_from_parse(
 
     let mut plan = build_relnode_from_fromexpr(root, jointree, sources)?;
 
-    // Wrapper-only keys are EC-derived extras; the query tree already supplies
-    // every syntactic equality. They are injected as a set once any join level
-    // is keyless, so an already-keyed level can pick up extras too - harmless,
-    // because an EC equality holds for every row the join emits. The gate is
-    // there to keep plan shape from deciding the key set, not to target levels.
+    // Wrapper-only keys supplement the query tree, which already supplies every
+    // syntactic equality. They are injected as a set once any join level is
+    // keyless, so an already-keyed level can pick up extras - safe because each
+    // key routes to the level whose sides straddle its two RTIs and dedups
+    // there, and because these come from the chosen path's own joinrestrictinfo
+    // rather than being derived here. The gate keeps plan shape from deciding
+    // the key set; it does not target levels.
     if !path_info.equi_keys.is_empty() {
         plan.inject_equi_keys(path_info.equi_keys);
     }
@@ -715,9 +717,11 @@ enum RestrictInfoOrigin {
 #[derive(Clone, Copy, Debug)]
 struct PathSearchClause {
     clause: *mut pg_sys::Node,
-    /// Which planner list this clause was reached through. PG16+ discriminates
-    /// by `rinfo_serial` instead, but the field is tiny and keeping it
-    /// unconditional keeps one plain constructor parameter on every version.
+    /// Which planner list this clause was reached through. Only PG15 reads it,
+    /// in `overlap`; PG16+ discriminates by `rinfo_serial`. Recorded on every
+    /// version anyway so the constructor takes one plain parameter rather than
+    /// a cfg-split `origin`/`_origin` pair.
+    #[cfg_attr(not(feature = "pg15"), allow(dead_code))]
     origin: RestrictInfoOrigin,
     // PG15 has no planner-assigned RestrictInfo identity to compare.
     #[cfg(not(feature = "pg15"))]
@@ -733,14 +737,17 @@ enum PathSearchClauseOverlap {
 impl PathSearchClause {
     /// Whether `other` is the same predicate this clause already stands for.
     ///
-    /// Rests on the planner sharing one `RestrictInfo` when a predicate is
-    /// reachable at two join levels, so pointer equality identifies a genuine
-    /// re-encounter rather than a second occurrence the query asked for twice.
-    /// The shapes that would break that assumption - partitionwise child
-    /// copies - decline earlier via the opaque-path check, so they never reach
-    /// here. Two structurally equal clauses that are *not* the same
-    /// `RestrictInfo` stay distinct: repeating a volatile conjunct in SQL asks
-    /// for two independent draws.
+    /// One predicate can reach the walk twice: through a parent join's
+    /// `joinrestrictinfo` and through a child's `ppi_clauses`. Identical
+    /// pointers settle that on every version.
+    ///
+    /// PG16+ then compares `rinfo_serial`, which survives copying, so copies
+    /// and genuinely repeated conjuncts are told apart exactly. PG15 has no
+    /// such identity and uses `origin` as a proxy - different lists mean one
+    /// predicate seen twice, the same list means the query really did ask for
+    /// it twice, as a repeated volatile conjunct wants two independent draws.
+    /// That proxy assumes the planner never delivers two copies of one clause
+    /// through the same list.
     unsafe fn overlap(&self, other: &Self) -> Option<PathSearchClauseOverlap> {
         if std::ptr::eq(self.clause, other.clause) {
             return Some(PathSearchClauseOverlap::Duplicate);
@@ -915,13 +922,7 @@ unsafe fn classify_path_restrictinfo(
                     .find_map(|existing| existing.overlap(&candidate));
 
                 match overlap {
-                    Some(PathSearchClauseOverlap::Duplicate) => {
-                        pgrx::debug1!(
-                            "agg-on-join: residual already inventoried, reached again via {:?}",
-                            candidate.origin
-                        );
-                        continue;
-                    }
+                    Some(PathSearchClauseOverlap::Duplicate) => continue,
                     #[cfg(feature = "pg15")]
                     Some(PathSearchClauseOverlap::Ambiguous) => {
                         info.decline(PathPredicateDeclineReason::AmbiguousVolatileOverlap);

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -204,12 +204,9 @@ pub unsafe fn extract_join_tree_from_parse(
     // keys and cross-table @@@ search predicates (mirrors JoinScan's approach).
     let path_info = analyze_join_path_restrictinfo(input_rel, sources);
 
-    // Preserve the pre-existing behavior for directly visible JoinPaths.
-    // The retained query tree already supplies every syntactic equality. Keys
-    // discovered only after traversing a newly supported wrapper are therefore
-    // supplemental EC-derived equalities: they are needed only when the
-    // reconstructed tree has a keyless join level. Injecting them otherwise
-    // would make plan shape, rather than SQL semantics, determine the key set.
+    // Wrapper-only keys are EC-derived extras; the query tree already supplies
+    // every syntactic equality. Inject them only for a keyless join level, or
+    // plan shape rather than SQL semantics decides the key set.
     if !path_info.equi_keys.is_empty() {
         plan.inject_equi_keys(path_info.equi_keys);
     }
@@ -227,10 +224,8 @@ pub unsafe fn extract_join_tree_from_parse(
     // Handles both @@@ predicates and non-@@@ cross-table predicates
     // (like `b.id > 5`) that reference fast fields.
     //
-    // Use the selected path's normalized predicate inventory first. If it
-    // contains no residual join predicate, inspect retained FromExpr.quals for
-    // a cross-table conjunct that PostgreSQL assigned elsewhere. The earlier
-    // coverage check guarantees that an opaque path cannot reach this fallback.
+    // The earlier coverage check guarantees an opaque path cannot reach the
+    // FromExpr.quals fallback below.
     let mut join_level_predicates = Vec::new();
     let mut multi_table_predicates = Vec::new();
     let mut multi_table_clauses: Vec<*mut pg_sys::Expr> = Vec::new();
@@ -680,8 +675,7 @@ unsafe fn extract_equi_keys_from_quals(
 
 /// Result of a single walk over the cheapest path's `joinrestrictinfo`.
 struct PathRestrictInfo {
-    /// Equi-join keys from JoinPaths that were directly visible before this
-    /// change (`a.id = b.id`).
+    /// Equi-join keys from directly inspected JoinPaths (`a.id = b.id`).
     equi_keys: Vec<JoinKeyPair>,
     /// Supplemental equality keys found only after traversing a transparent
     /// path wrapper.
@@ -771,21 +765,17 @@ unsafe fn classify_path_restrictinfo(
             continue;
         }
 
-        // Generic plans retain PARAM_EXTERN nodes. Executor-side translation
-        // of DataFusion join predicates has no ParamListInfo binding, so this
-        // candidate must decline instead of serializing a partially executable
-        // filter.
+        // No ParamListInfo binding for DataFusion join predicates; see
+        // apply_search_filter_or_decline.
         if contains_extern_param(clause) {
             info.unhandled += 1;
             continue;
         }
 
-        // A volatile predicate cannot be lowered into the DataFusion join at
-        // all: DataFusion evaluates it at a different point and row count than
-        // PostgreSQL would, so even a single evaluation changes the answer.
-        // Declining here also makes the residual inventory below idempotent,
-        // which is what lets it deduplicate by structure on every supported
-        // version. Matches the volatility guards in BaseScan and JoinScan.
+        // Volatile predicates can't be lowered into the DataFusion join at all:
+        // it evaluates them at a different point and row count than PostgreSQL,
+        // so even one evaluation changes the answer. The dedup below relies on
+        // this - it compares by structure. Mirrors BaseScan and JoinScan.
         if pg_sys::contain_volatile_functions(clause) {
             info.unhandled += 1;
             continue;
@@ -846,12 +836,9 @@ unsafe fn classify_path_restrictinfo(
                 all_vars_are_fast_fields_for_agg(clause, sources)
             };
             if acceptable {
-                // The same predicate is reachable from both joinrestrictinfo
-                // and a parameterized path's ppi_clauses, sometimes as separate
-                // node copies, so pointer identity is not enough. Compare by
-                // structure: the volatility guard above means every residual
-                // that reaches here is idempotent, so collapsing two equal
-                // conjuncts preserves the result set.
+                // Reachable from both joinrestrictinfo and ppi_clauses,
+                // sometimes as separate node copies - pointer identity misses
+                // those. Structural comparison is safe given the guard above.
                 if !info
                     .search_clauses
                     .iter()
@@ -884,17 +871,14 @@ unsafe fn walk_path_restrictinfo(
     // ppi_clauses at every path node before following wrappers or children.
     let param_info = (*path).param_info;
     if !param_info.is_null() {
-        // ppi_clauses belong to parameterized base paths. PostgreSQL marks
-        // WHERE and INNER JOIN clauses is_pushed_down=true, so the conservative
-        // false below still accepts inner-join residuals. It rejects only
-        // non-degenerate outer-join ON clauses, which cannot be applied as a
-        // post-join filter without changing NULL-extension semantics.
+        // PostgreSQL marks WHERE and INNER JOIN clauses is_pushed_down=true, so
+        // the conservative `false` still accepts inner-join residuals; it
+        // rejects only outer-join ON clauses, which would change NULL-extension
+        // semantics as a post-join filter.
         //
-        // AggregateScan reconstructs explicit and implicit equality keys from
-        // the retained query tree, so ppi equality clauses are coverage-only.
-        // Recording EC-derived ppi equalities here can add transitively
-        // redundant keys to a multi-table DataFusion join.  Residual ppi
-        // clauses still pass through the normal classifier and are retained.
+        // Equality keys come from the retained query tree, so ppi equalities are
+        // coverage-only - recording them would add transitively redundant keys
+        // to a multi-table join. Residual ppi clauses are still retained.
         classify_path_restrictinfo(
             (*param_info).ppi_clauses,
             false,

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -205,10 +205,11 @@ pub unsafe fn extract_join_tree_from_parse(
     let path_info = analyze_join_path_restrictinfo(input_rel, sources);
 
     // Preserve the pre-existing behavior for directly visible JoinPaths.
-    // Equality keys discovered only after traversing a newly supported wrapper
-    // are supplemental: the retained query tree remains canonical unless it
-    // left a join without a key.  This avoids injecting redundant EC-derived
-    // equalities merely because a Gather/Projection/etc. became inspectable.
+    // The retained query tree already supplies every syntactic equality. Keys
+    // discovered only after traversing a newly supported wrapper are therefore
+    // supplemental EC-derived equalities: they are needed only when the
+    // reconstructed tree has a keyless join level. Injecting them otherwise
+    // would make plan shape, rather than SQL semantics, determine the key set.
     if !path_info.equi_keys.is_empty() {
         plan.inject_equi_keys(path_info.equi_keys);
     }
@@ -688,6 +689,13 @@ struct PathRestrictInfo {
     /// Cross-table @@@ clause pointers (will be transformed via
     /// `build_search_filter` after plan_positions are assigned).
     search_clauses: Vec<*mut pg_sys::Node>,
+    /// Planner identity of every residual stored in `search_clauses`.
+    ///
+    /// The same RestrictInfo can be reachable from both joinrestrictinfo and a
+    /// parameterized base path's ppi_clauses, sometimes as different node
+    /// copies. `rinfo_serial` identifies that shared planner provenance without
+    /// collapsing two intentionally repeated, structurally equal SQL clauses.
+    search_clause_serials: crate::api::HashSet<i32>,
     /// Number of RestrictInfo entries we couldn't classify as equi-keys or
     /// @@@ predicates. Non-zero means unhandled quals that would be silently
     /// dropped - the caller should reject the DataFusion path.
@@ -743,6 +751,7 @@ unsafe fn analyze_join_path_restrictinfo(
         equi_keys: Vec::new(),
         wrapped_equi_keys: Vec::new(),
         search_clauses: Vec::new(),
+        search_clause_serials: Default::default(),
         unhandled: 0,
         coverage: PathPredicateCoverage::Complete,
     };
@@ -770,9 +779,10 @@ unsafe fn classify_path_restrictinfo(
             continue;
         }
 
-        // Generic plans retain PARAM_EXTERN nodes. AggregateScan does not yet
-        // bind those values in its DataFusion join executor, so this candidate
-        // must decline instead of serializing a partially executable filter.
+        // Generic plans retain PARAM_EXTERN nodes. Executor-side translation
+        // of DataFusion join predicates has no ParamListInfo binding, so this
+        // candidate must decline instead of serializing a partially executable
+        // filter.
         if contains_extern_param(clause) {
             info.unhandled += 1;
             continue;
@@ -833,11 +843,12 @@ unsafe fn classify_path_restrictinfo(
                 all_vars_are_fast_fields_for_agg(clause, sources)
             };
             if acceptable {
-                if !info
-                    .search_clauses
-                    .iter()
-                    .any(|&c| pg_sys::equal(c.cast(), clause.cast()))
-                {
+                // Deduplicate overlapping planner representations by
+                // RestrictInfo identity, not expression structure. Structural
+                // equality is not sufficient for volatile expressions, where
+                // two syntactically repeated conjuncts may require two
+                // evaluations even though they look identical.
+                if info.search_clause_serials.insert((*ri).rinfo_serial) {
                     info.search_clauses.push(clause);
                 }
                 continue;
@@ -865,6 +876,12 @@ unsafe fn walk_path_restrictinfo(
     // ppi_clauses at every path node before following wrappers or children.
     let param_info = (*path).param_info;
     if !param_info.is_null() {
+        // ppi_clauses belong to parameterized base paths. PostgreSQL marks
+        // WHERE and INNER JOIN clauses is_pushed_down=true, so the conservative
+        // false below still accepts inner-join residuals. It rejects only
+        // non-degenerate outer-join ON clauses, which cannot be applied as a
+        // post-join filter without changing NULL-extension semantics.
+        //
         // AggregateScan reconstructs explicit and implicit equality keys from
         // the retained query tree, so ppi equality clauses are coverage-only.
         // Recording EC-derived ppi equalities here can add transitively
@@ -1487,8 +1504,8 @@ unsafe fn build_search_filter(
 
     for &clause in clauses {
         // If any clause can't be fully transformed, bail out.
-        // Returning None leaves the clause as "unhandled", which causes
-        // has_non_equi_join_quals to reject the DataFusion path.
+        // Returning None causes the caller to decline the DataFusion path;
+        // silently omitting any one clause would compute incorrect rows.
         let expr = transform_to_search_expr(
             root,
             clause,

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -688,10 +688,9 @@ struct PathRestrictInfo {
     /// Cross-table residuals (transformed via `build_search_filter` after
     /// plan_positions are assigned), together with their planner identity.
     search_clauses: Vec<PathSearchClause>,
-    /// Number of RestrictInfo entries we couldn't classify as equi-keys or
-    /// @@@ predicates. Non-zero means unhandled quals that would be silently
-    /// dropped - the caller should reject the DataFusion path.
-    unhandled: usize,
+    /// First reason the selected path cannot be reconstructed safely. `None`
+    /// means every inspected predicate has been accounted for.
+    decline_reason: Option<PathPredicateDeclineReason>,
     /// Whether every join-level path node was either inspected directly or
     /// traversed through a known transparent wrapper.
     coverage: PathPredicateCoverage,
@@ -762,6 +761,10 @@ impl PathSearchClause {
 }
 
 impl PathRestrictInfo {
+    fn decline(&mut self, reason: PathPredicateDeclineReason) {
+        self.decline_reason.get_or_insert(reason);
+    }
+
     fn mark_incomplete(&mut self, tag: pg_sys::NodeTag) {
         if matches!(self.coverage, PathPredicateCoverage::Complete) {
             self.coverage = PathPredicateCoverage::Incomplete(tag);
@@ -773,19 +776,26 @@ impl PathRestrictInfo {
 #[derive(Clone, Copy, Debug)]
 pub enum JoinPathPredicateCheck {
     Complete,
-    UnhandledQuals,
+    Unsupported(PathPredicateDeclineReason),
     IncompletePath(pg_sys::NodeTag),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PathPredicateDeclineReason {
+    ExternParam,
+    #[cfg(feature = "pg15")]
+    AmbiguousVolatileOverlap,
+    OuterJoinOnResidual,
+    UnclassifiedClause,
 }
 
 /// Walk `input_rel.cheapest_total_path` once, traversing transparent wrappers
 /// and classifying every `joinrestrictinfo` and `ppi_clauses` entry as an
-/// equi-join key, a cross-table predicate (@@@ or non-@@@), or unhandled.
+/// equi-join key, a supported cross-table predicate, or a specific decline.
 ///
 /// For LEFT/RIGHT JOINs, ON-clause predicates (`is_pushed_down=false`)
 /// affect matching and NULL-extension semantics - they cannot be
-/// correctly applied as post-join filters. These are counted as
-/// "unhandled", causing [`check_join_path_predicates`] to reject the
-/// DataFusion path for such queries.
+/// correctly applied as post-join filters, so the DataFusion path declines.
 unsafe fn analyze_join_path_restrictinfo(
     input_rel: &pg_sys::RelOptInfo,
     sources: &[JoinAggSource],
@@ -794,7 +804,7 @@ unsafe fn analyze_join_path_restrictinfo(
         equi_keys: Vec::new(),
         wrapped_equi_keys: Vec::new(),
         search_clauses: Vec::new(),
-        unhandled: 0,
+        decline_reason: None,
         coverage: PathPredicateCoverage::Complete,
     };
     let path = input_rel.cheapest_total_path;
@@ -826,7 +836,7 @@ unsafe fn classify_path_restrictinfo(
         // No ParamListInfo binding for DataFusion join predicates; see
         // apply_search_filter_or_decline.
         if contains_extern_param(clause) {
-            info.unhandled += 1;
+            info.decline(PathPredicateDeclineReason::ExternParam);
             continue;
         }
 
@@ -866,13 +876,12 @@ unsafe fn classify_path_restrictinfo(
         //
         // Single-table @@@ predicates (rtis.len() == 1) are already handled
         // via baserestrictinfo in build_scan_node - they don't appear here
-        // under normal planning. If one does, it's counted as unhandled
-        // (conservative: reject the path rather than risk double-applying).
+        // under normal planning. If one does, reject the path rather than risk
+        // double-applying it.
         if !allow_unpushed_cross_table && !(*ri).is_pushed_down {
             // ON-clause predicate for an outer join - can't apply as post-join
-            // filter without changing NULL-extension semantics. Count as unhandled
-            // so check_join_path_predicates rejects the DataFusion path.
-            info.unhandled += 1;
+            // filter without changing NULL-extension semantics.
+            info.decline(PathPredicateDeclineReason::OuterJoinOnResidual);
             continue;
         }
 
@@ -901,7 +910,7 @@ unsafe fn classify_path_restrictinfo(
                     Some(PathSearchClauseOverlap::Duplicate) => continue,
                     #[cfg(feature = "pg15")]
                     Some(PathSearchClauseOverlap::Ambiguous) => {
-                        info.unhandled += 1;
+                        info.decline(PathPredicateDeclineReason::AmbiguousVolatileOverlap);
                         continue;
                     }
                     None => {}
@@ -913,7 +922,7 @@ unsafe fn classify_path_restrictinfo(
         }
 
         // 3. Unhandled
-        info.unhandled += 1;
+        info.decline(PathPredicateDeclineReason::UnclassifiedClause);
     }
 }
 
@@ -1021,8 +1030,8 @@ pub unsafe fn check_join_path_predicates(
     let info = analyze_join_path_restrictinfo(input_rel, sources);
     match info.coverage {
         PathPredicateCoverage::Incomplete(tag) => JoinPathPredicateCheck::IncompletePath(tag),
-        PathPredicateCoverage::Complete if info.unhandled > 0 => {
-            JoinPathPredicateCheck::UnhandledQuals
+        PathPredicateCoverage::Complete if let Some(reason) = info.decline_reason => {
+            JoinPathPredicateCheck::Unsupported(reason)
         }
         PathPredicateCoverage::Complete => JoinPathPredicateCheck::Complete,
     }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -34,12 +34,16 @@ use crate::postgres::customscan::joinscan::build::{
     lookup_base_rel_info, try_extract_equi_key,
 };
 use crate::postgres::customscan::joinscan::planning::{
-    ClassifiedBaseRestrictInfo, classify_base_restrictinfo, wrap_with_semi_anti,
+    ClassifiedBaseRestrictInfo, classify_base_restrictinfo, transparent_path_subpath,
+    wrap_with_semi_anti,
 };
 use crate::postgres::customscan::pullup::{
     get_attno_by_name, resolve_fast_field, resolve_fast_field_by_name,
 };
-use crate::postgres::customscan::qual_inspect::{PlannerContext, QualExtractState, extract_quals};
+use crate::postgres::customscan::qual_inspect::{
+    PlannerContext, QualExtractState, collect_implicit_and_conjuncts, contains_extern_param,
+    extract_quals,
+};
 use crate::postgres::customscan::range_table::bms_iter;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::utils::{
@@ -171,12 +175,11 @@ pub unsafe fn collect_join_agg_sources(
 ///
 /// 2. **Cheapest path** (`input_rel.cheapest_total_path`): provides the equi-join
 ///    **keys** (e.g., `a.id = b.id`). By the time we reach `UPPERREL_GROUP_AGG`,
-///    the planner has absorbed WHERE-clause quals into `RestrictInfo` lists on
-///    the planned `JoinPath` nodes - so `(*from).quals` can be null even for
-///    `SELECT ... FROM a, b WHERE a.id = b.id`. We recursively walk the path
-///    tree via `extract_equi_keys_from_path`, inspecting each `JoinPath`'s
-///    `joinrestrictinfo` for `OpExpr` nodes with merge-joinable (equality)
-///    operators whose two sides reference different base relations.
+///    the planner has distributed quals into `RestrictInfo` lists on the
+///    selected path. We recursively walk that path via
+///    [`analyze_join_path_restrictinfo`], traversing only known transparent
+///    wrappers and inspecting both `JoinPath.joinrestrictinfo` and
+///    `ParamPathInfo.ppi_clauses`.
 ///
 /// The parse tree gives the skeleton, the path gives the keys, and
 /// [`RelNode::inject_equi_keys`] attaches the keys to the correct join levels.
@@ -201,8 +204,16 @@ pub unsafe fn extract_join_tree_from_parse(
     // keys and cross-table @@@ search predicates (mirrors JoinScan's approach).
     let path_info = analyze_join_path_restrictinfo(input_rel, sources);
 
+    // Preserve the pre-existing behavior for directly visible JoinPaths.
+    // Equality keys discovered only after traversing a newly supported wrapper
+    // are supplemental: the retained query tree remains canonical unless it
+    // left a join without a key.  This avoids injecting redundant EC-derived
+    // equalities merely because a Gather/Projection/etc. became inspectable.
     if !path_info.equi_keys.is_empty() {
         plan.inject_equi_keys(path_info.equi_keys);
+    }
+    if plan.has_join_without_keys() && !path_info.wrapped_equi_keys.is_empty() {
+        plan.inject_equi_keys(path_info.wrapped_equi_keys);
     }
 
     // Fix plan_positions (they default to 0 from JoinSourceCandidate)
@@ -215,10 +226,10 @@ pub unsafe fn extract_join_tree_from_parse(
     // Handles both @@@ predicates and non-@@@ cross-table predicates
     // (like `b.id > 5`) that reference fast fields.
     //
-    // Try path-based extraction first, then fall back to the parse tree's
-    // FromExpr.quals. The path walk can miss predicates when the cheapest
-    // path isn't a standard join type (e.g. with certain GUC combinations),
-    // while the parse tree is always available.
+    // Use the selected path's normalized predicate inventory first. If it
+    // contains no residual join predicate, inspect retained FromExpr.quals for
+    // a cross-table conjunct that PostgreSQL assigned elsewhere. The earlier
+    // coverage check guarantees that an opaque path cannot reach this fallback.
     let mut join_level_predicates = Vec::new();
     let mut multi_table_predicates = Vec::new();
     let mut multi_table_clauses: Vec<*mut pg_sys::Expr> = Vec::new();
@@ -289,6 +300,17 @@ unsafe fn apply_search_filter_or_decline(
     if clauses.is_empty() {
         return Ok(());
     }
+
+    // Custom prepared plans substitute Const nodes before this hook. Generic
+    // plans retain PARAM_EXTERN nodes, but the DataFusion aggregate-on-join
+    // executor has no runtime binding contract for these expressions. Preserve
+    // supported PARAM_EXEC paths by rejecting only PARAM_EXTERN here.
+    if clauses.iter().any(|&clause| contains_extern_param(clause)) {
+        return Err(
+            "generic prepared-plan parameters are not supported for aggregate joins".into(),
+        );
+    }
+
     let Some((filter_expr, predicates, mt_predicates, mt_clauses)) =
         build_search_filter(root, clauses, sources, plan)
     else {
@@ -657,8 +679,12 @@ unsafe fn extract_equi_keys_from_quals(
 
 /// Result of a single walk over the cheapest path's `joinrestrictinfo`.
 struct PathRestrictInfo {
-    /// Equi-join keys (`a.id = b.id`).
+    /// Equi-join keys from JoinPaths that were directly visible before this
+    /// change (`a.id = b.id`).
     equi_keys: Vec<JoinKeyPair>,
+    /// Supplemental equality keys found only after traversing a transparent
+    /// path wrapper.
+    wrapped_equi_keys: Vec<JoinKeyPair>,
     /// Cross-table @@@ clause pointers (will be transformed via
     /// `build_search_filter` after plan_positions are assigned).
     search_clauses: Vec<*mut pg_sys::Node>,
@@ -666,16 +692,48 @@ struct PathRestrictInfo {
     /// @@@ predicates. Non-zero means unhandled quals that would be silently
     /// dropped - the caller should reject the DataFusion path.
     unhandled: usize,
+    /// Whether every join-level path node was either inspected directly or
+    /// traversed through a known transparent wrapper.
+    coverage: PathPredicateCoverage,
 }
 
-/// Walk `input_rel.cheapest_total_path` once, classifying every
-/// `joinrestrictinfo` entry as an equi-join key, a cross-table
-/// predicate (@@@ or non-@@@), or unhandled.
+#[derive(Clone, Copy, Debug)]
+enum PathPredicateCoverage {
+    Complete,
+    Incomplete(pg_sys::NodeTag),
+}
+
+#[derive(Clone, Copy, Debug)]
+enum EquiKeySource {
+    Ignore,
+    Direct,
+    BehindWrapper,
+}
+
+impl PathRestrictInfo {
+    fn mark_incomplete(&mut self, tag: pg_sys::NodeTag) {
+        if matches!(self.coverage, PathPredicateCoverage::Complete) {
+            self.coverage = PathPredicateCoverage::Incomplete(tag);
+        }
+    }
+}
+
+/// Result of validating the selected lower path's join-predicate inventory.
+#[derive(Clone, Copy, Debug)]
+pub enum JoinPathPredicateCheck {
+    Complete,
+    UnhandledQuals,
+    IncompletePath(pg_sys::NodeTag),
+}
+
+/// Walk `input_rel.cheapest_total_path` once, traversing transparent wrappers
+/// and classifying every `joinrestrictinfo` and `ppi_clauses` entry as an
+/// equi-join key, a cross-table predicate (@@@ or non-@@@), or unhandled.
 ///
 /// For LEFT/RIGHT JOINs, ON-clause predicates (`is_pushed_down=false`)
 /// affect matching and NULL-extension semantics - they cannot be
 /// correctly applied as post-join filters. These are counted as
-/// "unhandled", causing `has_non_equi_join_quals` to reject the
+/// "unhandled", causing [`check_join_path_predicates`] to reject the
 /// DataFusion path for such queries.
 unsafe fn analyze_join_path_restrictinfo(
     input_rel: &pg_sys::RelOptInfo,
@@ -683,44 +741,28 @@ unsafe fn analyze_join_path_restrictinfo(
 ) -> PathRestrictInfo {
     let mut info = PathRestrictInfo {
         equi_keys: Vec::new(),
+        wrapped_equi_keys: Vec::new(),
         search_clauses: Vec::new(),
         unhandled: 0,
+        coverage: PathPredicateCoverage::Complete,
     };
     let path = input_rel.cheapest_total_path;
     if !path.is_null() {
         let search_op = anyelement_query_input_opoid();
-        walk_path_restrictinfo(path, sources, search_op, &mut info);
+        walk_path_restrictinfo(path, false, sources, search_op, &mut info);
     }
     info
 }
 
-unsafe fn walk_path_restrictinfo(
-    path: *mut pg_sys::Path,
+unsafe fn classify_path_restrictinfo(
+    restrictinfo: *mut pg_sys::List,
+    allow_unpushed_cross_table: bool,
+    equi_key_source: EquiKeySource,
     sources: &[JoinAggSource],
     search_op: pg_sys::Oid,
     info: &mut PathRestrictInfo,
 ) {
-    if path.is_null() {
-        return;
-    }
-    let tag = (*path).type_;
-    let is_join_path = matches!(
-        tag,
-        pg_sys::NodeTag::T_NestPath | pg_sys::NodeTag::T_MergePath | pg_sys::NodeTag::T_HashPath
-    );
-    if !is_join_path {
-        return;
-    }
-
-    let join_path = path as *mut pg_sys::JoinPath;
-    let restrict_list = PgList::<pg_sys::RestrictInfo>::from_pg((*join_path).joinrestrictinfo);
-
-    // For outer joins (LEFT/RIGHT), ON-clause predicates affect matching
-    // and NULL-extension - they must NOT be applied as post-join filters.
-    // PostgreSQL marks ON-clause restrictions with is_pushed_down=false
-    // and a non-null outer_relids. We only accept cross-table predicates
-    // that are pushed down (WHERE-clause) for non-inner joins.
-    let is_inner = (*join_path).jointype == pg_sys::JoinType::JOIN_INNER;
+    let restrict_list = PgList::<pg_sys::RestrictInfo>::from_pg(restrictinfo);
 
     for ri in restrict_list.iter_ptr() {
         let clause = (*ri).clause as *mut pg_sys::Node;
@@ -728,22 +770,37 @@ unsafe fn walk_path_restrictinfo(
             continue;
         }
 
+        // Generic plans retain PARAM_EXTERN nodes. AggregateScan does not yet
+        // bind those values in its DataFusion join executor, so this candidate
+        // must decline instead of serializing a partially executable filter.
+        if contains_extern_param(clause) {
+            info.unhandled += 1;
+            continue;
+        }
+
         // 1. Equi-join key?
         if (*clause).type_ == pg_sys::NodeTag::T_OpExpr
             && let Some(key) = try_extract_one_equi_key(clause as *mut pg_sys::OpExpr, sources)
         {
-            let dup = info.equi_keys.iter().any(|k| {
-                (k.outer_rti == key.outer_rti
-                    && k.outer_attno == key.outer_attno
-                    && k.inner_rti == key.inner_rti
-                    && k.inner_attno == key.inner_attno)
-                    || (k.outer_rti == key.inner_rti
-                        && k.outer_attno == key.inner_attno
-                        && k.inner_rti == key.outer_rti
-                        && k.inner_attno == key.outer_attno)
-            });
-            if !dup {
-                info.equi_keys.push(key);
+            let destination = match equi_key_source {
+                EquiKeySource::Ignore => None,
+                EquiKeySource::Direct => Some(&mut info.equi_keys),
+                EquiKeySource::BehindWrapper => Some(&mut info.wrapped_equi_keys),
+            };
+            if let Some(destination) = destination {
+                let dup = destination.iter().any(|k| {
+                    (k.outer_rti == key.outer_rti
+                        && k.outer_attno == key.outer_attno
+                        && k.inner_rti == key.inner_rti
+                        && k.inner_attno == key.inner_attno)
+                        || (k.outer_rti == key.inner_rti
+                            && k.outer_attno == key.inner_attno
+                            && k.inner_rti == key.outer_rti
+                            && k.inner_attno == key.outer_attno)
+                });
+                if !dup {
+                    destination.push(key);
+                }
             }
             continue;
         }
@@ -759,10 +816,10 @@ unsafe fn walk_path_restrictinfo(
         // via baserestrictinfo in build_scan_node - they don't appear here
         // under normal planning. If one does, it's counted as unhandled
         // (conservative: reject the path rather than risk double-applying).
-        if !is_inner && !(*ri).is_pushed_down {
+        if !allow_unpushed_cross_table && !(*ri).is_pushed_down {
             // ON-clause predicate for an outer join - can't apply as post-join
             // filter without changing NULL-extension semantics. Count as unhandled
-            // so has_non_equi_join_quals rejects the DataFusion path.
+            // so check_join_path_predicates rejects the DataFusion path.
             info.unhandled += 1;
             continue;
         }
@@ -776,7 +833,11 @@ unsafe fn walk_path_restrictinfo(
                 all_vars_are_fast_fields_for_agg(clause, sources)
             };
             if acceptable {
-                if !info.search_clauses.iter().any(|&c| std::ptr::eq(c, clause)) {
+                if !info
+                    .search_clauses
+                    .iter()
+                    .any(|&c| pg_sys::equal(c.cast(), clause.cast()))
+                {
                     info.search_clauses.push(clause);
                 }
                 continue;
@@ -786,17 +847,112 @@ unsafe fn walk_path_restrictinfo(
         // 3. Unhandled
         info.unhandled += 1;
     }
-
-    walk_path_restrictinfo((*join_path).outerjoinpath, sources, search_op, info);
-    walk_path_restrictinfo((*join_path).innerjoinpath, sources, search_op, info);
 }
 
-/// Check whether the join path has quals we can't handle.
-pub unsafe fn has_non_equi_join_quals(
+unsafe fn walk_path_restrictinfo(
+    path: *mut pg_sys::Path,
+    behind_transparent_wrapper: bool,
+    sources: &[JoinAggSource],
+    search_op: pg_sys::Oid,
+    info: &mut PathRestrictInfo,
+) {
+    if path.is_null() {
+        return;
+    }
+
+    // Parameterized nested-loop clauses can be removed from the parent
+    // JoinPath.joinrestrictinfo once the inner path enforces them. Inventory
+    // ppi_clauses at every path node before following wrappers or children.
+    let param_info = (*path).param_info;
+    if !param_info.is_null() {
+        // AggregateScan reconstructs explicit and implicit equality keys from
+        // the retained query tree, so ppi equality clauses are coverage-only.
+        // Recording EC-derived ppi equalities here can add transitively
+        // redundant keys to a multi-table DataFusion join.  Residual ppi
+        // clauses still pass through the normal classifier and are retained.
+        classify_path_restrictinfo(
+            (*param_info).ppi_clauses,
+            false,
+            EquiKeySource::Ignore,
+            sources,
+            search_op,
+            info,
+        );
+    }
+
+    if let Some(subpath) = transparent_path_subpath(path) {
+        if subpath.is_null() || subpath == path {
+            info.mark_incomplete((*path).type_);
+            return;
+        }
+        walk_path_restrictinfo(subpath, true, sources, search_op, info);
+        return;
+    }
+
+    let tag = (*path).type_;
+    let is_join_path = matches!(
+        tag,
+        pg_sys::NodeTag::T_NestPath | pg_sys::NodeTag::T_MergePath | pg_sys::NodeTag::T_HashPath
+    );
+    if !is_join_path {
+        // Base-relation paths are leaves for this inventory; their predicates
+        // are covered separately by baserestrictinfo. A non-transparent path
+        // over a join relation is opaque and cannot be reconstructed safely.
+        let parent = (*path).parent;
+        if !parent.is_null() && pg_sys::bms_num_members((*parent).relids) > 1 {
+            info.mark_incomplete(tag);
+        }
+        return;
+    }
+
+    let join_path = path as *mut pg_sys::JoinPath;
+
+    // For outer joins, ON-clause residuals affect matching and NULL-extension;
+    // only inner joins may lower an unpushed residual as a post-join filter.
+    let allow_unpushed_cross_table = (*join_path).jointype == pg_sys::JoinType::JOIN_INNER;
+    classify_path_restrictinfo(
+        (*join_path).joinrestrictinfo,
+        allow_unpushed_cross_table,
+        if behind_transparent_wrapper {
+            EquiKeySource::BehindWrapper
+        } else {
+            EquiKeySource::Direct
+        },
+        sources,
+        search_op,
+        info,
+    );
+
+    walk_path_restrictinfo(
+        (*join_path).outerjoinpath,
+        behind_transparent_wrapper,
+        sources,
+        search_op,
+        info,
+    );
+    walk_path_restrictinfo(
+        (*join_path).innerjoinpath,
+        behind_transparent_wrapper,
+        sources,
+        search_op,
+        info,
+    );
+}
+
+/// Validate that the selected lower path has complete, supported
+/// join-predicate coverage.
+pub unsafe fn check_join_path_predicates(
     input_rel: &pg_sys::RelOptInfo,
     sources: &[JoinAggSource],
-) -> bool {
-    analyze_join_path_restrictinfo(input_rel, sources).unhandled > 0
+) -> JoinPathPredicateCheck {
+    let info = analyze_join_path_restrictinfo(input_rel, sources);
+    match info.coverage {
+        PathPredicateCoverage::Incomplete(tag) => JoinPathPredicateCheck::IncompletePath(tag),
+        PathPredicateCoverage::Complete if info.unhandled > 0 => {
+            JoinPathPredicateCheck::UnhandledQuals
+        }
+        PathPredicateCoverage::Complete => JoinPathPredicateCheck::Complete,
+    }
 }
 
 /// Build-phase context for translating PG expression trees to [`FilterExpr`].
@@ -1368,24 +1524,16 @@ unsafe fn collect_cross_table_search_quals(
     node: *mut pg_sys::Node,
     clauses: &mut Vec<*mut pg_sys::Node>,
 ) {
-    if node.is_null() {
-        return;
-    }
-    // Flatten top-level ANDs
-    if (*node).type_ == pg_sys::NodeTag::T_BoolExpr {
-        let boolexpr = node as *mut pg_sys::BoolExpr;
-        if (*boolexpr).boolop == pg_sys::BoolExprType::AND_EXPR {
-            let args = PgList::<pg_sys::Node>::from_pg((*boolexpr).args);
-            for arg in args.iter_ptr() {
-                collect_cross_table_search_quals(arg, clauses);
-            }
-            return;
+    let mut conjuncts = Vec::new();
+    collect_implicit_and_conjuncts(node, &mut conjuncts);
+
+    for conjunct in conjuncts {
+        // Keep cross-table conjuncts (both @@@ and non-@@@). Single-table
+        // conjuncts are already owned by the corresponding baserestrictinfo.
+        let rtis = expr_collect_rtis(conjunct);
+        if rtis.len() > 1 {
+            clauses.push(conjunct);
         }
-    }
-    // Keep cross-table conjuncts (both @@@ and non-@@@)
-    let rtis = expr_collect_rtis(node);
-    if rtis.len() > 1 {
-        clauses.push(node);
     }
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -173,20 +173,19 @@ pub unsafe fn collect_join_agg_sources(
 ///    comma-separated `FROM`, and the join type (INNER, LEFT, etc.). This is
 ///    walked via [`build_relnode_from_fromexpr`] to produce the `RelNode` skeleton.
 ///
-/// 2. **Cheapest path** (`input_rel.cheapest_total_path`): provides the equi-join
-///    **keys** (e.g., `a.id = b.id`). By the time we reach `UPPERREL_GROUP_AGG`,
-///    the planner has distributed quals into `RestrictInfo` lists on the
-///    selected path. We recursively walk that path via
-///    [`analyze_join_path_restrictinfo`], traversing only known transparent
-///    wrappers and inspecting both `JoinPath.joinrestrictinfo` and
-///    `ParamPathInfo.ppi_clauses`.
+/// 2. **Selected path** (`path_info`): provides the equi-join **keys** (e.g.,
+///    `a.id = b.id`). By the time we reach `UPPERREL_GROUP_AGG`, the planner has
+///    distributed quals into `RestrictInfo` lists on the selected path. That
+///    walk happens in [`check_join_path_predicates`], which hands its result
+///    here so the classification eligibility was decided on is the one the plan
+///    is built from.
 ///
 /// The parse tree gives the skeleton, the path gives the keys, and
 /// [`RelNode::inject_equi_keys`] attaches the keys to the correct join levels.
 pub unsafe fn extract_join_tree_from_parse(
     root: *mut pg_sys::PlannerInfo,
     sources: &[JoinAggSource],
-    input_rel: &pg_sys::RelOptInfo,
+    path_info: PathRestrictInfo,
 ) -> Result<JoinTreeResult, String> {
     let parse = (*root).parse;
     if parse.is_null() {
@@ -200,13 +199,11 @@ pub unsafe fn extract_join_tree_from_parse(
 
     let mut plan = build_relnode_from_fromexpr(root, jointree, sources)?;
 
-    // Walk the cheapest path's joinrestrictinfo once to extract both equi-join
-    // keys and cross-table @@@ search predicates (mirrors JoinScan's approach).
-    let path_info = analyze_join_path_restrictinfo(input_rel, sources);
-
     // Wrapper-only keys are EC-derived extras; the query tree already supplies
-    // every syntactic equality. Inject them only for a keyless join level, or
-    // plan shape rather than SQL semantics decides the key set.
+    // every syntactic equality. They are injected as a set once any join level
+    // is keyless, so an already-keyed level can pick up extras too - harmless,
+    // because an EC equality holds for every row the join emits. The gate is
+    // there to keep plan shape from deciding the key set, not to target levels.
     if !path_info.equi_keys.is_empty() {
         plan.inject_equi_keys(path_info.equi_keys);
     }
@@ -679,7 +676,7 @@ unsafe fn extract_equi_keys_from_quals(
 }
 
 /// Result of a single walk over the cheapest path's `joinrestrictinfo`.
-struct PathRestrictInfo {
+pub(crate) struct PathRestrictInfo {
     /// Equi-join keys from directly inspected JoinPaths (`a.id = b.id`).
     equi_keys: Vec<JoinKeyPair>,
     /// Supplemental equality keys found only after traversing a transparent
@@ -718,11 +715,12 @@ enum RestrictInfoOrigin {
 #[derive(Clone, Copy, Debug)]
 struct PathSearchClause {
     clause: *mut pg_sys::Node,
-    // PG15 has no planner-assigned RestrictInfo identity.
-    #[cfg(feature = "pg15")]
+    /// Which planner list this clause was reached through. PG16+ discriminates
+    /// by `rinfo_serial` instead, but the field is tiny and keeping it
+    /// unconditional keeps one plain constructor parameter on every version.
     origin: RestrictInfoOrigin,
-    // PG16+ uses this serial to identify quals enforced within a Path.
-    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    // PG15 has no planner-assigned RestrictInfo identity to compare.
+    #[cfg(not(feature = "pg15"))]
     rinfo_serial: i32,
 }
 
@@ -733,6 +731,16 @@ enum PathSearchClauseOverlap {
 }
 
 impl PathSearchClause {
+    /// Whether `other` is the same predicate this clause already stands for.
+    ///
+    /// Rests on the planner sharing one `RestrictInfo` when a predicate is
+    /// reachable at two join levels, so pointer equality identifies a genuine
+    /// re-encounter rather than a second occurrence the query asked for twice.
+    /// The shapes that would break that assumption - partitionwise child
+    /// copies - decline earlier via the opaque-path check, so they never reach
+    /// here. Two structurally equal clauses that are *not* the same
+    /// `RestrictInfo` stay distinct: repeating a volatile conjunct in SQL asks
+    /// for two independent draws.
     unsafe fn overlap(&self, other: &Self) -> Option<PathSearchClauseOverlap> {
         if std::ptr::eq(self.clause, other.clause) {
             return Some(PathSearchClauseOverlap::Duplicate);
@@ -753,7 +761,7 @@ impl PathSearchClause {
             }
         }
 
-        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+        #[cfg(not(feature = "pg15"))]
         {
             (self.rinfo_serial == other.rinfo_serial).then_some(PathSearchClauseOverlap::Duplicate)
         }
@@ -773,9 +781,11 @@ impl PathRestrictInfo {
 }
 
 /// Result of validating the selected lower path's join-predicate inventory.
-#[derive(Clone, Copy, Debug)]
 pub enum JoinPathPredicateCheck {
-    Complete,
+    /// Carries the walk that proved coverage. `extract_join_tree_from_parse`
+    /// consumes it rather than re-walking, so the classification the decision
+    /// was made on is the one the plan is built from.
+    Complete(PathRestrictInfo),
     Unsupported(PathPredicateDeclineReason),
     IncompletePath(pg_sys::NodeTag),
 }
@@ -819,8 +829,7 @@ unsafe fn classify_path_restrictinfo(
     restrictinfo: *mut pg_sys::List,
     allow_unpushed_cross_table: bool,
     equi_key_source: EquiKeySource,
-    #[cfg(feature = "pg15")] origin: RestrictInfoOrigin,
-    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))] _origin: RestrictInfoOrigin,
+    origin: RestrictInfoOrigin,
     sources: &[JoinAggSource],
     search_op: pg_sys::Oid,
     info: &mut PathRestrictInfo,
@@ -896,9 +905,8 @@ unsafe fn classify_path_restrictinfo(
             if acceptable {
                 let candidate = PathSearchClause {
                     clause,
-                    #[cfg(feature = "pg15")]
                     origin,
-                    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+                    #[cfg(not(feature = "pg15"))]
                     rinfo_serial: (*ri).rinfo_serial,
                 };
                 let overlap = info
@@ -907,7 +915,13 @@ unsafe fn classify_path_restrictinfo(
                     .find_map(|existing| existing.overlap(&candidate));
 
                 match overlap {
-                    Some(PathSearchClauseOverlap::Duplicate) => continue,
+                    Some(PathSearchClauseOverlap::Duplicate) => {
+                        pgrx::debug1!(
+                            "agg-on-join: residual already inventoried, reached again via {:?}",
+                            candidate.origin
+                        );
+                        continue;
+                    }
                     #[cfg(feature = "pg15")]
                     Some(PathSearchClauseOverlap::Ambiguous) => {
                         info.decline(PathPredicateDeclineReason::AmbiguousVolatileOverlap);
@@ -1033,7 +1047,7 @@ pub unsafe fn check_join_path_predicates(
         PathPredicateCoverage::Complete if let Some(reason) = info.decline_reason => {
             JoinPathPredicateCheck::Unsupported(reason)
         }
-        PathPredicateCoverage::Complete => JoinPathPredicateCheck::Complete,
+        PathPredicateCoverage::Complete => JoinPathPredicateCheck::Complete(info),
     }
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -235,10 +235,15 @@ pub unsafe fn extract_join_tree_from_parse(
     // is a fallback that only runs when Path 1 produced no predicates.
 
     // 1. Path-based: predicates classified by `walk_path_restrictinfo`.
+    let path_search_clauses: Vec<_> = path_info
+        .search_clauses
+        .iter()
+        .map(|search_clause| search_clause.clause)
+        .collect();
     apply_search_filter_or_decline(
         root,
         sources,
-        &path_info.search_clauses,
+        &path_search_clauses,
         "path joinrestrictinfo",
         "cross-table predicate cannot be pushed into the aggregate scan",
         &mut plan,
@@ -680,9 +685,10 @@ struct PathRestrictInfo {
     /// Supplemental equality keys found only after traversing a transparent
     /// path wrapper.
     wrapped_equi_keys: Vec<JoinKeyPair>,
-    /// Cross-table @@@ clause pointers (will be transformed via
-    /// `build_search_filter` after plan_positions are assigned).
-    search_clauses: Vec<*mut pg_sys::Node>,
+    /// Cross-table residuals (transformed via `build_search_filter` after
+    /// plan_positions are assigned), together with the planner inventory that
+    /// exposed each one.
+    search_clauses: Vec<PathSearchClause>,
     /// Number of RestrictInfo entries we couldn't classify as equi-keys or
     /// @@@ predicates. Non-zero means unhandled quals that would be silently
     /// dropped - the caller should reject the DataFusion path.
@@ -703,6 +709,18 @@ enum EquiKeySource {
     Ignore,
     Direct,
     BehindWrapper,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RestrictInfoOrigin {
+    JoinRestrictInfo,
+    ParamPathInfo,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PathSearchClause {
+    clause: *mut pg_sys::Node,
+    origin: RestrictInfoOrigin,
 }
 
 impl PathRestrictInfo {
@@ -753,6 +771,7 @@ unsafe fn classify_path_restrictinfo(
     restrictinfo: *mut pg_sys::List,
     allow_unpushed_cross_table: bool,
     equi_key_source: EquiKeySource,
+    origin: RestrictInfoOrigin,
     sources: &[JoinAggSource],
     search_op: pg_sys::Oid,
     info: &mut PathRestrictInfo,
@@ -768,15 +787,6 @@ unsafe fn classify_path_restrictinfo(
         // No ParamListInfo binding for DataFusion join predicates; see
         // apply_search_filter_or_decline.
         if contains_extern_param(clause) {
-            info.unhandled += 1;
-            continue;
-        }
-
-        // Volatile predicates can't be lowered into the DataFusion join at all:
-        // it evaluates them at a different point and row count than PostgreSQL,
-        // so even one evaluation changes the answer. The dedup below relies on
-        // this - it compares by structure. Mirrors BaseScan and JoinScan.
-        if pg_sys::contain_volatile_functions(clause) {
             info.unhandled += 1;
             continue;
         }
@@ -836,16 +846,28 @@ unsafe fn classify_path_restrictinfo(
                 all_vars_are_fast_fields_for_agg(clause, sources)
             };
             if acceptable {
-                // Reachable from both joinrestrictinfo and ppi_clauses,
-                // sometimes as separate node copies - pointer identity misses
-                // those. Structural comparison is safe given the guard above.
-                if !info
-                    .search_clauses
-                    .iter()
-                    .any(|&c| pg_sys::equal(c.cast(), clause.cast()))
-                {
-                    info.search_clauses.push(clause);
+                // Deduplicate structural copies only across the overlapping
+                // joinrestrictinfo and ppi_clauses inventories. Equal clauses
+                // within one inventory may be intentional repetitions.
+                let overlap = info.search_clauses.iter().find(|existing| {
+                    std::ptr::eq(existing.clause, clause)
+                        || (existing.origin != origin
+                            && pg_sys::equal(existing.clause.cast(), clause.cast()))
+                });
+
+                if let Some(existing) = overlap {
+                    // Without rinfo_serial on PG15, distinct volatile copies may
+                    // be one planner predicate or two intentional calls.
+                    if !std::ptr::eq(existing.clause, clause)
+                        && pg_sys::contain_volatile_functions(clause)
+                    {
+                        info.unhandled += 1;
+                    }
+                    continue;
                 }
+
+                info.search_clauses
+                    .push(PathSearchClause { clause, origin });
                 continue;
             }
         }
@@ -883,6 +905,7 @@ unsafe fn walk_path_restrictinfo(
             (*param_info).ppi_clauses,
             false,
             EquiKeySource::Ignore,
+            RestrictInfoOrigin::ParamPathInfo,
             sources,
             search_op,
             info,
@@ -927,6 +950,7 @@ unsafe fn walk_path_restrictinfo(
         } else {
             EquiKeySource::Direct
         },
+        RestrictInfoOrigin::JoinRestrictInfo,
         sources,
         search_op,
         info,

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -532,6 +532,32 @@ async fn build_source_df(
 ) -> Result<DataFrame> {
     let scan_info = source.scan_info.clone();
 
+    // Each source that solves runtime PostgreSQL expressions needs its own
+    // per-tuple memory context. SearchQueryInput::solve_postgres_expressions()
+    // resets that context before replacing Param/PostgresExpression nodes. If
+    // two providers share one context, solving the second source invalidates
+    // the Const/expression nodes retained by the first source. Generic plans
+    // that parameterize predicates on both join inputs then dereference stale
+    // nodes during reader construction and abort the backend.
+    let mut source_query = scan_info.query.clone();
+    let needs_runtime_context =
+        source_query.has_postgres_expressions() || source_query.has_parameters();
+    let source_expr_context = if needs_runtime_context {
+        unsafe {
+            planstate
+                .and_then(|planstate| {
+                    if planstate.is_null() || (*planstate).state.is_null() {
+                        None
+                    } else {
+                        Some(pg_sys::CreateExprContext((*planstate).state))
+                    }
+                })
+                .or(expr_context)
+        }
+    } else {
+        expr_context
+    };
+
     let alias = RelationAlias::new(scan_info.alias.as_deref()).execution(plan_position);
 
     // Use all fast fields from the source (the provider exposes them to DataFusion).
@@ -568,7 +594,7 @@ async fn build_source_df(
     // `init_postgres_expressions` / `solve_postgres_expressions` only
     // when needed, so threading them through here is what makes the
     // agg-on-join path match JoinScan and Base Scan.
-    provider.set_expr_context(expr_context);
+    provider.set_expr_context(source_expr_context);
     provider.set_planstate(planstate);
     let df = register_source_table(ctx, alias.as_str(), provider).await?;
 

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -542,6 +542,12 @@ async fn build_source_df(
     let mut source_query = scan_info.query.clone();
     let needs_runtime_context =
         source_query.has_postgres_expressions() || source_query.has_parameters();
+    // The `.or(expr_context)` fallback hands every source the same context, but
+    // only the EXPLAIN-only rebuild reaches it (`mod.rs` passes `planstate:
+    // None` there). That is safe because nothing solves without a planstate:
+    // `PgSearchTableProvider::scan()` returns "postgres expressions have not
+    // been solved: missing planstate" before calling
+    // `solve_postgres_expressions`, so the shared context is never reset.
     let source_expr_context = if needs_runtime_context {
         unsafe {
             planstate

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -542,12 +542,13 @@ async fn build_source_df(
     let mut source_query = scan_info.query.clone();
     let needs_runtime_context =
         source_query.has_postgres_expressions() || source_query.has_parameters();
-    // The `.or(expr_context)` fallback hands every source the same context, but
-    // only the EXPLAIN-only rebuild reaches it (`mod.rs` passes `planstate:
-    // None` there). That is safe because nothing solves without a planstate:
-    // `PgSearchTableProvider::scan()` returns "postgres expressions have not
-    // been solved: missing planstate" before calling
+    // `.or(expr_context)` can hand every source the same context, but only the
+    // EXPLAIN-only rebuild both reaches it and goes on to physical planning.
+    // There it is safe: `PgSearchTableProvider::scan()` returns "postgres
+    // expressions have not been solved: missing planstate" before it would call
     // `solve_postgres_expressions`, so the shared context is never reset.
+    // `stash_mpp_plan_bytes` also passes `planstate: None`, but stops at the
+    // logical plan, so `scan()` never runs there.
     let source_expr_context = if needs_runtime_context {
         unsafe {
             planstate

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -333,13 +333,18 @@ pub unsafe fn extract_aggregate_targetlist(
             let filter = if (*aggref).aggfilter.is_null() {
                 None
             } else {
-                FilterExpr::from_pg_node(
-                    (*aggref).aggfilter as *mut pg_sys::Node,
-                    &FilterExprBuildContext::Filter {
-                        sources,
-                        plan,
-                        outer_root_id,
-                    },
+                Some(
+                    FilterExpr::from_pg_node(
+                        (*aggref).aggfilter as *mut pg_sys::Node,
+                        &FilterExprBuildContext::Filter {
+                            sources,
+                            plan,
+                            outer_root_id,
+                        },
+                    )
+                    .ok_or_else(|| {
+                        "aggregate FILTER cannot be translated for aggregate-on-join".to_string()
+                    })?,
                 )
             };
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1212,8 +1212,10 @@ impl AggregateScan {
             return Err(warn(AggregateDeclineReason::NotAllBm25));
         }
 
-        match unsafe { datafusion_build::check_join_path_predicates(input_rel, &sources) } {
-            datafusion_build::JoinPathPredicateCheck::Complete => {}
+        let path_info = match unsafe {
+            datafusion_build::check_join_path_predicates(input_rel, &sources)
+        } {
+            datafusion_build::JoinPathPredicateCheck::Complete(info) => info,
             datafusion_build::JoinPathPredicateCheck::Unsupported(reason) => {
                 return Err(warn(AggregateDeclineReason::JoinPredicate(reason)));
             }
@@ -1225,11 +1227,11 @@ impl AggregateScan {
                     "the selected lower join path cannot be inspected completely".into(),
                 )));
             }
-        }
+        };
 
         // Extract the join tree from the parse tree
         let (mut plan, join_level_predicates, multi_table_predicates, multi_table_clauses) =
-            unsafe { extract_join_tree_from_parse(root, &sources, builder.args().input_rel()) }
+            unsafe { extract_join_tree_from_parse(root, &sources, path_info) }
                 .map_err(|e| warn(AggregateDeclineReason::Other(e)))?;
 
         // Extract aggregate target list (GROUP BY + aggregates)

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1205,9 +1205,12 @@ impl AggregateScan {
                 return Err(warn(AggregateDeclineReason::NonEquiJoinQuals));
             }
             datafusion_build::JoinPathPredicateCheck::IncompletePath(tag) => {
-                return Err(warn(AggregateDeclineReason::Other(format!(
-                    "selected lower path contains an opaque join-level node: {tag:?}"
-                ))));
+                pgrx::debug1!(
+                    "AggregateScan declined because the selected lower join path contains an opaque node: {tag:?}"
+                );
+                return Err(warn(AggregateDeclineReason::Other(
+                    "the selected lower join path cannot be inspected completely".into(),
+                )));
             }
         }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -136,11 +136,10 @@ enum AggregatePathDecline {
     Warn(AggregateDeclineReason),
 }
 
-/// Specific reason a `Warn` decline was raised. Each variant maps 1:1 to a
-/// planner-warning string the inline code used to emit.
+/// Specific reason a `Warn` decline was raised.
 enum AggregateDeclineReason {
     NotAllBm25,
-    NonEquiJoinQuals,
+    JoinPredicate(datafusion_build::PathPredicateDeclineReason),
     CrossJoin,
     /// Errors carrying a free-form message (parse-tree extraction, target-list
     /// extraction, fast-field population) — the underlying helper already
@@ -156,10 +155,27 @@ impl AggregateDeclineReason {
                 "Aggregate Scan (DataFusion) not used: all tables in the join must have BM25 indexes",
                 alias,
             ),
-            AggregateDeclineReason::NonEquiJoinQuals => AggregateScan::add_planner_warning(
-                "Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans",
-                alias,
-            ),
+            AggregateDeclineReason::JoinPredicate(reason) => {
+                let message = match reason {
+                    datafusion_build::PathPredicateDeclineReason::ExternParam => {
+                        "generic prepared-plan parameters in join predicates are not supported"
+                    }
+                    #[cfg(feature = "pg15")]
+                    datafusion_build::PathPredicateDeclineReason::AmbiguousVolatileOverlap => {
+                        "a volatile join predicate cannot be reconstructed safely on PostgreSQL 15"
+                    }
+                    datafusion_build::PathPredicateDeclineReason::OuterJoinOnResidual => {
+                        "outer-join ON residual predicates are not supported"
+                    }
+                    datafusion_build::PathPredicateDeclineReason::UnclassifiedClause => {
+                        "the selected lower join path contains a predicate that AggregateScan cannot classify"
+                    }
+                };
+                AggregateScan::add_planner_warning(
+                    format!("Aggregate Scan (DataFusion) not used: {message}"),
+                    alias,
+                )
+            }
             AggregateDeclineReason::CrossJoin => AggregateScan::add_planner_warning(
                 "Aggregate Scan (DataFusion) not used: CROSS JOINs are not supported (no equi-join keys)",
                 alias,
@@ -1198,8 +1214,8 @@ impl AggregateScan {
 
         match unsafe { datafusion_build::check_join_path_predicates(input_rel, &sources) } {
             datafusion_build::JoinPathPredicateCheck::Complete => {}
-            datafusion_build::JoinPathPredicateCheck::UnhandledQuals => {
-                return Err(warn(AggregateDeclineReason::NonEquiJoinQuals));
+            datafusion_build::JoinPathPredicateCheck::Unsupported(reason) => {
+                return Err(warn(AggregateDeclineReason::JoinPredicate(reason)));
             }
             datafusion_build::JoinPathPredicateCheck::IncompletePath(tag) => {
                 pgrx::debug1!(

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1196,9 +1196,6 @@ impl AggregateScan {
             return Err(warn(AggregateDeclineReason::NotAllBm25));
         }
 
-        // Prove predicate coverage for the selected lower path. Transparent
-        // execution wrappers are traversed; opaque join-level paths decline
-        // rather than relying on the retained parse tree as a coverage proxy.
         match unsafe { datafusion_build::check_join_path_predicates(input_rel, &sources) } {
             datafusion_build::JoinPathPredicateCheck::Complete => {}
             datafusion_build::JoinPathPredicateCheck::UnhandledQuals => {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1196,12 +1196,19 @@ impl AggregateScan {
             return Err(warn(AggregateDeclineReason::NotAllBm25));
         }
 
-        // Reject joins with non-equi quals (OR across tables, cross-table
-        // filters, non-@@@ conditions). Check both the cheapest path's
-        // joinrestrictinfo AND the parse tree's WHERE quals for cross-table
-        // references that our DataFusion backend can't apply.
-        if unsafe { datafusion_build::has_non_equi_join_quals(input_rel, &sources) } {
-            return Err(warn(AggregateDeclineReason::NonEquiJoinQuals));
+        // Prove predicate coverage for the selected lower path. Transparent
+        // execution wrappers are traversed; opaque join-level paths decline
+        // rather than relying on the retained parse tree as a coverage proxy.
+        match unsafe { datafusion_build::check_join_path_predicates(input_rel, &sources) } {
+            datafusion_build::JoinPathPredicateCheck::Complete => {}
+            datafusion_build::JoinPathPredicateCheck::UnhandledQuals => {
+                return Err(warn(AggregateDeclineReason::NonEquiJoinQuals));
+            }
+            datafusion_build::JoinPathPredicateCheck::IncompletePath(tag) => {
+                return Err(warn(AggregateDeclineReason::Other(format!(
+                    "selected lower path contains an opaque join-level node: {tag:?}"
+                ))));
+            }
         }
 
         // Extract the join tree from the parse tree
@@ -1251,13 +1258,20 @@ impl AggregateScan {
         let having_filter = unsafe {
             let parse = builder.args().root().parse;
             if !parse.is_null() && !(*parse).havingQual.is_null() {
-                privdat::FilterExpr::from_pg_node(
-                    (*parse).havingQual,
-                    &datafusion_build::FilterExprBuildContext::Having {
-                        targetlist: &targetlist,
-                        plan: &plan,
-                        outer_root_id,
-                    },
+                Some(
+                    privdat::FilterExpr::from_pg_node(
+                        (*parse).havingQual,
+                        &datafusion_build::FilterExprBuildContext::Having {
+                            targetlist: &targetlist,
+                            plan: &plan,
+                            outer_root_id,
+                        },
+                    )
+                    .ok_or_else(|| {
+                        warn(AggregateDeclineReason::Other(
+                            "HAVING clause cannot be translated for aggregate-on-join".into(),
+                        ))
+                    })?,
                 )
             } else {
                 None

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -299,12 +299,9 @@ impl<'a> PredicateTranslator<'a> {
             return None;
         }
 
-        // List is an implicit conjunction container, not an expression node.
-        // Reaching this point means a caller violated the normalization
-        // contract. Translation is also used as a capability probe, so an
-        // unsupported representation must return None rather than aborting a
-        // valid query during speculative path construction. The owning planner
-        // layer decides whether the failed probe warrants a user-facing warning.
+        // A List is an implicit conjunction container, so reaching here means a
+        // caller skipped normalization. `translate` doubles as a capability
+        // probe, so decline rather than abort an otherwise valid query.
         if (*node).type_ == pg_sys::NodeTag::T_List {
             pgrx::debug1!(
                 "PredicateTranslator received an unnormalized PostgreSQL List; implicit AND conjuncts must be normalized before translation"

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -781,8 +781,8 @@ mod unit_tests {
 #[pgrx::pg_schema]
 mod tests {
     use super::PredicateTranslator;
-    use pgrx::prelude::*;
     use pgrx::PgList;
+    use pgrx::prelude::*;
 
     #[pg_test]
     fn unnormalized_list_is_a_non_throwing_capability_miss() {

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -301,12 +301,15 @@ impl<'a> PredicateTranslator<'a> {
 
         // List is an implicit conjunction container, not an expression node.
         // Reaching this point means a caller violated the normalization
-        // contract. Do not silently decline the optimized path: AggregateScan
-        // eligibility is part of the product contract for supported queries.
+        // contract. Translation is also used as a capability probe, so an
+        // unsupported representation must return None rather than aborting a
+        // valid query during speculative path construction. The owning planner
+        // layer decides whether the failed probe warrants a user-facing warning.
         if (*node).type_ == pg_sys::NodeTag::T_List {
-            pgrx::error!(
-                "internal ParadeDB planner error: PredicateTranslator received an unnormalized PostgreSQL List; implicit AND conjuncts must be normalized before translation"
+            pgrx::debug1!(
+                "PredicateTranslator received an unnormalized PostgreSQL List; implicit AND conjuncts must be normalized before translation"
             );
+            return None;
         }
 
         let native = match (*node).type_ {
@@ -701,7 +704,7 @@ impl<'a> ColumnMapper for CombinedMapper<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::build_null_aware_anti_join;
     use datafusion::arrow::array::Int64Array;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
@@ -771,5 +774,26 @@ mod tests {
             JoinType::LeftAnti,
             "join type must remain LeftAnti after physical planning"
         );
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::PredicateTranslator;
+    use pgrx::prelude::*;
+    use pgrx::PgList;
+
+    #[pg_test]
+    fn unnormalized_list_is_a_non_throwing_capability_miss() {
+        unsafe {
+            let mut list = PgList::<pg_sys::Node>::new();
+            list.push(pg_sys::makeBoolConst(true, false).cast());
+
+            assert!(!PredicateTranslator::can_translate(
+                &[],
+                list.into_pg().cast()
+            ));
+        }
     }
 }

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -299,6 +299,16 @@ impl<'a> PredicateTranslator<'a> {
             return None;
         }
 
+        // List is an implicit conjunction container, not an expression node.
+        // Reaching this point means a caller violated the normalization
+        // contract. Do not silently decline the optimized path: AggregateScan
+        // eligibility is part of the product contract for supported queries.
+        if (*node).type_ == pg_sys::NodeTag::T_List {
+            pgrx::error!(
+                "internal ParadeDB planner error: PredicateTranslator received an unnormalized PostgreSQL List; implicit AND conjuncts must be normalized before translation"
+            );
+        }
+
         let native = match (*node).type_ {
             pg_sys::NodeTag::T_OpExpr => self.translate_op_expr(node as *mut pg_sys::OpExpr),
             pg_sys::NodeTag::T_Var => self.translate_var(node as *mut pg_sys::Var),

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -766,25 +766,47 @@ unsafe fn unwrap_path_wrappers(mut path: *mut pg_sys::Path) -> *mut pg_sys::Path
         if path.is_null() {
             return path;
         }
-        let next = match (*path).type_ {
-            // Parallel-to-serial bridge: same row set, same schema.
-            pg_sys::NodeTag::T_GatherPath => (*(path as *mut pg_sys::GatherPath)).subpath,
-            // Sorted parallel-to-serial bridge: same rows, preserves order.
-            pg_sys::NodeTag::T_GatherMergePath => (*(path as *mut pg_sys::GatherMergePath)).subpath,
-            // Required below GatherMerge when PG sorts each worker's partial
-            // path before merging: same rows, only adds ordering.
-            pg_sys::NodeTag::T_SortPath => (*(path as *mut pg_sys::SortPath)).subpath,
-            // Cached materialisation for inner-side replay: same rows, same schema.
-            pg_sys::NodeTag::T_MaterialPath => (*(path as *mut pg_sys::MaterialPath)).subpath,
-            // Adjusts the target list above the underlying path; the join
-            // structure (RTIs, equi-keys, jointype) we read below is unchanged.
-            pg_sys::NodeTag::T_ProjectionPath => (*(path as *mut pg_sys::ProjectionPath)).subpath,
-            _ => return path,
+        let Some(next) = transparent_path_subpath(path) else {
+            return path;
         };
         if next.is_null() || next == path {
             return path;
         }
         path = next;
+    }
+}
+
+/// Return the child of a PostgreSQL path wrapper that preserves the same row
+/// set and join-predicate semantics.
+///
+/// This is shared by JoinScan reconstruction and AggregateScan predicate
+/// coverage. Keep the list deliberately narrow: a caller may inspect the
+/// returned subpath as the semantic source of join predicates, so wrappers
+/// that filter, deduplicate, limit, or otherwise change rows do not belong
+/// here.
+pub(crate) unsafe fn transparent_path_subpath(
+    path: *mut pg_sys::Path,
+) -> Option<*mut pg_sys::Path> {
+    if path.is_null() {
+        return None;
+    }
+
+    match (*path).type_ {
+        // Parallel-to-serial bridge: same row set, same schema.
+        pg_sys::NodeTag::T_GatherPath => Some((*(path as *mut pg_sys::GatherPath)).subpath),
+        // Sorted parallel-to-serial bridge: same rows, preserves order.
+        pg_sys::NodeTag::T_GatherMergePath => {
+            Some((*(path as *mut pg_sys::GatherMergePath)).subpath)
+        }
+        // Required below GatherMerge when PG sorts each worker's partial
+        // path before merging: same rows, only adds ordering.
+        pg_sys::NodeTag::T_SortPath => Some((*(path as *mut pg_sys::SortPath)).subpath),
+        // Cached materialisation for inner-side replay: same rows, same schema.
+        pg_sys::NodeTag::T_MaterialPath => Some((*(path as *mut pg_sys::MaterialPath)).subpath),
+        // Adjusts the target list above the underlying path; the join
+        // structure (RTIs, equi-keys, jointype) remains unchanged.
+        pg_sys::NodeTag::T_ProjectionPath => Some((*(path as *mut pg_sys::ProjectionPath)).subpath),
+        _ => None,
     }
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -187,6 +187,33 @@ pub unsafe fn transform_to_search_expr(
         return None;
     }
 
+    // A List is an implicit conjunction container, not one expression. It
+    // must be decomposed before relation classification: collecting RTIs from
+    // the container can otherwise group unrelated single-table predicates into
+    // one apparent cross-table predicate.
+    let node_type = (*node).type_;
+    if node_type == pg_sys::NodeTag::T_List {
+        let list = PgList::<pg_sys::Node>::from_pg(node as *mut pg_sys::List);
+        let mut children = Vec::new();
+        for item in list.iter_ptr() {
+            let child_expr = transform_to_search_expr(
+                root,
+                item,
+                sources,
+                join_clause,
+                multi_table_predicate_clauses,
+            )?;
+            children.push(child_expr);
+        }
+        return if children.is_empty() {
+            None
+        } else if children.len() == 1 {
+            Some(children.pop().unwrap())
+        } else {
+            Some(JoinLevelExpr::And(children))
+        };
+    }
+
     let search_op = anyelement_query_input_opoid();
     let has_search_op = expr_contains_any_operator(node, &[search_op]);
 
@@ -233,31 +260,6 @@ pub unsafe fn transform_to_search_expr(
             join_clause.add_multi_table_predicate(description, multi_table_predicate_clauses.len());
         multi_table_predicate_clauses.push(node as *mut pg_sys::Expr);
         return Some(JoinLevelExpr::MultiTablePredicate { predicate_idx });
-    }
-
-    // Handle List nodes: Postgres may wrap quals in a List (common on PG18).
-    // Treat as an implicit AND of the list elements.
-    let node_type = (*node).type_;
-    if node_type == pg_sys::NodeTag::T_List {
-        let list = PgList::<pg_sys::Node>::from_pg(node as *mut pg_sys::List);
-        let mut children = Vec::new();
-        for item in list.iter_ptr() {
-            let child_expr = transform_to_search_expr(
-                root,
-                item,
-                sources,
-                join_clause,
-                multi_table_predicate_clauses,
-            )?;
-            children.push(child_expr);
-        }
-        return if children.is_empty() {
-            None
-        } else if children.len() == 1 {
-            Some(children.pop().unwrap())
-        } else {
-            Some(JoinLevelExpr::And(children))
-        };
     }
 
     // Handle BoolExpr

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -1512,27 +1512,32 @@ pub unsafe fn contains_correlated_param(
     walker(node, root as *mut core::ffi::c_void)
 }
 
-/// Returns true if the expression contains any `PARAM_EXEC` parameter.
-/// `PARAM_EXEC` parameters are evaluated at execution time, often for subqueries.
-pub unsafe fn contains_exec_param(root: *mut pg_sys::Node) -> bool {
+unsafe fn contains_param_of_kind(root: *mut pg_sys::Node, kind: pg_sys::ParamKind::Type) -> bool {
     #[pg_guard]
     unsafe extern "C-unwind" fn walker(
         node: *mut pg_sys::Node,
-        _data: *mut core::ffi::c_void,
+        data: *mut core::ffi::c_void,
     ) -> bool {
+        let kind = &*data.cast::<pg_sys::ParamKind::Type>();
         if let Some(param) = nodecast!(Param, T_Param, node)
-            && (*param).paramkind == pg_sys::ParamKind::PARAM_EXEC
+            && (*param).paramkind == *kind
         {
             return true;
         }
-        pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
+        pg_sys::expression_tree_walker(node, Some(walker), data)
     }
 
     if root.is_null() {
         return false;
     }
 
-    walker(root, std::ptr::null_mut())
+    walker(root, std::ptr::from_ref(&kind).cast_mut().cast())
+}
+
+/// Returns true if the expression contains any `PARAM_EXEC` parameter.
+/// `PARAM_EXEC` parameters are evaluated at execution time, often for subqueries.
+pub unsafe fn contains_exec_param(root: *mut pg_sys::Node) -> bool {
+    contains_param_of_kind(root, pg_sys::ParamKind::PARAM_EXEC)
 }
 
 /// Returns true if the expression contains a prepared-statement parameter.
@@ -1541,24 +1546,7 @@ pub unsafe fn contains_exec_param(root: *mut pg_sys::Node) -> bool {
 /// custom scan needs an executor-side contract for resolving them; planner-time
 /// translation alone is not sufficient.
 pub unsafe fn contains_extern_param(root: *mut pg_sys::Node) -> bool {
-    #[pg_guard]
-    unsafe extern "C-unwind" fn walker(
-        node: *mut pg_sys::Node,
-        _data: *mut core::ffi::c_void,
-    ) -> bool {
-        if let Some(param) = nodecast!(Param, T_Param, node)
-            && (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN
-        {
-            return true;
-        }
-        pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
-    }
-
-    if root.is_null() {
-        return false;
-    }
-
-    walker(root, std::ptr::null_mut())
+    contains_param_of_kind(root, pg_sys::ParamKind::PARAM_EXTERN)
 }
 
 /// Flatten PostgreSQL's two representations of an implicit conjunction into

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -1546,10 +1546,10 @@ pub unsafe fn contains_extern_param(root: *mut pg_sys::Node) -> bool {
         node: *mut pg_sys::Node,
         _data: *mut core::ffi::c_void,
     ) -> bool {
-        if let Some(param) = nodecast!(Param, T_Param, node) {
-            if (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN {
-                return true;
-            }
+        if let Some(param) = nodecast!(Param, T_Param, node)
+            && (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN
+        {
+            return true;
         }
         pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
     }
@@ -1585,14 +1585,14 @@ pub unsafe fn collect_implicit_and_conjuncts(
         return;
     }
 
-    if let Some(bool_expr) = nodecast!(BoolExpr, T_BoolExpr, node) {
-        if (*bool_expr).boolop == pg_sys::BoolExprType::AND_EXPR {
-            let args = PgList::<pg_sys::Node>::from_pg((*bool_expr).args);
-            for arg in args.iter_ptr() {
-                collect_implicit_and_conjuncts(arg, conjuncts);
-            }
-            return;
+    if let Some(bool_expr) = nodecast!(BoolExpr, T_BoolExpr, node)
+        && (*bool_expr).boolop == pg_sys::BoolExprType::AND_EXPR
+    {
+        let args = PgList::<pg_sys::Node>::from_pg((*bool_expr).args);
+        for arg in args.iter_ptr() {
+            collect_implicit_and_conjuncts(arg, conjuncts);
         }
+        return;
     }
 
     conjuncts.push(node);

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -1537,9 +1537,9 @@ pub unsafe fn contains_exec_param(root: *mut pg_sys::Node) -> bool {
 
 /// Returns true if the expression contains a prepared-statement parameter.
 ///
-/// `PARAM_EXTERN` values are bound when a generic prepared plan executes.  A
-/// custom scan must have an explicit executor contract for resolving them;
-/// planner-time expression translation alone is not sufficient.
+/// `PARAM_EXTERN` values are bound when a generic prepared plan executes, so a
+/// custom scan needs an executor-side contract for resolving them; planner-time
+/// translation alone is not sufficient.
 pub unsafe fn contains_extern_param(root: *mut pg_sys::Node) -> bool {
     #[pg_guard]
     unsafe extern "C-unwind" fn walker(

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -1535,6 +1535,69 @@ pub unsafe fn contains_exec_param(root: *mut pg_sys::Node) -> bool {
     walker(root, std::ptr::null_mut())
 }
 
+/// Returns true if the expression contains a prepared-statement parameter.
+///
+/// `PARAM_EXTERN` values are bound when a generic prepared plan executes.  A
+/// custom scan must have an explicit executor contract for resolving them;
+/// planner-time expression translation alone is not sufficient.
+pub unsafe fn contains_extern_param(root: *mut pg_sys::Node) -> bool {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        _data: *mut core::ffi::c_void,
+    ) -> bool {
+        if let Some(param) = nodecast!(Param, T_Param, node) {
+            if (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN {
+                return true;
+            }
+        }
+        pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
+    }
+
+    if root.is_null() {
+        return false;
+    }
+
+    walker(root, std::ptr::null_mut())
+}
+
+/// Flatten PostgreSQL's two representations of an implicit conjunction into
+/// individual semantic predicates.
+///
+/// `preprocess_qual_conditions()` applies `make_ands_implicit()`, which can
+/// leave a bare `T_List` where callers might otherwise expect a `BoolExpr(AND)`.
+/// Relation classification and expression translation must operate on each
+/// conjunct, never on the container. `OR` and `NOT` expressions deliberately
+/// remain intact.
+pub unsafe fn collect_implicit_and_conjuncts(
+    node: *mut pg_sys::Node,
+    conjuncts: &mut Vec<*mut pg_sys::Node>,
+) {
+    if node.is_null() {
+        return;
+    }
+
+    if (*node).type_ == pg_sys::NodeTag::T_List {
+        let list = PgList::<pg_sys::Node>::from_pg(node.cast::<pg_sys::List>());
+        for item in list.iter_ptr() {
+            collect_implicit_and_conjuncts(item, conjuncts);
+        }
+        return;
+    }
+
+    if let Some(bool_expr) = nodecast!(BoolExpr, T_BoolExpr, node) {
+        if (*bool_expr).boolop == pg_sys::BoolExprType::AND_EXPR {
+            let args = PgList::<pg_sys::Node>::from_pg((*bool_expr).args);
+            for arg in args.iter_ptr() {
+                collect_implicit_and_conjuncts(arg, conjuncts);
+            }
+            return;
+        }
+    }
+
+    conjuncts.push(node);
+}
+
 unsafe fn contains_var(root: *mut pg_sys::Node) -> bool {
     #[pg_guard]
     unsafe extern "C-unwind" fn walker(

--- a/pg_search/tests/pg_regress/expected/issue_5751.out
+++ b/pg_search/tests/pg_regress/expected/issue_5751.out
@@ -1,0 +1,335 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- #5751 predicate-normalization contract:
+--   1. T_List and top-level AND are containers, never executable expressions.
+--   2. Each conjunct is classified independently; OR and NOT stay intact.
+--   3. Single-relation conjuncts remain owned by their base scans.
+--   4. A present unsupported predicate declines AggregateScan; it is never dropped.
+--   5. Custom prepared plans with Const substitutions remain eligible.
+--   6. Base-filter PARAM_EXTERN uses the existing live ExprContext binding path.
+--   7. PARAM_EXTERN in cross-table, HAVING, or FILTER expressions declines.
+CREATE TABLE issue_5751_series (
+    id bigint PRIMARY KEY,
+    state text
+);
+CREATE TABLE issue_5751_entries (
+    id bigint PRIMARY KEY,
+    series_id bigint,
+    user_id text
+);
+INSERT INTO issue_5751_series VALUES
+    (1, 'active'),
+    (2, 'inactive'),
+    (3, 'active');
+INSERT INTO issue_5751_entries VALUES
+    (1, 1, 'u1'),
+    (2, 1, 'u2'),
+    (3, 2, 'u1'),
+    (4, 3, 'u1');
+CREATE INDEX issue_5751_series_idx
+ON issue_5751_series USING bm25 (id, ((state)::pdb.literal))
+WITH (key_field = 'id');
+CREATE INDEX issue_5751_entries_idx
+ON issue_5751_entries USING bm25 (id, series_id, ((user_id)::pdb.literal))
+WITH (key_field = 'id');
+-- Keep the plan assertion stable without recording DataFusion's physical plan.
+CREATE FUNCTION issue_5751_plan_uses(q text, needle text) RETURNS boolean AS $$
+DECLARE r record;
+BEGIN
+  FOR r IN EXECUTE 'EXPLAIN (COSTS OFF) ' || q LOOP
+    IF r."QUERY PLAN" LIKE '%' || needle || '%' THEN RETURN true; END IF;
+  END LOOP;
+  RETURN false;
+END $$ LANGUAGE plpgsql;
+-- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List.  Each
+-- item is a base predicate even though the container references both tables.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.state = 'active' AND e.user_id = 'u1'$$,
+  'ParadeDB Aggregate Scan') AS uses_aggregate_scan;
+ uses_aggregate_scan 
+---------------------
+ t
+(1 row)
+
+-- Both filters must remain effective: dropping either one returns three rows.
+SELECT count(*) AS filtered_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = 'active' AND e.user_id = 'u1';
+ filtered_count 
+----------------
+              2
+(1 row)
+
+-- The same semantic query can place the equality in the implicit-join WHERE
+-- list.  The equality is a join key; the other two conjuncts remain owned by
+-- their base scans.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_entries e, issue_5751_series s
+    WHERE s.id = e.series_id
+      AND s.state = 'active'
+      AND e.user_id = 'u1'$$,
+  'ParadeDB Aggregate Scan') AS implicit_uses_aggregate_scan;
+ implicit_uses_aggregate_scan 
+------------------------------
+ t
+(1 row)
+
+SELECT count(*) AS implicit_filtered_count
+FROM issue_5751_entries e, issue_5751_series s
+WHERE s.id = e.series_id
+  AND s.state = 'active'
+  AND e.user_id = 'u1';
+ implicit_filtered_count 
+-------------------------
+                       2
+(1 row)
+
+-- Only implicit AND containers are normalized.  OR remains one semantic
+-- predicate; flattening it would incorrectly require both states at once.
+SELECT count(*) AS preserved_or_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE (s.state = 'active' OR s.state = 'inactive')
+  AND e.user_id = 'u1';
+ preserved_or_count 
+--------------------
+                  3
+(1 row)
+
+-- The planner error was independent of row count.
+TRUNCATE issue_5751_entries, issue_5751_series;
+SELECT count(*) AS empty_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = 'active' AND e.user_id = 'u1';
+ empty_count 
+-------------
+           0
+(1 row)
+
+-- Custom prepared plans replace PARAM_EXTERN with Const nodes.  Preserve that
+-- existing supported path and verify that this fix does not merely fall back to
+-- PostgreSQL for every prepared statement.
+INSERT INTO issue_5751_series VALUES
+    (1, 'active'),
+    (2, 'inactive'),
+    (3, 'active');
+INSERT INTO issue_5751_entries VALUES
+    (1, 1, 'u1'),
+    (2, 1, 'u2'),
+    (3, 2, 'u1'),
+    (4, 3, 'u1');
+PREPARE issue_5751_generic(text, text) AS
+SELECT count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = $1 AND e.user_id = $2;
+SET plan_cache_mode = force_custom_plan;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_generic('active', 'u1')$$,
+  'ParadeDB Aggregate Scan') AS custom_uses_aggregate_scan;
+ custom_uses_aggregate_scan 
+----------------------------
+ t
+(1 row)
+
+EXECUTE issue_5751_generic('active', 'u1');
+ count 
+-------
+     2
+(1 row)
+
+-- A generic plan with parameters on both inputs chooses a wrapped lower path.
+-- AggregateScan must traverse the transparent wrapper, account for the
+-- parameterized-path clauses, and remain selected.
+SET plan_cache_mode = force_generic_plan;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_generic('active', 'u1')$$,
+  'ParadeDB Aggregate Scan') AS generic_uses_aggregate_scan;
+ generic_uses_aggregate_scan 
+-----------------------------
+ t
+(1 row)
+
+EXECUTE issue_5751_generic('active', 'u1');
+ count 
+-------
+     2
+(1 row)
+
+DEALLOCATE issue_5751_generic;
+-- Main already supports a single generic base-filter parameter through that
+-- runtime path. Keep an explicit compatibility assertion so a future safety
+-- guard cannot turn this working AggregateScan into fallback or an error.
+PREPARE issue_5751_main_compatible(text) AS
+SELECT count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = $1;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_main_compatible('active')$$,
+  'ParadeDB Aggregate Scan') AS main_compatible_uses_aggregate_scan;
+ main_compatible_uses_aggregate_scan 
+-------------------------------------
+ t
+(1 row)
+
+EXECUTE issue_5751_main_compatible('active');
+ count 
+-------
+     3
+(1 row)
+
+DEALLOCATE issue_5751_main_compatible;
+-- Cross-table DataFusion predicates do not yet receive the executing query's
+-- ParamListInfo. Decline this shape rather than raising "no value found for
+-- parameter" or evaluating an incomplete predicate.
+PREPARE issue_5751_cross_param(bigint) AS
+SELECT count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.id + $1 > e.series_id;
+SET client_min_messages = error;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_cross_param(0)$$,
+  'ParadeDB Aggregate Scan') AS cross_param_uses_aggregate_scan;
+ cross_param_uses_aggregate_scan 
+---------------------------------
+ f
+(1 row)
+
+EXECUTE issue_5751_cross_param(0);
+ count 
+-------
+     0
+(1 row)
+
+RESET client_min_messages;
+DEALLOCATE issue_5751_cross_param;
+-- A present HAVING or aggregate FILTER must not be represented as None merely
+-- because its PARAM_EXTERN cannot be translated.  Both shapes decline and
+-- PostgreSQL evaluates the original expression.
+PREPARE issue_5751_having(bigint) AS
+SELECT s.state, count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+GROUP BY s.state
+HAVING count(*) > $1
+ORDER BY s.state;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_having(1)$$,
+  'ParadeDB Aggregate Scan') AS having_uses_aggregate_scan;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause cannot be translated for aggregate-on-join (table: join)
+ having_uses_aggregate_scan 
+----------------------------
+ f
+(1 row)
+
+EXECUTE issue_5751_having(1);
+ state  | count 
+--------+-------
+ active |     3
+(1 row)
+
+DEALLOCATE issue_5751_having;
+PREPARE issue_5751_filter(text) AS
+SELECT count(*) FILTER (WHERE e.user_id = $1) AS filtered_aggregate_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_filter('u1')$$,
+  'ParadeDB Aggregate Scan') AS filter_uses_aggregate_scan;
+WARNING:  Aggregate Scan (DataFusion) not used: aggregate FILTER cannot be translated for aggregate-on-join (table: join)
+ filter_uses_aggregate_scan 
+----------------------------
+ f
+(1 row)
+
+EXECUTE issue_5751_filter('u1');
+ filtered_aggregate_count 
+--------------------------
+                        3
+(1 row)
+
+DEALLOCATE issue_5751_filter;
+RESET plan_cache_mode;
+-- PostgreSQL may enforce an inner-join predicate on a parameterized inner
+-- index path and remove it from the parent NestPath.joinrestrictinfo.  The
+-- predicate remains in ParamPathInfo.ppi_clauses and must be inventoried when
+-- AggregateScan reconstructs the DataFusion join.  Equality-only execution
+-- would incorrectly count all five rows instead of the three qualifying rows.
+CREATE TABLE issue_5751_ppi_series (
+    id bigint PRIMARY KEY,
+    threshold bigint
+);
+CREATE TABLE issue_5751_ppi_entries (
+    id bigint PRIMARY KEY,
+    series_id bigint,
+    amount bigint
+);
+INSERT INTO issue_5751_ppi_series VALUES (1, 10), (2, 20);
+INSERT INTO issue_5751_ppi_entries VALUES
+    (1, 1, 5),
+    (2, 1, 15),
+    (3, 1, 25),
+    (4, 2, 15),
+    (5, 2, 25);
+CREATE INDEX issue_5751_ppi_series_bm25
+ON issue_5751_ppi_series USING bm25 (id, threshold)
+WITH (key_field = 'id');
+CREATE INDEX issue_5751_ppi_entries_bm25
+ON issue_5751_ppi_entries USING bm25 (id, series_id, amount)
+WITH (key_field = 'id');
+CREATE INDEX issue_5751_ppi_lookup
+ON issue_5751_ppi_series (id, threshold);
+SET enable_hashjoin = off;
+SET enable_mergejoin = off;
+SET enable_seqscan = off;
+SET enable_material = off;
+SET enable_memoize = off;
+SET paradedb.enable_aggregate_custom_scan = off;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  'Nested Loop') AS lower_uses_parameterized_nestloop;
+ lower_uses_parameterized_nestloop 
+-----------------------------------
+ t
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan = on;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  'ParadeDB Aggregate Scan') AS ppi_uses_aggregate_scan;
+ ppi_uses_aggregate_scan 
+-------------------------
+ t
+(1 row)
+
+SELECT count(*) AS ppi_filtered_count
+FROM issue_5751_ppi_entries e
+JOIN issue_5751_ppi_series s
+  ON s.id = e.series_id AND s.threshold < e.amount;
+ ppi_filtered_count 
+--------------------
+                  3
+(1 row)
+
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+RESET enable_seqscan;
+RESET enable_material;
+RESET enable_memoize;
+DROP FUNCTION issue_5751_plan_uses(text, text);
+DROP TABLE issue_5751_entries, issue_5751_series,
+           issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/expected/issue_5751.out
+++ b/pg_search/tests/pg_regress/expected/issue_5751.out
@@ -223,10 +223,10 @@ SELECT count(*)
 FROM issue_5751_entries e
 JOIN issue_5751_series s ON s.id = e.series_id
 WHERE s.id + $1 > e.series_id;
-SET client_min_messages = error;
 SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_cross_param(0)$$,
   'ParadeDB Aggregate Scan') AS cross_param_uses_aggregate_scan;
+WARNING:  Aggregate Scan (DataFusion) not used: generic prepared-plan parameters in join predicates are not supported (table: join)
  cross_param_uses_aggregate_scan 
 ---------------------------------
  f
@@ -267,6 +267,7 @@ ORDER BY s.state;
 SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_having(1)$$,
   'ParadeDB Aggregate Scan') AS having_uses_aggregate_scan;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause cannot be translated for aggregate-on-join (table: join)
  having_uses_aggregate_scan 
 ----------------------------
  f
@@ -285,6 +286,7 @@ JOIN issue_5751_series s ON s.id = e.series_id;
 SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_filter('u1')$$,
   'ParadeDB Aggregate Scan') AS filter_uses_aggregate_scan;
+WARNING:  Aggregate Scan (DataFusion) not used: aggregate FILTER cannot be translated for aggregate-on-join (table: join)
  filter_uses_aggregate_scan 
 ----------------------------
  f
@@ -331,7 +333,6 @@ SELECT issue_5751_result(
 
 DEALLOCATE issue_5751_having;
 DEALLOCATE issue_5751_filter;
-RESET client_min_messages;
 RESET plan_cache_mode;
 -- PostgreSQL may enforce an inner-join predicate on a parameterized inner
 -- index path and remove it from the parent NestPath.joinrestrictinfo. The

--- a/pg_search/tests/pg_regress/expected/issue_5751.out
+++ b/pg_search/tests/pg_regress/expected/issue_5751.out
@@ -41,6 +41,25 @@ BEGIN
   END LOOP;
   RETURN false;
 END $$ LANGUAGE plpgsql;
+-- Compare the extension path against PostgreSQL's answer instead of blessing a
+-- newly generated literal result. Each dynamic statement is planned after its
+-- AggregateScan setting is applied.
+CREATE FUNCTION issue_5751_result(q text, use_aggregate_scan boolean)
+RETURNS jsonb AS $$
+DECLARE
+  r record;
+  result jsonb := '[]'::jsonb;
+BEGIN
+  PERFORM set_config(
+    'paradedb.enable_aggregate_custom_scan',
+    use_aggregate_scan::text,
+    true
+  );
+  FOR r IN EXECUTE q LOOP
+    result := result || jsonb_build_array(to_jsonb(r));
+  END LOOP;
+  RETURN result;
+END $$ LANGUAGE plpgsql;
 -- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List.  Each
 -- item is a base predicate even though the container references both tables.
 SELECT issue_5751_plan_uses(
@@ -62,6 +81,24 @@ WHERE s.state = 'active' AND e.user_id = 'u1';
  filtered_count 
 ----------------
               2
+(1 row)
+
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.state = 'active' AND e.user_id = 'u1'$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.state = 'active' AND e.user_id = 'u1'$$,
+  false
+) AS matches_postgres;
+ matches_postgres 
+------------------
+ t
 (1 row)
 
 -- The same semantic query can place the equality in the implicit-join WHERE
@@ -186,8 +223,8 @@ EXECUTE issue_5751_main_compatible('active');
 (1 row)
 
 DEALLOCATE issue_5751_main_compatible;
--- Cross-table DataFusion predicates do not yet receive the executing query's
--- ParamListInfo. Decline this shape rather than raising "no value found for
+-- Cross-table DataFusion predicates have no executor-side ParamListInfo
+-- binding. Decline this shape rather than raising "no value found for
 -- parameter" or evaluating an incomplete predicate.
 PREPARE issue_5751_cross_param(bigint) AS
 SELECT count(*)
@@ -209,7 +246,21 @@ EXECUTE issue_5751_cross_param(0);
      0
 (1 row)
 
-RESET client_min_messages;
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_cross_param(0)$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.id + 0 > e.series_id$$,
+  false
+) AS cross_param_matches_postgres;
+ cross_param_matches_postgres 
+------------------------------
+ t
+(1 row)
+
 DEALLOCATE issue_5751_cross_param;
 -- A present HAVING or aggregate FILTER must not be represented as None merely
 -- because its PARAM_EXTERN cannot be translated.  Both shapes decline and
@@ -224,7 +275,6 @@ ORDER BY s.state;
 SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_having(1)$$,
   'ParadeDB Aggregate Scan') AS having_uses_aggregate_scan;
-WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause cannot be translated for aggregate-on-join (table: join)
  having_uses_aggregate_scan 
 ----------------------------
  f
@@ -236,7 +286,6 @@ EXECUTE issue_5751_having(1);
  active |     3
 (1 row)
 
-DEALLOCATE issue_5751_having;
 PREPARE issue_5751_filter(text) AS
 SELECT count(*) FILTER (WHERE e.user_id = $1) AS filtered_aggregate_count
 FROM issue_5751_entries e
@@ -244,7 +293,6 @@ JOIN issue_5751_series s ON s.id = e.series_id;
 SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_filter('u1')$$,
   'ParadeDB Aggregate Scan') AS filter_uses_aggregate_scan;
-WARNING:  Aggregate Scan (DataFusion) not used: aggregate FILTER cannot be translated for aggregate-on-join (table: join)
  filter_uses_aggregate_scan 
 ----------------------------
  f
@@ -256,7 +304,43 @@ EXECUTE issue_5751_filter('u1');
                         3
 (1 row)
 
+-- The generic prepared executions above must match independently planned
+-- PostgreSQL queries with the same parameter values. This catches a present
+-- HAVING or FILTER being mistaken for an absent one.
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_having(1)$$,
+  true
+) = issue_5751_result(
+  $$SELECT s.state, count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    GROUP BY s.state
+    HAVING count(*) > 1
+    ORDER BY s.state$$,
+  false
+) AS having_matches_postgres;
+ having_matches_postgres 
+-------------------------
+ t
+(1 row)
+
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_filter('u1')$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*) FILTER (WHERE e.user_id = 'u1') AS filtered_aggregate_count
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id$$,
+  false
+) AS filter_matches_postgres;
+ filter_matches_postgres 
+-------------------------
+ t
+(1 row)
+
+DEALLOCATE issue_5751_having;
 DEALLOCATE issue_5751_filter;
+RESET client_min_messages;
 RESET plan_cache_mode;
 -- PostgreSQL may enforce an inner-join predicate on a parameterized inner
 -- index path and remove it from the parent NestPath.joinrestrictinfo.  The
@@ -290,8 +374,6 @@ ON issue_5751_ppi_series (id, threshold);
 SET enable_hashjoin = off;
 SET enable_mergejoin = off;
 SET enable_seqscan = off;
-SET enable_material = off;
-SET enable_memoize = off;
 SET paradedb.enable_aggregate_custom_scan = off;
 SELECT issue_5751_plan_uses(
   $$SELECT count(*)
@@ -325,11 +407,63 @@ JOIN issue_5751_ppi_series s
                   3
 (1 row)
 
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  false
+) AS ppi_matches_postgres;
+ ppi_matches_postgres 
+----------------------
+ t
+(1 row)
+
+-- Exercise generic-plan parameters and ParamPathInfo.ppi_clauses together.
+-- The parameter remains a supported base filter while the cross-table
+-- inequality is recovered from the parameterized lower path.
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_5751_ppi_generic(bigint) AS
+SELECT count(*)
+FROM issue_5751_ppi_entries e
+JOIN issue_5751_ppi_series s
+  ON s.id = e.series_id AND s.threshold < e.amount
+WHERE e.amount > $1;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_ppi_generic(20)$$,
+  'ParadeDB Aggregate Scan') AS generic_ppi_uses_aggregate_scan;
+ generic_ppi_uses_aggregate_scan 
+---------------------------------
+ t
+(1 row)
+
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_ppi_generic(20)$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount
+    WHERE e.amount > 20$$,
+  false
+) AS generic_ppi_matches_postgres;
+ generic_ppi_matches_postgres 
+------------------------------
+ t
+(1 row)
+
+DEALLOCATE issue_5751_ppi_generic;
+RESET plan_cache_mode;
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_seqscan;
-RESET enable_material;
-RESET enable_memoize;
-DROP FUNCTION issue_5751_plan_uses(text, text);
+DROP FUNCTION issue_5751_plan_uses(text, text), issue_5751_result(text, boolean);
 DROP TABLE issue_5751_entries, issue_5751_series,
            issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/expected/issue_5751.out
+++ b/pg_search/tests/pg_regress/expected/issue_5751.out
@@ -453,16 +453,26 @@ SELECT issue_5751_result(
 
 DEALLOCATE issue_5751_ppi_generic;
 RESET plan_cache_mode;
-RESET enable_hashjoin;
-RESET enable_mergejoin;
-RESET enable_seqscan;
--- A volatile cross-table residual. PG16+ discriminates residuals by
--- RestrictInfo identity, so two occurrences of the same predicate stay two
--- independent draws rather than collapsing into one. `random() * 0` is
--- value-stable, so the row count is deterministic and any divergence from
--- PostgreSQL means the predicate was dropped or applied the wrong number of
--- times. (PG15 has no such identity and declines instead; that arm is
--- compiled out here.)
+-- A volatile cross-table residual, still under the parameterized nested loop
+-- above so the predicate is reachable from both `joinrestrictinfo` and
+-- `ppi_clauses` - the overlap the residual dedup exists for. PG16+ tells the
+-- two encounters apart by `rinfo_serial`; PG15 has no such identity, falls
+-- back to comparing origins. Both accept this shape: the planner hands back
+-- the same RestrictInfo, so pointer equality settles it before either
+-- version-specific rule runs. `random() * 0` is value-stable, so the count is
+-- deterministic and any divergence means the predicate was dropped or applied
+-- twice.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount + (random() * 0)::bigint$$,
+  'ParadeDB Aggregate Scan') AS volatile_residual_uses_aggregate_scan;
+ volatile_residual_uses_aggregate_scan 
+---------------------------------------
+ t
+(1 row)
+
 SELECT issue_5751_result(
   $$SELECT count(*)
     FROM issue_5751_ppi_entries e
@@ -481,11 +491,11 @@ SELECT issue_5751_result(
  t
 (1 row)
 
--- JoinScan and AggregateScan both proposing for the same joinrel. With
--- `enable_join_custom_scan` on, JoinScan's CustomPath can be the joinrel's
--- cheapest path; AggregateScan cannot reconstruct predicates through it and
--- declines rather than falling back to the retained parse tree. Whichever
--- scan wins, the answer must match PostgreSQL.
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+RESET enable_seqscan;
+-- JoinScan and AggregateScan proposing for the same joinrel, with `@@@` on
+-- both sides so JoinScan genuinely competes.
 CREATE TABLE issue_5751_js_left (id bigint PRIMARY KEY, body text);
 CREATE TABLE issue_5751_js_right (id bigint PRIMARY KEY, left_id bigint, body text);
 INSERT INTO issue_5751_js_left SELECT g, 'alpha beta' FROM generate_series(1, 20) g;
@@ -495,6 +505,38 @@ ON issue_5751_js_left USING bm25 (id, body) WITH (key_field = 'id');
 CREATE INDEX issue_5751_js_right_bm25
 ON issue_5751_js_right USING bm25 (id, left_id, body) WITH (key_field = 'id');
 SET paradedb.enable_join_custom_scan = on;
+-- Both enabled: AggregateScan claims the query outright.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  'ParadeDB Aggregate Scan') AS both_scans_on_uses_aggregate_scan;
+ both_scans_on_uses_aggregate_scan 
+-----------------------------------
+ t
+(1 row)
+
+-- With AggregateScan out of the way, JoinScan still declines: it does not
+-- support aggregates (`JoinDeclineReason::ContainsAggregate`), so it never
+-- offers a CustomPath for this joinrel and AggregateScan's opaque-path check
+-- is never reached through it. The warning below is the anchor - #5285 will
+-- let JoinScan propose here, and this case then becomes a real interaction
+-- test rather than a record of why it cannot happen yet.
+SET paradedb.enable_aggregate_custom_scan = off;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  'ParadeDB Base Scan') AS joinscan_declines_falls_back_to_base_scans;
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: l, r)
+ joinscan_declines_falls_back_to_base_scans 
+--------------------------------------------
+ t
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan = on;
 SELECT issue_5751_result(
   $$SELECT count(*)
     FROM issue_5751_js_right r
@@ -515,7 +557,55 @@ WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enabl
 (1 row)
 
 RESET paradedb.enable_join_custom_scan;
+-- Partitionwise join: the other opaque path shape. Partitioned parents are
+-- ineligible well before the opaque-path check runs, so an Append over
+-- per-partition joins never reaches it either. Recorded so that adding
+-- partitioned support surfaces this case instead of silently changing it.
+CREATE TABLE issue_5751_pw_a (id bigint, k bigint, s text) PARTITION BY RANGE (id);
+CREATE TABLE issue_5751_pw_a1 PARTITION OF issue_5751_pw_a FOR VALUES FROM (0) TO (100);
+CREATE TABLE issue_5751_pw_a2 PARTITION OF issue_5751_pw_a FOR VALUES FROM (100) TO (200);
+CREATE TABLE issue_5751_pw_b (id bigint, k bigint, t text) PARTITION BY RANGE (id);
+CREATE TABLE issue_5751_pw_b1 PARTITION OF issue_5751_pw_b FOR VALUES FROM (0) TO (100);
+CREATE TABLE issue_5751_pw_b2 PARTITION OF issue_5751_pw_b FOR VALUES FROM (100) TO (200);
+INSERT INTO issue_5751_pw_a SELECT g, g, 'x' FROM generate_series(1, 199) g;
+INSERT INTO issue_5751_pw_b SELECT g, g, 'y' FROM generate_series(1, 199) g;
+CREATE INDEX issue_5751_pw_a_bm25
+ON issue_5751_pw_a USING bm25 (id, k, ((s)::pdb.literal)) WITH (key_field = 'id');
+CREATE INDEX issue_5751_pw_b_bm25
+ON issue_5751_pw_b USING bm25 (id, k, ((t)::pdb.literal)) WITH (key_field = 'id');
+SET enable_partitionwise_join = on;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_pw_a a
+    JOIN issue_5751_pw_b b ON a.id = b.id AND a.k = b.k
+    WHERE a.s = 'x' AND b.t = 'y'$$,
+  'ParadeDB Aggregate Scan') AS partitionwise_uses_aggregate_scan;
+ partitionwise_uses_aggregate_scan 
+-----------------------------------
+ f
+(1 row)
+
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_pw_a a
+    JOIN issue_5751_pw_b b ON a.id = b.id AND a.k = b.k
+    WHERE a.s = 'x' AND b.t = 'y'$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_pw_a a
+    JOIN issue_5751_pw_b b ON a.id = b.id AND a.k = b.k
+    WHERE a.s = 'x' AND b.t = 'y'$$,
+  false
+) AS partitionwise_matches_postgres;
+ partitionwise_matches_postgres 
+--------------------------------
+ t
+(1 row)
+
+RESET enable_partitionwise_join;
 DROP FUNCTION issue_5751_plan_uses(text, text), issue_5751_result(text, boolean);
 DROP TABLE issue_5751_js_left, issue_5751_js_right;
+DROP TABLE issue_5751_pw_a, issue_5751_pw_b;
 DROP TABLE issue_5751_entries, issue_5751_series,
            issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/expected/issue_5751.out
+++ b/pg_search/tests/pg_regress/expected/issue_5751.out
@@ -456,6 +456,66 @@ RESET plan_cache_mode;
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_seqscan;
+-- A volatile cross-table residual. PG16+ discriminates residuals by
+-- RestrictInfo identity, so two occurrences of the same predicate stay two
+-- independent draws rather than collapsing into one. `random() * 0` is
+-- value-stable, so the row count is deterministic and any divergence from
+-- PostgreSQL means the predicate was dropped or applied the wrong number of
+-- times. (PG15 has no such identity and declines instead; that arm is
+-- compiled out here.)
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount + (random() * 0)::bigint$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount + (random() * 0)::bigint$$,
+  false
+) AS volatile_residual_matches_postgres;
+ volatile_residual_matches_postgres 
+------------------------------------
+ t
+(1 row)
+
+-- JoinScan and AggregateScan both proposing for the same joinrel. With
+-- `enable_join_custom_scan` on, JoinScan's CustomPath can be the joinrel's
+-- cheapest path; AggregateScan cannot reconstruct predicates through it and
+-- declines rather than falling back to the retained parse tree. Whichever
+-- scan wins, the answer must match PostgreSQL.
+CREATE TABLE issue_5751_js_left (id bigint PRIMARY KEY, body text);
+CREATE TABLE issue_5751_js_right (id bigint PRIMARY KEY, left_id bigint, body text);
+INSERT INTO issue_5751_js_left SELECT g, 'alpha beta' FROM generate_series(1, 20) g;
+INSERT INTO issue_5751_js_right SELECT g, g, 'gamma delta' FROM generate_series(1, 20) g;
+CREATE INDEX issue_5751_js_left_bm25
+ON issue_5751_js_left USING bm25 (id, body) WITH (key_field = 'id');
+CREATE INDEX issue_5751_js_right_bm25
+ON issue_5751_js_right USING bm25 (id, left_id, body) WITH (key_field = 'id');
+SET paradedb.enable_join_custom_scan = on;
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  false
+) AS joinscan_interaction_matches_postgres;
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: l, r)
+ joinscan_interaction_matches_postgres 
+---------------------------------------
+ t
+(1 row)
+
+RESET paradedb.enable_join_custom_scan;
 DROP FUNCTION issue_5751_plan_uses(text, text), issue_5751_result(text, boolean);
+DROP TABLE issue_5751_js_left, issue_5751_js_right;
 DROP TABLE issue_5751_entries, issue_5751_series,
            issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/expected/issue_5751.out
+++ b/pg_search/tests/pg_regress/expected/issue_5751.out
@@ -1,13 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
--- #5751 predicate-normalization contract:
---   1. T_List and top-level AND are containers, never executable expressions.
---   2. Each conjunct is classified independently; OR and NOT stay intact.
---   3. Single-relation conjuncts remain owned by their base scans.
---   4. A present unsupported predicate declines AggregateScan; it is never dropped.
---   5. Custom prepared plans with Const substitutions remain eligible.
---   6. Base-filter PARAM_EXTERN uses the existing live ExprContext binding path.
---   7. PARAM_EXTERN in cross-table, HAVING, or FILTER expressions declines.
 CREATE TABLE issue_5751_series (
     id bigint PRIMARY KEY,
     state text
@@ -60,7 +52,7 @@ BEGIN
   END LOOP;
   RETURN result;
 END $$ LANGUAGE plpgsql;
--- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List.  Each
+-- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List. Each
 -- item is a base predicate even though the container references both tables.
 SELECT issue_5751_plan_uses(
   $$SELECT count(*)
@@ -102,7 +94,7 @@ SELECT issue_5751_result(
 (1 row)
 
 -- The same semantic query can place the equality in the implicit-join WHERE
--- list.  The equality is a join key; the other two conjuncts remain owned by
+-- list. The equality is a join key; the other two conjuncts remain owned by
 -- their base scans.
 SELECT issue_5751_plan_uses(
   $$SELECT count(*)
@@ -149,7 +141,7 @@ WHERE s.state = 'active' AND e.user_id = 'u1';
            0
 (1 row)
 
--- Custom prepared plans replace PARAM_EXTERN with Const nodes.  Preserve that
+-- Custom prepared plans replace PARAM_EXTERN with Const nodes. Preserve that
 -- existing supported path and verify that this fix does not merely fall back to
 -- PostgreSQL for every prepared statement.
 INSERT INTO issue_5751_series VALUES
@@ -263,7 +255,7 @@ SELECT issue_5751_result(
 
 DEALLOCATE issue_5751_cross_param;
 -- A present HAVING or aggregate FILTER must not be represented as None merely
--- because its PARAM_EXTERN cannot be translated.  Both shapes decline and
+-- because its PARAM_EXTERN cannot be translated. Both shapes decline and
 -- PostgreSQL evaluates the original expression.
 PREPARE issue_5751_having(bigint) AS
 SELECT s.state, count(*)
@@ -304,9 +296,8 @@ EXECUTE issue_5751_filter('u1');
                         3
 (1 row)
 
--- The generic prepared executions above must match independently planned
--- PostgreSQL queries with the same parameter values. This catches a present
--- HAVING or FILTER being mistaken for an absent one.
+-- Cross-check the values against literal equivalents. The decline itself is
+-- asserted by the plan checks above.
 SELECT issue_5751_result(
   $$EXECUTE issue_5751_having(1)$$,
   true
@@ -343,7 +334,7 @@ DEALLOCATE issue_5751_filter;
 RESET client_min_messages;
 RESET plan_cache_mode;
 -- PostgreSQL may enforce an inner-join predicate on a parameterized inner
--- index path and remove it from the parent NestPath.joinrestrictinfo.  The
+-- index path and remove it from the parent NestPath.joinrestrictinfo. The
 -- predicate remains in ParamPathInfo.ppi_clauses and must be inventoried when
 -- AggregateScan reconstructs the DataFusion join.  Equality-only execution
 -- would incorrectly count all five rows instead of the three qualifying rows.

--- a/pg_search/tests/pg_regress/expected/issue_5751.out
+++ b/pg_search/tests/pg_regress/expected/issue_5751.out
@@ -453,15 +453,15 @@ SELECT issue_5751_result(
 
 DEALLOCATE issue_5751_ppi_generic;
 RESET plan_cache_mode;
--- A volatile cross-table residual, still under the parameterized nested loop
--- above so the predicate is reachable from both `joinrestrictinfo` and
--- `ppi_clauses` - the overlap the residual dedup exists for. PG16+ tells the
--- two encounters apart by `rinfo_serial`; PG15 has no such identity, falls
--- back to comparing origins. Both accept this shape: the planner hands back
--- the same RestrictInfo, so pointer equality settles it before either
--- version-specific rule runs. `random() * 0` is value-stable, so the count is
--- deterministic and any divergence means the predicate was dropped or applied
--- twice.
+-- A volatile cross-table residual enforced through a parameterized inner path.
+-- For this selected nested-loop path, PostgreSQL records the clause in the
+-- inner path's `ParamPathInfo.ppi_clauses`. `create_nestloop_path()` then omits
+-- the clause assigned to the inner path from the `JoinPath.joinrestrictinfo`
+-- embedded in the parent `NestPath`.
+--
+-- This verifies that AggregateScan inventories and translates a volatile
+-- residual from `ppi_clauses` without dropping it. `random() * 0` keeps the
+-- expected result deterministic.
 SELECT issue_5751_plan_uses(
   $$SELECT count(*)
     FROM issue_5751_ppi_entries e

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -588,7 +588,7 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'story')
   AND (a.is_active = true OR b.is_published = true);
-WARNING:  Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: the selected lower join path contains a predicate that AggregateScan cannot classify (table: join)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 6.3: Unsafe conditions that cannot be pushed down
 SELECT 

--- a/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
+++ b/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
@@ -128,7 +128,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -143,7 +142,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -158,7 +156,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -173,7 +170,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -188,7 +184,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -203,7 +198,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -218,7 +212,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -235,7 +228,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -250,7 +242,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -265,7 +256,6 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -284,35 +274,30 @@ WHERE dt.full_text @@@ $1
   AND DATE(c.date_time_combined) <= $6;
 -- Execute multiple times to trigger generic plan after 5 executions
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -320,7 +305,6 @@ WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE c
 
 -- 6th execution uses generic plan
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20
@@ -352,7 +336,6 @@ WHERE dt.full_text @@@ $1
   AND DATE(c.date_time_combined) >= $5
   AND DATE(c.date_time_combined) <= $6;
 EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     20

--- a/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
+++ b/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
@@ -99,9 +99,12 @@ SELECT i, 'This is document ' || i || ' with text containing ea'
 FROM generate_series(16, 20) i;
 -- Create regular index on date (not in BM25 index - key part of customer scenario)
 CREATE INDEX idx_date_time_combined_date ON core (DATE(date_time_combined));
--- CRITICAL: Disable Custom Scan to force the use of Index Only Scan (Index AM path)
--- This is key to reproducing the customer's issue which occurs with Parallel Index Only Scan
+-- CRITICAL: Disable both custom-scan layers to force the Index AM path.
+-- AggregateScan can otherwise absorb the aggregate-on-join query and bypass
+-- the parallel Index Only Scan whose race this regression covers.
 SET paradedb.enable_custom_scan = false;
+SET paradedb.enable_aggregate_custom_scan = false;
+SET client_min_messages = error;
 -- Enable parallel workers
 SET max_parallel_workers_per_gather = 2;
 -- Force parallel plans
@@ -355,12 +358,14 @@ EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewter
 
 DEALLOCATE parallel_hash_join_query_generic;
 -- Reset settings
+RESET client_min_messages;
 RESET plan_cache_mode;
 RESET max_parallel_workers_per_gather;
 RESET parallel_tuple_cost;
 RESET parallel_setup_cost;
 RESET min_parallel_table_scan_size;
 RESET min_parallel_index_scan_size;
+RESET paradedb.enable_aggregate_custom_scan;
 RESET paradedb.enable_custom_scan;
 -- Clean up
 DROP TABLE document_text;

--- a/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
+++ b/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
@@ -104,7 +104,6 @@ CREATE INDEX idx_date_time_combined_date ON core (DATE(date_time_combined));
 -- the parallel Index Only Scan whose race this regression covers.
 SET paradedb.enable_custom_scan = false;
 SET paradedb.enable_aggregate_custom_scan = false;
-SET client_min_messages = error;
 -- Enable parallel workers
 SET max_parallel_workers_per_gather = 2;
 -- Force parallel plans
@@ -131,6 +130,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -145,6 +145,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -159,6 +160,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -173,6 +175,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -187,6 +190,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -201,6 +205,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -215,6 +220,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -231,6 +237,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -245,6 +252,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -259,6 +267,7 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -277,30 +286,35 @@ WHERE dt.full_text @@@ $1
   AND DATE(c.date_time_combined) <= $6;
 -- Execute multiple times to trigger generic plan after 5 executions
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -308,6 +322,7 @@ EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt'
 
 -- 6th execution uses generic plan
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -339,6 +354,7 @@ WHERE dt.full_text @@@ $1
   AND DATE(c.date_time_combined) >= $5
   AND DATE(c.date_time_combined) <= $6;
 EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     20
@@ -358,7 +374,6 @@ EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewter
 
 DEALLOCATE parallel_hash_join_query_generic;
 -- Reset settings
-RESET client_min_messages;
 RESET plan_cache_mode;
 RESET max_parallel_workers_per_gather;
 RESET parallel_tuple_cost;

--- a/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
+++ b/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
@@ -58,42 +58,36 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
 SET plan_cache_mode = force_custom_plan;
 -- All executions should return consistent results
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
    122
@@ -101,7 +95,6 @@ WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE c
 
 -- Try with different parameters
 EXECUTE test_parallel_join('ea', '2024-06-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     72
@@ -120,7 +113,6 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
   AND c.created_at::date <= $3::date;
 -- These should all return consistent results
 EXECUTE test_parallel_join_generic('ea', '2024-01-01', '2025-01-01');
-WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
    122

--- a/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
+++ b/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
@@ -42,6 +42,11 @@ USING bm25 (dwf_doid, full_text)
 WITH (key_field='dwf_doid');
 -- Enable parallel workers
 SET max_parallel_workers_per_gather = 2;
+-- Keep the join cases on their original parallel lower-plan path. AggregateScan
+-- can otherwise absorb these aggregate-on-join queries, so the test would stop
+-- exercising prepared parallel scans even though its row counts still pass.
+SET paradedb.enable_aggregate_custom_scan = false;
+SET client_min_messages = error;
 -- Test 1: Prepared statement with join and date filter
 -- This mimics the customer's scenario
 PREPARE test_parallel_join(text, timestamptz, timestamptz) AS
@@ -131,6 +136,8 @@ EXECUTE test_parallel_join_generic('ea', '2024-06-01', '2025-01-01');
 (1 row)
 
 DEALLOCATE test_parallel_join_generic;
+RESET client_min_messages;
+RESET paradedb.enable_aggregate_custom_scan;
 -- Test 2: Simple parallel index scan with parameters
 RESET plan_cache_mode;
 PREPARE test_simple_parallel(text) AS

--- a/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
+++ b/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
@@ -46,7 +46,6 @@ SET max_parallel_workers_per_gather = 2;
 -- can otherwise absorb these aggregate-on-join queries, so the test would stop
 -- exercising prepared parallel scans even though its row counts still pass.
 SET paradedb.enable_aggregate_custom_scan = false;
-SET client_min_messages = error;
 -- Test 1: Prepared statement with join and date filter
 -- This mimics the customer's scenario
 PREPARE test_parallel_join(text, timestamptz, timestamptz) AS
@@ -63,36 +62,42 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
 SET plan_cache_mode = force_custom_plan;
 -- All executions should return consistent results
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
    122
@@ -100,6 +105,7 @@ EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 
 -- Try with different parameters
 EXECUTE test_parallel_join('ea', '2024-06-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
     72
@@ -118,6 +124,7 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
   AND c.created_at::date <= $3::date;
 -- These should all return consistent results
 EXECUTE test_parallel_join_generic('ea', '2024-01-01', '2025-01-01');
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: c, dt)
  count 
 -------
    122
@@ -136,7 +143,6 @@ EXECUTE test_parallel_join_generic('ea', '2024-06-01', '2025-01-01');
 (1 row)
 
 DEALLOCATE test_parallel_join_generic;
-RESET client_min_messages;
 RESET paradedb.enable_aggregate_custom_scan;
 -- Test 2: Simple parallel index scan with parameters
 RESET plan_cache_mode;

--- a/pg_search/tests/pg_regress/sql/issue_5751.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5751.sql
@@ -356,17 +356,22 @@ SELECT issue_5751_result(
 DEALLOCATE issue_5751_ppi_generic;
 RESET plan_cache_mode;
 
-RESET enable_hashjoin;
-RESET enable_mergejoin;
-RESET enable_seqscan;
+-- A volatile cross-table residual, still under the parameterized nested loop
+-- above so the predicate is reachable from both `joinrestrictinfo` and
+-- `ppi_clauses` - the overlap the residual dedup exists for. PG16+ tells the
+-- two encounters apart by `rinfo_serial`; PG15 has no such identity, falls
+-- back to comparing origins. Both accept this shape: the planner hands back
+-- the same RestrictInfo, so pointer equality settles it before either
+-- version-specific rule runs. `random() * 0` is value-stable, so the count is
+-- deterministic and any divergence means the predicate was dropped or applied
+-- twice.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount + (random() * 0)::bigint$$,
+  'ParadeDB Aggregate Scan') AS volatile_residual_uses_aggregate_scan;
 
--- A volatile cross-table residual. PG16+ discriminates residuals by
--- RestrictInfo identity, so two occurrences of the same predicate stay two
--- independent draws rather than collapsing into one. `random() * 0` is
--- value-stable, so the row count is deterministic and any divergence from
--- PostgreSQL means the predicate was dropped or applied the wrong number of
--- times. (PG15 has no such identity and declines instead; that arm is
--- compiled out here.)
 SELECT issue_5751_result(
   $$SELECT count(*)
     FROM issue_5751_ppi_entries e
@@ -381,11 +386,12 @@ SELECT issue_5751_result(
   false
 ) AS volatile_residual_matches_postgres;
 
--- JoinScan and AggregateScan both proposing for the same joinrel. With
--- `enable_join_custom_scan` on, JoinScan's CustomPath can be the joinrel's
--- cheapest path; AggregateScan cannot reconstruct predicates through it and
--- declines rather than falling back to the retained parse tree. Whichever
--- scan wins, the answer must match PostgreSQL.
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+RESET enable_seqscan;
+
+-- JoinScan and AggregateScan proposing for the same joinrel, with `@@@` on
+-- both sides so JoinScan genuinely competes.
 CREATE TABLE issue_5751_js_left (id bigint PRIMARY KEY, body text);
 CREATE TABLE issue_5751_js_right (id bigint PRIMARY KEY, left_id bigint, body text);
 INSERT INTO issue_5751_js_left SELECT g, 'alpha beta' FROM generate_series(1, 20) g;
@@ -396,6 +402,30 @@ CREATE INDEX issue_5751_js_right_bm25
 ON issue_5751_js_right USING bm25 (id, left_id, body) WITH (key_field = 'id');
 
 SET paradedb.enable_join_custom_scan = on;
+
+-- Both enabled: AggregateScan claims the query outright.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  'ParadeDB Aggregate Scan') AS both_scans_on_uses_aggregate_scan;
+
+-- With AggregateScan out of the way, JoinScan still declines: it does not
+-- support aggregates (`JoinDeclineReason::ContainsAggregate`), so it never
+-- offers a CustomPath for this joinrel and AggregateScan's opaque-path check
+-- is never reached through it. The warning below is the anchor - #5285 will
+-- let JoinScan propose here, and this case then becomes a real interaction
+-- test rather than a record of why it cannot happen yet.
+SET paradedb.enable_aggregate_custom_scan = off;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  'ParadeDB Base Scan') AS joinscan_declines_falls_back_to_base_scans;
+SET paradedb.enable_aggregate_custom_scan = on;
+
 SELECT issue_5751_result(
   $$SELECT count(*)
     FROM issue_5751_js_right r
@@ -411,7 +441,48 @@ SELECT issue_5751_result(
 ) AS joinscan_interaction_matches_postgres;
 RESET paradedb.enable_join_custom_scan;
 
+-- Partitionwise join: the other opaque path shape. Partitioned parents are
+-- ineligible well before the opaque-path check runs, so an Append over
+-- per-partition joins never reaches it either. Recorded so that adding
+-- partitioned support surfaces this case instead of silently changing it.
+CREATE TABLE issue_5751_pw_a (id bigint, k bigint, s text) PARTITION BY RANGE (id);
+CREATE TABLE issue_5751_pw_a1 PARTITION OF issue_5751_pw_a FOR VALUES FROM (0) TO (100);
+CREATE TABLE issue_5751_pw_a2 PARTITION OF issue_5751_pw_a FOR VALUES FROM (100) TO (200);
+CREATE TABLE issue_5751_pw_b (id bigint, k bigint, t text) PARTITION BY RANGE (id);
+CREATE TABLE issue_5751_pw_b1 PARTITION OF issue_5751_pw_b FOR VALUES FROM (0) TO (100);
+CREATE TABLE issue_5751_pw_b2 PARTITION OF issue_5751_pw_b FOR VALUES FROM (100) TO (200);
+INSERT INTO issue_5751_pw_a SELECT g, g, 'x' FROM generate_series(1, 199) g;
+INSERT INTO issue_5751_pw_b SELECT g, g, 'y' FROM generate_series(1, 199) g;
+CREATE INDEX issue_5751_pw_a_bm25
+ON issue_5751_pw_a USING bm25 (id, k, ((s)::pdb.literal)) WITH (key_field = 'id');
+CREATE INDEX issue_5751_pw_b_bm25
+ON issue_5751_pw_b USING bm25 (id, k, ((t)::pdb.literal)) WITH (key_field = 'id');
+
+SET enable_partitionwise_join = on;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_pw_a a
+    JOIN issue_5751_pw_b b ON a.id = b.id AND a.k = b.k
+    WHERE a.s = 'x' AND b.t = 'y'$$,
+  'ParadeDB Aggregate Scan') AS partitionwise_uses_aggregate_scan;
+
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_pw_a a
+    JOIN issue_5751_pw_b b ON a.id = b.id AND a.k = b.k
+    WHERE a.s = 'x' AND b.t = 'y'$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_pw_a a
+    JOIN issue_5751_pw_b b ON a.id = b.id AND a.k = b.k
+    WHERE a.s = 'x' AND b.t = 'y'$$,
+  false
+) AS partitionwise_matches_postgres;
+RESET enable_partitionwise_join;
+
 DROP FUNCTION issue_5751_plan_uses(text, text), issue_5751_result(text, boolean);
 DROP TABLE issue_5751_js_left, issue_5751_js_right;
+DROP TABLE issue_5751_pw_a, issue_5751_pw_b;
 DROP TABLE issue_5751_entries, issue_5751_series,
            issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/sql/issue_5751.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5751.sql
@@ -2,14 +2,6 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 
--- #5751 predicate-normalization contract:
---   1. T_List and top-level AND are containers, never executable expressions.
---   2. Each conjunct is classified independently; OR and NOT stay intact.
---   3. Single-relation conjuncts remain owned by their base scans.
---   4. A present unsupported predicate declines AggregateScan; it is never dropped.
---   5. Custom prepared plans with Const substitutions remain eligible.
---   6. Base-filter PARAM_EXTERN uses the existing live ExprContext binding path.
---   7. PARAM_EXTERN in cross-table, HAVING, or FILTER expressions declines.
 
 CREATE TABLE issue_5751_series (
     id bigint PRIMARY KEY,
@@ -68,7 +60,7 @@ BEGIN
   RETURN result;
 END $$ LANGUAGE plpgsql;
 
--- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List.  Each
+-- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List. Each
 -- item is a base predicate even though the container references both tables.
 SELECT issue_5751_plan_uses(
   $$SELECT count(*)
@@ -98,7 +90,7 @@ SELECT issue_5751_result(
 ) AS matches_postgres;
 
 -- The same semantic query can place the equality in the implicit-join WHERE
--- list.  The equality is a join key; the other two conjuncts remain owned by
+-- list. The equality is a join key; the other two conjuncts remain owned by
 -- their base scans.
 SELECT issue_5751_plan_uses(
   $$SELECT count(*)
@@ -129,7 +121,7 @@ FROM issue_5751_entries e
 JOIN issue_5751_series s ON s.id = e.series_id
 WHERE s.state = 'active' AND e.user_id = 'u1';
 
--- Custom prepared plans replace PARAM_EXTERN with Const nodes.  Preserve that
+-- Custom prepared plans replace PARAM_EXTERN with Const nodes. Preserve that
 -- existing supported path and verify that this fix does not merely fall back to
 -- PostgreSQL for every prepared statement.
 INSERT INTO issue_5751_series VALUES
@@ -209,7 +201,7 @@ SELECT issue_5751_result(
 DEALLOCATE issue_5751_cross_param;
 
 -- A present HAVING or aggregate FILTER must not be represented as None merely
--- because its PARAM_EXTERN cannot be translated.  Both shapes decline and
+-- because its PARAM_EXTERN cannot be translated. Both shapes decline and
 -- PostgreSQL evaluates the original expression.
 PREPARE issue_5751_having(bigint) AS
 SELECT s.state, count(*)
@@ -234,9 +226,8 @@ SELECT issue_5751_plan_uses(
   'ParadeDB Aggregate Scan') AS filter_uses_aggregate_scan;
 EXECUTE issue_5751_filter('u1');
 
--- The generic prepared executions above must match independently planned
--- PostgreSQL queries with the same parameter values. This catches a present
--- HAVING or FILTER being mistaken for an absent one.
+-- Cross-check the values against literal equivalents. The decline itself is
+-- asserted by the plan checks above.
 SELECT issue_5751_result(
   $$EXECUTE issue_5751_having(1)$$,
   true
@@ -268,7 +259,7 @@ RESET client_min_messages;
 RESET plan_cache_mode;
 
 -- PostgreSQL may enforce an inner-join predicate on a parameterized inner
--- index path and remove it from the parent NestPath.joinrestrictinfo.  The
+-- index path and remove it from the parent NestPath.joinrestrictinfo. The
 -- predicate remains in ParamPathInfo.ppi_clauses and must be inventoried when
 -- AggregateScan reconstructs the DataFusion join.  Equality-only execution
 -- would incorrectly count all five rows instead of the three qualifying rows.

--- a/pg_search/tests/pg_regress/sql/issue_5751.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5751.sql
@@ -1,0 +1,263 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- #5751 predicate-normalization contract:
+--   1. T_List and top-level AND are containers, never executable expressions.
+--   2. Each conjunct is classified independently; OR and NOT stay intact.
+--   3. Single-relation conjuncts remain owned by their base scans.
+--   4. A present unsupported predicate declines AggregateScan; it is never dropped.
+--   5. Custom prepared plans with Const substitutions remain eligible.
+--   6. Base-filter PARAM_EXTERN uses the existing live ExprContext binding path.
+--   7. PARAM_EXTERN in cross-table, HAVING, or FILTER expressions declines.
+
+CREATE TABLE issue_5751_series (
+    id bigint PRIMARY KEY,
+    state text
+);
+CREATE TABLE issue_5751_entries (
+    id bigint PRIMARY KEY,
+    series_id bigint,
+    user_id text
+);
+
+INSERT INTO issue_5751_series VALUES
+    (1, 'active'),
+    (2, 'inactive'),
+    (3, 'active');
+INSERT INTO issue_5751_entries VALUES
+    (1, 1, 'u1'),
+    (2, 1, 'u2'),
+    (3, 2, 'u1'),
+    (4, 3, 'u1');
+
+CREATE INDEX issue_5751_series_idx
+ON issue_5751_series USING bm25 (id, ((state)::pdb.literal))
+WITH (key_field = 'id');
+CREATE INDEX issue_5751_entries_idx
+ON issue_5751_entries USING bm25 (id, series_id, ((user_id)::pdb.literal))
+WITH (key_field = 'id');
+
+-- Keep the plan assertion stable without recording DataFusion's physical plan.
+CREATE FUNCTION issue_5751_plan_uses(q text, needle text) RETURNS boolean AS $$
+DECLARE r record;
+BEGIN
+  FOR r IN EXECUTE 'EXPLAIN (COSTS OFF) ' || q LOOP
+    IF r."QUERY PLAN" LIKE '%' || needle || '%' THEN RETURN true; END IF;
+  END LOOP;
+  RETURN false;
+END $$ LANGUAGE plpgsql;
+
+-- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List.  Each
+-- item is a base predicate even though the container references both tables.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.state = 'active' AND e.user_id = 'u1'$$,
+  'ParadeDB Aggregate Scan') AS uses_aggregate_scan;
+
+-- Both filters must remain effective: dropping either one returns three rows.
+SELECT count(*) AS filtered_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = 'active' AND e.user_id = 'u1';
+
+-- The same semantic query can place the equality in the implicit-join WHERE
+-- list.  The equality is a join key; the other two conjuncts remain owned by
+-- their base scans.
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_entries e, issue_5751_series s
+    WHERE s.id = e.series_id
+      AND s.state = 'active'
+      AND e.user_id = 'u1'$$,
+  'ParadeDB Aggregate Scan') AS implicit_uses_aggregate_scan;
+
+SELECT count(*) AS implicit_filtered_count
+FROM issue_5751_entries e, issue_5751_series s
+WHERE s.id = e.series_id
+  AND s.state = 'active'
+  AND e.user_id = 'u1';
+
+-- Only implicit AND containers are normalized.  OR remains one semantic
+-- predicate; flattening it would incorrectly require both states at once.
+SELECT count(*) AS preserved_or_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE (s.state = 'active' OR s.state = 'inactive')
+  AND e.user_id = 'u1';
+
+-- The planner error was independent of row count.
+TRUNCATE issue_5751_entries, issue_5751_series;
+SELECT count(*) AS empty_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = 'active' AND e.user_id = 'u1';
+
+-- Custom prepared plans replace PARAM_EXTERN with Const nodes.  Preserve that
+-- existing supported path and verify that this fix does not merely fall back to
+-- PostgreSQL for every prepared statement.
+INSERT INTO issue_5751_series VALUES
+    (1, 'active'),
+    (2, 'inactive'),
+    (3, 'active');
+INSERT INTO issue_5751_entries VALUES
+    (1, 1, 'u1'),
+    (2, 1, 'u2'),
+    (3, 2, 'u1'),
+    (4, 3, 'u1');
+
+PREPARE issue_5751_generic(text, text) AS
+SELECT count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = $1 AND e.user_id = $2;
+
+SET plan_cache_mode = force_custom_plan;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_generic('active', 'u1')$$,
+  'ParadeDB Aggregate Scan') AS custom_uses_aggregate_scan;
+EXECUTE issue_5751_generic('active', 'u1');
+
+-- A generic plan with parameters on both inputs chooses a wrapped lower path.
+-- AggregateScan must traverse the transparent wrapper, account for the
+-- parameterized-path clauses, and remain selected.
+SET plan_cache_mode = force_generic_plan;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_generic('active', 'u1')$$,
+  'ParadeDB Aggregate Scan') AS generic_uses_aggregate_scan;
+EXECUTE issue_5751_generic('active', 'u1');
+
+DEALLOCATE issue_5751_generic;
+
+-- Main already supports a single generic base-filter parameter through that
+-- runtime path. Keep an explicit compatibility assertion so a future safety
+-- guard cannot turn this working AggregateScan into fallback or an error.
+PREPARE issue_5751_main_compatible(text) AS
+SELECT count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.state = $1;
+
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_main_compatible('active')$$,
+  'ParadeDB Aggregate Scan') AS main_compatible_uses_aggregate_scan;
+EXECUTE issue_5751_main_compatible('active');
+DEALLOCATE issue_5751_main_compatible;
+
+-- Cross-table DataFusion predicates do not yet receive the executing query's
+-- ParamListInfo. Decline this shape rather than raising "no value found for
+-- parameter" or evaluating an incomplete predicate.
+PREPARE issue_5751_cross_param(bigint) AS
+SELECT count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+WHERE s.id + $1 > e.series_id;
+
+SET client_min_messages = error;
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_cross_param(0)$$,
+  'ParadeDB Aggregate Scan') AS cross_param_uses_aggregate_scan;
+EXECUTE issue_5751_cross_param(0);
+RESET client_min_messages;
+DEALLOCATE issue_5751_cross_param;
+
+-- A present HAVING or aggregate FILTER must not be represented as None merely
+-- because its PARAM_EXTERN cannot be translated.  Both shapes decline and
+-- PostgreSQL evaluates the original expression.
+PREPARE issue_5751_having(bigint) AS
+SELECT s.state, count(*)
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id
+GROUP BY s.state
+HAVING count(*) > $1
+ORDER BY s.state;
+
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_having(1)$$,
+  'ParadeDB Aggregate Scan') AS having_uses_aggregate_scan;
+EXECUTE issue_5751_having(1);
+DEALLOCATE issue_5751_having;
+
+PREPARE issue_5751_filter(text) AS
+SELECT count(*) FILTER (WHERE e.user_id = $1) AS filtered_aggregate_count
+FROM issue_5751_entries e
+JOIN issue_5751_series s ON s.id = e.series_id;
+
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_filter('u1')$$,
+  'ParadeDB Aggregate Scan') AS filter_uses_aggregate_scan;
+EXECUTE issue_5751_filter('u1');
+DEALLOCATE issue_5751_filter;
+
+RESET plan_cache_mode;
+
+-- PostgreSQL may enforce an inner-join predicate on a parameterized inner
+-- index path and remove it from the parent NestPath.joinrestrictinfo.  The
+-- predicate remains in ParamPathInfo.ppi_clauses and must be inventoried when
+-- AggregateScan reconstructs the DataFusion join.  Equality-only execution
+-- would incorrectly count all five rows instead of the three qualifying rows.
+CREATE TABLE issue_5751_ppi_series (
+    id bigint PRIMARY KEY,
+    threshold bigint
+);
+CREATE TABLE issue_5751_ppi_entries (
+    id bigint PRIMARY KEY,
+    series_id bigint,
+    amount bigint
+);
+
+INSERT INTO issue_5751_ppi_series VALUES (1, 10), (2, 20);
+INSERT INTO issue_5751_ppi_entries VALUES
+    (1, 1, 5),
+    (2, 1, 15),
+    (3, 1, 25),
+    (4, 2, 15),
+    (5, 2, 25);
+
+CREATE INDEX issue_5751_ppi_series_bm25
+ON issue_5751_ppi_series USING bm25 (id, threshold)
+WITH (key_field = 'id');
+CREATE INDEX issue_5751_ppi_entries_bm25
+ON issue_5751_ppi_entries USING bm25 (id, series_id, amount)
+WITH (key_field = 'id');
+CREATE INDEX issue_5751_ppi_lookup
+ON issue_5751_ppi_series (id, threshold);
+
+SET enable_hashjoin = off;
+SET enable_mergejoin = off;
+SET enable_seqscan = off;
+SET enable_material = off;
+SET enable_memoize = off;
+
+SET paradedb.enable_aggregate_custom_scan = off;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  'Nested Loop') AS lower_uses_parameterized_nestloop;
+
+SET paradedb.enable_aggregate_custom_scan = on;
+SELECT issue_5751_plan_uses(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  'ParadeDB Aggregate Scan') AS ppi_uses_aggregate_scan;
+
+SELECT count(*) AS ppi_filtered_count
+FROM issue_5751_ppi_entries e
+JOIN issue_5751_ppi_series s
+  ON s.id = e.series_id AND s.threshold < e.amount;
+
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+RESET enable_seqscan;
+RESET enable_material;
+RESET enable_memoize;
+
+DROP FUNCTION issue_5751_plan_uses(text, text);
+DROP TABLE issue_5751_entries, issue_5751_series,
+           issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/sql/issue_5751.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5751.sql
@@ -48,6 +48,26 @@ BEGIN
   RETURN false;
 END $$ LANGUAGE plpgsql;
 
+-- Compare the extension path against PostgreSQL's answer instead of blessing a
+-- newly generated literal result. Each dynamic statement is planned after its
+-- AggregateScan setting is applied.
+CREATE FUNCTION issue_5751_result(q text, use_aggregate_scan boolean)
+RETURNS jsonb AS $$
+DECLARE
+  r record;
+  result jsonb := '[]'::jsonb;
+BEGIN
+  PERFORM set_config(
+    'paradedb.enable_aggregate_custom_scan',
+    use_aggregate_scan::text,
+    true
+  );
+  FOR r IN EXECUTE q LOOP
+    result := result || jsonb_build_array(to_jsonb(r));
+  END LOOP;
+  RETURN result;
+END $$ LANGUAGE plpgsql;
+
 -- PostgreSQL retains the two WHERE conjuncts in an implicit-AND List.  Each
 -- item is a base predicate even though the container references both tables.
 SELECT issue_5751_plan_uses(
@@ -62,6 +82,20 @@ SELECT count(*) AS filtered_count
 FROM issue_5751_entries e
 JOIN issue_5751_series s ON s.id = e.series_id
 WHERE s.state = 'active' AND e.user_id = 'u1';
+
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.state = 'active' AND e.user_id = 'u1'$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.state = 'active' AND e.user_id = 'u1'$$,
+  false
+) AS matches_postgres;
 
 -- The same semantic query can place the equality in the implicit-join WHERE
 -- list.  The equality is a join key; the other two conjuncts remain owned by
@@ -146,8 +180,8 @@ SELECT issue_5751_plan_uses(
 EXECUTE issue_5751_main_compatible('active');
 DEALLOCATE issue_5751_main_compatible;
 
--- Cross-table DataFusion predicates do not yet receive the executing query's
--- ParamListInfo. Decline this shape rather than raising "no value found for
+-- Cross-table DataFusion predicates have no executor-side ParamListInfo
+-- binding. Decline this shape rather than raising "no value found for
 -- parameter" or evaluating an incomplete predicate.
 PREPARE issue_5751_cross_param(bigint) AS
 SELECT count(*)
@@ -160,7 +194,18 @@ SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_cross_param(0)$$,
   'ParadeDB Aggregate Scan') AS cross_param_uses_aggregate_scan;
 EXECUTE issue_5751_cross_param(0);
-RESET client_min_messages;
+
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_cross_param(0)$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    WHERE s.id + 0 > e.series_id$$,
+  false
+) AS cross_param_matches_postgres;
+
 DEALLOCATE issue_5751_cross_param;
 
 -- A present HAVING or aggregate FILTER must not be represented as None merely
@@ -178,7 +223,6 @@ SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_having(1)$$,
   'ParadeDB Aggregate Scan') AS having_uses_aggregate_scan;
 EXECUTE issue_5751_having(1);
-DEALLOCATE issue_5751_having;
 
 PREPARE issue_5751_filter(text) AS
 SELECT count(*) FILTER (WHERE e.user_id = $1) AS filtered_aggregate_count
@@ -189,7 +233,37 @@ SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_filter('u1')$$,
   'ParadeDB Aggregate Scan') AS filter_uses_aggregate_scan;
 EXECUTE issue_5751_filter('u1');
+
+-- The generic prepared executions above must match independently planned
+-- PostgreSQL queries with the same parameter values. This catches a present
+-- HAVING or FILTER being mistaken for an absent one.
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_having(1)$$,
+  true
+) = issue_5751_result(
+  $$SELECT s.state, count(*)
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id
+    GROUP BY s.state
+    HAVING count(*) > 1
+    ORDER BY s.state$$,
+  false
+) AS having_matches_postgres;
+
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_filter('u1')$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*) FILTER (WHERE e.user_id = 'u1') AS filtered_aggregate_count
+    FROM issue_5751_entries e
+    JOIN issue_5751_series s ON s.id = e.series_id$$,
+  false
+) AS filter_matches_postgres;
+
+DEALLOCATE issue_5751_having;
 DEALLOCATE issue_5751_filter;
+
+RESET client_min_messages;
 
 RESET plan_cache_mode;
 
@@ -228,8 +302,6 @@ ON issue_5751_ppi_series (id, threshold);
 SET enable_hashjoin = off;
 SET enable_mergejoin = off;
 SET enable_seqscan = off;
-SET enable_material = off;
-SET enable_memoize = off;
 
 SET paradedb.enable_aggregate_custom_scan = off;
 SELECT issue_5751_plan_uses(
@@ -252,12 +324,54 @@ FROM issue_5751_ppi_entries e
 JOIN issue_5751_ppi_series s
   ON s.id = e.series_id AND s.threshold < e.amount;
 
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount$$,
+  false
+) AS ppi_matches_postgres;
+
+-- Exercise generic-plan parameters and ParamPathInfo.ppi_clauses together.
+-- The parameter remains a supported base filter while the cross-table
+-- inequality is recovered from the parameterized lower path.
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_5751_ppi_generic(bigint) AS
+SELECT count(*)
+FROM issue_5751_ppi_entries e
+JOIN issue_5751_ppi_series s
+  ON s.id = e.series_id AND s.threshold < e.amount
+WHERE e.amount > $1;
+
+SELECT issue_5751_plan_uses(
+  $$EXECUTE issue_5751_ppi_generic(20)$$,
+  'ParadeDB Aggregate Scan') AS generic_ppi_uses_aggregate_scan;
+
+SELECT issue_5751_result(
+  $$EXECUTE issue_5751_ppi_generic(20)$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount
+    WHERE e.amount > 20$$,
+  false
+) AS generic_ppi_matches_postgres;
+
+DEALLOCATE issue_5751_ppi_generic;
+RESET plan_cache_mode;
+
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_seqscan;
-RESET enable_material;
-RESET enable_memoize;
 
-DROP FUNCTION issue_5751_plan_uses(text, text);
+DROP FUNCTION issue_5751_plan_uses(text, text), issue_5751_result(text, boolean);
 DROP TABLE issue_5751_entries, issue_5751_series,
            issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/sql/issue_5751.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5751.sql
@@ -356,15 +356,15 @@ SELECT issue_5751_result(
 DEALLOCATE issue_5751_ppi_generic;
 RESET plan_cache_mode;
 
--- A volatile cross-table residual, still under the parameterized nested loop
--- above so the predicate is reachable from both `joinrestrictinfo` and
--- `ppi_clauses` - the overlap the residual dedup exists for. PG16+ tells the
--- two encounters apart by `rinfo_serial`; PG15 has no such identity, falls
--- back to comparing origins. Both accept this shape: the planner hands back
--- the same RestrictInfo, so pointer equality settles it before either
--- version-specific rule runs. `random() * 0` is value-stable, so the count is
--- deterministic and any divergence means the predicate was dropped or applied
--- twice.
+-- A volatile cross-table residual enforced through a parameterized inner path.
+-- For this selected nested-loop path, PostgreSQL records the clause in the
+-- inner path's `ParamPathInfo.ppi_clauses`. `create_nestloop_path()` then omits
+-- the clause assigned to the inner path from the `JoinPath.joinrestrictinfo`
+-- embedded in the parent `NestPath`.
+--
+-- This verifies that AggregateScan inventories and translates a volatile
+-- residual from `ppi_clauses` without dropping it. `random() * 0` keeps the
+-- expected result deterministic.
 SELECT issue_5751_plan_uses(
   $$SELECT count(*)
     FROM issue_5751_ppi_entries e

--- a/pg_search/tests/pg_regress/sql/issue_5751.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5751.sql
@@ -181,7 +181,6 @@ FROM issue_5751_entries e
 JOIN issue_5751_series s ON s.id = e.series_id
 WHERE s.id + $1 > e.series_id;
 
-SET client_min_messages = error;
 SELECT issue_5751_plan_uses(
   $$EXECUTE issue_5751_cross_param(0)$$,
   'ParadeDB Aggregate Scan') AS cross_param_uses_aggregate_scan;
@@ -253,8 +252,6 @@ SELECT issue_5751_result(
 
 DEALLOCATE issue_5751_having;
 DEALLOCATE issue_5751_filter;
-
-RESET client_min_messages;
 
 RESET plan_cache_mode;
 

--- a/pg_search/tests/pg_regress/sql/issue_5751.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5751.sql
@@ -360,6 +360,58 @@ RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_seqscan;
 
+-- A volatile cross-table residual. PG16+ discriminates residuals by
+-- RestrictInfo identity, so two occurrences of the same predicate stay two
+-- independent draws rather than collapsing into one. `random() * 0` is
+-- value-stable, so the row count is deterministic and any divergence from
+-- PostgreSQL means the predicate was dropped or applied the wrong number of
+-- times. (PG15 has no such identity and declines instead; that arm is
+-- compiled out here.)
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount + (random() * 0)::bigint$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_ppi_entries e
+    JOIN issue_5751_ppi_series s
+      ON s.id = e.series_id AND s.threshold < e.amount + (random() * 0)::bigint$$,
+  false
+) AS volatile_residual_matches_postgres;
+
+-- JoinScan and AggregateScan both proposing for the same joinrel. With
+-- `enable_join_custom_scan` on, JoinScan's CustomPath can be the joinrel's
+-- cheapest path; AggregateScan cannot reconstruct predicates through it and
+-- declines rather than falling back to the retained parse tree. Whichever
+-- scan wins, the answer must match PostgreSQL.
+CREATE TABLE issue_5751_js_left (id bigint PRIMARY KEY, body text);
+CREATE TABLE issue_5751_js_right (id bigint PRIMARY KEY, left_id bigint, body text);
+INSERT INTO issue_5751_js_left SELECT g, 'alpha beta' FROM generate_series(1, 20) g;
+INSERT INTO issue_5751_js_right SELECT g, g, 'gamma delta' FROM generate_series(1, 20) g;
+CREATE INDEX issue_5751_js_left_bm25
+ON issue_5751_js_left USING bm25 (id, body) WITH (key_field = 'id');
+CREATE INDEX issue_5751_js_right_bm25
+ON issue_5751_js_right USING bm25 (id, left_id, body) WITH (key_field = 'id');
+
+SET paradedb.enable_join_custom_scan = on;
+SELECT issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  true
+) = issue_5751_result(
+  $$SELECT count(*)
+    FROM issue_5751_js_right r
+    JOIN issue_5751_js_left l ON l.id = r.left_id
+    WHERE l.body @@@ 'alpha' AND r.body @@@ 'gamma'$$,
+  false
+) AS joinscan_interaction_matches_postgres;
+RESET paradedb.enable_join_custom_scan;
+
 DROP FUNCTION issue_5751_plan_uses(text, text), issue_5751_result(text, boolean);
+DROP TABLE issue_5751_js_left, issue_5751_js_right;
 DROP TABLE issue_5751_entries, issue_5751_series,
            issue_5751_ppi_entries, issue_5751_ppi_series;

--- a/pg_search/tests/pg_regress/sql/parallel_hash_join_race.sql
+++ b/pg_search/tests/pg_regress/sql/parallel_hash_join_race.sql
@@ -110,9 +110,12 @@ FROM generate_series(16, 20) i;
 -- Create regular index on date (not in BM25 index - key part of customer scenario)
 CREATE INDEX idx_date_time_combined_date ON core (DATE(date_time_combined));
 
--- CRITICAL: Disable Custom Scan to force the use of Index Only Scan (Index AM path)
--- This is key to reproducing the customer's issue which occurs with Parallel Index Only Scan
+-- CRITICAL: Disable both custom-scan layers to force the Index AM path.
+-- AggregateScan can otherwise absorb the aggregate-on-join query and bypass
+-- the parallel Index Only Scan whose race this regression covers.
 SET paradedb.enable_custom_scan = false;
+SET paradedb.enable_aggregate_custom_scan = false;
+SET client_min_messages = error;
 
 -- Enable parallel workers
 SET max_parallel_workers_per_gather = 2;
@@ -281,12 +284,14 @@ EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewter
 DEALLOCATE parallel_hash_join_query_generic;
 
 -- Reset settings
+RESET client_min_messages;
 RESET plan_cache_mode;
 RESET max_parallel_workers_per_gather;
 RESET parallel_tuple_cost;
 RESET parallel_setup_cost;
 RESET min_parallel_table_scan_size;
 RESET min_parallel_index_scan_size;
+RESET paradedb.enable_aggregate_custom_scan;
 RESET paradedb.enable_custom_scan;
 
 -- Clean up

--- a/pg_search/tests/pg_regress/sql/parallel_hash_join_race.sql
+++ b/pg_search/tests/pg_regress/sql/parallel_hash_join_race.sql
@@ -115,7 +115,6 @@ CREATE INDEX idx_date_time_combined_date ON core (DATE(date_time_combined));
 -- the parallel Index Only Scan whose race this regression covers.
 SET paradedb.enable_custom_scan = false;
 SET paradedb.enable_aggregate_custom_scan = false;
-SET client_min_messages = error;
 
 -- Enable parallel workers
 SET max_parallel_workers_per_gather = 2;
@@ -284,7 +283,6 @@ EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewter
 DEALLOCATE parallel_hash_join_query_generic;
 
 -- Reset settings
-RESET client_min_messages;
 RESET plan_cache_mode;
 RESET max_parallel_workers_per_gather;
 RESET parallel_tuple_cost;

--- a/pg_search/tests/pg_regress/sql/prepared_statement_parallel.sql
+++ b/pg_search/tests/pg_regress/sql/prepared_statement_parallel.sql
@@ -46,6 +46,12 @@ WITH (key_field='dwf_doid');
 -- Enable parallel workers
 SET max_parallel_workers_per_gather = 2;
 
+-- Keep the join cases on their original parallel lower-plan path. AggregateScan
+-- can otherwise absorb these aggregate-on-join queries, so the test would stop
+-- exercising prepared parallel scans even though its row counts still pass.
+SET paradedb.enable_aggregate_custom_scan = false;
+SET client_min_messages = error;
+
 -- Test 1: Prepared statement with join and date filter
 -- This mimics the customer's scenario
 PREPARE test_parallel_join(text, timestamptz, timestamptz) AS
@@ -94,6 +100,9 @@ EXECUTE test_parallel_join_generic('ea', '2024-06-01', '2025-01-01');
 
 DEALLOCATE test_parallel_join_generic;
 
+RESET client_min_messages;
+RESET paradedb.enable_aggregate_custom_scan;
+
 -- Test 2: Simple parallel index scan with parameters
 RESET plan_cache_mode;
 
@@ -119,4 +128,3 @@ DEALLOCATE test_simple_parallel;
 -- Clean up
 DROP TABLE document_text;
 DROP TABLE core;
-

--- a/pg_search/tests/pg_regress/sql/prepared_statement_parallel.sql
+++ b/pg_search/tests/pg_regress/sql/prepared_statement_parallel.sql
@@ -50,7 +50,6 @@ SET max_parallel_workers_per_gather = 2;
 -- can otherwise absorb these aggregate-on-join queries, so the test would stop
 -- exercising prepared parallel scans even though its row counts still pass.
 SET paradedb.enable_aggregate_custom_scan = false;
-SET client_min_messages = error;
 
 -- Test 1: Prepared statement with join and date filter
 -- This mimics the customer's scenario
@@ -100,7 +99,6 @@ EXECUTE test_parallel_join_generic('ea', '2024-06-01', '2025-01-01');
 
 DEALLOCATE test_parallel_join_generic;
 
-RESET client_min_messages;
 RESET paradedb.enable_aggregate_custom_scan;
 
 -- Test 2: Simple parallel index scan with parameters

--- a/tests/tests/parallel.rs
+++ b/tests/tests/parallel.rs
@@ -272,10 +272,14 @@ async fn test_parallel_hash_join_race_condition(database: Db) -> Result<()> {
     "CREATE INDEX idx_date_time_combined_date ON core (DATE(date_time_combined))"
         .execute(&mut conn);
 
-    // CRITICAL: Disable Custom Scan to force the use of Index Only Scan (Index AM path)
-    // Enable parallel workers and force parallel plans
+    // CRITICAL: Disable both custom-scan layers to force the native PostgreSQL
+    // parallel Index AM path. AggregateScan can otherwise satisfy COUNT over
+    // this join itself, which would bypass the parallel-hash behavior this test
+    // is specifically intended to exercise.
+    // Enable parallel workers and force parallel plans.
     r#"
     SET paradedb.enable_custom_scan = false;
+    SET paradedb.enable_aggregate_custom_scan = false;
     SET max_parallel_workers_per_gather = 2;
     SET parallel_tuple_cost = 0;
     SET parallel_setup_cost = 0;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5751

## What

Normalize PostgreSQL implicit-AND qual lists before classifying and translating their predicates.

Collect predicates from supported native join paths, including predicates beneath transparent path wrappers and in parameterized-path `ppi_clauses`. Decline AggregateScan when complete predicate coverage cannot be established.

Use per-source expression contexts for supported runtime base predicates, while declining unsupported cross-table runtime parameters.

## Why

PostgreSQL can retain multiple `WHERE` conjuncts in `FromExpr.quals` as a `T_List` after distributing the individual predicates into planner metadata.

AggregateScan treated the complete list as one cross-table expression and passed it to `PredicateTranslator`. Its fallback called `exprType(T_List)`, producing:

```text
ERROR: unrecognized node type: 1
```

Normalizing the list exposed related generic-plan and predicate-coverage gaps:

- join predicates could be hidden beneath transparent path wrappers or stored in `ppi_clauses`;
- runtime base predicates could be evaluated using the wrong relation's expression context;
- an untranslatable `HAVING` or aggregate `FILTER` could be confused with an absent expression.

A narrow flatten-only change fixed #5751, but it also removed an accidental decline that had been masking these gaps. Prepared and parallel plans then became eligible for AggregateScan with predicates hidden behind path wrappers or stored in `ppi_clauses`.

Omitting such predicates can produce incorrect results, not merely a missed optimization. This PR therefore enforces one predicate-conservation contract:

> AggregateScan is proposed only when every relevant predicate has been normalized, classified, deduplicated, and accounted for.

## How

- Flatten `T_List` and top-level `AND` containers before relation classification.
- Classify and translate each conjunct independently; preserve `OR` and `NOT` as semantic expressions.
- Make `PredicateTranslator` reject an unnormalized list as a non-throwing capability miss.
- Inspect transparent path wrappers and track whether predicate coverage is complete.
- Recover parameterized-path predicates from `ParamPathInfo.ppi_clauses`.
- Deduplicate overlapping planner representations using `RestrictInfo.rinfo_serial` on PostgreSQL 16+, with PostgreSQL 15-safe overlap handling.
- Reject unsupported cross-table `PARAM_EXTERN` predicates.
- Treat present-but-untranslatable `HAVING` and aggregate `FILTER` expressions as explicit declines.
- Propose AggregateScan only when every relevant predicate can be accounted for.

## Tests

- PostgreSQL 18 regression suite: 316 passed, 0 failed
- PostgreSQL 18 focused regressions: `issue_5751`, `prepared_statement_parallel`, and `parallel_hash_join_race` passed
- `cargo test -p pg_search`: 269 passed, 0 failed, 1 ignored
- Added direct `T_List` capability coverage

The regressions include differential comparisons against PostgreSQL for #5751, generic prepared plans, `HAVING`, aggregate `FILTER`, and parameterized nested-loop predicates.

## Review scope

The changes are kept together because the narrow `T_List` normalization makes previously masked prepared, parallel, and parameterized plans eligible for AggregateScan. Normalization therefore needs to land with the predicate-coverage checks that prevent unsupported predicates from being silently omitted.

Approximately 60% of the additions are regression SQL and expected output. If separate review or backport units would be preferable, I can adjust the sequencing.

Related to #5715.
