### PR TITLE
fix: Error fast if not enough memory is available for clustering

### DIFF
--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -185,7 +185,7 @@ impl DiskSpaceGuard {
     }
 }
 
-fn format_bytes(bytes: u64) -> String {
+pub(crate) fn format_bytes(bytes: u64) -> String {
     let bytes = bytes.min(i64::MAX as u64) as i64;
     unsafe {
         direct_function_call::<String>(pg_sys::pg_size_pretty, &[bytes.into_datum()])

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -20,6 +20,7 @@ use crate::gucs;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::writer::index::{
     DiskSpaceGuard, IndexWriterConfig, Mergeable, SearchIndexMerger, SerialIndexWriter,
+    format_bytes,
 };
 use crate::launch_parallel_process;
 use crate::parallel_worker::mqueue::MessageQueueSender;
@@ -895,11 +896,17 @@ mod plan {
 
         let mwm_bytes = unsafe { pg_sys::maintenance_work_mem as usize } * 1024;
         if total > mwm_bytes {
+            // Round up in the unit pg_size_pretty will display, so that setting
+            // `maintenance_work_mem` to the printed value always passes this check.
+            let mut unit = 1024;
+            while total.div_ceil(unit) >= 10 * 1024 {
+                unit *= 1024;
+            }
             ErrorReport::new(
                 PgSqlErrorCode::ERRCODE_INSUFFICIENT_RESOURCES,
                 format!(
-                    "vector clustering during index build requires `maintenance_work_mem` of at least {}MB",
-                    total.div_ceil(1024 * 1024)
+                    "vector clustering during index build requires `maintenance_work_mem` of at least {}",
+                    format_bytes((total.div_ceil(unit) * unit) as u64)
                 ),
                 function_name!(),
             )

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -897,13 +897,12 @@ mod plan {
         if total > mwm_bytes {
             ErrorReport::new(
                 PgSqlErrorCode::ERRCODE_INSUFFICIENT_RESOURCES,
-                "`maintenance_work_mem` is not high enough for vector clustering during index build",
+                format!(
+                    "vector clustering during index build requires `maintenance_work_mem` of at least {}MB",
+                    total.div_ceil(1024 * 1024)
+                ),
                 function_name!(),
             )
-            .set_hint(format!(
-                "`SET maintenance_work_mem = '{}MB'`",
-                total.div_ceil(1024 * 1024)
-            ))
             .report(PgLogLevel::ERROR);
         }
     }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -865,7 +865,14 @@ mod plan {
         let Ok(schema) = indexrel.schema() else {
             return;
         };
-        let dims = schema.vector_field_dims();
+        let dims = schema
+            .fields()
+            .filter_map(|(_, field_entry)| {
+                schema
+                    .get_field_type(field_entry.name())
+                    .and_then(|field_type| field_type.vector_dims())
+            })
+            .collect::<Vec<_>>();
         if dims.is_empty() {
             return;
         }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -888,19 +888,15 @@ mod plan {
 
         let mwm_bytes = unsafe { pg_sys::maintenance_work_mem as usize } * 1024;
         if total > mwm_bytes {
-            let to_mb = |bytes: usize| bytes.div_ceil(1024 * 1024);
             ErrorReport::new(
                 PgSqlErrorCode::ERRCODE_INSUFFICIENT_RESOURCES,
                 "`maintenance_work_mem` is not high enough for vector clustering during index build",
                 function_name!(),
             )
-            .set_detail(format!(
-                "{nlaunched} workers each need about {}MB to cluster a merged segment of ~{docs_per_merge} vectors ({}MB total), but `maintenance_work_mem` is {}MB",
-                to_mb(per_merge),
-                to_mb(total),
-                to_mb(mwm_bytes),
+            .set_hint(format!(
+                "`SET maintenance_work_mem = '{}MB'`",
+                total.div_ceil(1024 * 1024)
             ))
-            .set_hint("`SET maintenance_work_mem = <number>`, or reduce `max_parallel_maintenance_workers`")
             .report(PgLogLevel::ERROR);
         }
     }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -41,6 +41,7 @@ use crate::postgres::utils::{
     collect_composites_for_unpacking, get_field_value, row_to_search_document,
 };
 use crate::schema::{CategorizedFieldData, SearchField};
+use crate::vector::clusterer::{MergeMemoryEstimate, SuperKMeansIvfClusterer};
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::{
     PgLogLevel, PgMemoryContexts, PgSqlErrorCode, check_for_interrupts, function_name, pg_guard,
@@ -677,6 +678,7 @@ pub(super) fn build_index(
     );
     let nworkers = plan::create_index_nworkers(&heaprel, &indexrel);
     pgrx::debug1!("build_index: asked for {nworkers} workers");
+    plan::check_clustering_memory(&heaprel, &indexrel, nworkers);
 
     // This is updating `tuples_total` in the `pg_stat_progress_create_index` view - `tuples_done` is incremented in `build_callback`
     unsafe {
@@ -847,6 +849,60 @@ mod plan {
         }
 
         nworkers
+    }
+
+    /// Vector clustering during a merge materializes a training sample per vector field, and
+    /// every worker can be merging at once, so the build's projected peak clustering memory is
+    /// `nworkers × per-merge bytes`. Each merge combines segments down to roughly
+    /// `reltuples / target_segment_count` docs regardless of worker count, so this is knowable
+    /// before workers launch. Refuse to start a build projected to exceed
+    /// `maintenance_work_mem` rather than OOM mid-merge.
+    pub(super) fn check_clustering_memory(
+        heaprel: &PgSearchRelation,
+        indexrel: &PgSearchRelation,
+        nworkers: usize,
+    ) {
+        let Ok(schema) = indexrel.schema() else {
+            return;
+        };
+        let dims = schema.vector_field_dims();
+        if dims.is_empty() {
+            return;
+        }
+
+        let mut nlaunched = nworkers.max(1);
+        if nworkers > 0 && unsafe { pg_sys::parallel_leader_participation } {
+            nlaunched += 1;
+        }
+
+        let reltuples = estimate_heap_reltuples(heaprel);
+        let target_segment_count = adjusted_target_segment_count(heaprel, indexrel);
+        let docs_per_merge = (reltuples / target_segment_count as f64).ceil() as usize;
+
+        let clusterer = SuperKMeansIvfClusterer::from_options(indexrel.options());
+        let per_merge: usize = dims
+            .iter()
+            .map(|&dim| clusterer.estimated_merge_bytes(docs_per_merge, dim))
+            .sum();
+        let total = per_merge.saturating_mul(nlaunched);
+
+        let mwm_bytes = unsafe { pg_sys::maintenance_work_mem as usize } * 1024;
+        if total > mwm_bytes {
+            let to_mb = |bytes: usize| bytes.div_ceil(1024 * 1024);
+            ErrorReport::new(
+                PgSqlErrorCode::ERRCODE_INSUFFICIENT_RESOURCES,
+                "`maintenance_work_mem` is not high enough for vector clustering during index build",
+                function_name!(),
+            )
+            .set_detail(format!(
+                "{nlaunched} workers each need about {}MB to cluster a merged segment of ~{docs_per_merge} vectors ({}MB total), but `maintenance_work_mem` is {}MB",
+                to_mb(per_merge),
+                to_mb(total),
+                to_mb(mwm_bytes),
+            ))
+            .set_hint("`SET maintenance_work_mem = <number>`, or reduce `max_parallel_maintenance_workers`")
+            .report(PgLogLevel::ERROR);
+        }
     }
 
     /// If we determine that the table is very small, we should just create a single segment

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -524,6 +524,19 @@ impl SearchIndexSchema {
         })
     }
 
+    /// Dimensionality of each vector field in the schema.
+    pub fn vector_field_dims(&self) -> Vec<usize> {
+        self.fields()
+            .filter_map(|(_, field_entry)| {
+                let field_name: FieldName = field_entry.name().into();
+                match self.bm25_options.get_field_type(&field_name) {
+                    Some(SearchFieldType::Vector(_, dims, _)) => Some(dims),
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+
     /// A lookup from a Postgres column name to search fields that have
     /// marked it as their source column with the 'column' key.
     pub fn alias_lookup(&self) -> HashMap<String, Vec<SearchField>> {

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -136,6 +136,13 @@ impl SearchFieldType {
         .into()
     }
 
+    pub fn vector_dims(&self) -> Option<usize> {
+        match self {
+            SearchFieldType::Vector(_, dims, _) => Some(*dims),
+            _ => None,
+        }
+    }
+
     pub fn typmod(&self) -> Typmod {
         match self {
             SearchFieldType::Tokenized(_, typmod, ..) => *typmod,
@@ -522,19 +529,6 @@ impl SearchIndexSchema {
                 Some(SearchFieldType::Vector(..))
             )
         })
-    }
-
-    /// Dimensionality of each vector field in the schema.
-    pub fn vector_field_dims(&self) -> Vec<usize> {
-        self.fields()
-            .filter_map(|(_, field_entry)| {
-                let field_name: FieldName = field_entry.name().into();
-                match self.bm25_options.get_field_type(&field_name) {
-                    Some(SearchFieldType::Vector(_, dims, _)) => Some(dims),
-                    _ => None,
-                }
-            })
-            .collect()
     }
 
     /// A lookup from a Postgres column name to search fields that have

--- a/pg_search/src/vector/clusterer.rs
+++ b/pg_search/src/vector/clusterer.rs
@@ -106,16 +106,15 @@ impl MergeMemoryEstimate for SuperKMeansIvfClusterer {
     }
 
     // Mirrors the training-set sampling in tantivy's IVF merge. Peak residency is
-    // during `train`: the sampled training matrix plus superkmeans' rotated copy of
-    // it (`sample_and_rotate_vectors` always materializes one), its doc ids, and
-    // the centroid output.
+    // during `train`: the sampled training matrix (owned by superkmeans and rotated
+    // in place — no second copy), its doc ids, and the centroid output.
     fn estimated_merge_bytes(&self, num_docs: usize, dim: usize) -> usize {
         let num_centroids = ((num_docs as f64) * f64::from(self.centroid_ratio)).ceil() as usize;
         let num_centroids = num_centroids.clamp(1, num_docs.max(1));
         let training_samples =
             num_docs.min(num_centroids.saturating_mul(self.training_samples_per_centroid));
         let row_bytes = dim * self.bytes_per_dim();
-        training_samples * (2 * row_bytes + size_of::<u32>()) + num_centroids * row_bytes
+        training_samples * (row_bytes + size_of::<u32>()) + num_centroids * row_bytes
     }
 }
 
@@ -382,14 +381,14 @@ mod tests {
         let row = dim * 4;
         assert_eq!(
             clusterer.estimated_merge_bytes(1_000_000, dim),
-            320_000 * (2 * row + 4) + 10_000 * row
+            320_000 * (row + 4) + 10_000 * row
         );
 
         // sample count is capped at num_docs
         let saturated = SuperKMeansIvfClusterer::new().with_centroid_ratio(0.5);
         assert_eq!(
             saturated.estimated_merge_bytes(1000, dim),
-            1000 * (2 * row + 4) + 500 * row
+            1000 * (row + 4) + 500 * row
         );
 
         assert_eq!(clusterer.estimated_merge_bytes(0, dim), 4 * dim);

--- a/pg_search/src/vector/clusterer.rs
+++ b/pg_search/src/vector/clusterer.rs
@@ -85,9 +85,49 @@ impl Default for SuperKMeansIvfClusterer {
     }
 }
 
+/// Estimates the peak memory a clusterer holds resident while building the IVF
+/// structure for one merged segment's vector field. Used before an index build
+/// launches to reject builds whose concurrent merges would exceed
+/// `maintenance_work_mem`. Backends with cheaper representations (e.g. future
+/// quantized training sets) implement this with a smaller footprint.
+pub trait MergeMemoryEstimate {
+    /// Bytes to hold one dimension of one training vector in memory.
+    fn bytes_per_dim(&self) -> usize;
+
+    /// Estimated peak bytes to cluster one vector field of a merged segment
+    /// containing `num_docs` vectors of `dim` dimensions.
+    fn estimated_merge_bytes(&self, num_docs: usize, dim: usize) -> usize;
+}
+
+impl MergeMemoryEstimate for SuperKMeansIvfClusterer {
+    fn bytes_per_dim(&self) -> usize {
+        size_of::<f32>()
+    }
+
+    // Mirrors the training-set sampling in tantivy's IVF merge. Peak residency is
+    // during `train`: the sampled training matrix plus superkmeans' rotated copy of
+    // it (`sample_and_rotate_vectors` always materializes one), its doc ids, and
+    // the centroid output.
+    fn estimated_merge_bytes(&self, num_docs: usize, dim: usize) -> usize {
+        let num_centroids = ((num_docs as f64) * f64::from(self.centroid_ratio)).ceil() as usize;
+        let num_centroids = num_centroids.clamp(1, num_docs.max(1));
+        let training_samples =
+            num_docs.min(num_centroids.saturating_mul(self.training_samples_per_centroid));
+        let row_bytes = dim * self.bytes_per_dim();
+        training_samples * (2 * row_bytes + size_of::<u32>()) + num_centroids * row_bytes
+    }
+}
+
 impl SuperKMeansIvfClusterer {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn from_options(options: &BM25IndexOptions) -> Self {
+        Self::new()
+            .with_centroid_ratio(options.centroid_ratio())
+            .with_training_samples_per_centroid(options.training_samples_per_centroid())
+            .with_replicas(options.cluster_replication())
     }
 
     pub fn with_centroid_ratio(mut self, centroid_ratio: f32) -> Self {
@@ -297,11 +337,7 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
 }
 
 pub fn set_ivf_clusterer(index: &mut Index, options: &BM25IndexOptions) {
-    let clusterer = SuperKMeansIvfClusterer::new()
-        .with_centroid_ratio(options.centroid_ratio())
-        .with_training_samples_per_centroid(options.training_samples_per_centroid())
-        .with_replicas(options.cluster_replication());
-    index.set_ivf_clusterer(Arc::new(clusterer));
+    index.set_ivf_clusterer(Arc::new(SuperKMeansIvfClusterer::from_options(options)));
 }
 
 #[cfg(test)]
@@ -329,5 +365,29 @@ mod tests {
             .merge_settings(total)
             .unwrap();
         assert_eq!(clamped.replicas, 1, "non-positive clamps to primary-only");
+    }
+
+    #[test]
+    fn merge_memory_estimate() {
+        let clusterer = SuperKMeansIvfClusterer::new();
+        assert_eq!(clusterer.bytes_per_dim(), 4);
+
+        // defaults: centroid_ratio 0.01, 32 samples per centroid
+        // 1M docs, dim 96: 10k centroids, 320k samples
+        let dim = 96;
+        let row = dim * 4;
+        assert_eq!(
+            clusterer.estimated_merge_bytes(1_000_000, dim),
+            320_000 * (2 * row + 4) + 10_000 * row
+        );
+
+        // sample count is capped at num_docs
+        let saturated = SuperKMeansIvfClusterer::new().with_centroid_ratio(0.5);
+        assert_eq!(
+            saturated.estimated_merge_bytes(1000, dim),
+            1000 * (2 * row + 4) + 500 * row
+        );
+
+        assert_eq!(clusterer.estimated_merge_bytes(0, dim), 4 * dim);
     }
 }

--- a/pg_search/tests/pg_regress/expected/vector_build_clustering_memory.out
+++ b/pg_search/tests/pg_regress/expected/vector_build_clustering_memory.out
@@ -21,7 +21,7 @@ SET maintenance_work_mem = '16MB';
 CREATE INDEX clustering_mem_idx ON clustering_mem
     USING bm25 (id, embedding vector_l2_ops)
     WITH (key_field = 'id', centroid_ratio = 1.0);
-ERROR:  `maintenance_work_mem` is not high enough for vector clustering during index build
+ERROR:  vector clustering during index build requires `maintenance_work_mem` of at least 20MB
 -- at the default centroid_ratio the training set fits and the build succeeds
 CREATE INDEX clustering_mem_idx ON clustering_mem
     USING bm25 (id, embedding vector_l2_ops)

--- a/pg_search/tests/pg_regress/expected/vector_build_clustering_memory.out
+++ b/pg_search/tests/pg_regress/expected/vector_build_clustering_memory.out
@@ -21,7 +21,7 @@ SET maintenance_work_mem = '16MB';
 CREATE INDEX clustering_mem_idx ON clustering_mem
     USING bm25 (id, embedding vector_l2_ops)
     WITH (key_field = 'id', centroid_ratio = 1.0);
-ERROR:  vector clustering during index build requires `maintenance_work_mem` of at least 20MB
+ERROR:  vector clustering during index build requires `maintenance_work_mem` of at least 20 MB
 -- at the default centroid_ratio the training set fits and the build succeeds
 CREATE INDEX clustering_mem_idx ON clustering_mem
     USING bm25 (id, embedding vector_l2_ops)

--- a/pg_search/tests/pg_regress/expected/vector_build_clustering_memory.out
+++ b/pg_search/tests/pg_regress/expected/vector_build_clustering_memory.out
@@ -1,0 +1,35 @@
+-- The projected clustering memory for a vector index build (workers × per-merge
+-- training set) must fit in maintenance_work_mem; the build refuses to start
+-- otherwise.
+SET client_min_messages = WARNING;
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS clustering_mem;
+CREATE TABLE clustering_mem (id SERIAL PRIMARY KEY, embedding vector(128));
+INSERT INTO clustering_mem (embedding)
+SELECT ('[' || (SELECT string_agg('0.5', ',') FROM generate_series(1, 128)) || ']')::vector
+FROM generate_series(1, 20000);
+SET max_parallel_maintenance_workers = 0;
+SET maintenance_work_mem = '16MB';
+-- ~20k docs in one merged segment at centroid_ratio 1.0 needs ~20MB of training
+-- set, exceeding the 16MB maintenance_work_mem
+CREATE INDEX clustering_mem_idx ON clustering_mem
+    USING bm25 (id, embedding vector_l2_ops)
+    WITH (key_field = 'id', centroid_ratio = 1.0);
+ERROR:  `maintenance_work_mem` is not high enough for vector clustering during index build
+-- at the default centroid_ratio the training set fits and the build succeeds
+CREATE INDEX clustering_mem_idx ON clustering_mem
+    USING bm25 (id, embedding vector_l2_ops)
+    WITH (key_field = 'id');
+SELECT relname FROM pg_class WHERE relname = 'clustering_mem_idx';
+      relname       
+--------------------
+ clustering_mem_idx
+(1 row)
+
+DROP TABLE clustering_mem;

--- a/pg_search/tests/pg_regress/sql/vector_build_clustering_memory.sql
+++ b/pg_search/tests/pg_regress/sql/vector_build_clustering_memory.sql
@@ -1,0 +1,29 @@
+-- The projected clustering memory for a vector index build (workers × per-merge
+-- training set) must fit in maintenance_work_mem; the build refuses to start
+-- otherwise.
+SET client_min_messages = WARNING;
+CREATE EXTENSION IF NOT EXISTS vector;
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS clustering_mem;
+CREATE TABLE clustering_mem (id SERIAL PRIMARY KEY, embedding vector(128));
+INSERT INTO clustering_mem (embedding)
+SELECT ('[' || (SELECT string_agg('0.5', ',') FROM generate_series(1, 128)) || ']')::vector
+FROM generate_series(1, 20000);
+
+SET max_parallel_maintenance_workers = 0;
+SET maintenance_work_mem = '16MB';
+
+-- ~20k docs in one merged segment at centroid_ratio 1.0 needs ~20MB of training
+-- set, exceeding the 16MB maintenance_work_mem
+CREATE INDEX clustering_mem_idx ON clustering_mem
+    USING bm25 (id, embedding vector_l2_ops)
+    WITH (key_field = 'id', centroid_ratio = 1.0);
+
+-- at the default centroid_ratio the training set fits and the build succeeds
+CREATE INDEX clustering_mem_idx ON clustering_mem
+    USING bm25 (id, embedding vector_l2_ops)
+    WITH (key_field = 'id');
+SELECT relname FROM pg_class WHERE relname = 'clustering_mem_idx';
+
+DROP TABLE clustering_mem;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Before index build kicks off, estimate how much memory clustering requires, and assert that we have at least that much in `maintenance_work_mem`.

## Why

## How

## Tests
