### PR TITLE
docs: standardise naming, code fences, links and heading case

### DIFF
--- a/docs/changelog/0.20.0.mdx
+++ b/docs/changelog/0.20.0.mdx
@@ -55,7 +55,7 @@ WHERE description @@@ 'electronics'
 GROUP BY brand;
 ```
 
-Standard PostgreSQL aggregations like [`COUNT(*)`](/documentation/aggregates/metrics/count) are automatically routed to use this optimized path when possible.
+Standard Postgres aggregations like [`COUNT(*)`](/documentation/aggregates/metrics/count) are automatically routed to use this optimized path when possible.
 
 ### v2 API
 

--- a/docs/changelog/0.21.1.mdx
+++ b/docs/changelog/0.21.1.mdx
@@ -6,7 +6,7 @@ noindex: true
 ## Stability Improvements 💪
 
 - Fixed an intermittent issue where parallel index scans in hash join scenarios return zero results instead
-- Fixed a crash that occurs when executing prepared statements with parallel hash joins on BM25 indexes after PostgreSQL switches to a generic plan
+- Fixed a crash that occurs when executing prepared statements with parallel hash joins on BM25 indexes after Postgres switches to a generic plan
 - Return an error instead of silently returning the wrong results if a phrase or proximity query is executed over a field that was not indexed with positions
 
 ## Performance Improvements 🚀

--- a/docs/deploy/byoc.mdx
+++ b/docs/deploy/byoc.mdx
@@ -33,7 +33,7 @@ In a fully managed deployment, these steps will be performed by ParadeDB on your
 
 ### Install Dependencies
 
-First, ensure that you are in the BYOC module repository. Next, install Terraform, Kubectl, PostgreSQL, and the CLI for your desired cloud provider:
+First, ensure that you are in the BYOC module repository. Next, install Terraform, Kubectl, Postgres, and the CLI for your desired cloud provider:
 
 <CodeGroup>
 

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -4,7 +4,7 @@ description: Distributed full-text search with Citus and ParadeDB
 canonical: https://docs.paradedb.com/deploy/citus
 ---
 
-[Citus](https://github.com/citusdata/citus) transforms PostgreSQL into a distributed database with horizontal sharding. ParadeDB is fully compatible with Citus, enabling distributed full-text search across sharded tables.
+[Citus](https://github.com/citusdata/citus) transforms Postgres into a distributed database with horizontal sharding. ParadeDB is fully compatible with Citus, enabling distributed full-text search across sharded tables.
 
 ## What's Supported
 
@@ -109,7 +109,7 @@ The plan should show:
 
 <Accordion title="Example EXPLAIN Output">
 
-```
+```text
 Sort  (cost=11041.82..11291.82 rows=100000 width=36)
   Output: remote_scan.id, remote_scan.title
   Sort Key: remote_scan.id
@@ -172,7 +172,7 @@ ORDER BY a.name;
 
 <Accordion title="Example EXPLAIN Output for JOIN">
 
-```
+```text
 Sort  (cost=12067.32..12317.32 rows=100000 width=64)
   Output: remote_scan.name, remote_scan.title
   Sort Key: remote_scan.name
@@ -207,7 +207,7 @@ Key indicators:
 
 ## Known Limitations
 
-- ❌ **Citus columnar tables** — ParadeDB indexes and other PostgreSQL indexes (like GiST, GIN) cannot be created on Citus columnar tables due to limitations in Citus's columnar storage implementation. However, you can use regular distributed tables with ParadeDB indexes alongside columnar tables for analytics.
+- ❌ **Citus columnar tables** — ParadeDB indexes and other Postgres indexes (like GiST, GIN) cannot be created on Citus columnar tables due to limitations in Citus's columnar storage implementation. However, you can use regular distributed tables with ParadeDB indexes alongside columnar tables for analytics.
 
 ## Performance Considerations
 

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -12,7 +12,7 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/digitalocean
 </Note>
 
 [DigitalOcean](https://www.digitalocean.com) is a cloud platform for deploying and managing applications. This guide walks through
-deploying ParadeDB on a DigitalOcean Droplet using Docker. Docker packages PostgreSQL and `pg_search` together, so you don't need to install them manually.
+deploying ParadeDB on a DigitalOcean Droplet using Docker. Docker packages Postgres and `pg_search` together, so you don't need to install them manually.
 
 ## Prerequisites
 

--- a/docs/deploy/cloud-platforms/dokku.mdx
+++ b/docs/deploy/cloud-platforms/dokku.mdx
@@ -16,7 +16,6 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/dokku
 ## Prerequisites
 
 1. A Dokku host with the [`dokku` CLI installed](https://dokku.com/docs/getting-started/installation/) (this guide assumes Dokku 0.34 or newer)
-
 2. SSH access to the host as a user that can invoke `dokku` (typically `root` via `sudo`, or a user in the `dokku` group)
 
 Run all `dokku ...` commands from the host, either directly on the host over SSH or via `ssh dokku@<HOST> <command>` from your local machine.

--- a/docs/deploy/cloud-platforms/fly.mdx
+++ b/docs/deploy/cloud-platforms/fly.mdx
@@ -15,9 +15,8 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/fly
 
 ## Prerequisites
 
-1. A Fly.io account.
-
-2. The [Fly.io CLI (`flyctl`)](https://fly.io/docs/hands-on/install-flyctl/) installed and authenticated with `fly auth login`.
+1. A Fly.io account
+2. The [Fly.io CLI (`flyctl`)](https://fly.io/docs/hands-on/install-flyctl/) installed and authenticated with `fly auth login`
 
 ## Launch the App
 

--- a/docs/deploy/cloud-platforms/fly.mdx
+++ b/docs/deploy/cloud-platforms/fly.mdx
@@ -15,7 +15,7 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/fly
 
 ## Prerequisites
 
-1. A Fly.io account. 
+1. A Fly.io account.
 
 2. The [Fly.io CLI (`flyctl`)](https://fly.io/docs/hands-on/install-flyctl/) installed and authenticated with `fly auth login`.
 

--- a/docs/deploy/cloud-platforms/render.mdx
+++ b/docs/deploy/cloud-platforms/render.mdx
@@ -50,7 +50,7 @@ If you prefer to configure the deployment yourself:
 
 ParadeDB runs as a **private service** on Render, which means it is not exposed to the public internet.
 
-### From another Render service
+### From Another Render Service
 
 Connect from any other service in your Render private network using the service name as the host:
 
@@ -58,7 +58,7 @@ Connect from any other service in your Render private network using the service 
 psql -h paradedb -U postgres -d paradedb
 ```
 
