### PR TITLE
fix(mpp): align plain EXPLAIN with serial fallback when MPP cannot launch

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -55,6 +55,7 @@ use datafusion_distributed::shm::MppMesh;
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
 use crate::postgres::customscan::mpp::launch::MppLifecycle;
+use crate::postgres::customscan::mpp::worker_fragments::mpp_plan_has_data_parallelism;
 
 use crate::api::SortDirection;
 use crate::api::agg_funcoid;
@@ -1089,11 +1090,10 @@ impl AggregateScan {
     /// and contains execution metrics. We merge in MPP worker metrics if applicable.
     ///
     /// In plain EXPLAIN, execution hasn't happened, so we must rebuild the physical plan.
-    /// When `mpp_is_active()` we rebuild with the same distributed planner the leader
-    /// will run with, attached to a drain-less stub mesh. The planner only consults
-    /// the mesh's worker count, not the actual `shm_mq` queues, so the stub is enough
-    /// to produce a `DistributedExec` root. That lets us render the stage boxes via
-    /// `datafusion_distributed::display_plan_ascii`.
+    /// When `mpp_is_active()` we first rebuild against `producer_worker_cap()` (`mesh = None`)
+    /// so the distributed planner can emit a `DistributedExec` for display. If task
+    /// discovery says launch will not run (#5784 / `max_producer_task_count < 2`), rebuild
+    /// serially so the printed shape matches execution.
     fn render_df_physical_plan(
         df_state: &scan_state::DataFusionAggState,
         explainer: &mut Explainer,
@@ -1118,36 +1118,40 @@ impl AggregateScan {
 
             let custom_exprs = df_state.custom_exprs;
             let custom_scan_tlist = df_state.custom_scan_tlist;
-            let ctx = if mpp_is_active() {
-                // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
-                // The shared session-context builder takes `mesh = None` and derives `n_workers`
-                // from `producer_worker_cap()`, so the planner still emits a `DistributedExec`
-                // root with the right stage sizing for display.
-                Self::build_mpp_session_context(None)
-            } else {
-                create_aggregate_session_context()
-            };
             let Ok(runtime) = tokio::runtime::Builder::new_current_thread().build() else {
                 explainer.add_text("DataFusion Plan", "(tokio runtime unavailable)");
                 return;
             };
-            let plan_result = runtime.block_on(async {
-                let (logical, _) = build_join_aggregate_plan(
-                    &df_state.plan,
-                    &df_state.targetlist,
-                    df_state.topk.as_ref(),
-                    &df_state.join_level_predicates,
-                    custom_exprs,
-                    custom_scan_tlist,
-                    df_state.having_filter.as_ref(),
-                    &ctx,
-                    Some(expr_context.as_ptr()),
-                    None,
-                    false,
-                )
-                .await?;
-                build_physical_plan(&ctx, logical).await
-            });
+            let build_with = |ctx: &datafusion::prelude::SessionContext| {
+                runtime.block_on(async {
+                    let (logical, _) = build_join_aggregate_plan(
+                        &df_state.plan,
+                        &df_state.targetlist,
+                        df_state.topk.as_ref(),
+                        &df_state.join_level_predicates,
+                        custom_exprs,
+                        custom_scan_tlist,
+                        df_state.having_filter.as_ref(),
+                        ctx,
+                        Some(expr_context.as_ptr()),
+                        None,
+                        false,
+                    )
+                    .await?;
+                    build_physical_plan(ctx, logical).await
+                })
+            };
+            let plan_result = if mpp_is_active() {
+                // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
+                // Plan against the cap first; fall back to serial when launch would not run (#5784).
+                match build_with(&Self::build_mpp_session_context(None)) {
+                    Ok(mpp_plan) if mpp_plan_has_data_parallelism(&mpp_plan) => Ok(mpp_plan),
+                    Ok(_) => build_with(&create_aggregate_session_context()),
+                    Err(e) => Err(e),
+                }
+            } else {
+                build_with(&create_aggregate_session_context())
+            };
             match plan_result {
                 Ok(p) => p,
                 Err(e) => {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -55,6 +55,7 @@ use datafusion_distributed::shm::MppMesh;
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
 use crate::postgres::customscan::mpp::launch::MppLifecycle;
+use crate::postgres::customscan::mpp::worker_fragments::mpp_plan_has_data_parallelism;
 
 use crate::api::SortDirection;
 use crate::api::agg_funcoid;
@@ -960,11 +961,10 @@ impl AggregateScan {
     /// and contains execution metrics. We merge in MPP worker metrics if applicable.
     ///
     /// In plain EXPLAIN, execution hasn't happened, so we must rebuild the physical plan.
-    /// When `mpp_is_active()` we rebuild with the same distributed planner the leader
-    /// will run with, attached to a drain-less stub mesh. The planner only consults
-    /// the mesh's worker count, not the actual `shm_mq` queues, so the stub is enough
-    /// to produce a `DistributedExec` root. That lets us render the stage boxes via
-    /// `datafusion_distributed::display_plan_ascii`.
+    /// When `mpp_is_active()` we first rebuild against `producer_worker_cap()` (`mesh = None`)
+    /// so the distributed planner can emit a `DistributedExec` for display. If task
+    /// discovery says launch will not run (#5784 / `max_producer_task_count < 2`), rebuild
+    /// serially so the printed shape matches execution.
     fn render_df_physical_plan(
         df_state: &scan_state::DataFusionAggState,
         explainer: &mut Explainer,
@@ -989,36 +989,40 @@ impl AggregateScan {
 
             let custom_exprs = df_state.custom_exprs;
             let custom_scan_tlist = df_state.custom_scan_tlist;
-            let ctx = if mpp_is_active() {
-                // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
-                // The shared session-context builder takes `mesh = None` and derives `n_workers`
-                // from `producer_worker_cap()`, so the planner still emits a `DistributedExec`
-                // root with the right stage sizing for display.
-                Self::build_mpp_session_context(None)
-            } else {
-                create_aggregate_session_context()
-            };
             let Ok(runtime) = tokio::runtime::Builder::new_current_thread().build() else {
                 explainer.add_text("DataFusion Plan", "(tokio runtime unavailable)");
                 return;
             };
-            let plan_result = runtime.block_on(async {
-                let (logical, _) = build_join_aggregate_plan(
-                    &df_state.plan,
-                    &df_state.targetlist,
-                    df_state.topk.as_ref(),
-                    &df_state.join_level_predicates,
-                    custom_exprs,
-                    custom_scan_tlist,
-                    df_state.having_filter.as_ref(),
-                    &ctx,
-                    Some(expr_context.as_ptr()),
-                    None,
-                    false,
-                )
-                .await?;
-                build_physical_plan(&ctx, logical).await
-            });
+            let build_with = |ctx: &datafusion::prelude::SessionContext| {
+                runtime.block_on(async {
+                    let (logical, _) = build_join_aggregate_plan(
+                        &df_state.plan,
+                        &df_state.targetlist,
+                        df_state.topk.as_ref(),
+                        &df_state.join_level_predicates,
+                        custom_exprs,
+                        custom_scan_tlist,
+                        df_state.having_filter.as_ref(),
+                        ctx,
+                        Some(expr_context.as_ptr()),
+                        None,
+                        false,
+                    )
+                    .await?;
+                    build_physical_plan(ctx, logical).await
+                })
+            };
+            let plan_result = if mpp_is_active() {
+                // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
+                // Plan against the cap first; fall back to serial when launch would not run (#5784).
+                match build_with(&Self::build_mpp_session_context(None)) {
+                    Ok(mpp_plan) if mpp_plan_has_data_parallelism(&mpp_plan) => Ok(mpp_plan),
+                    Ok(_) => build_with(&create_aggregate_session_context()),
+                    Err(e) => Err(e),
+                }
+            } else {
+                build_with(&create_aggregate_session_context())
+            };
             match plan_result {
                 Ok(p) => p,
                 Err(e) => {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -184,6 +184,7 @@ use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
 use crate::postgres::customscan::mpp::launch::MppLifecycle;
+use crate::postgres::customscan::mpp::worker_fragments::mpp_plan_has_data_parallelism;
 use arrow_array::Array;
 use datafusion_distributed::shm::MppMesh;
 
@@ -1325,30 +1326,42 @@ impl CustomScan for JoinScan {
             }
             // For plain EXPLAIN, reconstruct the plan using the same session configuration
             // that execution uses so `VisibilityFilterExec` appears in the displayed plan,
-            // matching EXPLAIN ANALYZE. When MPP is active, pass `mesh = None`; the shared
-            // session-context builder derives `n_workers` from `producer_worker_cap()` and
-            // skips the shm_mq transport install (EXPLAIN doesn't execute).
+            // matching EXPLAIN ANALYZE. When MPP is active, first build against
+            // `producer_worker_cap()` (`mesh = None`); if task discovery says launch will
+            // not run (#5784 / `max_producer_task_count < 2`), rebuild serially so the
+            // printed shape matches execution.
             let expr_context = crate::postgres::utils::ExprContextGuard::new();
-            let ctx = if mpp_is_active() {
-                Self::build_mpp_session_context(None)
-            } else {
-                create_datafusion_session_context(SessionContextProfile::Join)
-            };
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
                 .expect("Failed to create tokio runtime");
-            let logical_plan = deserialize_logical_plan_with_runtime(
-                logical_plan,
-                &ctx.task_ctx(),
-                None,
-                Some(expr_context.as_ptr()),
-                None,
-                vec![],
-            )
-            .expect("Failed to deserialize logical plan");
-            let physical_plan = runtime
-                .block_on(build_physical_plan(&ctx, logical_plan))
-                .expect("Failed to create execution plan");
+            let build_with = |ctx: &datafusion::prelude::SessionContext| {
+                let logical_plan = deserialize_logical_plan_with_runtime(
+                    logical_plan,
+                    &ctx.task_ctx(),
+                    None,
+                    Some(expr_context.as_ptr()),
+                    None,
+                    vec![],
+                )
+                .expect("Failed to deserialize logical plan");
+                runtime
+                    .block_on(build_physical_plan(ctx, logical_plan))
+                    .expect("Failed to create execution plan")
+            };
+            let physical_plan = if mpp_is_active() {
+                let mpp_plan = build_with(&Self::build_mpp_session_context(None));
+                if mpp_plan_has_data_parallelism(&mpp_plan) {
+                    mpp_plan
+                } else {
+                    build_with(&create_datafusion_session_context(
+                        SessionContextProfile::Join,
+                    ))
+                }
+            } else {
+                build_with(&create_datafusion_session_context(
+                    SessionContextProfile::Join,
+                ))
+            };
             explain_physical_plan(&physical_plan, explainer);
         }
     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -182,6 +182,7 @@ use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
 use crate::postgres::customscan::mpp::launch::MppLifecycle;
+use crate::postgres::customscan::mpp::worker_fragments::mpp_plan_has_data_parallelism;
 use arrow_array::Array;
 use datafusion_distributed::shm::MppMesh;
 
@@ -1191,30 +1192,42 @@ impl CustomScan for JoinScan {
             }
             // For plain EXPLAIN, reconstruct the plan using the same session configuration
             // that execution uses so `VisibilityFilterExec` appears in the displayed plan,
-            // matching EXPLAIN ANALYZE. When MPP is active, pass `mesh = None`; the shared
-            // session-context builder derives `n_workers` from `producer_worker_cap()` and
-            // skips the shm_mq transport install (EXPLAIN doesn't execute).
+            // matching EXPLAIN ANALYZE. When MPP is active, first build against
+            // `producer_worker_cap()` (`mesh = None`); if task discovery says launch will
+            // not run (#5784 / `max_producer_task_count < 2`), rebuild serially so the
+            // printed shape matches execution.
             let expr_context = crate::postgres::utils::ExprContextGuard::new();
-            let ctx = if mpp_is_active() {
-                Self::build_mpp_session_context(None)
-            } else {
-                create_datafusion_session_context(SessionContextProfile::Join)
-            };
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
                 .expect("Failed to create tokio runtime");
-            let logical_plan = deserialize_logical_plan_with_runtime(
-                logical_plan,
-                &ctx.task_ctx(),
-                None,
-                Some(expr_context.as_ptr()),
-                None,
-                vec![],
-            )
-            .expect("Failed to deserialize logical plan");
-            let physical_plan = runtime
-                .block_on(build_physical_plan(&ctx, logical_plan))
-                .expect("Failed to create execution plan");
+            let build_with = |ctx: &datafusion::prelude::SessionContext| {
+                let logical_plan = deserialize_logical_plan_with_runtime(
+                    logical_plan,
+                    &ctx.task_ctx(),
+                    None,
+                    Some(expr_context.as_ptr()),
+                    None,
+                    vec![],
+                )
+                .expect("Failed to deserialize logical plan");
+                runtime
+                    .block_on(build_physical_plan(ctx, logical_plan))
+                    .expect("Failed to create execution plan")
+            };
+            let physical_plan = if mpp_is_active() {
+                let mpp_plan = build_with(&Self::build_mpp_session_context(None));
+                if mpp_plan_has_data_parallelism(&mpp_plan) {
+                    mpp_plan
+                } else {
+                    build_with(&create_datafusion_session_context(
+                        SessionContextProfile::Join,
+                    ))
+                }
+            } else {
+                build_with(&create_datafusion_session_context(
+                    SessionContextProfile::Join,
+                ))
+            };
             explain_physical_plan(&physical_plan, explainer);
         }
     }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -100,8 +100,11 @@ pub(crate) fn build_mpp_session_context(
     // for stage sizing and target_partitions, so it plans against the cap
     // (`producer_worker_cap()`, from PG's parallelism GUCs). EXPLAIN never opens a
     // `WorkerConnection`, so we skip the transport install and the fork's default sits
-    // unused. mesh = Some reads the launched width from the mesh header, which the plan-first
-    // launch sized from the plan's task counts (#5667).
+    // unused. Callers that render plain EXPLAIN must still apply the launch gate
+    // (`mpp_plan_has_data_parallelism`) and replan serially when the finished plan has
+    // fewer than 2 producer tasks (#5784), matching execution. mesh = Some reads the
+    // launched width from the mesh header, which the plan-first launch sized from the
+    // plan's task counts (#5667).
     let n_workers = match mesh.as_ref() {
         Some(m) => m.n_workers() as usize,
         None => producer_worker_cap() as usize,

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -103,8 +103,11 @@ pub(crate) fn build_mpp_session_context(
     // for stage sizing and target_partitions, so it plans against the cap
     // (`producer_worker_cap()`, from PG's parallelism GUCs). EXPLAIN never opens a
     // `WorkerConnection`, so we skip the transport install and the fork's default sits
-    // unused. mesh = Some reads the launched width from the mesh header, which the plan-first
-    // launch sized from the plan's task counts (#5667).
+    // unused. Callers that render plain EXPLAIN must still apply the launch gate
+    // (`mpp_plan_has_data_parallelism`) and replan serially when the finished plan has
+    // fewer than 2 producer tasks (#5784), matching execution. mesh = Some reads the
+    // launched width from the mesh header, which the plan-first launch sized from the
+    // plan's task counts (#5667).
     let n_workers = match mesh.as_ref() {
         Some(m) => m.n_workers() as usize,
         None => producer_worker_cap() as usize,

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -64,7 +64,9 @@ use crate::postgres::customscan::mpp::glue::{
     MIN_TOTAL_WORKER_COUNT, MppLeaderState, estimate_dsm_size, leader_setup, producer_worker_cap,
     worker_setup,
 };
-use crate::postgres::customscan::mpp::worker_fragments::{collect_stages, max_producer_task_count};
+use crate::postgres::customscan::mpp::worker_fragments::{
+    collect_stages, max_producer_task_count, stages_have_data_parallelism,
+};
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
 
 /// `state_values()` order. Each index maps to a `ParallelState` TOC entry the workers look up.
@@ -305,15 +307,15 @@ fn launch_mpp(
 
     // Task counts were capped by `target_partitions = cap` at plan time and reflect segment
     // counts (#5657). The producer floor keeps the mesh-width invariant; see
-    // [`MIN_TOTAL_WORKER_COUNT`].
-    let max_tasks = max_producer_task_count(&stages);
-    if max_tasks < 2 {
+    // [`MIN_TOTAL_WORKER_COUNT`]. Same gate as plain EXPLAIN (#5784).
+    if !stages_have_data_parallelism(&stages) {
         // 0: nothing to distribute. 1: no data parallelism — every 1-task stage lands on
         // proc 1 (`proc_for_task`), leaving the second (floor) producer idle. Run serially.
         // This also keeps `producer_count <= max_tasks`, so every launched proc owns at
         // least one fragment of the widest stage.
         return None;
     }
+    let max_tasks = max_producer_task_count(&stages);
     let cap = producer_worker_cap();
     let producer_count = (max_tasks as u32).clamp(MIN_TOTAL_WORKER_COUNT - 1, cap);
 

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -63,7 +63,9 @@ use crate::postgres::customscan::mpp::glue::{
     MIN_TOTAL_WORKER_COUNT, MppLeaderState, estimate_dsm_size, leader_setup, producer_worker_cap,
     worker_setup,
 };
-use crate::postgres::customscan::mpp::worker_fragments::{collect_stages, max_producer_task_count};
+use crate::postgres::customscan::mpp::worker_fragments::{
+    collect_stages, max_producer_task_count, stages_have_data_parallelism,
+};
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
 
 /// `state_values()` order. Each index maps to a `ParallelState` TOC entry the workers look up.
@@ -277,15 +279,15 @@ fn launch_mpp(
 
     // Task counts were capped by `target_partitions = cap` at plan time and reflect segment
     // counts (#5657). The producer floor keeps the mesh-width invariant; see
-    // [`MIN_TOTAL_WORKER_COUNT`].
-    let max_tasks = max_producer_task_count(&stages);
-    if max_tasks < 2 {
+    // [`MIN_TOTAL_WORKER_COUNT`]. Same gate as plain EXPLAIN (#5784).
+    if !stages_have_data_parallelism(&stages) {
         // 0: nothing to distribute. 1: no data parallelism — every 1-task stage lands on
         // proc 1 (`proc_for_task`), leaving the second (floor) producer idle. Run serially.
         // This also keeps `producer_count <= max_tasks`, so every launched proc owns at
         // least one fragment of the widest stage.
         return None;
     }
+    let max_tasks = max_producer_task_count(&stages);
     let cap = producer_worker_cap();
     let producer_count = (max_tasks as u32).clamp(MIN_TOTAL_WORKER_COUNT - 1, cap);
 

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -170,6 +170,19 @@ pub(crate) fn max_producer_task_count(stages: &[DiscoveredStage]) -> usize {
         .unwrap_or(0)
 }
 
+/// True when discovered stages have enough producer tasks for MPP to launch (#5784).
+/// Same `>= 2` gate as the plan-first path in [`crate::postgres::customscan::mpp::launch`]:
+/// below that there is no data parallelism, so execution runs serially and plain EXPLAIN
+/// must render the serial shape rather than a cap-sized distributed plan.
+pub(crate) fn stages_have_data_parallelism(stages: &[DiscoveredStage]) -> bool {
+    max_producer_task_count(stages) >= 2
+}
+
+/// Convenience wrapper over [`stages_have_data_parallelism`] for a finished physical plan.
+pub(crate) fn mpp_plan_has_data_parallelism(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    stages_have_data_parallelism(&collect_stages(plan))
+}
+
 /// Classify each discovered stage's routing from the physical-plan boundary type. The routing blob
 /// contains task IDs, not worker ownership, so it remains valid when PostgreSQL attaches fewer
 /// workers than requested. Not filtered by proc; each worker later selects its own `(stage, task)`
@@ -295,6 +308,7 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
         assert_eq!(max_producer_task_count(&collect_stages(&plan)), 0);
+        assert!(!mpp_plan_has_data_parallelism(&plan));
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -168,6 +168,19 @@ pub(crate) fn max_producer_task_count(stages: &[DiscoveredStage]) -> usize {
         .unwrap_or(0)
 }
 
+/// True when discovered stages have enough producer tasks for MPP to launch (#5784).
+/// Same `>= 2` gate as the plan-first path in [`crate::postgres::customscan::mpp::launch`]:
+/// below that there is no data parallelism, so execution runs serially and plain EXPLAIN
+/// must render the serial shape rather than a cap-sized distributed plan.
+pub(crate) fn stages_have_data_parallelism(stages: &[DiscoveredStage]) -> bool {
+    max_producer_task_count(stages) >= 2
+}
+
+/// Convenience wrapper over [`stages_have_data_parallelism`] for a finished physical plan.
+pub(crate) fn mpp_plan_has_data_parallelism(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    stages_have_data_parallelism(&collect_stages(plan))
+}
+
 /// Classify each discovered stage's routing, once the worker count is known. The leader runs this
 /// (replacing the worker-side re-plan) to derive routing from the boundary type. Not filtered by
 /// proc; the blob is shared and each worker selects its own `(stage, task)` slots.
@@ -297,6 +310,7 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
         assert_eq!(max_producer_task_count(&collect_stages(&plan)), 0);
+        assert!(!mpp_plan_has_data_parallelism(&plan));
     }
 
     #[test]

--- a/pg_search/tests/pg_regress/expected/issue_4779.out
+++ b/pg_search/tests/pg_regress/expected/issue_4779.out
@@ -169,8 +169,8 @@ WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.a
   AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
   AND m.id @@@ pdb.all()
 ORDER BY m.id DESC LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: (m SEMI b) SEMI a
@@ -179,17 +179,16 @@ ORDER BY m.id DESC LIMIT 10;
          Order By: m.id desc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
-           :   SortPreservingMergeExec: [id@1 DESC], fetch=10
-           :     SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
-           :       VisibilityFilterExec: tables=[m]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[m]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
            :         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           :           CoalescePartitionsExec
-           :             HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           :               PgSearchScan: table=m, segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :               RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
-           :                 PgSearchScan: table=b, segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :           RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
-           :             PgSearchScan: table=a, segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-(19 rows)
+           :           CooperativeExec
+           :             PgSearchScan: table=m, segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :           CooperativeExec
+           :             PgSearchScan: table=b, segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :         CooperativeExec
+           :           PgSearchScan: table=a, segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(18 rows)
 
 DROP TABLE t_main_4779, t_a_4779, t_b_4779 CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_4779.out
+++ b/pg_search/tests/pg_regress/expected/issue_4779.out
@@ -169,8 +169,8 @@ WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.a
   AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
   AND m.id @@@ pdb.all()
 ORDER BY m.id DESC LIMIT 10;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: (m SEMI b) SEMI a
@@ -179,17 +179,16 @@ ORDER BY m.id DESC LIMIT 10;
          Order By: m.id desc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
-           :   SortPreservingMergeExec: [id@1 DESC], fetch=10
-           :     SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
-           :       VisibilityFilterExec: tables=[m]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[m]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
            :         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           :           CoalescePartitionsExec
-           :             HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :               RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
-           :                 PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :           RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
+           :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-(19 rows)
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(18 rows)
 
 DROP TABLE t_main_4779, t_a_4779, t_b_4779 CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_4910.out
+++ b/pg_search/tests/pg_regress/expected/issue_4910.out
@@ -89,16 +89,17 @@ LIMIT 25;
          Order By: cccf.revenue_rank desc nulls last, cccf.contact_id asc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[contact_id@3 as col_1, company_id@1 as col_2, revenue_rank@2 as col_3, ctid_0@0 as ctid_0]
-           :   SortPreservingMergeExec: [revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], fetch=25
-           :     SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[true]
-           :       VisibilityFilterExec: tables=[cccf]
-           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
+           :   SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[cccf]
+           :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
+           :         CooperativeExec
            :           PgSearchScan: table=ce, segments=1, query="all"
-           :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
+           :         HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
+           :           CooperativeExec
            :             PgSearchScan: table=cne, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
-           :             RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
-           :               PgSearchScan: table=cccf, segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
-(17 rows)
+           :           CooperativeExec
+           :             PgSearchScan: table=cccf, segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
+(18 rows)
 
 -- Result rows in parallel mode (verifies correctness, not just plan shape).
 SELECT contact_id, company_id, revenue_rank

--- a/pg_search/tests/pg_regress/expected/issue_4910.out
+++ b/pg_search/tests/pg_regress/expected/issue_4910.out
@@ -89,16 +89,17 @@ LIMIT 25;
          Order By: cccf.revenue_rank desc nulls last, cccf.contact_id asc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[contact_id@3 as col_1, company_id@1 as col_2, revenue_rank@2 as col_3, ctid_0@0 as ctid_0]
-           :   SortPreservingMergeExec: [revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], fetch=25
-           :     SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[true]
-           :       VisibilityFilterExec: tables=[cccf]
-           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
+           :   SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[cccf]
+           :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
+           :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
-           :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
+           :         HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
+           :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
-           :             RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
-           :               PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
-(17 rows)
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
+(18 rows)
 
 -- Result rows in parallel mode (verifies correctness, not just plan shape).
 SELECT contact_id, company_id, revenue_rank

--- a/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
+++ b/pg_search/tests/pg_regress/expected/mpp_worker_sizing.out
@@ -8,7 +8,8 @@
 --   - 1 segment per table produces no distributable stages: the query
 --     runs serially ("MPP Launch" line absent), and under
 --     paradedb.mpp_debug no "spawning" trace appears — no launch is
---     even attempted.
+--     even attempted. Plain EXPLAIN must also render the serial shape
+--     (#5784), not a cap-sized distributed plan.
 --   - 4 segments per table under a cap of 2 launch exactly 2 producers;
 --     the extra tasks multiplex and results match the serial run.
 --   - AggregateScan rides the same launch: a 2-segment GROUP BY join
@@ -104,6 +105,47 @@ BEGIN
         INSERT INTO mpp_ws_outcome VALUES ('1-segment join: UNEXPECTED distributed launch');
     ELSE
         INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially (no MPP launch recorded)');
+    END IF;
+END$$;
+-- #5784: plain EXPLAIN must match the serial ANALYZE shape when launch
+-- will not run — no cap-sized RoundRobin / SortPreservingMerge.
+DO $$
+DECLARE
+    r record;
+    plan text := '';
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (VERBOSE, COSTS OFF)
+        SELECT u.id FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        plan := plan || E'\n' || r."QUERY PLAN";
+    END LOOP;
+    IF plan LIKE '%RoundRobinBatch%' OR plan LIKE '%SortPreservingMergeExec%' THEN
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment join plain EXPLAIN: UNEXPECTED distributed shape');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment join plain EXPLAIN: serial shape (no distributed merge/repartition)');
+    END IF;
+END$$;
+DO $$
+DECLARE
+    r record;
+    plan text := '';
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (VERBOSE, COSTS OFF)
+        SELECT p.age, count(*) FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' GROUP BY p.age ORDER BY p.age LIMIT 5'
+    LOOP
+        plan := plan || E'\n' || r."QUERY PLAN";
+    END LOOP;
+    IF plan LIKE '%RoundRobinBatch%' OR plan LIKE '%SortPreservingMergeExec%'
+       OR plan LIKE '%NetworkShuffle%' OR plan LIKE '%DistributedExec%' THEN
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment aggregate plain EXPLAIN: UNEXPECTED distributed shape');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment aggregate plain EXPLAIN: serial shape (no distributed merge/repartition)');
     END IF;
 END$$;
 -- AggregateScan rides the same plan-first launch: same 2-segment tables under
@@ -218,13 +260,15 @@ BEGIN
 END$$;
 SET paradedb.mpp_debug TO off;
 SELECT line FROM mpp_ws_outcome ORDER BY line;
-                                line                                 
----------------------------------------------------------------------
+                                        line                                        
+------------------------------------------------------------------------------------
+ 1-segment aggregate plain EXPLAIN: serial shape (no distributed merge/repartition)
+ 1-segment join plain EXPLAIN: serial shape (no distributed merge/repartition)
  1-segment join: ran serially (no MPP launch recorded)
  2-segment aggregate: launched exactly 2 producers
  2-segment join: launched exactly 2 producers
  4-segment join at cap 2: launched 2 producers, results match serial
-(4 rows)
+(6 rows)
 
 DROP TABLE mpp_ws_outcome, mpp_ws_users, mpp_ws_products, mpp_ws1_users, mpp_ws1_products,
            mpp_ws4_users, mpp_ws4_products;

--- a/pg_search/tests/pg_regress/expected/numeric_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/numeric_aggregate.out
@@ -44,20 +44,18 @@ ANALYZE numagg;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                           QUERY PLAN                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
    Indexes: numagg_idx (numagg)
    Aggregates: SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price)
    DataFusion Physical Plan: 
-     : AggregateExec: mode=Final, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric64_avg(numagg_0.price, 2) as agg_1, min(numagg_0.price) as agg_2, max(numagg_0.price) as agg_3, count(numagg_0.price) as agg_4]
-     :   CoalescePartitionsExec
-     :     AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric64_avg(numagg_0.price, 2) as agg_1, min(numagg_0.price) as agg_2, max(numagg_0.price) as agg_3, count(numagg_0.price) as agg_4]
-     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-     :         PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(11 rows)
+     : AggregateExec: mode=Single, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric64_avg(numagg_0.price, 2) as agg_1, min(numagg_0.price) as agg_2, max(numagg_0.price) as agg_3, count(numagg_0.price) as agg_4]
+     :   CooperativeExec
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
 
 SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description ||| 'apple OR basket OR crate';
    sum   |         avg          |  min  |   max   | count 
@@ -79,20 +77,18 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                           QUERY PLAN                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
    Indexes: numagg_idx (numagg)
    Aggregates: SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight)
    DataFusion Physical Plan: 
-     : AggregateExec: mode=Final, gby=[], aggr=[numeric_bytes_sum(numagg_0.weight) as agg_0, numeric_bytes_avg(numagg_0.weight) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.weight) as agg_3, count(numagg_0.weight) as agg_4]
-     :   CoalescePartitionsExec
-     :     AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.weight) as agg_0, numeric_bytes_avg(numagg_0.weight) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.weight) as agg_3, count(numagg_0.weight) as agg_4]
-     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-     :         PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(11 rows)
+     : AggregateExec: mode=Single, gby=[], aggr=[numeric_bytes_sum(numagg_0.weight) as agg_0, numeric_bytes_avg(numagg_0.weight) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.weight) as agg_3, count(numagg_0.weight) as agg_4]
+     :   CooperativeExec
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
 
 SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description ||| 'apple OR basket OR crate';
      sum     |          avg           |     min     |     max     | count 
@@ -113,20 +109,18 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                           QUERY PLAN                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
    Indexes: numagg_idx (numagg)
    Aggregates: SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount)
    DataFusion Physical Plan: 
-     : AggregateExec: mode=Final, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.amount) as agg_2, max(numagg_0.amount) as agg_3, count(numagg_0.amount) as agg_4]
-     :   CoalescePartitionsExec
-     :     AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.amount) as agg_2, max(numagg_0.amount) as agg_3, count(numagg_0.amount) as agg_4]
-     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-     :         PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(11 rows)
+     : AggregateExec: mode=Single, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.amount) as agg_2, max(numagg_0.amount) as agg_3, count(numagg_0.amount) as agg_4]
+     :   CooperativeExec
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
 
 SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description ||| 'apple OR basket OR crate';
                                       sum                                       |                                      avg                                      | min |                                      max                                       | count 
