### PR TITLE
feat: cap vector index build parallelism at 4 workers

### DIFF
--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -384,17 +384,6 @@ jobs:
           psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
             -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;"
 
-      # The restore above overwrote postgresql.auto.conf with the snapshot's config
-      # (8 maintenance workers), so re-apply after every restore. Lowered to 4 for the
-      # pg_search index build only.
-      - name: Lower maintenance workers after restore (cohere/pg_search, 1M)
-        if: ${{ env.RUN_COHERE == 'true' && env.COHERE_INDEX == 'pg_search' }}
-        run: |
-          set -euo pipefail
-          psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
-            -c "ALTER SYSTEM SET max_parallel_maintenance_workers = 4;" \
-            -c "SELECT pg_reload_conf();"
-
       - name: Benchmark "cohere" Dataset (1M)
         if: ${{ env.RUN_COHERE == 'true' }}
         uses: ./.github/actions/benchmark-queries
@@ -441,14 +430,6 @@ jobs:
           (cd pg_search && cargo pgrx start pg${{ env.pg_version }})
           psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
             -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;"
-
-      - name: Lower maintenance workers after restore (cohere/pg_search, 10M)
-        if: ${{ env.RUN_COHERE == 'true' && env.COHERE_INDEX == 'pg_search' }}
-        run: |
-          set -euo pipefail
-          psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
-            -c "ALTER SYSTEM SET max_parallel_maintenance_workers = 4;" \
-            -c "SELECT pg_reload_conf();"
 
       - name: Benchmark "cohere" Dataset (10M)
         if: ${{ env.RUN_COHERE == 'true' }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -384,6 +384,17 @@ jobs:
           psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
             -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;"
 
+      # The restore above overwrote postgresql.auto.conf with the snapshot's config
+      # (8 maintenance workers), so re-apply after every restore. Lowered to 4 for the
+      # pg_search index build only.
+      - name: Lower maintenance workers after restore (cohere/pg_search, 1M)
+        if: ${{ env.RUN_COHERE == 'true' && env.COHERE_INDEX == 'pg_search' }}
+        run: |
+          set -euo pipefail
+          psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
+            -c "ALTER SYSTEM SET max_parallel_maintenance_workers = 4;" \
+            -c "SELECT pg_reload_conf();"
+
       - name: Benchmark "cohere" Dataset (1M)
         if: ${{ env.RUN_COHERE == 'true' }}
         uses: ./.github/actions/benchmark-queries
@@ -430,6 +441,14 @@ jobs:
           (cd pg_search && cargo pgrx start pg${{ env.pg_version }})
           psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
             -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;"
+
+      - name: Lower maintenance workers after restore (cohere/pg_search, 10M)
+        if: ${{ env.RUN_COHERE == 'true' && env.COHERE_INDEX == 'pg_search' }}
+        run: |
+          set -euo pipefail
+          psql "postgresql://localhost:288${{ env.pg_version }}/postgres" \
+            -c "ALTER SYSTEM SET max_parallel_maintenance_workers = 4;" \
+            -c "SELECT pg_reload_conf();"
 
       - name: Benchmark "cohere" Dataset (10M)
         if: ${{ env.RUN_COHERE == 'true' }}

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -816,11 +816,9 @@ mod plan {
             .min(unsafe { pg_sys::max_parallel_workers as usize })
             .min(unsafe { pg_sys::max_worker_processes as usize });
 
-        // More workers than this has not shown build-time wins: vector builds are dominated
-        // by IVF clustering, whose GEMMs already parallelize across the whole machine via
-        // BLAS threads from any one worker, so extra workers only multiply peak clustering
-        // memory (each holds its own training set while merging). Benchmarked on cohere
-        // 10m: 4 workers matched 8 on build time.
+        // Beyond 4 workers there's no improvement to index build time, because parallelizing
+        // the heap scan/segment flushing isn't the bottleneck. Constrain to 4 because fewer
+        // concurrent merges means less memory.
         let maintenance_workers = maintenance_workers.min(MAX_BUILD_WORKERS);
 
         if maintenance_workers < 3 {

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -775,7 +775,7 @@ pub(super) fn build_index(
 mod plan {
     use super::*;
 
-    pub(super) const MAX_BUILD_WORKERS: usize = 4;
+    pub(super) const MAX_VECTOR_BUILD_WORKERS: usize = 4;
 
     /// Determine the number of workers to use for a given CREATE INDEX/REINDEX statement.
     ///
@@ -815,10 +815,18 @@ mod plan {
             .min(unsafe { pg_sys::max_parallel_workers as usize })
             .min(unsafe { pg_sys::max_worker_processes as usize });
 
-        // Beyond 4 workers there's no improvement to index build time, because parallelizing
-        // the heap scan/segment flushing isn't the bottleneck. Constrain to 4 because fewer
-        // concurrent merges means less memory.
-        let maintenance_workers = maintenance_workers.min(MAX_BUILD_WORKERS);
+        // For vector builds, beyond 4 workers there's no improvement to index build time:
+        // clustering dominates and parallelizes internally (rayon + BLAS threads), so
+        // parallelizing the heap scan/segment flushing isn't the bottleneck. Constrain to 4
+        // because fewer concurrent merges means less memory.
+        let maintenance_workers = if indexrel
+            .schema()
+            .is_ok_and(|schema| schema.has_vector_field())
+        {
+            maintenance_workers.min(MAX_VECTOR_BUILD_WORKERS)
+        } else {
+            maintenance_workers
+        };
 
         if maintenance_workers < 3 {
             ErrorReport::new(

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -775,8 +775,8 @@ pub(super) fn build_index(
 mod plan {
     use super::*;
 
-    /// Cap on parallel workers for builds of indexes with vector fields.
-    pub(super) const MAX_VECTOR_BUILD_WORKERS: usize = 4;
+    /// Cap on parallel workers for index builds.
+    pub(super) const MAX_BUILD_WORKERS: usize = 4;
 
     /// Determine the number of workers to use for a given CREATE INDEX/REINDEX statement.
     ///
@@ -816,19 +816,12 @@ mod plan {
             .min(unsafe { pg_sys::max_parallel_workers as usize })
             .min(unsafe { pg_sys::max_worker_processes as usize });
 
-        // Vector builds are dominated by IVF clustering, whose GEMMs already parallelize
-        // across the whole machine via BLAS threads from any one worker. Extra workers do
-        // not speed up the build; they only multiply peak clustering memory (each worker
-        // holds its own training set while merging). Benchmarked on cohere 10m: 4 workers
-        // matched 8 on build time.
-        let maintenance_workers = if indexrel
-            .schema()
-            .is_ok_and(|schema| schema.has_vector_field())
-        {
-            maintenance_workers.min(MAX_VECTOR_BUILD_WORKERS)
-        } else {
-            maintenance_workers
-        };
+        // More workers than this has not shown build-time wins: vector builds are dominated
+        // by IVF clustering, whose GEMMs already parallelize across the whole machine via
+        // BLAS threads from any one worker, so extra workers only multiply peak clustering
+        // memory (each holds its own training set while merging). Benchmarked on cohere
+        // 10m: 4 workers matched 8 on build time.
+        let maintenance_workers = maintenance_workers.min(MAX_BUILD_WORKERS);
 
         if maintenance_workers < 3 {
             ErrorReport::new(

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -775,6 +775,9 @@ pub(super) fn build_index(
 mod plan {
     use super::*;
 
+    /// Cap on parallel workers for builds of indexes with vector fields.
+    pub(super) const MAX_VECTOR_BUILD_WORKERS: usize = 4;
+
     /// Determine the number of workers to use for a given CREATE INDEX/REINDEX statement.
     ///
     /// The number of workers is determined by max_parallel_maintenance_workers. However, if max_parallel_maintenance_workers
@@ -812,6 +815,20 @@ mod plan {
         let maintenance_workers = maintenance_workers
             .min(unsafe { pg_sys::max_parallel_workers as usize })
             .min(unsafe { pg_sys::max_worker_processes as usize });
+
+        // Vector builds are dominated by IVF clustering, whose GEMMs already parallelize
+        // across the whole machine via BLAS threads from any one worker. Extra workers do
+        // not speed up the build; they only multiply peak clustering memory (each worker
+        // holds its own training set while merging). Benchmarked on cohere 10m: 4 workers
+        // matched 8 on build time.
+        let maintenance_workers = if indexrel
+            .schema()
+            .is_ok_and(|schema| schema.has_vector_field())
+        {
+            maintenance_workers.min(MAX_VECTOR_BUILD_WORKERS)
+        } else {
+            maintenance_workers
+        };
 
         if maintenance_workers < 3 {
             ErrorReport::new(

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -775,7 +775,6 @@ pub(super) fn build_index(
 mod plan {
     use super::*;
 
-    /// Cap on parallel workers for index builds.
     pub(super) const MAX_BUILD_WORKERS: usize = 4;
 
     /// Determine the number of workers to use for a given CREATE INDEX/REINDEX statement.


### PR DESCRIPTION
In experiments (and verified in CI), we don't see any appreciable benefit in index build time beyond 4 parallel workers. The intuition is that parallelizing the heap scan/segment flushes isn't the bottleneck, it's vector clustering/training which SuperKMeans already spreads out over all available cores (regardless of Postgres worker settings).

However, using fewer workers saves memory because it means fewer concurrent merges -> fewer concurrent clustering/assignment operations.