### PR TITLE
fix(aggregatescan): honour check_aggregate_scan on the join decline path

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1115,7 +1115,9 @@ impl AggregateScan {
             Ok(path) => vec![path],
             Err(AggregatePathDecline::Quiet) => Vec::new(),
             Err(AggregatePathDecline::Warn(reason)) => {
-                reason.emit();
+                if gucs::check_aggregate_scan() {
+                    reason.emit();
+                }
                 Vec::new()
             }
         }


### PR DESCRIPTION
### Problem

`paradedb.check_aggregate_scan = false` does not silence the decline warnings raised on the join path. `build_datafusion_aggregate_path` emits unconditionally:

```rust
Err(AggregatePathDecline::Warn(reason)) => {
    reason.emit();
    Vec::new()
}
```

The single-table path gates the same kind of warning behind `enable_aggregate_custom_scan && check_aggregate_scan` (`aggregatescan/mod.rs:1091`). So a query whose aggregate sits above a join that pg_search cannot accelerate logs `WARNING: Aggregate Scan (DataFusion) not used: …` on every execution.

The only way out today is `enable_aggregate_custom_scan = off`, but the hook checks that GUC before path selection (`hook.rs:307`), so it also disables the single-table Tantivy aggregate scan.

On Postgres 18 with 0.24.3, a workload whose requests aggregate over a join of subqueries logs roughly 750k of these a day in the database log alone. Same code on `main`.

### Fix

Gate `reason.emit()` behind `gucs::check_aggregate_scan()`, like the single-table path. `CHECK_AGGREGATE_SCAN` defaults to true, so the `pg_regress` expectations that contain these warnings are unchanged.

Can add a regression test if you want one.
