### PR TITLE
fix: avoid spurious datetime_fields error

### DIFF
--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -590,6 +590,17 @@ impl BM25IndexOptions {
                     .cloned()
             })
             .or_else(|| {
+                // `datetime_fields` only applies to fields stored as tantivy Date. Indexes
+                // created by v0.24.1+ store datetimes as i64, where the option is deprecated
+                // and must be discarded: its `SearchFieldConfig::Date` cannot be converted to
+                // the tantivy options of an i64 field. The available options (fast) are already on
+                // by default for i64 anyways.
+                if !matches!(
+                    self.get_field_type(field_name),
+                    Some(SearchFieldType::Date(_))
+                ) {
+                    return None;
+                }
                 self.datetime_config()
                     .as_ref()
                     .unwrap()

--- a/pg_search/tests/pg_regress/expected/datetime_fields_deprecated.out
+++ b/pg_search/tests/pg_regress/expected/datetime_fields_deprecated.out
@@ -1,0 +1,57 @@
+-- The `datetime_fields` option was deprecated in v0.24.1: datetimes are now
+-- stored as i64 and the option has no effect. DDL from before v0.24.1 that
+-- still contains `datetime_fields` must replay cleanly — a warning, not an
+-- error (issue #5824).
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS deprecated_dt CASCADE;
+CREATE TABLE deprecated_dt (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    ts TIMESTAMP,
+    tstz TIMESTAMPTZ
+);
+INSERT INTO deprecated_dt (ts, tstz) VALUES
+    ('2024-01-01 10:00:00', '2024-01-01 10:00:00+00'),
+    ('2024-01-02 11:00:00', '2024-01-02 11:00:00+00'),
+    ('2024-01-03 12:00:00', '2024-01-03 12:00:00+00');
+-- Warns that the option is deprecated, but must not fail
+CREATE INDEX deprecated_dt_idx ON deprecated_dt
+USING bm25 (id, ts, tstz)
+WITH (
+    key_field = 'id',
+    datetime_fields = '{"ts": {"fast": true}, "tstz": {"fast": true}}'
+);
+WARNING:  As of v0.24.1, "datetime_fields" is deprecated and should be removed. It no longer has any effect. The performance improvement options it provided are now on by default.
+-- The index must behave as if the option had not been specified
+SELECT id, ts, tstz
+FROM deprecated_dt
+WHERE id @@@ pdb.all()
+ORDER BY id;
+ id |            ts            |             tstz             
+----+--------------------------+------------------------------
+  1 | Mon Jan 01 10:00:00 2024 | Mon Jan 01 02:00:00 2024 PST
+  2 | Tue Jan 02 11:00:00 2024 | Tue Jan 02 03:00:00 2024 PST
+  3 | Wed Jan 03 12:00:00 2024 | Wed Jan 03 04:00:00 2024 PST
+(3 rows)
+
+SELECT id
+FROM deprecated_dt
+WHERE ts @@@ '[2024-01-02T00:00:00Z TO 2024-01-03T00:00:00Z]'
+ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+SELECT id, tstz
+FROM deprecated_dt
+WHERE id @@@ pdb.all()
+ORDER BY tstz DESC
+LIMIT 2;
+ id |             tstz             
+----+------------------------------
+  3 | Wed Jan 03 04:00:00 2024 PST
+  2 | Tue Jan 02 03:00:00 2024 PST
+(2 rows)
+
+-- Cleanup
+DROP TABLE deprecated_dt CASCADE;

--- a/pg_search/tests/pg_regress/sql/datetime_fields_deprecated.sql
+++ b/pg_search/tests/pg_regress/sql/datetime_fields_deprecated.sql
@@ -1,0 +1,47 @@
+-- The `datetime_fields` option was deprecated in v0.24.1: datetimes are now
+-- stored as i64 and the option has no effect. DDL from before v0.24.1 that
+-- still contains `datetime_fields` must replay cleanly — a warning, not an
+-- error (issue #5824).
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS deprecated_dt CASCADE;
+
+CREATE TABLE deprecated_dt (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    ts TIMESTAMP,
+    tstz TIMESTAMPTZ
+);
+
+INSERT INTO deprecated_dt (ts, tstz) VALUES
+    ('2024-01-01 10:00:00', '2024-01-01 10:00:00+00'),
+    ('2024-01-02 11:00:00', '2024-01-02 11:00:00+00'),
+    ('2024-01-03 12:00:00', '2024-01-03 12:00:00+00');
+
+-- Warns that the option is deprecated, but must not fail
+CREATE INDEX deprecated_dt_idx ON deprecated_dt
+USING bm25 (id, ts, tstz)
+WITH (
+    key_field = 'id',
+    datetime_fields = '{"ts": {"fast": true}, "tstz": {"fast": true}}'
+);
+
+-- The index must behave as if the option had not been specified
+SELECT id, ts, tstz
+FROM deprecated_dt
+WHERE id @@@ pdb.all()
+ORDER BY id;
+
+SELECT id
+FROM deprecated_dt
+WHERE ts @@@ '[2024-01-02T00:00:00Z TO 2024-01-03T00:00:00Z]'
+ORDER BY id;
+
+SELECT id, tstz
+FROM deprecated_dt
+WHERE id @@@ pdb.all()
+ORDER BY tstz DESC
+LIMIT 2;
+
+-- Cleanup
+DROP TABLE deprecated_dt CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #5824 

## How
Discard non-Date datetime fields in BM25IndexOptions::field_config()

## Tests
Adds a regression test containing `datetime_fields` index-creation DDL.