### PR TITLE
feat(vector): bounds gate + work budget + result-anchored base replace epsilon (0.25.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -2932,7 +2932,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5465,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5610,7 +5610,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -7701,7 +7701,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7875,7 +7875,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "bitpacking",
 ]
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7954,7 +7954,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7987,7 +7987,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
 dependencies = [
  "serde",
 ]
@@ -8095,7 +8095,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -8258,7 +8258,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5465,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7875,7 +7875,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "bitpacking",
 ]
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7954,7 +7954,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7987,7 +7987,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=56364789511c6c804d15b360ee31c4e43751e028#56364789511c6c804d15b360ee31c4e43751e028"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ debug-assertions = false
 inherits = "dev"
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "56364789511c6c804d15b360ee31c4e43751e028", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "c97fc25d7dbac9218d0b5724c290c2bafd785f03", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -71,7 +71,7 @@ pgrx-tests = "=0.19.2"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "56364789511c6c804d15b360ee31c4e43751e028" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c97fc25d7dbac9218d0b5724c290c2bafd785f03" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 license = "AGPL-3.0"
 
@@ -58,7 +58,7 @@ debug-assertions = false
 inherits = "dev"
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "eadcfaf293c91cd69fec2e009ca20818688dc5fe", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "56364789511c6c804d15b360ee31c4e43751e028", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -71,7 +71,7 @@ pgrx-tests = "=0.19.2"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "eadcfaf293c91cd69fec2e009ca20818688dc5fe" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "56364789511c6c804d15b360ee31c4e43751e028" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/benchmarks/datasets/cohere/config.toml
+++ b/benchmarks/datasets/cohere/config.toml
@@ -246,66 +246,62 @@ values = [
   "2000",
 ]
 
-# pg_search: the distance-ratio gate. Runs past 1.0 because 1% at 10m was still climbing at 0.9.
+# pg_search: the work-budget ceiling (the bounds gate skips provably-useless
+# clusters within it, so the ceiling is the recall/latency knob). 1.0 allows
+# an exhaustive scan.
 [sweeps.pg_search.knn_top10_unfiltered]
-param = "pg_search_probe_epsilon_unfiltered"
+param = "pg_search_max_probe_unfiltered"
 values = [
-  "0.1",
-  "0.15",
+  "0.005",
+  "0.0075",
+  "0.01",
+  "0.015",
+  "0.02",
+  "0.03",
+  "0.05",
+  "0.08",
+  "0.12",
   "0.2",
-  "0.25",
-  "0.3",
   "0.35",
-  "0.4",
-  "0.45",
   "0.5",
-  "0.55",
-  "0.6",
-  "0.7",
-  "0.8",
-  "0.9",
+  "0.75",
   "1.0",
-  "1.2",
 ]
 
 [sweeps.pg_search.knn_top10_10pct]
-param = "pg_search_probe_epsilon_10pct"
+param = "pg_search_max_probe_10pct"
 values = [
-  "0.1",
-  "0.15",
+  "0.005",
+  "0.0075",
+  "0.01",
+  "0.015",
+  "0.02",
+  "0.03",
+  "0.05",
+  "0.08",
+  "0.12",
   "0.2",
-  "0.25",
-  "0.3",
   "0.35",
-  "0.4",
-  "0.45",
   "0.5",
-  "0.55",
-  "0.6",
-  "0.7",
-  "0.8",
-  "0.9",
+  "0.75",
   "1.0",
-  "1.2",
 ]
 
 [sweeps.pg_search.knn_top10_1pct]
-param = "pg_search_probe_epsilon_1pct"
+param = "pg_search_max_probe_1pct"
 values = [
-  "0.1",
-  "0.15",
+  "0.005",
+  "0.0075",
+  "0.01",
+  "0.015",
+  "0.02",
+  "0.03",
+  "0.05",
+  "0.08",
+  "0.12",
   "0.2",
-  "0.25",
-  "0.3",
   "0.35",
-  "0.4",
-  "0.45",
   "0.5",
-  "0.55",
-  "0.6",
-  "0.7",
-  "0.8",
-  "0.9",
+  "0.75",
   "1.0",
-  "1.2",
 ]