@@ -176,20 +170,18 @@ SET max_parallel_workers_per_gather = 2;
 -- COUNT on an unbounded NUMERIC column still pushes down
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                           QUERY PLAN                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
    Indexes: numagg_idx (numagg)
    Aggregates: COUNT(free)
    DataFusion Physical Plan: 
-     : AggregateExec: mode=Final, gby=[], aggr=[count(numagg_0.free) as agg_0]
-     :   CoalescePartitionsExec
-     :     AggregateExec: mode=Partial, gby=[], aggr=[count(numagg_0.free) as agg_0]
-     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-     :         PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(11 rows)
+     : AggregateExec: mode=Single, gby=[], aggr=[count(numagg_0.free) as agg_0]
+     :   CooperativeExec
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
 
 SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
  count 
@@ -202,8 +194,8 @@ SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description ||| 'apple OR basket OR crate' GROUP BY category ORDER BY category;
-                                                                                                                               QUERY PLAN                                                                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                            QUERY PLAN                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: category, (sum(price)), (avg(amount)), (min(weight)), (max(price))
    Sort Key: numagg.category
@@ -214,13 +206,10 @@ SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WH
          Group By: category
          Aggregates: SUM(price), AVG(amount), MIN(weight), MAX(price)
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.price) as agg_3]
-           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.price) as agg_3]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(16 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.price) as agg_3]
+           :   CooperativeExec
+           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(13 rows)
 
 SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description ||| 'apple OR basket OR crate' GROUP BY category ORDER BY category;
   category   |   sum   |                                      avg                                       |     min     |   max   
