### PR TITLE
chore: upgrade rstest to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3207,7 +3207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4302,7 +4302,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5459,7 +5459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6471,7 +6471,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6906,21 +6906,20 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -7010,7 +7009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7069,7 +7068,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8081,7 +8080,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9017,7 +9016,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -28,7 +28,7 @@ distrs = "0.2.3"
 
 [dev-dependencies]
 approx = "0.5.1"
-rstest = "0.25.0"
+rstest = "0.26.1"
 
 [lib]
 name = "paradedb"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -108,5 +108,5 @@ superkmeans = { git = "https://github.com/paradedb/superkmeans-rs", package = "s
 
 [dev-dependencies]
 pgrx-tests.workspace = true
-rstest = "0.25.0"
+rstest = "0.26.1"
 proptest = "1.11.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -25,7 +25,7 @@ lockfree-object-pool = "0.1.6"
 pgvector = { version = "0.4.1", features = ["sqlx"] }
 pretty_assertions = "1.4.1"
 rand = "0.9.4"
-rstest = "0.25.0"
+rstest = "0.26.1"
 rustc-hash = "2.1.2"
 serde_json = "1.0.149"
 soa_derive = "0.14.0"

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -26,6 +26,7 @@ use std::str::FromStr;
 use tests::fixtures::*;
 
 #[rstest]
+#[async_std::test]
 async fn basic_search_query(mut conn: PgConnection) -> Result<(), sqlx::Error> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -54,6 +55,7 @@ async fn basic_search_query(mut conn: PgConnection) -> Result<(), sqlx::Error> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn basic_search_ids(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -550,6 +552,7 @@ fn update_non_indexed_column(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn json_array_flattening(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -576,6 +579,7 @@ async fn json_array_flattening(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn json_array_multiple_documents(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -609,6 +613,7 @@ async fn json_array_multiple_documents(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn json_array_mixed_data(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -635,6 +640,7 @@ async fn json_array_mixed_data(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn json_nested_arrays(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 

--- a/tests/tests/copy.rs
+++ b/tests/tests/copy.rs
@@ -21,6 +21,7 @@ use sqlx::PgConnection;
 use tests::fixtures::*;
 
 #[rstest]
+#[async_std::test]
 async fn test_copy_to_table(mut conn: PgConnection) {
     r#"
         DROP TABLE IF EXISTS test_copy_to_table;

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -69,6 +69,7 @@ fn prevent_duplicate(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn drop_column(mut conn: PgConnection) {
     r#"
     CREATE TABLE f_table (

--- a/tests/tests/lindera.rs
+++ b/tests/tests/lindera.rs
@@ -23,6 +23,7 @@ use sqlx::PgConnection;
 use tests::fixtures::*;
 
 #[rstest]
+#[async_std::test]
 async fn lindera_korean_tokenizer(mut conn: PgConnection) {
     r#"CREATE TABLE IF NOT EXISTS korean (
         id SERIAL PRIMARY KEY,
@@ -73,6 +74,7 @@ async fn lindera_korean_tokenizer(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn lindera_chinese_tokenizer(mut conn: PgConnection) {
     r#"CREATE TABLE IF NOT EXISTS chinese (
         id SERIAL PRIMARY KEY,
@@ -122,6 +124,7 @@ async fn lindera_chinese_tokenizer(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn lindera_japenese_tokenizer(mut conn: PgConnection) {
     r#"
     CREATE TABLE IF NOT EXISTS japanese (

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -1203,6 +1203,7 @@ fn range_term(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn prepared_statement_replanning(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -1220,6 +1221,7 @@ async fn prepared_statement_replanning(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn direct_prepared_statement_replanning(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -1233,6 +1235,7 @@ async fn direct_prepared_statement_replanning(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn direct_prepared_statement_replanning_custom_scan(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -1292,6 +1295,7 @@ fn verify_prepared_stmt_matches_literal(conn: &mut PgConnection, tc: PreparedStm
 }
 
 #[rstest]
+#[async_std::test]
 async fn generic_plan_text_and_text_array_params_issue_3900(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     "SET plan_cache_mode = force_generic_plan".execute(&mut conn);

--- a/tests/tests/range_term.rs
+++ b/tests/tests/range_term.rs
@@ -138,6 +138,7 @@ pub enum RangeRelation {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_contains_int4range(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -153,6 +154,7 @@ async fn range_term_contains_int4range(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_contains_int8range(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -168,6 +170,7 @@ async fn range_term_contains_int8range(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_contains_numrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -183,6 +186,7 @@ async fn range_term_contains_numrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_contains_daterange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -198,6 +202,7 @@ async fn range_term_contains_daterange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_contains_tsrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -213,6 +218,7 @@ async fn range_term_contains_tsrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_contains_tstzrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -228,6 +234,7 @@ async fn range_term_contains_tstzrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_within_int4range(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -243,6 +250,7 @@ async fn range_term_within_int4range(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_within_int8range(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -258,6 +266,7 @@ async fn range_term_within_int8range(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_within_numrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -273,6 +282,7 @@ async fn range_term_within_numrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_within_daterange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -288,6 +298,7 @@ async fn range_term_within_daterange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_within_tsrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -303,6 +314,7 @@ async fn range_term_within_tsrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_within_tstzrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -318,6 +330,7 @@ async fn range_term_within_tstzrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_intersects_int4range(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -333,6 +346,7 @@ async fn range_term_intersects_int4range(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_intersects_int8range(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -348,6 +362,7 @@ async fn range_term_intersects_int8range(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_intersects_numrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -363,6 +378,7 @@ async fn range_term_intersects_numrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_intersects_daterange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -378,6 +394,7 @@ async fn range_term_intersects_daterange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_intersects_tsrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,
@@ -393,6 +410,7 @@ async fn range_term_intersects_tsrange(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn range_term_intersects_tstzrange(mut conn: PgConnection) {
     execute_range_test(
         &mut conn,

--- a/tests/tests/reindex.rs
+++ b/tests/tests/reindex.rs
@@ -22,6 +22,7 @@ use sqlx::PgConnection;
 use tests::fixtures::*;
 
 #[rstest]
+#[async_std::test]
 async fn basic_reindex(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -44,6 +45,7 @@ async fn basic_reindex(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn concurrent_reindex(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -66,6 +68,7 @@ async fn concurrent_reindex(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn reindex_with_updates(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -99,6 +102,7 @@ async fn reindex_with_updates(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn reindex_with_deletes(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -130,6 +134,7 @@ async fn reindex_with_deletes(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn reindex_schema_validation(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -153,6 +158,7 @@ async fn reindex_schema_validation(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn reindex_partial_index(mut conn: PgConnection) -> Result<()> {
     "CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');"
         .execute(&mut conn);
@@ -183,6 +189,7 @@ async fn reindex_partial_index(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn concurrent_reindex_with_updates(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -210,6 +217,7 @@ async fn concurrent_reindex_with_updates(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn reindex_table(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -232,6 +240,7 @@ async fn reindex_table(mut conn: PgConnection) -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn concurrent_index_creation(mut conn: PgConnection) -> Result<()> {
     SimpleProductsTable::setup().execute(&mut conn);
 

--- a/tests/tests/replication.rs
+++ b/tests/tests/replication.rs
@@ -201,6 +201,7 @@ impl EphemeralPostgres {
 
 // Test function to test the ephemeral PostgreSQL setup
 #[rstest]
+#[async_std::test]
 async fn test_logical_replication() -> Result<()> {
     let config = "
         wal_level = logical
@@ -387,6 +388,7 @@ async fn test_logical_replication() -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn test_ephemeral_postgres_with_pg_basebackup() -> Result<()> {
     let config = "
         wal_level = logical
@@ -485,6 +487,7 @@ async fn test_ephemeral_postgres_with_pg_basebackup() -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn test_physical_streaming_replication() -> Result<()> {
     // Create a unique directory for WAL archiving
     let archive_dir = TempDir::new().expect("Failed to create archive dir for WALs");
@@ -643,6 +646,7 @@ async fn test_physical_streaming_replication() -> Result<()> {
 }
 
 #[rstest]
+#[async_std::test]
 async fn test_wal_streaming_replication_with_pg_search() -> Result<()> {
     // Primary Postgres setup + insert data
     let postgresql_conf = "

--- a/tests/tests/snapshot.rs
+++ b/tests/tests/snapshot.rs
@@ -21,6 +21,7 @@ use sqlx::PgConnection;
 use tests::fixtures::*;
 
 #[rstest]
+#[async_std::test]
 async fn score_bm25_after_delete(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -35,6 +36,7 @@ async fn score_bm25_after_delete(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn snippet_after_delete(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -49,6 +51,7 @@ async fn snippet_after_delete(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn score_bm25_after_update(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -69,6 +72,7 @@ async fn score_bm25_after_update(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn snippet_after_update(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -91,6 +95,7 @@ async fn snippet_after_update(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn score_bm25_after_rollback(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     "DELETE FROM paradedb.bm25_search WHERE id = 3".execute(&mut conn);
@@ -113,6 +118,7 @@ async fn score_bm25_after_rollback(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn snippet_after_rollback(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     "DELETE FROM paradedb.bm25_search WHERE id = 3".execute(&mut conn);
@@ -135,6 +141,7 @@ async fn snippet_after_rollback(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn score_bm25_after_vacuum(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -157,6 +164,7 @@ async fn score_bm25_after_vacuum(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn snippet_after_vacuum(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 

--- a/tests/tests/sorting.rs
+++ b/tests/tests/sorting.rs
@@ -204,6 +204,7 @@ fn sort_by_raw(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn test_compound_sort(mut conn: PgConnection) {
     "SET max_parallel_workers to 0;".execute(&mut conn);
 
@@ -225,6 +226,7 @@ async fn test_compound_sort(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn compound_sort_expression(mut conn: PgConnection) {
     "SET max_parallel_workers to 0;".execute(&mut conn);
 
@@ -247,6 +249,7 @@ async fn compound_sort_expression(mut conn: PgConnection) {
 }
 
 #[rstest]
+#[async_std::test]
 async fn compound_sort_partitioned(mut conn: PgConnection) {
     "SET max_parallel_workers to 0;".execute(&mut conn);
 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -33,7 +33,7 @@ icu_segmenter = "2.2.0"
 opencc-jieba-rs = { git = "https://github.com/paradedb/opencc-jieba-rs", branch = "paradedb.no-msrv" }
 
 [dev-dependencies]
-rstest = "0.25.0"
+rstest = "0.26.1"
 
 [package.metadata.cargo-machete]
 ignored = ["strum"]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Bumps `rstest` from `0.25.0` to `0.26.1` in the four crates that use it — `benchmarks`, `pg_search`, `tests` and `tokenizers` — and adds an explicit `#[async_std::test]` to the 57 async `#[rstest]` tests that 0.26 no longer accepts without one.

Third of the major-version dependency upgrades, done one at a time (after #5843 sysinfo and #5844 syn).

## Why

`rstest` backs 557 `#[rstest]` call sites across the workspace.

## How

### The documented breaking change does not affect us

`0.26.0`'s changelog lists one breaking change — `#[files(...)]` now ignores matched directory paths by default. Nothing here uses `#[files]`, `#[dirs]` or `#[mode]`, so it doesn't apply.

### The undocumented one does

0.26 also rejects an async `#[rstest]` that carries no test attribute:

```
error: async test requires either explicit `test_attr` or implicit (attribute path ends with `test`)
  --> tests/tests/replication.rs:204:10
```

0.25 supplied one silently: `resolve_default_test_attr` in `rstest_macros` returned `#[async_std::test]` for async functions. 0.26 requires it written out.

The fix adds exactly what 0.25 generated, `#[async_std::test]`, so behaviour is unchanged. `tests` already depends on `async-std` with the `attributes` feature, and sqlx already runs on `runtime-async-std`.

**Scope:** CI reported only the 4 sites in `replication.rs`, because the build aborts at the first failing test target. Scanning the workspace for `#[rstest]` on an `async fn` with no attribute whose path ends in `test` found **57 sites across 10 files**, all under `tests/`. The 27 places that already stack `#[rstest]` with `#[tokio::test]` are untouched.

**Placement matters.** The attribute goes immediately before the function signature, not directly under `#[rstest]`. Putting it above the `#[case(...)]` attributes silently drops every case but the first — a two-case async test generated only `case_1`, with no error. A compile check would not catch that. None of the 57 sites carry `#[case]` today, so both placements happen to work here, but the correct one shouldn't depend on that.

## Tests

Only `benchmarks` builds locally; `pg_search`, `tests` and `tokenizers` all reach lindera, whose build script downloads dictionaries from `lindera.dev` — blocked by egress policy in my environment. So the rstest behaviour was verified directly against both versions instead.

**Equivalence of the async fix** — bare `#[rstest] async fn` under 0.25 vs. the rewritten form under 0.26.1, over no-arg, fixture-injected, `Result`-returning and multi-case async tests. Identical test names, identical results, all cases present. This is the check that caught the case-dropping placement bug.

**The non-async surface** — fixtures (including a fixture depending on another fixture, as `conn(database)` does), `#[from(..)]` renaming, plain and named `#[case]`, `#[ignore]` bare and with a reason, and `#[rstest]` + `#[tokio::test]` stacking. Identical across both versions, which matters because named cases expand to filterable names like `case_1_asc_serial`.

Also run against this branch:

- `cargo check -p benchmarks --all-targets` — clean
- `cargo clippy -p benchmarks --all-targets` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p benchmarks` — all passed, including the 16 rstest-generated cases

The full `tests` suite compiles only on CI, which is what the matrix jobs on this PR now cover.

## Remaining

After this and `toml` (#5847): `lindera` (1.5.1 → 4.0.1), `bincode` (2.0.1 → 3.0.0), `strum`/`strum_macros` (0.27.2 → 0.28.0), `cmd_lib` (1.9.6 → 2.0.0), `proptest-derive` (0.6.0 → 0.8.0), `emojis` (0.8.2 → 0.9.0).

Two carry real risk: **lindera 4.0** dropped the `compress` feature, so embedded dictionaries become raw `include_bytes!` — a `.so` size vs. startup trade-off worth measuring, plus segmentation output needs checking. **bincode 3** touches an on-disk encoding.