--- a/benchmarks/datasets/cohere/config.toml
+++ b/benchmarks/datasets/cohere/config.toml
@@ -252,6 +252,9 @@ values = [
 [sweeps.pg_search.knn_top10_unfiltered]
 param = "pg_search_max_probe_unfiltered"
 values = [
+  "0.001",
+  "0.002",
+  "0.003",
   "0.005",
   "0.0075",
   "0.01",
@@ -271,6 +274,9 @@ values = [
 [sweeps.pg_search.knn_top10_10pct]
 param = "pg_search_max_probe_10pct"
 values = [
+  "0.001",
+  "0.002",
+  "0.003",
   "0.005",
   "0.0075",
   "0.01",
@@ -290,6 +296,9 @@ values = [
 [sweeps.pg_search.knn_top10_1pct]
 param = "pg_search_max_probe_1pct"
 values = [
+  "0.001",
+  "0.002",
+  "0.003",
   "0.005",
   "0.0075",
   "0.01",

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_10pct.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_10pct.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe=0.2; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_10pct }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe_10pct }}; SELECT _id, title FROM cohere_wiki
 WHERE text @@@ current_setting('cohere.titles_10pct')
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_1pct.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_1pct.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe=0.2; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_1pct }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe_1pct }}; SELECT _id, title FROM cohere_wiki
 WHERE text @@@ current_setting('cohere.titles_1pct')
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_unfiltered.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe=0.2; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_unfiltered }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe_unfiltered }}; SELECT _id, title FROM cohere_wiki
 WHERE _id @@@ paradedb.all()
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/docs/documentation/vector/tuning.mdx
+++ b/docs/documentation/vector/tuning.mdx
@@ -4,25 +4,22 @@ description: Trade recall against latency for vector search
 canonical: https://docs.paradedb.com/documentation/vector/tuning
 ---
 
-Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. Two session-level settings control this tradeoff:
+Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. One session-level setting controls this tradeoff:
 
 ```sql
-SET paradedb.vector_cluster_probe_epsilon = 0.5;
 SET paradedb.vector_cluster_max_probe = 0.02;
 ```
 
-<ParamField body="paradedb.vector_cluster_probe_epsilon" default={0.5}>
-  The primary recall driver. A higher epsilon improves recall by probing more
-  clusters at the expense of higher latency. Think of epsilon as an early
-  termination value, where lower epsilon terminates early more aggressively.
-  When tuning this value, we recommend sweeping in increments of `0.1`. Must be
-  between `0.0` and `100.0`.
-</ParamField>
-
 <ParamField body="paradedb.vector_cluster_max_probe" default={0.02}>
-  A control for tail latency. This setting enforces a ceiling on how many clusters a query may probe. For instance, at the default value of `0.02`, at most 2% of clusters are probed. Must be between `0.000001` and `1.0`, where `1.0` effectively means "no ceiling."
+  The recall/latency driver: a ceiling on how much probe work a query may
+  spend, expressed as a fraction of each segment's clusters. For instance, at
+  the default value of `0.02`, at most 2% of a segment's cluster-scan work is
+  spent. Must be between `0.000001` and `1.0`, where `1.0` allows an
+  exhaustive scan.
 
-Note that setting this value to `1.0` does not equal exhaustive search, since the epsilon value still drives early termination.
+Within the ceiling, clusters that provably cannot improve the current top-K
+are skipped automatically using per-cluster bounds stored in the index; this
+skipping never reduces recall, so raising the ceiling only ever improves it.
 
 </ParamField>
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-ndxGpgSuI8uL2FLGm6IYHnCfkScb0jCfqA1X1IbzNcg=";
+  cargoHash = "sha256-px3JpX3EWKN/ca12xZZ1ryxczl0qf42OtDUBgsGItLA=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.25.0--0.25.1.sql
+++ b/pg_search/sql/pg_search--0.25.0--0.25.1.sql
@@ -1,0 +1,4 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.1'" to load this file. \quit
+
+-- 0.25.0 -> 0.25.1: no schema changes (epsilon GUC removal and the
+-- bounds_scope reloption are not schema objects).

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -216,16 +216,6 @@ pub fn vector_cluster_max_probe() -> f32 {
     VECTOR_CLUSTER_MAX_PROBE.get() as f32
 }
 