@@ -243,8 +232,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY price ORDER BY price;
-                                                                                                                           QUERY PLAN                                                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: price, (count(*))
    Sort Key: numagg.price
@@ -255,13 +244,10 @@ SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP
          Group By: price
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[price@0 as price], aggr=[count(1) as agg_0]
-           :     RepartitionExec: partitioning=Hash([price@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[price@0 as price], aggr=[count(1) as agg_0]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(16 rows)
+           : AggregateExec: mode=Single, gby=[price@0 as price], aggr=[count(1) as agg_0]
+           :   CooperativeExec
+           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(13 rows)
 
 SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY price ORDER BY price;
   price  | count 
@@ -274,8 +260,8 @@ SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY amount ORDER BY amount;
-                                                                                                                           QUERY PLAN                                                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: amount, (count(*))
    Sort Key: numagg.amount
@@ -286,13 +272,10 @@ SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROU
          Group By: amount
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[amount@0 as amount], aggr=[count(1) as agg_0]
-           :     RepartitionExec: partitioning=Hash([amount@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[amount@0 as amount], aggr=[count(1) as agg_0]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(16 rows)
+           : AggregateExec: mode=Single, gby=[amount@0 as amount], aggr=[count(1) as agg_0]
+           :   CooperativeExec
+           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(13 rows)
 
 SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY amount ORDER BY amount;
                                      amount                                     | count 
@@ -309,8 +292,8 @@ SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROU
 -- SUM sorts natively: decimal-bytes ordering matches numeric ordering
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
-                                                                                                                               QUERY PLAN                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                            QUERY PLAN                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(amount))
    ->  Sort
@@ -323,14 +306,11 @@ SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR baske
                Group By: category
                Aggregates: SUM(amount)
                DataFusion Physical Plan: 
-                 : SortPreservingMergeExec: [agg_0@1 DESC], fetch=1
-                 :   SortExec: TopK(fetch=1), expr=[agg_0@1 DESC], preserve_partitioning=[true]
-                 :     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0]
-                 :       RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-                 :         AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0]
-                 :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-                 :             PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(19 rows)
+                 : SortExec: TopK(fetch=1), expr=[agg_0@1 DESC], preserve_partitioning=[false]
+                 :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0]
+                 :     CooperativeExec
+                 :       PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(16 rows)
 
 SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
   category   |                                       s                                        
