### PR TITLE
docs: replace banner with ParadeDB Cloud early access announcement

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,7 +9,7 @@
   },
   "favicon": "/favicon.png",
   "banner": {
-    "content": "ParadeDB Cloud is now in early access! [Sign up here](https://www.paradedb.com/cloud) to try it out.",
+    "content": "ParadeDB Cloud is coming soon. [Request access here](https://www.paradedb.com/cloud).",
     "dismissible": false
   },
   "navigation": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,7 +9,7 @@
   },
   "favicon": "/favicon.png",
   "banner": {
-    "content": "As of `0.20.0`, ParadeDB has migrated to a new SQL syntax. The old syntax is still supported and we have preserved the [legacy docs here](/legacy/indexing/create-index).",
+    "content": "ParadeDB Cloud is now in early access! [Sign up here](https://www.paradedb.com/cloud) to try it out.",
     "dismissible": false
   },
   "navigation": {


### PR DESCRIPTION
Replaces the 0.20.0 SQL syntax migration banner at the top of the docs with a ParadeDB Cloud early access announcement linking to https://www.paradedb.com/cloud.