### PR TITLE
refactor: share the UDF codec between the logical and physical plan codecs

### DIFF
--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -31,10 +31,9 @@ use tantivy::index::SegmentId;
 use crate::api::HashSet;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterNode;
-use crate::postgres::customscan::pg_expr_udf::{PG_EXPR_UDF_PREFIX, PgExprUdf};
 use crate::scan::late_materialization::{DeferredField, LateMaterializeNode};
-use crate::scan::search_predicate_udf::SearchPredicateUDF;
 use crate::scan::table_provider::PgSearchTableProvider;
+use crate::scan::udf_codec::{try_decode_pg_search_udf, try_encode_pg_search_udf};
 
 /// Datafusion `LogicalPlan`s are serialized/deserialized with protobuf.
 /// Any custom nodes (e.g. UDFs, table providers) must use this codec to instruct
@@ -266,68 +265,19 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
     }
 
     fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
-        if name == "pdb_search_predicate" {
-            let mut udf: SearchPredicateUDF = serde_json::from_slice(buf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to deserialize SearchPredicateUDF: {e}"))
-            })?;
-            if let Some(plan_position) = udf.plan_position()
-                && !self.index_segment_ids.is_empty()
-            {
-                let ids = self
-                    .index_segment_ids
-                    .get(plan_position)
-                    .cloned()
-                    .expect("missing canonical segment IDs for plan_position");
-                udf.set_canonical_segment_ids(ids);
-            }
-            return Ok(Arc::new(ScalarUDF::new_from_impl(udf)));
-        }
-
-        if name.starts_with(PG_EXPR_UDF_PREFIX) {
-            let mut udf: PgExprUdf = serde_json::from_slice(buf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to deserialize PgExprUdf: {e}"))
-            })?;
-            udf.fixup_after_deserialize();
-            return Ok(Arc::new(ScalarUDF::new_from_impl(udf)));
-        }
-
-        Err(DataFusionError::NotImplemented(format!(
-            "UDF '{}' deserialization not implemented",
-            name
-        )))
+        try_decode_pg_search_udf(name, buf, &self.index_segment_ids)?.ok_or_else(|| {
+            DataFusionError::NotImplemented(format!("UDF '{name}' deserialization not implemented"))
+        })
     }
 
     fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<()> {
-        let name = node.name();
-        if name == "pdb_search_predicate" {
-            let udf = node
-                .inner()
-                .downcast_ref::<SearchPredicateUDF>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal("UDF is not a SearchPredicateUDF".into())
-                })?;
-            let bytes = serde_json::to_vec(udf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to serialize SearchPredicateUDF: {e}"))
-            })?;
-            buf.extend_from_slice(&bytes);
-            return Ok(());
-        }
-
-        if name.starts_with(PG_EXPR_UDF_PREFIX) {
-            let udf = node
-                .inner()
-                .downcast_ref::<PgExprUdf>()
-                .ok_or_else(|| DataFusionError::Internal("UDF is not a PgExprUdf".into()))?;
-            let bytes = serde_json::to_vec(udf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to serialize PgExprUdf: {e}"))
-            })?;
-            buf.extend_from_slice(&bytes);
+        if try_encode_pg_search_udf(node, buf)? {
             return Ok(());
         }
 
         Err(DataFusionError::NotImplemented(format!(
             "UDF '{}' serialization not implemented",
-            name
+            node.name()
         )))
     }
 }

--- a/pg_search/src/scan/mod.rs
+++ b/pg_search/src/scan/mod.rs
@@ -33,6 +33,7 @@ pub mod table_provider;
 pub mod tantivy_lookup_exec;
 #[cfg(any(test, feature = "pg_test"))]
 mod tests;
+mod udf_codec;
 pub mod visibility_ctid_resolver_rule;
 
 pub use batch_scanner::Scanner;

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -45,12 +45,13 @@ use crate::api::{HashMap, HashSet};
 use crate::index::fast_fields_helper::FFHelper;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
-use crate::postgres::customscan::pg_expr_udf::{PG_EXPR_UDF_PREFIX, PgExprUdf};
 use crate::scan::execution_plan::PgSearchScanPlan;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
-use crate::scan::search_predicate_udf::SearchPredicateUDF;
 use crate::scan::segmented_topk_exec::SegmentedTopKExec;
 use crate::scan::tantivy_lookup_exec::TantivyLookupExec;