@@ -349,8 +329,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- Numeric64 SUM sorts the same way
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
-                                                                                                                               QUERY PLAN                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                            QUERY PLAN                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(price))
    ->  Sort
@@ -363,14 +343,11 @@ SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket
                Group By: category
                Aggregates: SUM(price)
                DataFusion Physical Plan: 
-                 : SortPreservingMergeExec: [agg_0@1 ASC NULLS LAST], fetch=1
-                 :   SortExec: TopK(fetch=1), expr=[agg_0@1 ASC NULLS LAST], preserve_partitioning=[true]
-                 :     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
-                 :       RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-                 :         AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
-                 :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-                 :             PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(19 rows)
+                 : SortExec: TopK(fetch=1), expr=[agg_0@1 ASC NULLS LAST], preserve_partitioning=[false]
+                 :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
+                 :     CooperativeExec
+                 :       PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(16 rows)
 
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
  category |   s   
@@ -389,8 +366,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- AVG blobs do not sort; TopK is skipped and Postgres sorts above the scan
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
-                                                                                                                              QUERY PLAN                                                                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                           QUERY PLAN                                                                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (avg(price))
    ->  Sort
@@ -403,13 +380,10 @@ SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket
                Group By: category
                Aggregates: AVG(price)
                DataFusion Physical Plan: 
