### PR TITLE
chore: drop references to closed issues and fix a workflow typo

### DIFF
--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -2,7 +2,7 @@
 #
 # Benchmark pg_search (Stressgres)
 # Run our Stressgres stress testing tool against pg_search on the
-# testing suites specificed in stressgres/suites/.
+# testing suites specified in stressgres/suites/.
 
 name: Benchmark pg_search (Stressgres)
 

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -2243,9 +2243,8 @@ fn compute_exec_which_fast_fields(
         // In some cases, enough columns are pruned between planning and execution that there
         // is no point actually using fast fields, and we can fall back to `Normal`.
         //
-        // TODO: In order to implement https://github.com/paradedb/paradedb/issues/2623, we will
-        // need to differentiate these cases, so that we can always emit the sort order that we
-        // claimed.
+        // TODO: To always emit the sort order that we claimed, we will need to differentiate
+        // these cases.
         return None;
     }
 

--- a/pg_search/src/postgres/customscan/datafusion/explain.rs
+++ b/pg_search/src/postgres/customscan/datafusion/explain.rs
@@ -148,7 +148,7 @@ pub fn format_join_level_expr(expr: &JoinLevelExpr, join_clause: &JoinCSClause) 
 /// (`elapsed_compute`, named `Time` values) are stripped so that regression
 /// test output remains stable.  Pass `true` (e.g. for EXPLAIN ANALYZE VERBOSE)
 /// to include everything.
-// TODO(#4152): PG parallel workers each run their own `exec_custom_scan` with their
+// NOTE: PG parallel workers each run their own `exec_custom_scan` with their
 // own plan instance, so these metrics only cover the leader's share.
 fn render_plan_with_metrics(
     plan: &dyn ExecutionPlan,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1672,7 +1672,7 @@ unsafe fn build_output_projection(
     // Normal path: build output_projection, enriching expression entries with
     // metadata when DISTINCT is active.
     //
-    // TODO(#4604): This is the second call to distinct_columns_are_fast_fields
+    // TODO: This is the second call to distinct_columns_are_fast_fields
     // in the same planning phase (first in validate_and_build_clause). Both
     // calls walk the same parse tree. Consider caching the result in a
     // planning-phase-scoped structure to avoid redundant work.

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -760,8 +760,9 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
     assert_eq!(rows.len(), 6);
 }
 
-// TODO: This test is currently ignored because hybrid plans do not reliably trigger the custom
-// scan on a partial BM25 index yet: see https://github.com/paradedb/paradedb/issues/2747
+// TODO: This test is currently ignored because hybrid plans did not reliably trigger the custom
+// scan on a partial BM25 index. The issue this pointed at (#2747) has since been closed, so the
+// test should be re-run and un-ignored if it now passes.
 #[ignore]
 #[rstest]
 fn bm25_partial_index_hybrid(mut conn: PgConnection) {


### PR DESCRIPTION
Another round of very small audits on the codebase. Nothing major