+use crate::scan::udf_codec::{
+    is_pg_search_udf, try_decode_pg_search_udf, try_encode_pg_search_udf,
+};
 
 /// Byte tags identifying each custom exec in the extension payload. The composed codec already
 /// records which codec decoded a node; the tag picks the exec within this codec.
@@ -180,70 +181,15 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
     }
 
     fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
-        if name == "pdb_search_predicate" {
-            let mut udf: SearchPredicateUDF = serde_json::from_slice(buf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to deserialize SearchPredicateUDF: {e}"))
-            })?;
-            if let Some(plan_position) = udf.plan_position()
-                && !self.index_segment_ids.is_empty()
-            {
-                let ids = self
-                    .index_segment_ids
-                    .get(plan_position)
-                    .cloned()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal(format!(
-                            "missing canonical segment IDs for plan_position {plan_position}"
-                        ))
-                    })?;
-                udf.set_canonical_segment_ids(ids);
-            }
-            return Ok(Arc::new(ScalarUDF::new_from_impl(udf)));
-        }
-
-        if name.starts_with(PG_EXPR_UDF_PREFIX) {
-            let mut udf: PgExprUdf = serde_json::from_slice(buf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to deserialize PgExprUdf: {e}"))
-            })?;
-            udf.fixup_after_deserialize();
-            return Ok(Arc::new(ScalarUDF::new_from_impl(udf)));
-        }
-
-        Err(DataFusionError::NotImplemented(format!(
-            "UDF '{name}' deserialization not implemented"
-        )))
+        try_decode_pg_search_udf(name, buf, &self.index_segment_ids)?.ok_or_else(|| {
+            DataFusionError::NotImplemented(format!("UDF '{name}' deserialization not implemented"))
+        })
     }
 
     fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<()> {
-        let name = node.name();
-        if name == "pdb_search_predicate" {
-            let udf = node
-                .inner()
-                .downcast_ref::<SearchPredicateUDF>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal("UDF is not a SearchPredicateUDF".into())
-                })?;
-            let bytes = serde_json::to_vec(udf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to serialize SearchPredicateUDF: {e}"))
-            })?;
-            buf.extend_from_slice(&bytes);
-            return Ok(());
-        }
-
-        if name.starts_with(PG_EXPR_UDF_PREFIX) {
-            let udf = node
-                .inner()
-                .downcast_ref::<PgExprUdf>()
-                .ok_or_else(|| DataFusionError::Internal("UDF is not a PgExprUdf".into()))?;
-            let bytes = serde_json::to_vec(udf).map_err(|e| {
-                DataFusionError::Internal(format!("Failed to serialize PgExprUdf: {e}"))
-            })?;
-            buf.extend_from_slice(&bytes);
-            return Ok(());
-        }
-
         // Not ours: encode nothing so the expression travels by name and the decoding session
         // resolves it from its registry (DataFusion built-ins are registered there).
+        try_encode_pg_search_udf(node, buf)?;
         Ok(())
     }
 }
@@ -323,10 +269,6 @@ fn collect_ffhelpers_by_indexrelid(input: &Arc<dyn ExecutionPlan>) -> HashMap<u3
 /// to [`PgSearchPhysicalExtensionCodec`], which ships the real definition.
 #[derive(Debug)]
 struct DistributedCodecHostingPgSearchUdfs(DistributedCodec);