-                 : CoalescePartitionsExec
-                 :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric64_avg(numagg_0.price, 2) as agg_0]
-                 :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-                 :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_avg(numagg_0.price, 2) as agg_0]
-                 :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-                 :           PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(18 rows)
+                 : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_avg(numagg_0.price, 2) as agg_0]
+                 :   CooperativeExec
+                 :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(15 rows)
 
 SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
  category |          a          

--- a/pg_search/tests/pg_regress/expected/select_distinct.out
+++ b/pg_search/tests/pg_regress/expected/select_distinct.out
@@ -55,8 +55,8 @@ SELECT DISTINCT category
 FROM dist_products
 WHERE name @@@ 'laptop OR jacket OR shoes'
 ORDER BY category;
-                                                                                                         QUERY PLAN                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                      QUERY PLAN                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -64,13 +64,10 @@ ORDER BY category;
          Indexes: dist_products_idx (dist_products)
          Group By: category
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[]
-           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_products, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_products, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
 SELECT DISTINCT category
 FROM dist_products
@@ -105,8 +102,8 @@ SELECT DISTINCT rating
 FROM dist_products
 WHERE name @@@ 'laptop OR keyboard'
 ORDER BY rating;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: rating
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -114,13 +111,10 @@ ORDER BY rating;
          Indexes: dist_products_idx (dist_products)
          Group By: rating
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[rating@0 as rating], aggr=[]
-           :     RepartitionExec: partitioning=Hash([rating@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[rating@0 as rating], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_products, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+           : AggregateExec: mode=Single, gby=[rating@0 as rating], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_products, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
 SELECT DISTINCT rating
 FROM dist_products
@@ -149,8 +143,8 @@ FROM dist_products
 WHERE name @@@ 'laptop OR keyboard OR jacket OR shoes OR headphones OR hub OR monitor OR mat OR chair OR desk'
 ORDER BY rating
 LIMIT 2;
-                                                                                                                                                         QUERY PLAN                                                                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                      QUERY PLAN                                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: rating
@@ -159,14 +153,11 @@ LIMIT 2;
                Indexes: dist_products_idx (dist_products)
                Group By: rating
                DataFusion Physical Plan: 
-                 : SortPreservingMergeExec: [rating@0 ASC NULLS LAST], fetch=2
-                 :   SortExec: TopK(fetch=2), expr=[rating@0 ASC NULLS LAST], preserve_partitioning=[true]
-                 :     AggregateExec: mode=FinalPartitioned, gby=[rating@0 as rating], aggr=[], lim=[2]
-                 :       RepartitionExec: partitioning=Hash([rating@0], 2), input_partitions=2
-                 :         AggregateExec: mode=Partial, gby=[rating@0 as rating], aggr=[], lim=[2]
-                 :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-                 :             PgSearchScan: table=dist_products, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard OR jacket OR shoes OR headphones OR hub OR monitor OR mat OR chair OR desk","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+                 : SortExec: TopK(fetch=2), expr=[rating@0 ASC NULLS LAST], preserve_partitioning=[false]
+                 :   AggregateExec: mode=Single, gby=[rating@0 as rating], aggr=[], lim=[2]
+                 :     CooperativeExec
+                 :       PgSearchScan: table=dist_products, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard OR jacket OR shoes OR headphones OR hub OR monitor OR mat OR chair OR desk","lenient":null,"conjunction_mode":null}}}}
+(12 rows)
 
 SELECT DISTINCT rating
 FROM dist_products
@@ -216,8 +207,8 @@ SELECT DISTINCT category, brand
 FROM dist_products
 WHERE name @@@ 'laptop OR keyboard OR headphones'
 ORDER BY category, brand;
-                                                                                                             QUERY PLAN                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: category, brand
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -225,13 +216,10 @@ ORDER BY category, brand;
          Indexes: dist_products_idx (dist_products)
          Group By: brand, category
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category, brand@1 as brand], aggr=[]
-           :     RepartitionExec: partitioning=Hash([category@0, brand@1], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category, brand@1 as brand], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_products, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard OR headphones","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category, brand@1 as brand], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_products, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard OR headphones","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
 SELECT DISTINCT category, brand
 FROM dist_products