-### From your local machine
+### From Your Local Machine
 
 Since the service isn't exposed publicly, [SSH into the service](https://render.com/docs/ssh) and run `psql` from inside the container:
 

--- a/docs/deploy/logical-replication/configuration.mdx
+++ b/docs/deploy/logical-replication/configuration.mdx
@@ -13,7 +13,7 @@ canonical: https://docs.paradedb.com/deploy/logical-replication/configuration
 
 ## Schema Changes
 
-PostgreSQL logical replication copies row changes, not DDL. That means schema
+Postgres logical replication copies row changes, not DDL. That means schema
 changes on the publisher are not applied automatically on ParadeDB.
 
 Keep these rules in mind:

--- a/docs/deploy/logical-replication/getting-started.mdx
+++ b/docs/deploy/logical-replication/getting-started.mdx
@@ -129,7 +129,7 @@ INSERT INTO mock_items (description, category, in_stock, latest_available_time, 
 VALUES ('Red sports shoes', 'Footwear', true, '12:00:00', '2024-07-10', '{}', '2024-07-10 12:00:00', 1);
 ```
 
-PostgreSQL's default replica identity uses the primary key. Because
+Postgres's default replica identity uses the primary key. Because
 `mock_items` has a primary key, it already has a valid replica identity
 for `INSERT`, `UPDATE`, and `DELETE`, so no additional replica identity
 configuration is needed here.
@@ -187,7 +187,7 @@ CONNECTION 'host=192.168.0.30 port=5432 dbname=marketplace user=replicator passw
 PUBLICATION marketplace_pub;
 ```
 
-By default, PostgreSQL copies existing rows from the publisher and then keeps
+By default, Postgres copies existing rows from the publisher and then keeps
 streaming new changes. If you do not want the initial copy, create the
 subscription with `WITH (copy_data = false)` and backfill the tables by another
 method.

--- a/docs/deploy/logical-replication/multi-database.mdx
+++ b/docs/deploy/logical-replication/multi-database.mdx
@@ -37,7 +37,7 @@ As shown in the diagram:
 
 Instead of having all tables in the `public` schema across multiple databases:
 
-```
+```text
 Database: users_service
 Schema: public
   - users
@@ -51,7 +51,7 @@ Schema: public
 
 Reorganize each database to use a dedicated schema:
 
-```
+```text
 Database: users_service
 Schema: users_service
   - users
@@ -155,7 +155,7 @@ CREATE SUBSCRIPTION orders_sub
 
 - **Multi Database BM25 Search**: Perform full-text search across tables distributed across multiple microservice databases in a single query
 - **Avoid Distributed Joins in Application**: Execute cross-database joins directly in ParadeDB instead of implementing complex join logic in your application
-- **Simple Architecture**: Uses standard PostgreSQL logical replication without extra infrastructure
+- **Simple Architecture**: Uses standard Postgres logical replication without extra infrastructure
 - **Namespace Isolation**: Schema-based separation prevents naming conflicts
 - **No Source Database Changes**: Microservices continue operating independently; ParadeDB acts as a read replica
 

--- a/docs/deploy/logical-replication/operational-guide.mdx
+++ b/docs/deploy/logical-replication/operational-guide.mdx
@@ -17,7 +17,7 @@ the link is established and ParadeDB is staying in sync continuously.
 When ParadeDB is used as a logical subscriber:
 
 1. Your application writes to tables on the publisher
-2. PostgreSQL logical replication applies those row changes to matching tables
+2. Postgres logical replication applies those row changes to matching tables
    on ParadeDB
 3. ParadeDB maintains ParadeDB indexes locally on the subscriber
 4. Search and analytics queries run against ParadeDB instead of the primary
@@ -36,7 +36,7 @@ OLTP traffic.
 
 ### 1. Wait for the Initial Copy to Finish
 
-Let PostgreSQL finish copying the base table data before you build ParadeDB indexes.
+Let Postgres finish copying the base table data before you build ParadeDB indexes.
 This avoids extra indexing work during the bootstrap phase.
 
 On ParadeDB, you can check whether the initial copy is still running with:
@@ -99,7 +99,7 @@ For large or high-churn production tables, use one publication and one
 subscription per large table, or group only small related tables together.
 
 This gives each subscription its own main apply worker and replication slot.
-In normal steady-state replication, PostgreSQL does not parallelize ordinary
+In normal steady-state replication, Postgres does not parallelize ordinary
 change application across tables within a single subscription, so one hot table
 can delay other tables that share that apply worker. A publication per table
 alone does not provide that isolation unless it also has its own subscription.
@@ -163,7 +163,7 @@ workflow.
 
 ### Roll Out DDL Safely
 
-PostgreSQL logical replication does not replicate schema changes. That means
+Postgres logical replication does not replicate schema changes. That means
 the publisher and ParadeDB must be kept in sync manually.
 
 In practice, most teams do this through their existing migration runner or
@@ -177,7 +177,7 @@ For additive changes such as `ADD COLUMN`, the safest rollout is usually:
 3. Let replication continue normally
 4. Rebuild any ParadeDB indexes whose indexed column list changed
 
-This follows PostgreSQL's recommendation to apply additive schema changes on the
+This follows Postgres's recommendation to apply additive schema changes on the
 subscriber first whenever possible, which avoids intermittent apply failures.
 Logical replication can tolerate extra columns on the subscriber, so adding a
 column on ParadeDB first will not stop replication by itself. Those extra
@@ -212,7 +212,7 @@ ALTER SUBSCRIPTION marketplace_sub ENABLE;
 
 ### Handle Tables Without Primary Keys
 
-PostgreSQL needs a replica identity to replicate `UPDATE` and `DELETE`
+Postgres needs a replica identity to replicate `UPDATE` and `DELETE`
 operations. A primary key is best. Another suitable unique index can also be
 used as the replica identity. If a table has no suitable key, you can use the
 per-table fallback:
@@ -225,7 +225,7 @@ Do not think of this as a server-wide setting. `REPLICA IDENTITY FULL` is set
 per published table and should be treated as a fallback rather than the default
 design.
 
-PostgreSQL explicitly warns that subscriber-side `UPDATE` and `DELETE` can
+Postgres explicitly warns that subscriber-side `UPDATE` and `DELETE` can
 become very inefficient under `FULL`, because the subscriber must locate the
 matching row using the entire old row image rather than a compact key.
 `FULL` also increases WAL volume and replication traffic on the publisher,
@@ -297,7 +297,7 @@ background worker "logical replication apply worker" (PID 2570238) exited with e
 ```
 
 The first message is the root cause. The second means the apply worker crashed
-after hitting that error and PostgreSQL will try to restart it.
+after hitting that error and Postgres will try to restart it.
 
 When you see these messages:
 
@@ -321,7 +321,7 @@ CONTEXT: processing remote data during INSERT for replication target relation ..
 When you suspect a replication conflict:
 
 1. Inspect the subscriber logs for the first conflict error and note the finish
-   LSN and replication origin if PostgreSQL logged them
+   LSN and replication origin if Postgres logged them
 2. Resolve the underlying issue on the subscriber, such as conflicting local
    data, missing privileges, or row-level security policy interference
 3. Resume replication normally once the conflict is removed
@@ -330,7 +330,7 @@ When you suspect a replication conflict:
 
 Skipping a conflicting transaction can leave the subscriber inconsistent, so it
 should be treated as a last resort rather than the default fix. For conflict
-types and the PostgreSQL recovery workflow, see the [PostgreSQL logical
+types and the Postgres recovery workflow, see the [PostgreSQL logical
 replication conflicts
 documentation](https://www.postgresql.org/docs/current/logical-replication-conflicts.html).
 

--- a/docs/deploy/overview.mdx
+++ b/docs/deploy/overview.mdx
@@ -20,7 +20,7 @@ A fourth option, **[ParadeDB Cloud](#paradedb-cloud)**, our fully managed offeri
 
 ## Cloud Platforms
 
-ParadeDB Community is supported by several cloud platforms. These all use Docker containers, which package PostgreSQL and `pg_search` together:
+ParadeDB Community is supported by several cloud platforms. These all use Docker containers, which package Postgres and `pg_search` together:
 
 - [Railway](/deploy/cloud-platforms/railway) — One-click deploy to Railway
 - [Render](/deploy/cloud-platforms/render) — One-click deploy to Render

--- a/docs/deploy/third-party-extensions.mdx
+++ b/docs/deploy/third-party-extensions.mdx
@@ -11,7 +11,7 @@ canonical: https://docs.paradedb.com/deploy/third-party-extensions
   from ParadeDB.
 </Note>
 
-Postgres has a rich ecosystem of extensions. ParadeDB is designed to work alongside other PostgreSQL extensions for a complete data platform.
+Postgres has a rich ecosystem of extensions. ParadeDB is designed to work alongside other Postgres extensions for a complete data platform.
 
 ## Pre-installed Extensions
 
@@ -32,7 +32,7 @@ To keep the ParadeDB Docker image size manageable, the following extensions are 
 
 ParadeDB has been tested with and supports the following popular extensions:
 
-- **[Citus](/deploy/citus)** — Distributed PostgreSQL for horizontal scaling
+- **[Citus](/deploy/citus)** — Distributed Postgres for horizontal scaling
 - **`pg_partman`** — Automated partition management
 - **`pg_stat_statements`** — Query performance monitoring
 - **`postgres_fdw`** — Foreign data wrappers for federated queries

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -124,7 +124,7 @@ When a fallback happens, the query still runs correctly through Postgres' native
 
 ## NUMERIC Columns
 
-`NUMERIC` columns do not support aggregate pushdown. Queries with aggregates on `NUMERIC` columns will automatically fall back to PostgreSQL for aggregation.
+`NUMERIC` columns do not support aggregate pushdown. Queries with aggregates on `NUMERIC` columns will automatically fall back to Postgres for aggregation.
 
 For numeric data that requires aggregate pushdown, use `FLOAT` or `DOUBLE PRECISION` instead:
 

--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -4,7 +4,7 @@ description: Filter search results based on metadata from other fields
 canonical: https://docs.paradedb.com/documentation/filtering
 ---
 
-Adding filters to a search query is as simple as using PostgreSQL's built-in `WHERE` clauses and operators.
+Adding filters to a search query is as simple as using Postgres's built-in `WHERE` clauses and operators.
 For instance, the following query filters out results that do not meet `rating > 2`.
 
 <CodeGroup>

--- a/docs/documentation/getting-started/ai-agents.mdx
+++ b/docs/documentation/getting-started/ai-agents.mdx
@@ -21,7 +21,7 @@ ParadeDB documentation is available via the [Model Context Protocol (MCP)](https
 
 **MCP Endpoint:**
 
-```
+```text
 https://docs.paradedb.com/mcp
 ```
 

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -575,7 +575,7 @@ You're all set! Try [running some queries](/documentation/getting-started/querie
 </Accordion>
 
 <Accordion title="Rails (Ruby)">
-To get started, create a [Rails](https://rubyonrails.org/) app that uses PostgreSQL.
+To get started, create a [Rails](https://rubyonrails.org/) app that uses Postgres.
 
 ```bash
 rails new paradedb -d postgresql

--- a/docs/documentation/getting-started/load.mdx
+++ b/docs/documentation/getting-started/load.mdx
@@ -55,4 +55,4 @@ pg_restore --verbose --clean --no-acl --no-owner \
     old_db.dump
 ```
 
-Congratulations! You are now ready to run real queries over your data. To get started, refer to our [full text search documentation](https://docs.paradedb.com/documentation/full-text/overview).
+Congratulations! You are now ready to run real queries over your data. To get started, refer to our [full text search documentation](/documentation/full-text/overview).

--- a/docs/documentation/hybrid/rrf.mdx
+++ b/docs/documentation/hybrid/rrf.mdx
@@ -23,7 +23,7 @@ Each branch contributes `weight / (k + rank)`, and the contributions are added.
 
 Suppose a row comes back 5th in the text branch and 10th in the vector branch, with `k = 60` and the text branch weighted `1.0` against the vector branch's `0.7`:
 
-```
+```text
 text        1.0 / (60 +  5) = 0.0154
 vector      0.7 / (60 + 10) = 0.0100
                               ------
@@ -84,7 +84,7 @@ SELECT ...;
 
 If the query is accelerated, there should be a `TopKScanExecState` printed for each branch.
 
-```
+```text
 ->  WindowAgg
       Window: w1 AS (ORDER BY pdb.score(id), id ROWS UNBOUNDED PRECEDING)
       ->  Custom Scan (ParadeDB Base Scan) on mock_items

--- a/docs/documentation/indexing/indexing-partial.mdx
+++ b/docs/documentation/indexing/indexing-partial.mdx
@@ -8,7 +8,7 @@ A partial index is an index that only includes rows that satisfy a `WHERE` condi
 Instead of indexing every row in a table, Postgres evaluates the predicate and only indexes rows that match it.
 This can reduce index size and improve performance when you only query a subset of a table.
 
-The ParadeDB index supports partial indexes using the same syntax as PostgreSQL.
+The ParadeDB index supports partial indexes using the same syntax as Postgres.
 
 <CodeGroup>
 ```sql SQL

--- a/docs/documentation/indexing/verify-index.mdx
+++ b/docs/documentation/indexing/verify-index.mdx
@@ -59,7 +59,7 @@ This returns a table with three columns:
 
 ### Example Output
 
-```
+```ini
                check_name               | passed |                    details
 ----------------------------------------+--------+-----------------------------------------------
  search_idx: schema_valid               | t      | Index schema loaded successfully
@@ -261,7 +261,7 @@ await dbContext.Database.VerifyIndex(
 
 </CodeGroup>
 
-Progress messages are emitted via PostgreSQL's `NOTICE` channel.
+Progress messages are emitted via Postgres's `NOTICE` channel.
 
 ### Verbose Mode
 
@@ -387,7 +387,7 @@ await dbContext.Database.VerifyIndex(
 
 ## Parallel Verification
 
-A single `verify_index` call processes segments sequentially within one PostgreSQL backend.
+A single `verify_index` call processes segments sequentially within one Postgres backend.
 For very large indexes, you can distribute verification across multiple database connections
 by specifying which segments each connection should check using the `segment_ids` parameter.
 This allows you to utilize multiple CPU cores by running verification in parallel processes.
@@ -429,7 +429,7 @@ await dbContext.Database.IndexSegments("search_idx").ToListAsync();
 
 </CodeGroup>
 
-```
+```ini
  partition_name | segment_idx | segment_id | num_docs | num_deleted | max_doc
 ----------------+-------------+------------+----------+-------------+---------
  search_idx     |           0 | b7e661af   |    10000 |           0 |   10000
@@ -882,7 +882,7 @@ await dbContext.Database
 
 </CodeGroup>
 
-```
+```ini
  schemaname |  tablename  |   indexname   | indexrelid | num_segments | total_docs
 ------------+-------------+---------------+------------+--------------+------------
  public     | products    | products_idx  |      16421 |            3 |      50000
@@ -898,7 +898,7 @@ To see the wall-clock time a ParadeDB index was built at:
 SELECT paradedb.index_created_at('search_idx');
 ```
 
-```
+```ini
        index_created_at
 ------------------------------
  2026-07-02 14:31:07.442218+00

--- a/docs/documentation/joins/overview.mdx
+++ b/docs/documentation/joins/overview.mdx
@@ -4,7 +4,7 @@ description: Optimize JOIN queries in ParadeDB
 canonical: https://docs.paradedb.com/documentation/joins/overview
 ---
 
-ParadeDB supports all standard PostgreSQL `JOIN` types, including:
+ParadeDB supports all standard Postgres `JOIN` types, including:
 
 - `INNER JOIN`
 - `LEFT JOIN`
@@ -17,7 +17,7 @@ ParadeDB optimizes standard `JOIN` queries involving search operations through a
 
 Our goal is to support and accelerate all `JOIN` queries shaped like Top-K or aggregate queries. Because join pushdown is enabled by default, ParadeDB automatically executes parts of a `JOIN` directly inside the ParadeDB executor for queries that meet the requirements.
 
-If a query does not meet the requirements, ParadeDB falls back to PostgreSQL’s native row-based execution.
+If a query does not meet the requirements, ParadeDB falls back to Postgres’s native row-based execution.
 
 ## Join Pushdown
 
@@ -30,7 +30,7 @@ Join pushdown reduces query latency by answering as much of the query as possibl
 
 ## Requirements for Join Pushdown
 
-Join pushdown is automatically used when a query meets several conditions. If any of these are not satisfied, PostgreSQL will simply execute the join normally.
+Join pushdown is automatically used when a query meets several conditions. If any of these are not satisfied, Postgres will simply execute the join normally.
 
 | Requirement      | Description                                                                                                                                                      |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/documentation/performance-tuning/overview.mdx
+++ b/docs/documentation/performance-tuning/overview.mdx
@@ -40,7 +40,7 @@ max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
 
 To disable auto-tuning, set `PDB_TUNE=false` when you first run the container:
 
-```
+```bash
 docker run \
     -e POSTGRES_USER=postgres \
     -e POSTGRES_PASSWORD=postgres \

--- a/docs/documentation/performance-tuning/reads.mdx
+++ b/docs/documentation/performance-tuning/reads.mdx
@@ -15,7 +15,7 @@ First, `max_worker_processes` is a global limit for the number of workers.
 Next, `max_parallel_workers` is a subset of `max_worker_processes`, and sets the limit for workers used in
 parallel queries. Finally, `max_parallel_workers_per_gather` limits how many workers a _single query_ can receive.
 
-```init postgresql.conf
+```ini postgresql.conf
 max_worker_processes = 72
 max_parallel_workers = 64
 max_parallel_workers_per_gather = 4
@@ -27,7 +27,7 @@ set to `72` to give headroom for other workers like autovacuum and replication.
 
 This is a good starting point:
 
-```
+```ini postgresql.conf
 max_parallel_workers = 5 * CPUs
 max_worker_processes = max_parallel_workers + 8
 max_parallel_workers_per_gather = CPUs / 2
@@ -47,7 +47,7 @@ query patterns, and volume of data.
 
 `shared_buffers` controls how much memory is available to the Postgres buffer cache. We recommend starting with 25% of total memory for `shared_buffers` and no more than 40% of total memory.
 
-```bash postgresql.conf
+```ini postgresql.conf
 shared_buffers = 8GB
 ```
 

--- a/docs/legacy/advanced/compound/disjunction-max.mdx
+++ b/docs/legacy/advanced/compound/disjunction-max.mdx
@@ -50,6 +50,6 @@ If `tie_breaker` is provided, documents that match on more than one subquery wil
 than documents that match on only one subquery. For instance, if there are two subqueries and `tie_breaker` is set to
 `0.5`, the score is computed as:
 
-```
+```text
 max_score + (second_highest_score × 0.5)
 ```

--- a/docs/legacy/full-text/filtering.mdx
+++ b/docs/legacy/full-text/filtering.mdx
@@ -8,7 +8,7 @@ noindex: true
   a future version. Please use the [v2 API](/) where possible.
 </Danger>
 
-Adding filters to text search is as simple as using PostgreSQL's built-in `WHERE` clauses and operators.
+Adding filters to text search is as simple as using Postgres's built-in `WHERE` clauses and operators.
 For instance, the following query filters out results that do not meet `rating > 2`.
 
 ```sql

--- a/docs/legacy/full-text/sorting.mdx
+++ b/docs/legacy/full-text/sorting.mdx
@@ -135,9 +135,9 @@ Not all `ORDER BY`s are pushed down. The following queries are not pushed down:
 
 ## Partial Ordering with Multiple Sort Fields
 
-When using `ORDER BY` with multiple sort fields, ParadeDB can partially push down the sorting operation. In this case, only the first column is pushed down to the BM25 index, and PostgreSQL handles the additional columns using sort operations.
+When using `ORDER BY` with multiple sort fields, ParadeDB can partially push down the sorting operation. In this case, only the first column is pushed down to the BM25 index, and Postgres handles the additional columns using sort operations.
 
-For example, in the following query with multiple sort fields, sorting by `sale_date` is pushed down to the BM25 index, while sorting by `amount` is handled by PostgreSQL:
+For example, in the following query with multiple sort fields, sorting by `sale_date` is pushed down to the BM25 index, while sorting by `amount` is handled by Postgres:
 
 ```sql
 SELECT description, sale_date, amount, pdb.score(id) as score
@@ -178,7 +178,7 @@ You can verify if partial ORDER BY pushdown occurred by running `EXPLAIN` on the
 ```
 </Accordion>
 
-This feature significantly improves performance when sorting by multiple columns, as the index is used for the first level of sorting, requiring PostgreSQL to perform less work to produce the final ordered results.
+This feature significantly improves performance when sorting by multiple columns, as the index is used for the first level of sorting, requiring Postgres to perform less work to produce the final ordered results.
 
 <Note>
 Limitations for partial `ORDER BY` pushdown:

--- a/docs/welcome/limitations.mdx
+++ b/docs/welcome/limitations.mdx
@@ -14,7 +14,7 @@ If you're working with very large datasets, please [reach out to us](mailto:supp
 
 ## Join Support
 
-ParadeDB supports all PostgreSQL `JOIN` types. As of v0.22.0, ParadeDB includes [join pushdown](/documentation/joins/overview) (beta) for `INNER`, `SEMI`, and `ANTI` joins, which pushes search predicates directly into the index for significantly better performance. Other join types work correctly but fall back to standard Postgres execution — pushdown support for these is coming soon. See the [joins guide](/documentation/joins/overview) for more details.
+ParadeDB supports all Postgres `JOIN` types. As of v0.22.0, ParadeDB includes [join pushdown](/documentation/joins/overview) (beta) for `INNER`, `SEMI`, and `ANTI` joins, which pushes search predicates directly into the index for significantly better performance. Other join types work correctly but fall back to standard Postgres execution — pushdown support for these is coming soon. See the [joins guide](/documentation/joins/overview) for more details.
 
 ## Covering Index
 


### PR DESCRIPTION
Small docs audit while doing Rust build time optimization