### PR TITLE
chore: upgrade syn to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4960,7 +4960,7 @@ version = "0.25.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "uuid",
 ]
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.106"
-syn = { version = "2.0.117", features = ["full"] }
+syn = { version = "3.0.3", features = ["full"] }
 uuid = { version = "1.23.1", features = ["v4"] }
 quote = "1.0.45"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-z9hWK+GCzwvZs99An10dFQbIUTM6YdtxUlO+jkH1+fU=";
+  cargoHash = "sha256-gzSTcfXaR8HEV5NDE22PWJ6DehOI6g3nxfNXmc0YeyA=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-LxmzQb5fErMp+C8wFzz5R6T4ZJMt5cR0hR1pcvkEQSo=";
+  cargoHash = "sha256-ndxGpgSuI8uL2FLGm6IYHnCfkScb0jCfqA1X1IbzNcg=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Moves the `macros` crate off `syn 2.0.117` onto `syn 3.0.3`. Second of the major-version dependency upgrades, done one at a time (first was #5843, sysinfo).

The entire diff is two lines: one in `macros/Cargo.toml`, one in `Cargo.lock`. No source changes were needed.

## Why

`macros` was one of the last things in the workspace still pinned to syn 2.

**This costs nothing in build time.** syn 3 is *already* compiled for this workspace — it's pulled in by `serde_derive`, `thiserror-impl`, `clap_derive`, `async-trait`, `tokio-macros`, `typetag-impl`, `displaydoc`, `linkme-impl`, `proc-macro-error3` and `foreign-types-macros`. So this moves our crate onto a version that's already being built rather than adding a new one.

To set expectations: this does **not** remove syn 2 from the graph. Roughly 60 crates still depend on it — `pgrx-macros`, `pgrx-bindgen`, `pgrx-sql-entity-graph`, `sqlx-macros`, `strum_macros`, `rstest_macros`, `prost-derive` and others. This just takes our own crate off that list.

## How

Every syn API the crate uses is unchanged across the major version:

- `syn::parse::{Parse, ParseStream}`, `parse_macro_input!`
- `Error`, `Ident`, `LitStr`, `LitBool`, `Lit`, `Result`, `Token!`
- `FnArg`, `ItemFn`, `Pat`, `spanned::Spanned`
- `syn::__private::{ToTokens, quote}` — `builder_fn.rs` imports from syn's private module, which is the most fragile thing here across a major bump. Confirmed those re-exports are byte-identical in `src/export.rs` between both versions.

syn's feature set and MSRV (1.71) are also unchanged between 2.0.119 and 3.0.3.

## Tests

`macros` is a proc-macro crate whose only consumer is `pg_search`, so "it compiles" is weak evidence on its own — a proc macro can compile fine and still emit different tokens.

So expansion was checked directly. A temporary harness drove `build_function` and the `NamedArgs` parser under **both** syn 2 and syn 3 over representative and error-path inputs:

- three `#[builder_fn]` shapes (named `pg_extern`, multi-arg incl. `Option<T>`, zero-arg with multiple attributes), with the generated module's UUID normalized
- both `build_function` error paths (missing attributes, unsupported argument pattern)
- a full 12-key `generate_tokenizer_sql!` argument list through the parser and every accessor
- `NamedArgs` error paths: duplicate key, wrong value type, missing key, unparseable value, trailing comma

Generated token streams and every diagnostic message came out **byte-identical** between the two versions. That harness was scaffolding for this verification and is deliberately not part of the commit.

Also run against this branch:

- `cargo clippy -p macros --all-targets` — clean
- `cargo fmt -p macros -- --check` — clean
- `cargo test -p macros` — 2 passed (the `compile_fail` doctests)

One caveat worth stating plainly: the `pg_search` build could not be exercised locally, because `tokenizers` depends on lindera, whose build script downloads dictionaries from `lindera.dev` — a host blocked by egress policy in my environment. CI covers that path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEm6G1qKw694BQQqb9HBiU)_