### PR TITLE
fix: Propagate MPP worker panics through the transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-08-100736#91667bfc003a3118abdec2b2c4358f93ca564b08"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-10-030937#fe1a153fc0c2d46002c6cc3dd8b51a3588b5b7f9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5090,6 +5090,7 @@ dependencies = [
  "time",
  "tokenizers",
  "tokio",
+ "tokio-util",
  "typetag",
  "uuid",
 ]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-X1KvUV/Ei4NbjwTWsnuwP0zMUJhJyTLpjx2Nw3s8Mlc=";
+  cargoHash = "sha256-4uFOckvmexPeat1PaBh7dYNCcn4PBfT9Pq1bWjn+vbU=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -87,12 +87,13 @@ decimal-bytes = "0.4.2"
 paste = "1.0.15"
 typetag = "0.2"
 tokio = { version = "1", features = ["rt"] }
+tokio-util = "0.7"
 bytes = { version = "1", features = ["serde"] }
 # Here and the equivalent in our datafusion-distributed fork will need to be updated in sync so that
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-08-100736", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-10-030937", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -134,6 +134,9 @@ static ENABLE_SEGMENTED_TOPK: GucSetting<bool> = GucSetting::<bool>::new(true);
 /// the Postgres server log (and in CI benchmark logs). When off, `mpp_log!()` is a no-op.
 static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+#[cfg(debug_assertions)]
+static MPP_TEST_PANIC_IN_WORKER: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// Dedicated diagnostic GUC for per-shuffle EOF row counts. These lines emit concurrently
 /// from every participant and can reorder between runs, so they're kept off `mpp_debug` to
 /// avoid flaking regress expected files. Turn this on in long-running benchmark queries to
@@ -624,6 +627,16 @@ pub fn init() {
         GucFlags::default(),
     );
 