-/// Query-time pruning factor for tantivy's `AdaptiveProbeParams`: how far
-/// past the best centroid the IVF probe loop keeps probing clusters. Lower
-/// epsilon probes fewer clusters, decreasing latency at the expense of
-/// recall. Default `0.5`.
-static VECTOR_CLUSTER_PROBE_EPSILON: GucSetting<f64> = GucSetting::<f64>::new(0.5);
-
-pub fn vector_cluster_probe_epsilon() -> f32 {
-    VECTOR_CLUSTER_PROBE_EPSILON.get() as f32
-}
-
 /// Doc-count boundary at which a merged segment's vector storage switches
 /// from flat (exact scan) to IVF (clustered). Captured into the index's
 /// stored `IndexSettings` at CREATE INDEX time, so it applies to every merge
@@ -446,17 +436,6 @@ pub fn init() {
         &VECTOR_CLUSTER_MAX_PROBE,
         0.000001,
         1.0,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_float_guc(
-        c"paradedb.vector_cluster_probe_epsilon",
-        c"SPANN-style pruning factor (ε₂) for vector ORDER BY queries",
-        c"How far past the best centroid the IVF probe loop keeps probing clusters. Lower epsilon probes fewer clusters, decreasing latency at the expense of recall.",
-        &VECTOR_CLUSTER_PROBE_EPSILON,
-        0.0,
-        100.0,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -44,6 +44,7 @@ pub fn index_settings(
         docstore_compress_dedicated_thread: false,
         codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
         vector_clustering_threshold: crate::gucs::vector_clustering_threshold(),
+        vector_bounds_scope: options.bounds_scope(),
         ..IndexSettings::default()
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -1036,7 +1036,6 @@ impl SearchIndexReader {
                     .and_offset(offset)
                     .order_by_similarity(tantivy_field, query_vector)
                     .with_adaptive_params(AdaptiveProbeParams {
-                        epsilon: crate::gucs::vector_cluster_probe_epsilon(),
                         max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
                         ..Default::default()
                     });

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -33,6 +33,7 @@ use pgrx::pg_sys::AsPgCStr;
 use pgrx::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
+use tantivy::vector::BoundsScope;
 use tokenizers::manager::SearchTokenizerFilters;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
 /* ADDING OPTIONS
@@ -183,6 +184,23 @@ extern "C-unwind" fn validate_search_tokenizer(value: *const std::os::raw::c_cha
         .unwrap_or_else(|| panic!("invalid search_tokenizer: '{s}'"));
 }
 
+/// The only legal `bounds_scope`: the merge folds centroid bounds over a
+/// cluster's NATIVE (primary-assignment) members. Captured into the stored
+/// tantivy `IndexSettings` at CREATE INDEX, like the clustering threshold.
+pub(crate) const BOUNDS_SCOPE_NATIVE: &str = "native";
+
+#[pg_guard]
+extern "C-unwind" fn validate_bounds_scope(value: *const std::os::raw::c_char) {
+    if value.is_null() {
+        return;
+    }
+    let cstr = unsafe { core::ffi::CStr::from_ptr(value) };
+    let value = cstr.to_str().expect("`bounds_scope` must be valid UTF-8");
+    if value != BOUNDS_SCOPE_NATIVE {
+        panic!("invalid `bounds_scope`: {value:?}; the only supported value is 'native'");
+    }
+}
+
 #[pg_guard]
 extern "C-unwind" fn validate_layer_sizes(value: *const std::os::raw::c_char) {
     if value.is_null() {
@@ -222,7 +240,7 @@ fn cstr_to_rust_str(value: *const std::os::raw::c_char) -> String {
         .to_string()
 }
 
-const NUM_REL_OPTS: usize = 18;
+const NUM_REL_OPTS: usize = 19;
 #[pg_guard]
 pub unsafe extern "C-unwind" fn amoptions(
     reloptions: pg_sys::Datum,
@@ -325,6 +343,13 @@ pub unsafe extern "C-unwind" fn amoptions(
             optname: "search_tokenizer".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
             offset: std::mem::offset_of!(BM25IndexOptionsData, search_tokenizer_offset) as i32,
+            #[cfg(feature = "pg18")]
+            isset_offset: 0,
+        },
+        pg_sys::relopt_parse_elt {
+            optname: "bounds_scope".as_pg_cstr(),
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, bounds_scope_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
@@ -444,6 +469,10 @@ impl BM25IndexOptions {
 
     pub fn centroid_ratio(&self) -> f32 {
         self.options_data().centroid_ratio()
+    }
+
+    pub fn bounds_scope(&self) -> BoundsScope {
+        self.options_data().bounds_scope()
     }
 
     pub fn training_samples_per_centroid(&self) -> usize {
@@ -805,6 +834,7 @@ struct BM25IndexOptionsData {
     training_samples_per_centroid: i32,
     cluster_replication: i32,
     partition_by_offset: i32,
+    bounds_scope_offset: i32,
 }
 
 impl BM25IndexOptionsData {
@@ -846,6 +876,16 @@ impl BM25IndexOptionsData {
 
     pub fn centroid_ratio(&self) -> f32 {
         self.centroid_ratio as f32
+    }
+
+    /// The stored-bounds scope, validated at option-set time; anything but
+    /// the default reads as `Native` (the only variant).
+    pub fn bounds_scope(&self) -> BoundsScope {
+        let value = self.get_str(self.bounds_scope_offset, BOUNDS_SCOPE_NATIVE.to_string());
+        match value.as_str() {
+            BOUNDS_SCOPE_NATIVE => BoundsScope::Native,
+            other => panic!("invalid stored `bounds_scope`: {other:?}"),
+        }
     }
 
     pub fn training_samples_per_centroid(&self) -> usize {
@@ -1093,6 +1133,15 @@ pub unsafe fn init() {
         "Default search-time tokenizer for text/JSON fields".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_search_tokenizer),
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
+    );
+    pg_sys::add_string_reloption(
+        RELOPT_KIND_PDB,
+        "bounds_scope".as_pg_cstr(),
+        "Which rows a cluster's stored centroid bound covers; only 'native' is supported"
+            .as_pg_cstr(),
+        BOUNDS_SCOPE_NATIVE.as_pg_cstr(),
+        Some(validate_bounds_scope),
         pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_real_reloption(


### PR DESCRIPTION
Related Issue: https://github.com/paradedb/paradedb/issues/5687

Retires the epsilon knob in favor of a proof-based recall gate, cutting tail latency up to 6x with far tighter recall/latency confidence intervals.

Companion to paradedb/tantivy `vector-bounds-gate` (paradedb/tantivy#196). Re-pins tantivy and aligns the pg_search surface with the gated engine.

## Changes

- **Re-pin** `tantivy` (and `tantivy-tokenizer-api`) to the bounds-gate tip.
- **`paradedb.vector_cluster_probe_epsilon` removed** — the engine's gate
  is now proof-based and has no recall knob to misconfigure.
  `paradedb.vector_cluster_max_probe` (the work-budget ceiling) is the
  only recall/latency setting.
- **`bounds_scope` reloption** — `CREATE INDEX ... WITH (bounds_scope = 'native')`; `'native'` is the only legal value and the default, validated at option-set time and captured into the stored index settings so merges fold the scope the index was created with. 
(This is for future testing, so I have kept it around for now, will remove it in a later release)
- **Telemetry** — `Segment Info` gains `bounds_skips` and `bound_armed_at_probe` (JSON `null` when the top-K heap never filled).
- **Docs** — the vector tuning page drops the epsilon section; the ceiling section notes that within-budget skipping is provably recall-neutral.
- **Version** 0.25.1 — the next release after 0.25.0.

## Migration

Pre-V2 vector indexes error at query time with the remedy in the message: `REINDEX`, then `VACUUM` — REINDEX alone leaves flat build segments; clustering happens at merge and requires `background_layer_sizes` to be set (the default is empty). On replicated indexes, retune the ceiling upward by roughly the replication factor: the budget charges a document once, whichever copy arrives first.

## Benchmark

We see a reduction of up to `6x` tail latency and much tighter confidence intervals for recal vs latency curves across the whole benchmark. 

The reasons for the whole query set:
- Around 5-10% due to the `Radius gate`
- Rest is a mix: 
  - New `Work Budget` accounting for unbalanced clusters (caps higher tail latencies)
  - `Result anchored base`, which replaces the SPANN style best centroid anchored gate (caps lower tail variance by preventing early terminations)

All 3 result in much more `predictable` latencies across different query shapes, based on the `work budget`. 

*And the mix of their influence will vary across datasets; this is what we get for Cohere 1M for now.*

## Notes

- No SQL surface reads the new header in this change, so there is no
  header/catalog pair to split across releases.