@@ -383,8 +371,8 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT DISTINCT category
 FROM dist_products
 ORDER BY category;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Sort
    Sort Key: category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -392,13 +380,10 @@ ORDER BY category;
          Indexes: dist_products_idx (dist_products)
          Group By: category
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[]
-           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_products, segments=1, query="all"
-(13 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_products, segments=1, query="all"
+(10 rows)
 
 SELECT DISTINCT category
 FROM dist_products
@@ -443,8 +428,8 @@ FROM dist_products dp
 JOIN dist_regions dr ON dp.category = dr.category
 WHERE dp.name @@@ 'laptop OR jacket OR shoes'
 ORDER BY dp.category;
-                                                                                                              QUERY PLAN                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: dp.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -452,15 +437,13 @@ ORDER BY dp.category;
          Indexes: dist_products_idx (dp), dist_regions_idx (dr)
          Group By: category
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[]
-           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[]
-           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(category@0, category@0)]
-           :           PgSearchScan: table=dr, segments=1, query="all"
-           :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :             PgSearchScan: table=dp, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[]
+           :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(category@0, category@0)]
+           :     CooperativeExec
+           :       PgSearchScan: table=dr, segments=1, query="all"
+           :     CooperativeExec
+           :       PgSearchScan: table=dp, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
+(13 rows)
 
 SELECT DISTINCT dp.category
 FROM dist_products dp