-
-fn is_pg_search_udf(name: &str) -> bool {
-    name == "pdb_search_predicate" || name.starts_with(PG_EXPR_UDF_PREFIX)
-}
 
 impl PhysicalExtensionCodec for DistributedCodecHostingPgSearchUdfs {
     fn try_decode(

--- a/pg_search/src/scan/udf_codec.rs
+++ b/pg_search/src/scan/udf_codec.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Shared encoding for the scalar UDFs `pg_search` puts into DataFusion plans.
+//!
+//! Both the logical codec ([`crate::scan::codec`]) and the physical codec
+//! ([`crate::scan::physical_codec`]) have to move `SearchPredicateUDF` and
+//! `PgExprUdf` across a serialization boundary, in exactly the same way. The two
+//! codecs differ only in what they do with a UDF that is *not* one of ours, so
+//! these helpers report "not mine" rather than deciding, and each codec applies
+//! its own fallback.
+
+use std::sync::Arc;
+
+use datafusion::common::{DataFusionError, Result};
+use datafusion::logical_expr::ScalarUDF;
+use tantivy::index::SegmentId;
+
+use crate::api::HashSet;
+use crate::postgres::customscan::pg_expr_udf::{PG_EXPR_UDF_PREFIX, PgExprUdf};
+use crate::scan::search_predicate_udf::SearchPredicateUDF;
+
+/// Whether `name` identifies a scalar UDF that `pg_search` owns the encoding for.
+///
+/// This is the single definition of that predicate; the decode/encode helpers
+/// below and the composed physical codec all agree by construction.
+pub(crate) fn is_pg_search_udf(name: &str) -> bool {
+    name == "pdb_search_predicate" || name.starts_with(PG_EXPR_UDF_PREFIX)
+}
+
+/// Decode a `pg_search` scalar UDF.
+///
+/// Returns `Ok(None)` when `name` does not belong to `pg_search`, leaving the
+/// caller to decide whether that is an error or should fall through to the
+/// session registry.
+///
+/// `index_segment_ids` supplies the canonical segment IDs to re-attach to a
+/// `SearchPredicateUDF`; pass an empty slice when the caller has none.
+pub(crate) fn try_decode_pg_search_udf(
+    name: &str,
+    buf: &[u8],
+    index_segment_ids: &[HashSet<SegmentId>],
+) -> Result<Option<Arc<ScalarUDF>>> {
+    if name == "pdb_search_predicate" {
+        let mut udf: SearchPredicateUDF = serde_json::from_slice(buf).map_err(|e| {
+            DataFusionError::Internal(format!("Failed to deserialize SearchPredicateUDF: {e}"))
+        })?;
+        if let Some(plan_position) = udf.plan_position()
+            && !index_segment_ids.is_empty()
+        {
+            let ids = index_segment_ids
+                .get(plan_position)
+                .cloned()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "missing canonical segment IDs for plan_position {plan_position}"
+                    ))
+                })?;
+            udf.set_canonical_segment_ids(ids);
+        }
+        return Ok(Some(Arc::new(ScalarUDF::new_from_impl(udf))));
+    }
+
+    if name.starts_with(PG_EXPR_UDF_PREFIX) {
+        let mut udf: PgExprUdf = serde_json::from_slice(buf).map_err(|e| {
+            DataFusionError::Internal(format!("Failed to deserialize PgExprUdf: {e}"))
+        })?;
+        udf.fixup_after_deserialize();
+        return Ok(Some(Arc::new(ScalarUDF::new_from_impl(udf))));
+    }
+
+    Ok(None)
+}
+
+/// Encode a `pg_search` scalar UDF into `buf`.
+///
+/// Returns `Ok(false)` when `node` does not belong to `pg_search`, in which case
+/// nothing has been written to `buf` and the caller decides the fallback.
+pub(crate) fn try_encode_pg_search_udf(node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<bool> {
+    let name = node.name();
+
+    if name == "pdb_search_predicate" {
+        let udf = node
+            .inner()
+            .downcast_ref::<SearchPredicateUDF>()
+            .ok_or_else(|| DataFusionError::Internal("UDF is not a SearchPredicateUDF".into()))?;
+        let bytes = serde_json::to_vec(udf).map_err(|e| {
+            DataFusionError::Internal(format!("Failed to serialize SearchPredicateUDF: {e}"))
+        })?;
+        buf.extend_from_slice(&bytes);
+        return Ok(true);
+    }
+
+    if name.starts_with(PG_EXPR_UDF_PREFIX) {
+        let udf = node
+            .inner()
+            .downcast_ref::<PgExprUdf>()
+            .ok_or_else(|| DataFusionError::Internal("UDF is not a PgExprUdf".into()))?;
+        let bytes = serde_json::to_vec(udf).map_err(|e| {
+            DataFusionError::Internal(format!("Failed to serialize PgExprUdf: {e}"))
+        })?;
+        buf.extend_from_slice(&bytes);
+        return Ok(true);
+    }
+
+    Ok(false)
+}


### PR DESCRIPTION
Small cleanup audit I noticed while investigating build speedup