### PR TITLE
ci: smoke-test the legacy docs' SQL snippets too

### DIFF
--- a/.github/scripts/extract_code_snippets.py
+++ b/.github/scripts/extract_code_snippets.py
@@ -21,6 +21,9 @@ IGNORED_CODEGROUPS = {
     # CodeGroup is used here to switch between Chinese, Korean, and Japanese
     # not SQL vs ORMs
     "documentation__tokenizers__available-tokenizers__lindera__group-001",
+    # Queries a custom enum column ("assume we have indexed an enum called
+    # color"), which the shared snippet fixture does not define.
+    "legacy__advanced__term__term__group-003",
 }
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
@@ -99,9 +102,10 @@ def main() -> int:
     """Extract all supported verification snippets from the docs tree."""
     output_dirs = build_output_dirs()
 
-    docs = sorted(
-        path for path in DOCS_ROOT.rglob("*.mdx") if "legacy" not in path.parts
-    )
+    # Every published page is verified, including `legacy`. The legacy pages
+    # document the pre-0.20 syntax, which is still supported and still shipped
+    # in the nav, so their snippets have to keep working too.
+    docs = sorted(DOCS_ROOT.rglob("*.mdx"))
     if not docs:
         print(f"No .mdx files found under {DOCS_ROOT}", file=sys.stderr)
         return 1

--- a/docs/legacy/advanced/compound/boolean.mdx
+++ b/docs/legacy/advanced/compound/boolean.mdx
@@ -59,9 +59,8 @@ WHERE id @@@
         {
           "range": {
             "field": "rating",
-            "from": null,
-            "to": 2,
-            "bounds": "()"
+            "lower_bound": null,
+            "upper_bound": {"excluded": 2}
           }
         }
       ]


### PR DESCRIPTION
`extract_code_snippets.py` skipped every page under `docs/legacy`, so **none of those snippets were ever run**. Legacy isn't dead content: it documents the pre-0.20 syntax, which is still supported, and it's still in the published nav at 39 pages.

That gap is exactly why a broken `CREATE_INDEX` example and two missing `field-options` sections survived until I hit them by hand in #5823 — nothing was executing those pages.

## Purely additive

| target | before | after | delta |
|---|---|---|---|
| sql | 127 | **165** | **+38** |
| django / rails / sqlalchemy / drizzle / efcore | 124 | 124 | +0 |

I verified no previously-extracted snippet is dropped. The ORM targets are byte-identical because the legacy pages carry SQL and JSON syntax only. (I also briefly excluded `changelog` while working on this and backed it out — it was already covered, and dropping it would have *reduced* coverage by 2.)

## The widened set surfaced two failures, both real

**1. A genuinely broken example.** `legacy/advanced/compound/boolean` wrote its range clause as:

```json
{"from": null, "to": 2, "bounds": "()"}
```

That form no longer deserializes — the query fails with ``missing field `lower_bound` ``. Rewritten to the shape the rest of the legacy docs already use, preserving the original meaning (exclusive upper bound of 2, no lower bound):

```json
{"lower_bound": null, "upper_bound": {"excluded": 2}}
```

I confirmed `null` is the accepted unbounded form by testing against a live instance — `"unbounded"` and `{"Unbounded": null}` both fail.

**2. A snippet that can't run.** `legacy/advanced/term/term` group 3 queries a custom enum column under its own *"assume we have indexed an enum called color"* caveat. The shared fixture defines no such column, so it joins `IGNORED_CODEGROUPS` next to the existing Lindera entry.

## Result

`165 passed, 0 failed` against a local 0.25.0 instance.

## Scope note

I deliberately did **not** also extract standalone (non-`CodeGroup`) fences. There are ~175 of those in `documentation/` alone, and many are intentionally fragments — `EXPLAIN` output, partial clauses, illustrative errors. Wiring them in would bury the signal. Covering them properly needs a convention for "this block is runnable", which is separate work.

https://claude.ai/code/session_01ESbGCQzXnRB8GrQ49FfBHf