@@ -516,8 +499,8 @@ SELECT DISTINCT url
 FROM dist_urls
 WHERE name @@@ 'Page'
 ORDER BY url;
-                                                                                             QUERY PLAN                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: url
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -525,13 +508,10 @@ ORDER BY url;
          Indexes: dist_urls_idx (dist_urls)
          Group By: url
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[url@0 as url], aggr=[]
-           :     RepartitionExec: partitioning=Hash([url@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_urls, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+           : AggregateExec: mode=Single, gby=[url@0 as url], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_urls, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
 SELECT DISTINCT url
 FROM dist_urls
@@ -587,8 +567,8 @@ SELECT DISTINCT category
 FROM dist_nullable
 WHERE name @@@ 'laptop OR keyboard OR widget OR gadget OR thingamajig'
 ORDER BY category;
-                                                                                                                       QUERY PLAN                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                    QUERY PLAN                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -596,13 +576,10 @@ ORDER BY category;
          Indexes: dist_nullable_idx (dist_nullable)
          Group By: category
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[]
-           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_nullable, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard OR widget OR gadget OR thingamajig","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_nullable, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR keyboard OR widget OR gadget OR thingamajig","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
 -- DISTINCT must return: Accessories, Electronics, NULL (three rows)
 SELECT DISTINCT category
@@ -669,8 +646,8 @@ SELECT DISTINCT url
 FROM dist_highcard
 WHERE name @@@ 'Page'
 ORDER BY url;
-                                                                                               QUERY PLAN                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: url
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -678,13 +655,10 @@ ORDER BY url;
          Indexes: dist_highcard_idx (dist_highcard)
          Group By: url
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[url@0 as url], aggr=[]
-           :     RepartitionExec: partitioning=Hash([url@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_highcard, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+           : AggregateExec: mode=Single, gby=[url@0 as url], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_highcard, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
 -- Verify all 20 distinct values are returned, not just 10.
 SELECT COUNT(*)
@@ -901,8 +875,8 @@ JOIN dist_regions dr ON dp.category = dr.category
 WHERE dp.name @@@ 'laptop OR jacket OR shoes'
 GROUP BY dp.category
 ORDER BY dp.category;
-                                                                                                                 QUERY PLAN                                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique
    ->  Sort
          Sort Key: dp.category
@@ -912,15 +886,13 @@ ORDER BY dp.category;
                Group By: category
                Aggregates: COUNT(*)
                DataFusion Physical Plan: 
-                 : CoalescePartitionsExec
-                 :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[count(1) as agg_0]
-                 :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-                 :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[category@1]
-                 :           PgSearchScan: table=dr, segments=1, query="all"
-                 :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-                 :             PgSearchScan: table=dp, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
-(17 rows)
+                 : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
+                 :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[category@1]
+                 :     CooperativeExec
+                 :       PgSearchScan: table=dr, segments=1, query="all"
+                 :     CooperativeExec
+                 :       PgSearchScan: table=dp, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
+(15 rows)
 
 SELECT DISTINCT ON (dp.category) dp.category, COUNT(*)
 FROM dist_products dp
@@ -966,8 +938,8 @@ JOIN dist_regions dr ON dp.category = dr.category
 WHERE dp.name @@@ 'laptop OR jacket OR shoes'
 ORDER BY dp.category;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: dp, dr)
-                                                                                                              QUERY PLAN                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: dp.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -975,15 +947,13 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: dp
          Indexes: dist_products_idx (dp), dist_regions_idx (dr)
          Group By: category
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[]
-           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[]
-           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(category@0, category@0)]
-           :           PgSearchScan: table=dr, segments=1, query="all"
-           :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :             PgSearchScan: table=dp, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[]
+           :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(category@0, category@0)]
+           :     CooperativeExec
+           :       PgSearchScan: table=dr, segments=1, query="all"
+           :     CooperativeExec
+           :       PgSearchScan: table=dp, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}}
+(13 rows)
 
 SELECT DISTINCT dp.category
 FROM dist_products dp
