### PR TITLE
ci: collapse the hand-enumerated publish matrices into dimensions

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -47,138 +47,26 @@ jobs:
         shell: bash
     strategy:
       matrix:
+        # 2 distros x 4 Postgres majors x 2 arches = 16 jobs. `include` attaches the keys that are
+        # functionally determined by a dimension -- the display name for an image, the runner sizing
+        # for an arch -- instead of re-listing all 16 combinations by hand.
+        image: [debian:12-slim, debian:13-slim]
+        pg_version: [15, 16, 17, 18]
+        arch: [amd64, arm64]
         include:
-          # Debian 12 (Bookworm)
-          - name: Debian 12 (Bookworm)
-            cpu: 8
+          # No dimension keys, so these apply to every combination.
+          - cpu: 8
             ram: 16
+          - image: debian:12-slim
+            name: Debian 12 (Bookworm)
+          - image: debian:13-slim
+            name: Debian 13 (Trixie)
+          - arch: amd64
             runner_family: c7a+c7i
             runner_image: ubuntu24-full-x64
-            image: debian:12-slim
-            pg_version: 15
-            arch: amd64
-          - name: Debian 12 (Bookworm)
-            cpu: 8
-            ram: 16
+          - arch: arm64
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
-            image: debian:12-slim
-            pg_version: 15
-            arch: arm64
-          - name: Debian 12 (Bookworm)
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: debian:12-slim
-            pg_version: 16
-            arch: amd64
-          - name: Debian 12 (Bookworm)
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: debian:12-slim
-            pg_version: 16
-            arch: arm64
-          - name: Debian 12 (Bookworm)
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: debian:12-slim
-            pg_version: 17
-            arch: amd64
-          - name: Debian 12 (Bookworm)
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: debian:12-slim
-            pg_version: 17
-            arch: arm64
-          - name: Debian 12 (Bookworm)
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: debian:12-slim
-            pg_version: 18
-            arch: amd64
-          - name: Debian 12 (Bookworm)
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: debian:12-slim
-            pg_version: 18
-            arch: arm64
-          # Debian 13 (Trixie)
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: debian:13-slim
-            pg_version: 15
-            arch: amd64
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: debian:13-slim
-            pg_version: 15
-            arch: arm64
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: debian:13-slim
-            pg_version: 16
-            arch: amd64
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: debian:13-slim
-            pg_version: 16
-            arch: arm64
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: debian:13-slim
-            pg_version: 17
-            arch: amd64
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: debian:13-slim
-            pg_version: 17
-            arch: arm64
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: debian:13-slim
-            pg_version: 18
-            arch: amd64
-          - name: Debian 13 (Trixie)
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: debian:13-slim
-            pg_version: 18
-            arch: arm64
-
     steps:
       # A job-level `if` cannot read the `matrix` context, so beta filtering happens here, per step:
       # stable releases build every row; beta (`-rc.`) releases build only the Debian 13 (Trixie)

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -46,138 +46,26 @@ jobs:
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
       matrix:
+        # 2 RHEL majors x 4 Postgres majors x 2 arches = 16 jobs. `include` attaches the keys that are
+        # functionally determined by a dimension -- the display name for an image, the runner sizing
+        # for an arch -- instead of re-listing all 16 combinations by hand.
+        image: [redhat/ubi9:latest, redhat/ubi10:latest]
+        pg_version: [15, 16, 17, 18]
+        arch: [x86_64, aarch64]
         include:
-          # Red Hat Enterprise Linux 9
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
+          # No dimension keys, so these apply to every combination.
+          - cpu: 8
             ram: 16
+          - image: redhat/ubi9:latest
+            name: Red Hat Enterprise Linux 9
+          - image: redhat/ubi10:latest
+            name: Red Hat Enterprise Linux 10
+          - arch: x86_64
             runner_family: c7a+c7i
             runner_image: ubuntu24-full-x64
-            image: redhat/ubi9:latest
-            pg_version: 15
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
-            ram: 16
+          - arch: aarch64
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
-            image: redhat/ubi9:latest
-            pg_version: 15
-            arch: aarch64
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: redhat/ubi9:latest
-            pg_version: 16
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: redhat/ubi9:latest
-            pg_version: 16
-            arch: aarch64
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: redhat/ubi9:latest
-            pg_version: 17
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: redhat/ubi9:latest
-            pg_version: 17
-            arch: aarch64
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: redhat/ubi9:latest
-            pg_version: 18
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 9
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: redhat/ubi9:latest
-            pg_version: 18
-            arch: aarch64
-          # Red Hat Enterprise Linux 10
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: redhat/ubi10:latest
-            pg_version: 15
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: redhat/ubi10:latest
-            pg_version: 15
-            arch: aarch64
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: redhat/ubi10:latest
-            pg_version: 16
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: redhat/ubi10:latest
-            pg_version: 16
-            arch: aarch64
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: redhat/ubi10:latest
-            pg_version: 17
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: redhat/ubi10:latest
-            pg_version: 17
-            arch: aarch64
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: redhat/ubi10:latest
-            pg_version: 18
-            arch: x86_64
-          - name: Red Hat Enterprise Linux 10
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: redhat/ubi10:latest
-            pg_version: 18
-            arch: aarch64
-
     steps:
       - name: Install Dependencies
         run: |

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -46,154 +46,28 @@ jobs:
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
       matrix:
+        # 2 releases x 4 Postgres majors x 2 arches = 16 jobs. `include` attaches the keys that are
+        # functionally determined by a dimension -- the display name and codename for an image, the
+        # runner sizing for an arch -- instead of re-listing all 16 combinations by hand.
+        image: [ubuntu:24.04, ubuntu:26.04]
+        pg_version: [15, 16, 17, 18]
+        arch: [amd64, arm64]
         include:
-          # Ubuntu 26.04
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
+          # No dimension keys, so these apply to every combination.
+          - cpu: 8
             ram: 16
+          - image: ubuntu:24.04
+            name: Ubuntu 24.04 (Noble)
+            os_codename: noble
+          - image: ubuntu:26.04
+            name: Ubuntu 26.04 (Resolute)
+            os_codename: resolute
+          - arch: amd64
             runner_family: c7a+c7i
             runner_image: ubuntu24-full-x64
-            image: ubuntu:26.04
-            pg_version: 15
-            arch: amd64
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
-            ram: 16
+          - arch: arm64
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
-            image: ubuntu:26.04
-            pg_version: 15
-            arch: arm64
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: ubuntu:26.04
-            pg_version: 16
-            arch: amd64
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: ubuntu:26.04
-            pg_version: 16
-            arch: arm64
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: ubuntu:26.04
-            pg_version: 17
-            arch: amd64
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: ubuntu:26.04
-            pg_version: 17
-            arch: arm64
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: ubuntu:26.04
-            pg_version: 18
-            arch: amd64
-          - name: Ubuntu 26.04 (Resolute)
-            os_codename: resolute
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: ubuntu:26.04
-            pg_version: 18
-            arch: arm64
-          # Ubuntu 24.04
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: ubuntu:24.04
-            pg_version: 15
-            arch: amd64
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: ubuntu:24.04
-            pg_version: 15
-            arch: arm64
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: ubuntu:24.04
-            pg_version: 16
-            arch: amd64
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: ubuntu:24.04
-            pg_version: 16
-            arch: arm64
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: ubuntu:24.04
-            pg_version: 17
-            arch: amd64
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: ubuntu:24.04
-            pg_version: 17
-            arch: arm64
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
-            image: ubuntu:24.04
-            pg_version: 18
-            arch: amd64
-          - name: Ubuntu 24.04 (Noble)
-            os_codename: noble
-            cpu: 8
-            ram: 16
-            runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
-            image: ubuntu:24.04
-            pg_version: 18
-            arch: arm64
-
     steps:
       - name: Install Dependencies
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base


### PR DESCRIPTION
The Debian, Ubuntu and RHEL publish workflows each enumerated all 16 matrix rows by hand — **134–150 lines apiece** restating the same distro / PG major / arch values. Adding a Postgres major today means appending four rows to each of three files.

Each matrix is really a **2 × 4 × 2 product** where two groups of keys are functionally determined by a dimension:

- display name (and Ubuntu's `os_codename`) follow from `image`
- `runner_family` / `runner_image` follow from `arch`

Expressed that way it needs three dimensions plus four `include` entries. **Every existing `matrix.*` reference in the steps keeps working**, so no step bodies change.

**393 deletions, 43 insertions.**

## Verification

I expanded both the old and new matrices using GitHub's documented `include` semantics and compared the resulting job sets:

```
debian: old=16 new=16 IDENTICAL=True
ubuntu: old=16 new=16 IDENTICAL=True
rhel:   old=16 new=16 IDENTICAL=True
```

Identical down to the key/value set of every job, `cpu`/`ram` included. Also confirmed every `matrix.*` key referenced in the steps is still provided by the new matrix.

- `actionlint`: **no new warnings** vs the pre-change files (the 2 `action` + 24 `shellcheck` findings are pre-existing).
- `prettier --check`: clean.

## One deliberate non-obvious choice

`cpu`/`ram` are constant across all 16 rows, so the tempting move is to inline them into `runs-on` as `cpu=8` / `ram=16`. I tried that and backed it out: as literals, actionlint parses them as runner labels and flags 6 new "unknown label" errors, whereas `${{ matrix.cpu }}` is an opaque expression it skips. They stay matrix values via a dimensionless `include` entry (which GitHub applies to every combination), keeping the lint delta at zero.

https://claude.ai/code/session_01ESbGCQzXnRB8GrQ49FfBHf