+    #[cfg(debug_assertions)]
+    GucRegistry::define_bool_guc(
+        c"paradedb.mpp_test_panic_in_worker",
+        c"Trigger a panic in the MPP worker",
+        c"Used for testing error propagation.",
+        &MPP_TEST_PANIC_IN_WORKER,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
     GucRegistry::define_bool_guc(
         c"paradedb.mpp_trace",
         c"Emit MPP setup timing at WARNING level",
@@ -864,6 +877,11 @@ pub fn enable_segmented_topk() -> bool {
 
 pub fn mpp_debug() -> bool {
     MPP_DEBUG.get()
+}
+
+#[cfg(debug_assertions)]
+pub fn mpp_test_panic_in_worker() -> bool {
+    MPP_TEST_PANIC_IN_WORKER.get()
 }
 
 pub fn mpp_trace() -> bool {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -20,9 +20,9 @@
 //! The natural-shape MPP path is the same flow for every customscan that opts in: read the
 //! leader's dispatch blob from DSM, decode this proc's per-stage physical subplans (the leader
 //! built and sliced the plan once, so workers don't re-plan), and run each fragment via
-//! [`run_worker_fragment`] + `FuturesUnordered`. The only customscan-specific pieces are the seed
-//! `SessionContext` (different `SessionContextProfile`) and where the inputs come from in
-//! per-scan state.
+//! [`datafusion_distributed::shm::setup::run_worker_fragment`] + `FuturesUnordered`. The only
+//! customscan-specific pieces are the seed `SessionContext` (different `SessionContextProfile`)
+//! and where the inputs come from in per-scan state.
 //!
 //! This module isolates the shape-agnostic logic. Per-scan
 //! `crate::postgres::customscan::mpp::host::MppWorkerHost` impls (in
@@ -49,16 +49,13 @@ use datafusion_distributed::PartitionSink;
 use datafusion_distributed::shm::{
     CooperativeDrainSet, InProcessWorkerResolver, MppDataStreamKey, MppFrameHeader, MppMesh,
     MppPartitionSink, ShmChannelResolver, WorkerSession, collect_task_metrics, proc_for_task,
-    run_worker_fragment,
 };
 use datafusion_proto::physical_plan::DeduplicatingProtoConverter;
 
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
 use crate::postgres::customscan::mpp::glue::producer_worker_cap;
-use crate::postgres::customscan::mpp::interrupt::{
-    HeldInterrupts, cancel_pending, check_for_interrupts, interrupted,
-};
+use crate::postgres::customscan::mpp::interrupt::{HeldInterrupts, check_for_interrupts};
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::utils::ExprContextGuard;
 use crate::scan::execution_plan::{
@@ -187,125 +184,6 @@ async fn take_set_plan_draining(
     }
 }
 
-/// Dispatches execution of a worker fragment upon receiving partition-range RPC requests.
-///
-/// Waits for incoming `ExecuteTask` requests on `mesh` for `(stage_id, task_idx)`, slicing
-/// and assigning partition sinks to spawned `run_worker_fragment` sub-futures.
-/// Concurrently drains the inbound channel pass while yielding.
-async fn dispatch_fragment_requests(
-    mesh: Arc<MppMesh>,
-    stage_id: u32,
-    task_idx: u32,
-    per_partition_sinks: Vec<Box<dyn PartitionSink>>,
-    plan: Arc<dyn ExecutionPlan>,
-    task_ctx: Arc<TaskContext>,
-) -> Result<(), datafusion::common::DataFusionError> {
-    let mut rx = mesh.take_execute_task_rx(stage_id, task_idx)?;
-    let mut sub_futures = futures::stream::FuturesUnordered::new();
-    let n_out = per_partition_sinks.len();
-    let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
-    let mut partitions_requested = 0;
-
-    if n_out == 0 {
-        return Ok(());
-    }
-
-    // Consumers issue every request while building their streams, so a fragment with
-    // nothing running normally waits milliseconds for its next request. A stall this
-    // long means a consumer stopped requesting (a planning or routing bug), and
-    // without the bound this fragment and the leader waiting on it hang forever.
-    let stall_secs = crate::gucs::mpp_request_timeout_secs();
-    let stall_duration = std::time::Duration::from_secs(stall_secs.max(0) as u64);
-    let mut stall_deadline = tokio::time::Instant::now() + stall_duration;
-
-    loop {
-        if partitions_requested >= n_out && sub_futures.is_empty() {
-            break;
-        }
-        tokio::select! {
-            frame_res = rx.recv(), if partitions_requested < n_out => {
-                match frame_res {
-                    Some(Ok(frame)) => {
-                        let (request, _headers) = frame.into_parts()?;
-                        let start = request.target_partition_start as usize;
-                        let end = request.target_partition_end as usize;
-
-                        if start > end || end > sinks_opt.len() {
-                            return Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker dispatch: requested partition range {start}..{end} \
-                                 out of bounds for sink count {} (stage_id={stage_id}, task_idx={task_idx})",
-                                sinks_opt.len()
-                            )));
-                        }
-
-                        let len = end - start;
-
-                        let mut task_sinks = Vec::with_capacity(len);
-                        for (i, sink) in sinks_opt.iter_mut().enumerate().take(end).skip(start) {
-                            let Some(s) = sink.take() else {
-                                return Err(datafusion::common::DataFusionError::Internal(format!(
-                                    "mpp worker dispatch: sink for partition {i} already taken \
-                                     (stage_id={stage_id}, task_idx={task_idx})",
-                                )));
-                            };
-                            task_sinks.push(s);
-                        }
-
-                        sub_futures.push(run_worker_fragment(
-                            Arc::clone(&plan),
-                            task_sinks,
-                            Arc::clone(&task_ctx),
-                            start..end,
-                        ));
-                        partitions_requested += len;
-                        stall_deadline = tokio::time::Instant::now() + stall_duration;
-                    }
-                    Some(Err(e)) => {
-                        return Err(datafusion::common::DataFusionError::Execution(format!(
-                            "mpp worker rx error: {e} (stage_id={stage_id}, task_idx={task_idx}, \
-                             requested={partitions_requested}/{n_out})"
-                        )));
-                    }
-                    None => {
-                        // Closed feed: consumers are done requesting; unrequested partitions have no waiter.
-                        partitions_requested = n_out;
-                    }
-                }
-            }
-            next_res = sub_futures.next(), if !sub_futures.is_empty() => {
-                match next_res {
-                    Some(Ok(_)) => {}
-                    Some(Err(e)) => return Err(e),
-                    None => unreachable!(),
-                }
-                stall_deadline = tokio::time::Instant::now() + stall_duration;
-            }
-            _ = tokio::time::sleep_until(stall_deadline),
-                if stall_secs > 0 && partitions_requested < n_out && sub_futures.is_empty() => {
-                return Err(datafusion::common::DataFusionError::Execution(format!(
-                    "mpp worker dispatch: no ExecuteTask request for {stall_secs}s \
-                     (stage_id={stage_id}, task_idx={task_idx}, \
-                     requested={partitions_requested}/{n_out}); a consumer stopped \
-                     requesting this task's partitions"
-                )));
-            }
-            _ = tokio::task::yield_now() => {
-                // Interrupts are held for the whole dispatcher, so a cancel or a
-                // backend-die only ends this wait if the loop polls for it.
-                if cancel_pending() {
-                    return Err(interrupted());
-                }
-                if let Err(e) = mesh.inbound_receiver().try_drain_pass() {
-                    return Err(datafusion::common::DataFusionError::Execution(format!(
-                        "mpp worker drain error: {e} (stage_id={stage_id}, task_idx={task_idx}, \
-                         requested={partitions_requested}/{n_out})"
-                    )));
-                }
-            }
-        }
-    }
-    Ok(())
-}
 
 /// Shape-agnostic body of `exec_mpp_worker`. Runs to completion on the caller's tokio runtime,
 /// pgrx::error!s on fatal failures, returns normally on EOF (the customscan's
@@ -314,6 +192,7 @@ async fn dispatch_fragment_requests(
 /// `seed_ctx` is a bare serial `SessionContext` used only for plan deserialization
 /// (`ctx.task_ctx()`). The distributed planner config is built separately via
 /// [`build_mpp_session_context`] over the same seed.
+// TODO: Unwieldy. Once the dust settles on task multiplexing, should push more of this into `df-d`.
 pub(crate) fn run_mpp_worker(
     inputs: MppWorkerInputs,
     seed_ctx: SessionContext,
@@ -437,7 +316,7 @@ pub(crate) fn run_mpp_worker(
     // live runtime. The loops poll cooperatively to bail promptly; see `mpp::interrupt`.
     let held = HeldInterrupts::hold();
     let mesh_for_block = Arc::clone(worker_mesh);
-    let result = runtime.block_on(async move {
+    let outcome = runtime.block_on(async move {
         let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
         let mut executed_fragments: Vec<(u32, u32, usize, Arc<dyn ExecutionPlan>)> =
             Vec::with_capacity(fragments.len());
@@ -540,16 +419,37 @@ pub(crate) fn run_mpp_worker(
                 fragment.task_idx,
                 fragment.task_count,
                 Arc::clone(&plan),
-            ));
+            ));            let stage_id = fragment.stage_id;
+            let task_idx = fragment.task_idx;
+            let mesh_for_block = Arc::clone(&mesh_for_block);
 
-            futures.push(Box::pin(dispatch_fragment_requests(
-                Arc::clone(&mesh_for_block),
-                fragment.stage_id,
-                fragment.task_idx,
-                per_partition_sinks,
-                plan,
-                task_ctx,
-            )));
+            futures.push(Box::pin(async move {
+                let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
+                let n_partitions = sinks_opt.len();
+
+                let token = tokio_util::sync::CancellationToken::new();
+
+                datafusion_distributed::shm::run_execute_task_loop(
+                    &mesh_for_block,
+                    stage_id,
+                    task_idx,
+                    n_partitions,
+                    token,
+                    move |_request, _headers, range| {
+                        let len = range.end - range.start;
+                        let mut task_sinks = Vec::with_capacity(len);
+                        for sink in sinks_opt.iter_mut().take(range.end).skip(range.start) {
+                            task_sinks.push(sink.take().unwrap());
+                        }
+                        datafusion_distributed::shm::run_worker_fragment(
+                            Arc::clone(&plan),
+                            task_sinks,
+                            Arc::clone(&task_ctx),
+                            range,
+                        )
+                    }
+                ).await
+            }));
         }
         // The metrics frames go to the leader after the fragments finish.
         let metrics_sender_base = worker_session
@@ -616,7 +516,7 @@ pub(crate) fn run_mpp_worker(
     // of mid-`block_on`.
     drop(held);
     check_for_interrupts();
-    if let Err(e) = result {
+    if let Err(e) = outcome {
         pgrx::error!("mpp worker: fragment dispatch failed: {e}");
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -20,7 +20,7 @@
 //! The natural-shape MPP path is the same flow for every customscan that opts in: read the
 //! leader's dispatch blob from DSM, decode this proc's per-stage physical subplans (the leader
 //! built and sliced the plan once, so workers don't re-plan), and run each fragment via
-//! [`datafusion_distributed::shm::setup::run_worker_fragment`] + `FuturesUnordered`. The only
+//! [`datafusion_distributed::shm::run_worker_fragment`] + `FuturesUnordered`. The only
 //! customscan-specific pieces are the seed `SessionContext` (different `SessionContextProfile`)
 //! and where the inputs come from in per-scan state.
 //!
@@ -38,7 +38,7 @@ use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
     DistributedConfig, DistributedExt, DistributedTaskContext, SessionStateBuilderExt,
 };
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use pgrx::pg_sys;
 use tantivy::index::SegmentId;
 
@@ -49,8 +49,10 @@ use datafusion_distributed::PartitionSink;
 use datafusion_distributed::shm::{
     CooperativeDrainSet, InProcessWorkerResolver, MppDataStreamKey, MppFrameHeader, MppMesh,
     MppPartitionSink, ShmChannelResolver, WorkerSession, collect_task_metrics, proc_for_task,
+    run_execute_task_loop, run_worker_fragment,
 };
 use datafusion_proto::physical_plan::DeduplicatingProtoConverter;
+use tokio_util::sync::CancellationToken;
 
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
@@ -184,6 +186,88 @@ async fn take_set_plan_draining(
     }
 }
 
+/// All fragment futures share this type. The alias keeps `Vec<FragmentFuture>` legible and silences
+/// clippy::type_complexity.
+type FragmentFuture = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>> + Send>,
+>;
+
+/// Extract an error message string from a `pgrx`-raised panic payload (`ErrorReportWithLevel` or
+/// `CaughtError`), returning `None` if the payload is not a known `pgrx` type.
+fn downcast_pgrx_panic_payload(payload: &(dyn std::any::Any + Send)) -> Option<String> {
+    use pgrx::pg_sys::panic::{CaughtError, ErrorReportWithLevel};
+
+    if let Some(report) = payload.downcast_ref::<ErrorReportWithLevel>() {
+        return Some(report.message().to_string());
+    }
+    if let Some(caught) = payload.downcast_ref::<CaughtError>() {
+        return Some(match caught {
+            CaughtError::RustPanic { ereport, .. } => ereport.message().to_string(),
+            CaughtError::PostgresError(report) | CaughtError::ErrorReport(report) => {
+                report.message().to_string()
+            }
+        });
+    }
+    None
+}
+
+/// Spawns the execution task loop for a worker fragment over `run_execute_task_loop`.
+fn spawn_fragment_execution_task(
+    mesh: Arc<MppMesh>,
+    stage_id: u32,
+    task_idx: u32,
+    per_partition_sinks: Vec<Box<dyn PartitionSink>>,
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> FragmentFuture {
+    Box::pin(async move {
+        let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
+        let n_partitions = sinks_opt.len();
+
+        // The cancellation token is never cancelled on this path; worker interrupts bail via
+        // the cooperative drain pass.
+        let token = CancellationToken::new();
+
+        run_execute_task_loop(
+            &mesh,
+            stage_id,
+            task_idx,
+            n_partitions,
+            token,
+            move |_request, _headers, range| {
+                let len = range.end - range.start;
+                let mut task_sinks = Vec::with_capacity(len);
+                for sink in sinks_opt.iter_mut().take(range.end).skip(range.start) {
+                    task_sinks.push(
+                        sink.take()
+                            .expect("mpp worker: partition sink already claimed"),
+                    );
+                }
+                let plan = Arc::clone(&plan);
+                let task_ctx = Arc::clone(&task_ctx);
+                async move {
+                    let fut = std::panic::AssertUnwindSafe(run_worker_fragment(
+                        plan, task_sinks, task_ctx, range,
+                    ));
+                    // `df-d`'s panic handler downcasts `&str` and `String` panics, but doesn't
+                    // know about `pgrx` error types. Intercept `pgrx` panic types here to format
+                    // them to a `DataFusionError::Execution`, and resume unwinding for everything else.
+                    match fut.catch_unwind().await {
+                        Ok(res) => res,
+                        Err(payload) => {
+                            if let Some(msg) = downcast_pgrx_panic_payload(&*payload) {
+                                Err(datafusion::common::DataFusionError::Execution(msg))
+                            } else {
+                                std::panic::resume_unwind(payload);
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        .await
+    })
+}
 
 /// Shape-agnostic body of `exec_mpp_worker`. Runs to completion on the caller's tokio runtime,
 /// pgrx::error!s on fatal failures, returns normally on EOF (the customscan's
@@ -302,15 +386,6 @@ pub(crate) fn run_mpp_worker(
     let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
     let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
     let session_arc = Arc::new(session);
-
-    // All fragment futures share this vector. The alias keeps the `Vec<_>` declaration legible and silences
-    // clippy::type_complexity.
-    type FragmentFuture = std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
-                + Send,
-        >,
-    >;
     // Hold cancel/die off for the duration so neither our drain/send loops nor a subroutine
     // (the scanner's own `CHECK_FOR_INTERRUPTS`, a buffer wait) can `proc_exit` out of the
     // live runtime. The loops poll cooperatively to bail promptly; see `mpp::interrupt`.
@@ -412,44 +487,20 @@ pub(crate) fn run_mpp_worker(
             // already `Remote`, so its boundary leaves read the mesh through the session's
             // `ShmChannelResolver`.
             let plan = Arc::clone(frag_plan);
-            // Kept for the post-run metrics frame: the executed nodes (and their metrics)
-            // live in this plan.
             executed_fragments.push((
                 fragment.stage_id,
                 fragment.task_idx,
                 fragment.task_count,
                 Arc::clone(&plan),
-            ));            let stage_id = fragment.stage_id;
-            let task_idx = fragment.task_idx;
-            let mesh_for_block = Arc::clone(&mesh_for_block);
-
-            futures.push(Box::pin(async move {
-                let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
-                let n_partitions = sinks_opt.len();
-
-                let token = tokio_util::sync::CancellationToken::new();
-
-                datafusion_distributed::shm::run_execute_task_loop(
-                    &mesh_for_block,
-                    stage_id,
-                    task_idx,
-                    n_partitions,
-                    token,
-                    move |_request, _headers, range| {
-                        let len = range.end - range.start;
-                        let mut task_sinks = Vec::with_capacity(len);
-                        for sink in sinks_opt.iter_mut().take(range.end).skip(range.start) {
-                            task_sinks.push(sink.take().unwrap());
-                        }
-                        datafusion_distributed::shm::run_worker_fragment(
-                            Arc::clone(&plan),
-                            task_sinks,
-                            Arc::clone(&task_ctx),
-                            range,
-                        )
-                    }
-                ).await
-            }));
+            ));
+            futures.push(spawn_fragment_execution_task(
+                Arc::clone(&mesh_for_block),
+                fragment.stage_id,
+                fragment.task_idx,
+                per_partition_sinks,
+                plan,
+                task_ctx,
+            ));
         }
         // The metrics frames go to the leader after the fragments finish.
         let metrics_sender_base = worker_session

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -883,7 +883,7 @@ impl ExecutionPlan for PgSearchScanPlan {
     ) -> Result<SendableRecordBatchStream> {
         #[cfg(debug_assertions)]
         if crate::gucs::mpp_test_panic_in_worker() {
-            panic!("artificial panic to test worker error propagation");
+            pgrx::error!("artificial panic to test worker error propagation");
         }
 
         // Under DataFusion Distributed execution, upstream stage operators (such as `RepartitionExec`)

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -881,6 +881,11 @@ impl ExecutionPlan for PgSearchScanPlan {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        #[cfg(debug_assertions)]
+        if crate::gucs::mpp_test_panic_in_worker() {
+            panic!("artificial panic to test worker error propagation");
+        }
+
         // Under DataFusion Distributed execution, upstream stage operators (such as `RepartitionExec`)
         // call `execute(p)` for all partition indices `p` in the stage's requested partition range.
         // For partitions where `p != assigned`, we return an empty stream so multi-partition

--- a/tests/tests/mpp_error_masking.rs
+++ b/tests/tests/mpp_error_masking.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::Result;
+use rstest::*;
+use sqlx::{AssertSqlSafe, Executor};
+use tests::fixtures::*;
+
+const SETUP_SQL: &str = r#"
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
+
+CREATE TABLE mem_a (id bigint PRIMARY KEY, state text);
+CREATE TABLE mem_b (id bigint PRIMARY KEY, aid bigint, u text);
+CREATE INDEX mem_a_idx ON mem_a USING bm25 (id, state)
+  WITH (key_field = 'id', target_segment_count = '3', mutable_segment_rows = '0');
+CREATE INDEX mem_b_idx ON mem_b USING bm25 (id, aid, u)
+  WITH (key_field = 'id', target_segment_count = '3');
+
+INSERT INTO mem_a SELECT g, 'active' FROM generate_series(1, 50000) g;
+INSERT INTO mem_a SELECT g, 'merged' FROM generate_series(50001, 100000) g;
+INSERT INTO mem_b SELECT g, g, 'u1'  FROM generate_series(1, 100000) g;
+"#;
+
+const MPP_GUCS: &str = r#"
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 2;
+SET max_parallel_workers TO 2;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET paradedb.mpp_test_panic_in_worker TO on;
+"#;
+
+const MPP_QUERY: &str = r#"
+SELECT count(*)
+FROM mem_b le
+JOIN mem_a sv ON sv.id = le.aid
+WHERE le.id @@@ paradedb.term('u', 'u1')
+  AND sv.id @@@ paradedb.term('state', 'merged')
+"#;
+
+#[rstest]
+#[tokio::test]
+async fn mpp_error_masking(database: Db) -> Result<()> {
+    let mut setup = database.connection().await;
+    setup.execute(SETUP_SQL).await?;
+    setup.execute(MPP_GUCS).await?;
+
+    let iterations = 10;
+    let mut real_error_count = 0;
+    let mut masked_error_count = 0;
+
+    let explain_rows: Vec<(String,)> =
+        sqlx::query_as(AssertSqlSafe(format!("EXPLAIN {}", MPP_QUERY)))
+            .fetch_all(&mut setup)
+            .await
+            .unwrap();
+    println!(
+        "EXPLAIN output:\n{}",
+        explain_rows
+            .into_iter()
+            .map(|(r,)| r)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    for i in 0..iterations {
+        let res = setup.execute(MPP_QUERY).await;
+        if let Err(e) = res {
+            let err_str = e.to_string().to_lowercase();
+            println!("Iteration {}: got error: {}", i, err_str);
+            if err_str.contains("artificial panic") {
+                real_error_count += 1;
+            } else if err_str.contains("transport receiver detached") {
+                masked_error_count += 1;
+            } else {
+                panic!("Unexpected error: {e}");
+            }
+        } else {
+            panic!("Expected query to fail due to panic, but it succeeded");
+        }
+    }
+
+    assert_eq!(
+        masked_error_count, 0,
+        "Failed: observed {masked_error_count} masked errors ('transport receiver detached') and {real_error_count} real errors."
+    );
+    assert_eq!(
+        real_error_count, iterations,
+        "Expected all {iterations} iterations to return the real error."
+    );
+
+    Ok(())
+}

--- a/tests/tests/mpp_error_masking.rs
+++ b/tests/tests/mpp_error_masking.rs
@@ -58,6 +58,19 @@ WHERE le.id @@@ paradedb.term('u', 'u1')
 async fn mpp_error_masking(database: Db) -> Result<()> {
     let mut setup = database.connection().await;
     setup.execute(SETUP_SQL).await?;
+    let guc_exists: Option<(String,)> = sqlx::query_as(
+        "SELECT name FROM pg_settings WHERE name = 'paradedb.mpp_test_panic_in_worker'",
+    )
+    .fetch_optional(&mut setup)
+    .await?;
+
+    if guc_exists.is_none() {
+        println!(
+            "Skipping mpp_error_masking: paradedb.mpp_test_panic_in_worker GUC is not present (non-debug build)"
+        );
+        return Ok(());
+    }
+
     setup.execute(MPP_GUCS).await?;
 
     let iterations = 10;
@@ -69,13 +82,16 @@ async fn mpp_error_masking(database: Db) -> Result<()> {
             .fetch_all(&mut setup)
             .await
             .unwrap();
-    println!(
-        "EXPLAIN output:\n{}",
-        explain_rows
-            .into_iter()
-            .map(|(r,)| r)
-            .collect::<Vec<_>>()
-            .join("\n")
+    let explain_str = explain_rows
+        .into_iter()
+        .map(|(r,)| r)
+        .collect::<Vec<_>>()
+        .join("\n");
+    println!("EXPLAIN output:\n{explain_str}");
+
+    assert!(
+        explain_str.contains("DistributedExec") && explain_str.contains("PgSearchScan"),
+        "Expected EXPLAIN plan to use MPP (DistributedExec & PgSearchScan), got:\n{explain_str}"
     );
 
     for i in 0..iterations {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5749

## What

Incorporate https://github.com/paradedb/datafusion-distributed/pull/66 to add an explicit error frame, and panic handling.

## Why

Without an explicit error frame on the wire, there was no way for the leader process to receive errors, and so we always relied on Postgres's process-exit mechanism to propagate errors.

Explicitly passing errors resolves a race condition (see #5749), and better aligns us with the canonical implementation. We additionally switch to using the `run_execute_task_loop` method, which was meant to replace `dispatch_fragment_requests` in a previous edit.

## Tests

Added a new unit test to validate that the race condition is resolved (fails flakily before, succeeds reliably afterward).