@@ -1013,8 +983,8 @@ WHERE dp.name @@@ 'laptop OR jacket OR shoes'
 ORDER BY dp.category
 LIMIT 10;
 WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to volatile functions (tables: dp, dr)
-                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: dp.category
@@ -1023,16 +993,14 @@ WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to volatile functions 
                Indexes: dist_products_idx (dp), dist_regions_idx (dr)
                Group By: category
                DataFusion Physical Plan: 
-                 : SortPreservingMergeExec: [category@0 ASC NULLS LAST], fetch=10
-                 :   SortExec: TopK(fetch=10), expr=[category@0 ASC NULLS LAST], preserve_partitioning=[true]
-                 :     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[], lim=[10]
-                 :       RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-                 :         AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[], lim=[10]
-                 :           HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(category@0, category@0)]
-                 :             PgSearchScan: table=dr, segments=1, dynamic_filters=1, query="all"
-                 :             RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-                 :               PgSearchScan: table=dp, segments=1, dynamic_filters=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(((id)::double precision + random()) > '0'::double precision)"}]}}]}}
-(17 rows)
+                 : SortExec: TopK(fetch=10), expr=[category@0 ASC NULLS LAST], preserve_partitioning=[false]
+                 :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[], lim=[10]
+                 :     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(category@0, category@0)]
+                 :       CooperativeExec
+                 :         PgSearchScan: table=dr, segments=1, dynamic_filters=1, query="all"
+                 :       CooperativeExec
+                 :         PgSearchScan: table=dp, segments=1, dynamic_filters=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"laptop OR jacket OR shoes","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(((id)::double precision + random()) > '0'::double precision)"}]}}]}}
+(15 rows)
 
 SELECT DISTINCT dp.category
 FROM dist_products dp
@@ -1401,8 +1369,8 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT DISTINCT category
 FROM ONLY dist_inh_parent
 ORDER BY category;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Sort
    Sort Key: category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -1410,13 +1378,10 @@ ORDER BY category;
          Indexes: dist_inh_parent_idx (dist_inh_parent)
          Group By: category
          DataFusion Physical Plan: 
-           : CoalescePartitionsExec
-           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[]
-           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
-           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[]
-           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-           :           PgSearchScan: table=dist_inh_parent, segments=1, query="all"
-(13 rows)
+           : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[]
+           :   CooperativeExec
+           :     PgSearchScan: table=dist_inh_parent, segments=1, query="all"
+(10 rows)
 
 SELECT DISTINCT category
 FROM ONLY dist_inh_parent

--- a/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_worker_sizing.sql
@@ -8,7 +8,8 @@
 --   - 1 segment per table produces no distributable stages: the query
 --     runs serially ("MPP Launch" line absent), and under
 --     paradedb.mpp_debug no "spawning" trace appears — no launch is
---     even attempted.
+--     even attempted. Plain EXPLAIN must also render the serial shape
+--     (#5784), not a cap-sized distributed plan.
 --   - 4 segments per table under a cap of 2 launch exactly 2 producers;
 --     the extra tasks multiplex and results match the serial run.
 --   - AggregateScan rides the same launch: a 2-segment GROUP BY join
@@ -113,6 +114,49 @@ BEGIN
         INSERT INTO mpp_ws_outcome VALUES ('1-segment join: UNEXPECTED distributed launch');
     ELSE
         INSERT INTO mpp_ws_outcome VALUES ('1-segment join: ran serially (no MPP launch recorded)');
+    END IF;
+END$$;
+
+-- #5784: plain EXPLAIN must match the serial ANALYZE shape when launch
+-- will not run — no cap-sized RoundRobin / SortPreservingMerge.
+DO $$
+DECLARE
+    r record;
+    plan text := '';
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (VERBOSE, COSTS OFF)
+        SELECT u.id FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' ORDER BY u.id LIMIT 10'
+    LOOP
+        plan := plan || E'\n' || r."QUERY PLAN";
+    END LOOP;
+    IF plan LIKE '%RoundRobinBatch%' OR plan LIKE '%SortPreservingMergeExec%' THEN
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment join plain EXPLAIN: UNEXPECTED distributed shape');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment join plain EXPLAIN: serial shape (no distributed merge/repartition)');
+    END IF;
+END$$;
+
+DO $$
+DECLARE
+    r record;
+    plan text := '';
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (VERBOSE, COSTS OFF)
+        SELECT p.age, count(*) FROM mpp_ws1_users u JOIN mpp_ws1_products p ON u.age = p.age
+        WHERE u.name @@@ ''bob'' GROUP BY p.age ORDER BY p.age LIMIT 5'
+    LOOP
+        plan := plan || E'\n' || r."QUERY PLAN";
+    END LOOP;
+    IF plan LIKE '%RoundRobinBatch%' OR plan LIKE '%SortPreservingMergeExec%'
+       OR plan LIKE '%NetworkShuffle%' OR plan LIKE '%DistributedExec%' THEN
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment aggregate plain EXPLAIN: UNEXPECTED distributed shape');
+    ELSE
+        INSERT INTO mpp_ws_outcome
+        VALUES ('1-segment aggregate plain EXPLAIN: serial shape (no distributed merge/repartition)');
     END IF;
 END$$;
 


### PR DESCRIPTION
## Summary
- Fixes [#5784](https://github.com/paradedb/paradedb/issues/5784): when task discovery finds fewer than 2 producer tasks, plain `EXPLAIN` rebuilds and renders the serial plan instead of a cap-sized distributed shape.
- Shares the launch gate (`mpp_plan_has_data_parallelism`) across JoinScan and AggregateScan, matching plan-first MPP launch behavior from #5756.
- Extends `mpp_worker_sizing` to assert the 1-segment plain-EXPLAIN serial contract.

## Test plan
- [x] `mpp_worker_sizing` regress
- [x] 1-segment join: plain EXPLAIN has no `RoundRobinBatch` / `SortPreservingMergeExec`
- [x] 1-segment join: EXPLAIN ANALYZE has no `MPP Launch` line
- [x] 2-segment join still launches `workers=2` under an oversized cap