### PR TITLE
chore: upgrade toml to 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
- "toml 0.8.23",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -6199,7 +6199,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -7249,15 +7249,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -7726,7 +7717,7 @@ dependencies = [
  "shutdown_hooks",
  "sysinfo",
  "tempfile",
- "toml 0.8.23",
+ "toml 1.1.4+spec-1.1.0",
  "url",
 ]
 
@@ -8380,25 +8371,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -8413,20 +8392,11 @@ checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -8449,20 +8419,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
@@ -8481,12 +8437,6 @@ checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -9231,9 +9181,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -22,7 +22,7 @@ sqlx = { version = "0.9.0", features = [
 ] }
 tokio = { version = "1.52", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
-toml = "0.8"
+toml = "1.1"
 duckdb = { version = "1.10502.0", features = ["bundled"] }
 distrs = "0.2.3"
 

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1.0.149", features = [
 ] }
 shutdown_hooks = "0.1.0"
 sysinfo = { version = "0.39.6", features = ["multithread"] }
-toml = "0.8.23"
+toml = "1.1"
 url = "2.5.8"
 postgres-openssl = "0.5.3"
 openssl = "0.10.78"


### PR DESCRIPTION
### Motivation
- Bring the workspace up to the `toml` 1.1 series to use the newer TOML parser/writer implementation and spec fixes.
- Ensure direct consumers in the repo (`benchmarks` and `stressgres`) use a consistent `toml` major version.

### Description
- Bumped `toml` from `0.8`/`0.8.23` to `1.1` in `benchmarks/Cargo.toml` and `stressgres/Cargo.toml` via the workspace manifests.
- Updated `Cargo.lock` to resolve `toml` to `1.1.4+spec-1.1.0` and removed the older `toml` 0.8 dependency chain and related now-obsolete transitive entries.
- Cleaned up lockfile entries for related `toml_*` crates as part of the resolution to the 1.1 ecosystem.

### Testing
- Ran `cargo check --offline -p stressgres` which completed successfully.
- Ran `cargo check --offline -p benchmarks --lib` which compiled the Rust dependency graph (including `toml` 1.1) but was stopped during the bundled DuckDB C++ build due to runtime length; Rust side succeeded prior to that step.
- Ran `cargo metadata --offline --no-deps --format-version 1` and `cargo fmt --all -- --check` which both succeeded.
- Performed an offline `cargo update --offline -p toml@0.8.23` to refresh the lockfile after an initial network error, which succeeded and produced the updated `Cargo.lock`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a715db0f138832b989661c1b573766d)