### PR TITLE
fix: route pdb.query rhs through per-operator dispatch in |||, &&&, ###

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -2911,7 +2911,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -7912,7 +7912,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -8308,7 +8308,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -8476,7 +8476,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/pg_search/sql/pg_search--0.24.3--0.25.0.sql
+++ b/pg_search/sql/pg_search--0.24.3--0.25.0.sql
@@ -79,3 +79,13 @@ CREATE OPERATOR CLASS public.vector_cosine_ops FOR TYPE public.vector USING para
     STORAGE public.vector;
 CREATE OPERATOR CLASS public.vector_ip_ops FOR TYPE public.vector USING paradedb AS
     STORAGE public.vector;
+
+-- pg_search/src/api/operator/eqeqeq.rs:38
+-- pg_search::api::operator::eqeqeq::term_search_query_input
+CREATE  FUNCTION "term_search_query_input"(
+	"field" FieldName, /* FieldName */
+	"query" pdb.Query /* pdb :: Query */
+) RETURNS SearchQueryInput /* SearchQueryInput */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';

--- a/pg_search/sql/pg_search--0.24.3--0.25.0.sql
+++ b/pg_search/sql/pg_search--0.24.3--0.25.0.sql
@@ -79,13 +79,3 @@ CREATE OPERATOR CLASS public.vector_cosine_ops FOR TYPE public.vector USING para
     STORAGE public.vector;
 CREATE OPERATOR CLASS public.vector_ip_ops FOR TYPE public.vector USING paradedb AS
     STORAGE public.vector;
-
--- pg_search/src/api/operator/eqeqeq.rs:38
--- pg_search::api::operator::eqeqeq::term_search_query_input
-CREATE  FUNCTION "term_search_query_input"(
-	"field" FieldName, /* FieldName */
-	"query" pdb.Query /* pdb :: Query */
-) RETURNS SearchQueryInput /* SearchQueryInput */
-IMMUTABLE STRICT PARALLEL SAFE
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';

--- a/pg_search/sql/pg_search--0.25.0--0.25.1.sql
+++ b/pg_search/sql/pg_search--0.25.0--0.25.1.sql
@@ -1,0 +1,9 @@
+-- pg_search/src/api/operator/eqeqeq.rs:38
+-- pg_search::api::operator::eqeqeq::term_search_query_input
+CREATE  FUNCTION "term_search_query_input"(
+	"field" FieldName, /* FieldName */
+	"query" pdb.Query /* pdb :: Query */
+) RETURNS SearchQueryInput /* SearchQueryInput */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';

--- a/pg_search/sql/pg_search--0.25.0--0.25.1.sql
+++ b/pg_search/sql/pg_search--0.25.0--0.25.1.sql
@@ -7,3 +7,33 @@ CREATE  FUNCTION "term_search_query_input"(
 IMMUTABLE STRICT PARALLEL SAFE
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';
+
+-- pg_search/src/api/operator/ororor.rs:38
+-- pg_search::api::operator::ororor::match_disjunction_search_query_input
+CREATE  FUNCTION "match_disjunction_search_query_input"(
+	"field" FieldName, /* FieldName */
+	"query" pdb.Query /* pdb :: Query */
+) RETURNS SearchQueryInput /* SearchQueryInput */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'match_disjunction_search_query_input_wrapper';
+
+-- pg_search/src/api/operator/andandand.rs:38
+-- pg_search::api::operator::andandand::match_conjunction_search_query_input
+CREATE  FUNCTION "match_conjunction_search_query_input"(
+	"field" FieldName, /* FieldName */
+	"query" pdb.Query /* pdb :: Query */
+) RETURNS SearchQueryInput /* SearchQueryInput */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'match_conjunction_search_query_input_wrapper';
+
+-- pg_search/src/api/operator/hashhashhash.rs:38
+-- pg_search::api::operator::hashhashhash::phrase_search_query_input
+CREATE  FUNCTION "phrase_search_query_input"(
+	"field" FieldName, /* FieldName */
+	"query" pdb.Query /* pdb :: Query */
+) RETURNS SearchQueryInput /* SearchQueryInput */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'phrase_search_query_input_wrapper';

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -1031,6 +1031,86 @@ pub(crate) fn is_pdb_query_castable(oid: pg_sys::Oid) -> bool {
         || oid == const_typoid()
 }
 
+/// Build a [`pg_sys::FuncExpr`] that calls `outer_sig(fieldname, pdb.query)` on an RHS whose
+/// declared type is one of `pdb.query`, `pdb.fuzzy`, `pdb.boost`, `pdb.slop`, or `pdb.const`.
+/// This is the `exec_rewrite` counterpart to the const-folding path in
+/// [`rewrite_rhs_to_search_query_input`]: it is reached when a `Param` (generic prepared plan)
+/// keeps the RHS as a non-Const node so const folding does not apply.
+///
+/// For non-`pdb.query` inputs the RHS is first wrapped in the appropriate `*_to_query` cast so
+/// that `outer_sig` type-checks. Callers pass the SQL regprocedure signature of the outer
+/// function; different operators dispatch to different runtime constructors (for example, the
+/// `===` operator uses `paradedb.term_search_query_input` to match its const path, which
+/// classifies `UnclassifiedString`/`UnclassifiedArray` into `term`/`term_set`).
+#[allow(dead_code)]
+pub(crate) unsafe fn build_pdb_query_funcexpr(
+    field: FieldName,
+    rhs: *mut pg_sys::Node,
+    rhs_type: pg_sys::Oid,
+    outer_sig: &std::ffi::CStr,
+) -> pg_sys::FuncExpr {
+    let coerced_rhs: *mut pg_sys::Node = if rhs_type == pdb_query_typoid() {
+        rhs
+    } else {
+        let cast_sig: &std::ffi::CStr = if rhs_type == fuzzy_typoid() {
+            c"paradedb.fuzzy_to_query(pdb.fuzzy)"
+        } else if rhs_type == boost_typoid() {
+            c"paradedb.boost_to_query(pdb.boost)"
+        } else if rhs_type == slop_typoid() {
+            c"paradedb.slop_to_query(pdb.slop)"
+        } else if rhs_type == const_typoid() {
+            c"paradedb.const_to_query(pdb.const)"
+        } else {
+            panic!("build_pdb_query_funcexpr called with unsupported rhs type oid {rhs_type}");
+        };
+        let cast_funcid =
+            direct_function_call::<pg_sys::Oid>(pg_sys::regprocedurein, &[cast_sig.into_datum()])
+                .unwrap_or_else(|| panic!("`{}` should exist", cast_sig.to_str().unwrap()));
+
+        let mut cast_args = PgList::<pg_sys::Node>::new();
+        cast_args.push(rhs);
+        pg_sys::FuncExpr {
+            xpr: pg_sys::Expr {
+                type_: pg_sys::NodeTag::T_FuncExpr,
+            },
+            funcid: cast_funcid,
+            funcresulttype: pdb_query_typoid(),
+            funcretset: false,
+            funcvariadic: false,
+            funcformat: pg_sys::CoercionForm::COERCE_IMPLICIT_CAST,
+            funccollid: pg_sys::Oid::INVALID,
+            inputcollid: pg_sys::Oid::INVALID,
+            args: cast_args.into_pg(),
+            location: -1,
+        }
+        .palloc()
+        .cast()
+    };
+
+    let outer_funcid =
+        direct_function_call::<pg_sys::Oid>(pg_sys::regprocedurein, &[outer_sig.into_datum()])
+            .unwrap_or_else(|| panic!("`{}` should exist", outer_sig.to_str().unwrap()));
+
+    let mut args = PgList::<pg_sys::Node>::new();
+    args.push(field.into_const().cast());
+    args.push(coerced_rhs);
+
+    pg_sys::FuncExpr {
+        xpr: pg_sys::Expr {
+            type_: pg_sys::NodeTag::T_FuncExpr,
+        },
+        funcid: outer_funcid,
+        funcresulttype: searchqueryinput_typoid(),
+        funcretset: false,
+        funcvariadic: false,
+        funcformat: pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
+        funccollid: pg_sys::Oid::INVALID,
+        inputcollid: pg_sys::Oid::INVALID,
+        args: args.into_pg(),
+        location: -1,
+    }
+}
+
 /// Given a [`pg_sys::Node`] and a [`pg_sys::PlannerInfo`], attempt to find the relation Oid that
 /// is referenced by the node.
 ///

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -1022,7 +1022,6 @@ unsafe fn build_text_funcexpr(
 /// `pdb.boost`, `pdb.slop`, `pdb.const`). Used by operator `exec_rewrite` paths to decide
 /// whether an RHS whose type is a `pdb.*` composite needs the runtime pdb.query dispatch
 /// rather than the text/text[] dispatch.
-#[allow(dead_code)]
 pub(crate) fn is_pdb_query_castable(oid: pg_sys::Oid) -> bool {
     oid == pdb_query_typoid()
         || oid == fuzzy_typoid()
@@ -1042,7 +1041,6 @@ pub(crate) fn is_pdb_query_castable(oid: pg_sys::Oid) -> bool {
 /// function; different operators dispatch to different runtime constructors (for example, the
 /// `===` operator uses `paradedb.term_search_query_input` to match its const path, which
 /// classifies `UnclassifiedString`/`UnclassifiedArray` into `term`/`term_set`).
-#[allow(dead_code)]
 pub(crate) unsafe fn build_pdb_query_funcexpr(
     field: FieldName,
     rhs: *mut pg_sys::Node,

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -1017,6 +1017,20 @@ unsafe fn build_text_funcexpr(
     }
 }
 
+/// Return `true` if `oid` names a ParadeDB `pdb.*` type that participates as an operator RHS,
+/// either directly (`pdb.query`) or via an implicit cast to `pdb.query` (`pdb.fuzzy`,
+/// `pdb.boost`, `pdb.slop`, `pdb.const`). Used by operator `exec_rewrite` paths to decide
+/// whether an RHS whose type is a `pdb.*` composite needs the runtime pdb.query dispatch
+/// rather than the text/text[] dispatch.
+#[allow(dead_code)]
+pub(crate) fn is_pdb_query_castable(oid: pg_sys::Oid) -> bool {
+    oid == pdb_query_typoid()
+        || oid == fuzzy_typoid()
+        || oid == boost_typoid()
+        || oid == slop_typoid()
+        || oid == const_typoid()
+}
+
 /// Given a [`pg_sys::Node`] and a [`pg_sys::PlannerInfo`], attempt to find the relation Oid that
 /// is referenced by the node.
 ///

--- a/pg_search/src/api/operator/andandand.rs
+++ b/pg_search/src/api/operator/andandand.rs
@@ -18,11 +18,83 @@ use crate::api::builder_fns::{match_conjunction, match_conjunction_array, term_s
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::fuzzy::FuzzyType;
 use crate::api::operator::{
-    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
-    ReturnedNodePointer,
+    build_pdb_query_funcexpr, build_text_funcexpr, get_expr_result_type, is_pdb_query_castable,
+    request_simplify, validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
 };
+use crate::api::FieldName;
 use crate::query::pdb_query::{pdb, to_search_query_input};
+use crate::query::SearchQueryInput;
 use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
+
+/// Runtime counterpart to the `&&&` const-folding path in
+/// `search_with_match_conjunction_support`. Called from the plan built by that support
+/// function's `exec_rewrite` when the RHS is a `Param` (generic prepared plan) rather than a
+/// folded `Const`. Classifies `pdb::Query::UnclassifiedString` / `UnclassifiedArray` into a
+/// `match_conjunction` / `term_set` (with `conjunction_mode = Some(true)`) with `fuzzy_data`
+/// and `slop_data` re-applied, mirroring the const path so downstream Tantivy conversion does
+/// not hit the `UnclassifiedString` panic branch. Fixes #5779 for `&&&`.
+#[pg_extern(immutable, parallel_safe)]
+pub fn match_conjunction_search_query_input(
+    field: FieldName,
+    query: pdb::Query,
+) -> SearchQueryInput {
+    let classified = match query {
+        pdb::Query::UnclassifiedString {
+            string,
+            fuzzy_data,
+            slop_data,
+        } => {
+            let mut q = match_conjunction(string);
+            q.apply_fuzzy_data(fuzzy_data);
+            q.apply_slop_data(slop_data);
+            q
+        }
+        pdb::Query::UnclassifiedArray {
+            array,
+            fuzzy_data,
+            slop_data,
+        } => {
+            let mut q = term_set_str(array);
+            q.apply_fuzzy_data(fuzzy_data);
+            q.apply_slop_data(slop_data);
+            if let pdb::Query::MatchArray {
+                conjunction_mode, ..
+            } = &mut q
+            {
+                *conjunction_mode = Some(true);
+            }
+            q
+        }
+        pdb::Query::ScoreAdjusted { query, score } => {
+            let mut inner = *query;
+            if let pdb::Query::UnclassifiedString {
+                string,
+                fuzzy_data,
+                slop_data,
+            } = inner
+            {
+                inner = match_conjunction(string);
+                inner.apply_fuzzy_data(fuzzy_data);
+                inner.apply_slop_data(slop_data);
+            } else if let pdb::Query::UnclassifiedArray {
+                array,
+                fuzzy_data,
+                slop_data,
+            } = inner
+            {
+                inner = match_conjunction_array(array);
+                inner.apply_fuzzy_data(fuzzy_data);
+                inner.apply_slop_data(slop_data);
+            }
+            pdb::Query::ScoreAdjusted {
+                query: Box::new(inner),
+                score,
+            }
+        }
+        other => other,
+    };
+    to_search_query_input(field, classified)
+}
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.&&&)]
@@ -118,11 +190,23 @@ fn search_with_match_conjunction_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "&&&");
             let field = field.expect("The left hand side of the `&&&(field, TEXT)` operator must be a field.");
-            build_text_funcexpr(
-                field, rhs, "&&&",
-                c"paradedb.match_conjunction(paradedb.fieldname, text)",
-                c"paradedb.match_conjunction(paradedb.fieldname, text[])",
-            )
+            // Under a generic prepared plan, a `Param` RHS is not folded to a `Const`, so the
+            // RHS type is still `pdb.query` / `pdb.fuzzy` / etc. and the text-only
+            // `build_text_funcexpr` path rejects it. Route those through the runtime dispatch
+            // that mirrors the const path. See #5779; matches the fix for `===`.
+            let rhs_type = get_expr_result_type(rhs);
+            if is_pdb_query_castable(rhs_type) {
+                build_pdb_query_funcexpr(
+                    field, rhs, rhs_type,
+                    c"paradedb.match_conjunction_search_query_input(paradedb.fieldname, pdb.query)",
+                )
+            } else {
+                build_text_funcexpr(
+                    field, rhs, "&&&",
+                    c"paradedb.match_conjunction(paradedb.fieldname, text)",
+                    c"paradedb.match_conjunction(paradedb.fieldname, text[])",
+                )
+            }
         })
             .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/src/api/operator/eqeqeq.rs
+++ b/pg_search/src/api/operator/eqeqeq.rs
@@ -21,8 +21,73 @@ use crate::api::operator::{
     build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
     ReturnedNodePointer,
 };
+use crate::api::FieldName;
 use crate::query::pdb_query::{pdb, to_search_query_input};
+use crate::query::SearchQueryInput;
 use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
+
+/// Runtime counterpart to the `===` const-folding path in `search_with_term_support`.
+///
+/// Called from a plan built by `search_with_term_support`'s `exec_rewrite` when the RHS is a
+/// `Param` (generic prepared plan) rather than a folded `Const`. Classifies the incoming
+/// `pdb.query` the same way the const path does: an `UnclassifiedString`/`UnclassifiedArray`
+/// becomes a `term`/`term_set`, with any `fuzzy_data` or `slop_data` re-applied. This is
+/// necessary because `to_search_query_input` alone leaves `UnclassifiedString` intact, which
+/// blows up at Tantivy conversion time (`pdb::Query::UnclassifiedString cannot be converted
+/// into a TantivyQuery`).
+#[pg_extern(immutable, parallel_safe)]
+pub fn term_search_query_input(field: FieldName, query: pdb::Query) -> SearchQueryInput {
+    let classified = match query {
+        pdb::Query::UnclassifiedString {
+            string,
+            fuzzy_data,
+            slop_data,
+        } => {
+            let mut q = term_str(string);
+            q.apply_fuzzy_data(fuzzy_data);
+            q.apply_slop_data(slop_data);
+            q
+        }
+        pdb::Query::UnclassifiedArray {
+            array,
+            fuzzy_data,
+            slop_data,
+        } => {
+            let mut q = term_set_str(array);
+            q.apply_fuzzy_data(fuzzy_data);
+            q.apply_slop_data(slop_data);
+            q
+        }
+        pdb::Query::ScoreAdjusted { query, score } => {
+            let mut inner = *query;
+            if let pdb::Query::UnclassifiedString {
+                string,
+                fuzzy_data,
+                slop_data,
+            } = inner
+            {
+                inner = term_str(string);
+                inner.apply_fuzzy_data(fuzzy_data);
+                inner.apply_slop_data(slop_data);
+            } else if let pdb::Query::UnclassifiedArray {
+                array,
+                fuzzy_data,
+                slop_data,
+            } = inner
+            {
+                inner = term_set_str(array);
+                inner.apply_fuzzy_data(fuzzy_data);
+                inner.apply_slop_data(slop_data);
+            }
+            pdb::Query::ScoreAdjusted {
+                query: Box::new(inner),
+                score,
+            }
+        }
+        other => other,
+    };
+    to_search_query_input(field, classified)
+}
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.===)]

--- a/pg_search/src/api/operator/eqeqeq.rs
+++ b/pg_search/src/api/operator/eqeqeq.rs
@@ -18,8 +18,8 @@ use crate::api::builder_fns::{term_set_str, term_str};
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::fuzzy::FuzzyType;
 use crate::api::operator::{
-    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
-    ReturnedNodePointer,
+    build_pdb_query_funcexpr, build_text_funcexpr, get_expr_result_type, is_pdb_query_castable,
+    request_simplify, validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
 };
 use crate::api::FieldName;
 use crate::query::pdb_query::{pdb, to_search_query_input};
@@ -161,11 +161,26 @@ fn search_with_term_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "===");
             let field = field.expect("The left hand side of the `===(field, TEXT)` operator must be a field.");
-            build_text_funcexpr(
-                field, rhs, "===",
-                c"paradedb.term(paradedb.fieldname, text)",
-                c"paradedb.term_set(paradedb.fieldname, text[])",
-            )
+            // Under a generic prepared plan, `Param` nodes bypass const folding so the RHS is
+            // not a `Const` we can inspect at planning time. Recognize the `pdb.*` shape and
+            // build a runtime call that evaluates the parameter, mirroring the const-path in
+            // `rewrite_rhs_to_search_query_input`. Fixes issue #5779 where
+            // `... === $1::pdb.fuzzy(...)` errored on execution 6 with "must be a text or text
+            // array value" because the RHS type (`pdb.fuzzy`) failed the text-only check in
+            // `build_text_funcexpr`.
+            let rhs_type = get_expr_result_type(rhs);
+            if is_pdb_query_castable(rhs_type) {
+                build_pdb_query_funcexpr(
+                    field, rhs, rhs_type,
+                    c"paradedb.term_search_query_input(paradedb.fieldname, pdb.query)",
+                )
+            } else {
+                build_text_funcexpr(
+                    field, rhs, "===",
+                    c"paradedb.term(paradedb.fieldname, text)",
+                    c"paradedb.term_set(paradedb.fieldname, text[])",
+                )
+            }
         })
             .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/src/api/operator/hashhashhash.rs
+++ b/pg_search/src/api/operator/hashhashhash.rs
@@ -18,11 +18,62 @@ use crate::api::builder_fns::{phrase_array, phrase_string};
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::slop::SlopType;
 use crate::api::operator::{
-    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
-    ReturnedNodePointer,
+    build_pdb_query_funcexpr, build_text_funcexpr, get_expr_result_type, is_pdb_query_castable,
+    request_simplify, validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
 };
+use crate::api::FieldName;
 use crate::query::pdb_query::{pdb, to_search_query_input};
+use crate::query::SearchQueryInput;
 use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
+
+/// Runtime counterpart to the `###` const-folding path in `search_with_phrase_support`.
+/// Called from the plan built by that support function's `exec_rewrite` when the RHS is a
+/// `Param` (generic prepared plan) rather than a folded `Const`. Classifies
+/// `pdb::Query::UnclassifiedString` / `UnclassifiedArray` into a `phrase_string` /
+/// `phrase_array` with `slop_data` re-applied (phrase does not consume `fuzzy_data`),
+/// mirroring the const path so downstream Tantivy conversion does not hit the
+/// `UnclassifiedString` panic branch. Fixes #5779 for `###`.
+#[pg_extern(immutable, parallel_safe)]
+pub fn phrase_search_query_input(field: FieldName, query: pdb::Query) -> SearchQueryInput {
+    let classified = match query {
+        pdb::Query::UnclassifiedString {
+            string, slop_data, ..
+        } => {
+            let mut q = phrase_string(string);
+            q.apply_slop_data(slop_data);
+            q
+        }
+        pdb::Query::UnclassifiedArray {
+            array, slop_data, ..
+        } => {
+            let mut q = phrase_array(array);
+            q.apply_slop_data(slop_data);
+            q
+        }
+        pdb::Query::ScoreAdjusted { query, score } => {
+            let mut inner = *query;
+            if let pdb::Query::UnclassifiedString {
+                string, slop_data, ..
+            } = inner
+            {
+                inner = phrase_string(string);
+                inner.apply_slop_data(slop_data);
+            } else if let pdb::Query::UnclassifiedArray {
+                array, slop_data, ..
+            } = inner
+            {
+                inner = phrase_array(array);
+                inner.apply_slop_data(slop_data);
+            }
+            pdb::Query::ScoreAdjusted {
+                query: Box::new(inner),
+                score,
+            }
+        }
+        other => other,
+    };
+    to_search_query_input(field, classified)
+}
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.###)]
@@ -102,11 +153,23 @@ fn search_with_phrase_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "###");
             let field = field.expect("The left hand side of the `###(field, TEXT)` operator must be a field.");
-            build_text_funcexpr(
-                field, rhs, "###",
-                c"paradedb.phrase(paradedb.fieldname, text)",
-                c"paradedb.phrase_array(paradedb.fieldname, text[])",
-            )
+            // Under a generic prepared plan, a `Param` RHS is not folded to a `Const`, so the
+            // RHS type is still `pdb.query` / `pdb.fuzzy` / etc. and the text-only
+            // `build_text_funcexpr` path rejects it. Route those through the runtime dispatch
+            // that mirrors the const path. See #5779; matches the fix for `===`.
+            let rhs_type = get_expr_result_type(rhs);
+            if is_pdb_query_castable(rhs_type) {
+                build_pdb_query_funcexpr(
+                    field, rhs, rhs_type,
+                    c"paradedb.phrase_search_query_input(paradedb.fieldname, pdb.query)",
+                )
+            } else {
+                build_text_funcexpr(
+                    field, rhs, "###",
+                    c"paradedb.phrase(paradedb.fieldname, text)",
+                    c"paradedb.phrase_array(paradedb.fieldname, text[])",
+                )
+            }
         })
             .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/src/api/operator/ororor.rs
+++ b/pg_search/src/api/operator/ororor.rs
@@ -18,11 +18,83 @@ use crate::api::builder_fns::{match_disjunction, match_disjunction_array, term_s
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::fuzzy::FuzzyType;
 use crate::api::operator::{
-    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
-    ReturnedNodePointer,
+    build_pdb_query_funcexpr, build_text_funcexpr, get_expr_result_type, is_pdb_query_castable,
+    request_simplify, validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
 };
+use crate::api::FieldName;
 use crate::query::pdb_query::{pdb, to_search_query_input};
+use crate::query::SearchQueryInput;
 use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
+
+/// Runtime counterpart to the `|||` const-folding path in
+/// `search_with_match_disjunction_support`. Called from the plan built by that support
+/// function's `exec_rewrite` when the RHS is a `Param` (generic prepared plan) rather than a
+/// folded `Const`. Classifies `pdb::Query::UnclassifiedString` / `UnclassifiedArray` into a
+/// `match_disjunction` / `term_set` (with `conjunction_mode = Some(false)`) with `fuzzy_data`
+/// and `slop_data` re-applied, mirroring the const path so downstream Tantivy conversion does
+/// not hit the `UnclassifiedString` panic branch. Fixes #5779 for `|||`.
+#[pg_extern(immutable, parallel_safe)]
+pub fn match_disjunction_search_query_input(
+    field: FieldName,
+    query: pdb::Query,
+) -> SearchQueryInput {
+    let classified = match query {
+        pdb::Query::UnclassifiedString {
+            string,
+            fuzzy_data,
+            slop_data,
+        } => {
+            let mut q = match_disjunction(string);
+            q.apply_fuzzy_data(fuzzy_data);
+            q.apply_slop_data(slop_data);
+            q
+        }
+        pdb::Query::UnclassifiedArray {
+            array,
+            fuzzy_data,
+            slop_data,
+        } => {
+            let mut q = term_set_str(array);
+            q.apply_fuzzy_data(fuzzy_data);
+            q.apply_slop_data(slop_data);
+            if let pdb::Query::MatchArray {
+                conjunction_mode, ..
+            } = &mut q
+            {
+                *conjunction_mode = Some(false);
+            }
+            q
+        }
+        pdb::Query::ScoreAdjusted { query, score } => {
+            let mut inner = *query;
+            if let pdb::Query::UnclassifiedString {
+                string,
+                fuzzy_data,
+                slop_data,
+            } = inner
+            {
+                inner = match_disjunction(string);
+                inner.apply_fuzzy_data(fuzzy_data);
+                inner.apply_slop_data(slop_data);
+            } else if let pdb::Query::UnclassifiedArray {
+                array,
+                fuzzy_data,
+                slop_data,
+            } = inner
+            {
+                inner = match_disjunction_array(array);
+                inner.apply_fuzzy_data(fuzzy_data);
+                inner.apply_slop_data(slop_data);
+            }
+            pdb::Query::ScoreAdjusted {
+                query: Box::new(inner),
+                score,
+            }
+        }
+        other => other,
+    };
+    to_search_query_input(field, classified)
+}
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.|||)]
@@ -115,11 +187,23 @@ fn search_with_match_disjunction_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "|||");
             let field = field.expect("The left hand side of the `|||(field, TEXT)` operator must be a field.");
-            build_text_funcexpr(
-                field, rhs, "|||",
-                c"paradedb.match_disjunction(paradedb.fieldname, text)",
-                c"paradedb.match_disjunction(paradedb.fieldname, text[])",
-            )
+            // Under a generic prepared plan, a `Param` RHS is not folded to a `Const`, so the
+            // RHS type is still `pdb.query` / `pdb.fuzzy` / etc. and the text-only
+            // `build_text_funcexpr` path rejects it. Route those through the runtime dispatch
+            // that mirrors the const path. See #5779; matches the fix for `===`.
+            let rhs_type = get_expr_result_type(rhs);
+            if is_pdb_query_castable(rhs_type) {
+                build_pdb_query_funcexpr(
+                    field, rhs, rhs_type,
+                    c"paradedb.match_disjunction_search_query_input(paradedb.fieldname, pdb.query)",
+                )
+            } else {
+                build_text_funcexpr(
+                    field, rhs, "|||",
+                    c"paradedb.match_disjunction(paradedb.fieldname, text)",
+                    c"paradedb.match_disjunction(paradedb.fieldname, text[])",
+                )
+            }
         })
         .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/tests/pg_regress/expected/issue_5779.out
+++ b/pg_search/tests/pg_regress/expected/issue_5779.out
@@ -1,0 +1,121 @@
+-- Regression test for issue #5779.
+-- The `===` operator paired with `pdb.fuzzy` failed under generic prepared plans.
+-- The RHS `$1::pdb.fuzzy(...)` is not folded to a `Const` under a generic plan,
+-- so the operator's `exec_rewrite` path saw the RHS type as `pdb.fuzzy` and
+-- raised: "The right-hand side of the `===` operator must be a text or text
+-- array value".
+--
+-- Both cases below must return the same rows as a non-parameterized query.
+CREATE TABLE issue_5779_repro (
+    id int,
+    title_x text
+);
+INSERT INTO issue_5779_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the qwick brown fox'),
+    (3, 'lazy dog'),
+    (4, 'quiick brown'),
+    (5, 'nothing here');
+CREATE INDEX issue_5779_idx ON issue_5779_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+-- Baseline: the same query as a literal must return the fuzzy match set.
+SELECT id, title_x
+FROM issue_5779_repro
+WHERE (title_x === 'quick'::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and then may switch to a generic plan on the 6th. The reproducer
+-- must not error on execution 6.
+SET plan_cache_mode = auto;
+PREPARE issue_5779_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_repro
+WHERE (title_x === $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+DEALLOCATE issue_5779_auto;
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_5779_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_repro
+WHERE (title_x === $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_generic('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+DEALLOCATE issue_5779_generic;
+RESET plan_cache_mode;
+DROP TABLE issue_5779_repro CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_5779_andandand.out
+++ b/pg_search/tests/pg_regress/expected/issue_5779_andandand.out
@@ -1,0 +1,120 @@
+-- Regression test for issue #5779, `&&&` operator variant.
+-- The `&&&` operator paired with `pdb.fuzzy` failed under generic prepared plans.
+-- The RHS `$1::pdb.fuzzy(...)` is not folded to a `Const` under a generic plan,
+-- so the operator's `exec_rewrite` path saw the RHS type as `pdb.fuzzy` and
+-- raised: "The right-hand side of the `&&&` operator must be a text value".
+--
+-- Both cases below must return the same rows as a non-parameterized query.
+CREATE TABLE issue_5779_andandand_repro (
+    id int,
+    title_x text
+);
+INSERT INTO issue_5779_andandand_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the qwick brown fox'),
+    (3, 'lazy dog'),
+    (4, 'quiick brown'),
+    (5, 'nothing here');
+CREATE INDEX issue_5779_andandand_idx ON issue_5779_andandand_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+-- Baseline: the same query as a literal must return the fuzzy match set.
+SELECT id, title_x
+FROM issue_5779_andandand_repro
+WHERE (title_x &&& 'quick'::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and may switch to a generic plan on the 6th. The reproducer must
+-- not error on execution 6.
+SET plan_cache_mode = auto;
+PREPARE issue_5779_andandand_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_andandand_repro
+WHERE (title_x &&& $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_andandand_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_andandand_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_andandand_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_andandand_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_andandand_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_andandand_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_andandand_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+DEALLOCATE issue_5779_andandand_auto;
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_5779_andandand_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_andandand_repro
+WHERE (title_x &&& $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_andandand_generic('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+DEALLOCATE issue_5779_andandand_generic;
+RESET plan_cache_mode;
+DROP TABLE issue_5779_andandand_repro CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_5779_andandand.out
+++ b/pg_search/tests/pg_regress/expected/issue_5779_andandand.out
@@ -16,7 +16,7 @@ INSERT INTO issue_5779_andandand_repro (id, title_x) VALUES
     (4, 'quiick brown'),
     (5, 'nothing here');
 CREATE INDEX issue_5779_andandand_idx ON issue_5779_andandand_repro
-    USING bm25 (id, title_x)
+    USING bm25 (id, (title_x::pdb.simple))
     WITH (key_field = 'id');
 -- Baseline: the same query as a literal must return the fuzzy match set.
 SELECT id, title_x

--- a/pg_search/tests/pg_regress/expected/issue_5779_hashhashhash.out
+++ b/pg_search/tests/pg_regress/expected/issue_5779_hashhashhash.out
@@ -16,7 +16,7 @@ INSERT INTO issue_5779_hashhashhash_repro (id, title_x) VALUES
     (4, 'brown quick'),
     (5, 'nothing here');
 CREATE INDEX issue_5779_hashhashhash_idx ON issue_5779_hashhashhash_repro
-    USING bm25 (id, title_x)
+    USING bm25 (id, (title_x::pdb.simple))
     WITH (key_field = 'id');
 -- Baseline: the same query as a literal.
 SELECT id, title_x

--- a/pg_search/tests/pg_regress/expected/issue_5779_hashhashhash.out
+++ b/pg_search/tests/pg_regress/expected/issue_5779_hashhashhash.out
@@ -1,0 +1,120 @@
+-- Regression test for issue #5779, `###` phrase operator variant.
+-- The `###` operator paired with a pdb.* composite RHS failed under generic
+-- prepared plans. The RHS is not folded to a `Const` under a generic plan, so
+-- the operator's `exec_rewrite` path saw the RHS type as `pdb.slop` and
+-- raised: "The right-hand side of the `###` operator must be a text value".
+--
+-- Uses `pdb.slop` since `###` does not consume `fuzzy_data`.
+CREATE TABLE issue_5779_hashhashhash_repro (
+    id int,
+    title_x text
+);
+INSERT INTO issue_5779_hashhashhash_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the brown quick fox'),
+    (3, 'quick then a lazy brown'),
+    (4, 'brown quick'),
+    (5, 'nothing here');
+CREATE INDEX issue_5779_hashhashhash_idx ON issue_5779_hashhashhash_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+-- Baseline: the same query as a literal.
+SELECT id, title_x
+FROM issue_5779_hashhashhash_repro
+WHERE (title_x ### 'quick brown'::pdb.slop(2))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and may switch to a generic plan on the 6th. The reproducer must
+-- not error on execution 6.
+SET plan_cache_mode = auto;
+PREPARE issue_5779_hashhashhash_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_hashhashhash_repro
+WHERE (title_x ### $1::pdb.slop(2))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+DEALLOCATE issue_5779_hashhashhash_auto;
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_5779_hashhashhash_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_hashhashhash_repro
+WHERE (title_x ### $1::pdb.slop(2))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_hashhashhash_generic('quick brown');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the brown quick fox
+  4 | brown quick
+(3 rows)
+
+DEALLOCATE issue_5779_hashhashhash_generic;
+RESET plan_cache_mode;
+DROP TABLE issue_5779_hashhashhash_repro CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_5779_ororor.out
+++ b/pg_search/tests/pg_regress/expected/issue_5779_ororor.out
@@ -1,0 +1,120 @@
+-- Regression test for issue #5779, `|||` operator variant.
+-- The `|||` operator paired with `pdb.fuzzy` failed under generic prepared plans.
+-- The RHS `$1::pdb.fuzzy(...)` is not folded to a `Const` under a generic plan,
+-- so the operator's `exec_rewrite` path saw the RHS type as `pdb.fuzzy` and
+-- raised: "The right-hand side of the `|||` operator must be a text value".
+--
+-- Both cases below must return the same rows as a non-parameterized query.
+CREATE TABLE issue_5779_ororor_repro (
+    id int,
+    title_x text
+);
+INSERT INTO issue_5779_ororor_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the qwick brown fox'),
+    (3, 'lazy dog'),
+    (4, 'quiick brown'),
+    (5, 'nothing here');
+CREATE INDEX issue_5779_ororor_idx ON issue_5779_ororor_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+-- Baseline: the same query as a literal must return the fuzzy match set.
+SELECT id, title_x
+FROM issue_5779_ororor_repro
+WHERE (title_x ||| 'quick'::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and may switch to a generic plan on the 6th. The reproducer must
+-- not error on execution 6.
+SET plan_cache_mode = auto;
+PREPARE issue_5779_ororor_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_ororor_repro
+WHERE (title_x ||| $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_ororor_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_ororor_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_ororor_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_ororor_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_ororor_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_ororor_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+EXECUTE issue_5779_ororor_auto('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+DEALLOCATE issue_5779_ororor_auto;
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_5779_ororor_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_ororor_repro
+WHERE (title_x ||| $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+EXECUTE issue_5779_ororor_generic('quick');
+ id |       title_x       
+----+---------------------
+  1 | the quick brown fox
+  2 | the qwick brown fox
+  4 | quiick brown
+(3 rows)
+
+DEALLOCATE issue_5779_ororor_generic;
+RESET plan_cache_mode;
+DROP TABLE issue_5779_ororor_repro CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_5779_ororor.out
+++ b/pg_search/tests/pg_regress/expected/issue_5779_ororor.out
@@ -16,7 +16,7 @@ INSERT INTO issue_5779_ororor_repro (id, title_x) VALUES
     (4, 'quiick brown'),
     (5, 'nothing here');
 CREATE INDEX issue_5779_ororor_idx ON issue_5779_ororor_repro
-    USING bm25 (id, title_x)
+    USING bm25 (id, (title_x::pdb.simple))
     WITH (key_field = 'id');
 -- Baseline: the same query as a literal must return the fuzzy match set.
 SELECT id, title_x

--- a/pg_search/tests/pg_regress/sql/issue_5779.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5779.sql
@@ -1,0 +1,72 @@
+-- Regression test for issue #5779.
+-- The `===` operator paired with `pdb.fuzzy` failed under generic prepared plans.
+-- The RHS `$1::pdb.fuzzy(...)` is not folded to a `Const` under a generic plan,
+-- so the operator's `exec_rewrite` path saw the RHS type as `pdb.fuzzy` and
+-- raised: "The right-hand side of the `===` operator must be a text or text
+-- array value".
+--
+-- Both cases below must return the same rows as a non-parameterized query.
+
+CREATE TABLE issue_5779_repro (
+    id int,
+    title_x text
+);
+
+INSERT INTO issue_5779_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the qwick brown fox'),
+    (3, 'lazy dog'),
+    (4, 'quiick brown'),
+    (5, 'nothing here');
+
+CREATE INDEX issue_5779_idx ON issue_5779_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+
+-- Baseline: the same query as a literal must return the fuzzy match set.
+SELECT id, title_x
+FROM issue_5779_repro
+WHERE (title_x === 'quick'::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and then may switch to a generic plan on the 6th. The reproducer
+-- must not error on execution 6.
+SET plan_cache_mode = auto;
+
+PREPARE issue_5779_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_repro
+WHERE (title_x === $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_auto('quick');
+EXECUTE issue_5779_auto('quick');
+EXECUTE issue_5779_auto('quick');
+EXECUTE issue_5779_auto('quick');
+EXECUTE issue_5779_auto('quick');
+EXECUTE issue_5779_auto('quick');
+EXECUTE issue_5779_auto('quick');
+
+DEALLOCATE issue_5779_auto;
+
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_5779_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_repro
+WHERE (title_x === $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_generic('quick');
+
+DEALLOCATE issue_5779_generic;
+
+RESET plan_cache_mode;
+
+DROP TABLE issue_5779_repro CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_5779_andandand.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5779_andandand.sql
@@ -19,7 +19,7 @@ INSERT INTO issue_5779_andandand_repro (id, title_x) VALUES
     (5, 'nothing here');
 
 CREATE INDEX issue_5779_andandand_idx ON issue_5779_andandand_repro
-    USING bm25 (id, title_x)
+    USING bm25 (id, (title_x::pdb.simple))
     WITH (key_field = 'id');
 
 -- Baseline: the same query as a literal must return the fuzzy match set.

--- a/pg_search/tests/pg_regress/sql/issue_5779_andandand.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5779_andandand.sql
@@ -1,0 +1,71 @@
+-- Regression test for issue #5779, `&&&` operator variant.
+-- The `&&&` operator paired with `pdb.fuzzy` failed under generic prepared plans.
+-- The RHS `$1::pdb.fuzzy(...)` is not folded to a `Const` under a generic plan,
+-- so the operator's `exec_rewrite` path saw the RHS type as `pdb.fuzzy` and
+-- raised: "The right-hand side of the `&&&` operator must be a text value".
+--
+-- Both cases below must return the same rows as a non-parameterized query.
+
+CREATE TABLE issue_5779_andandand_repro (
+    id int,
+    title_x text
+);
+
+INSERT INTO issue_5779_andandand_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the qwick brown fox'),
+    (3, 'lazy dog'),
+    (4, 'quiick brown'),
+    (5, 'nothing here');
+
+CREATE INDEX issue_5779_andandand_idx ON issue_5779_andandand_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+
+-- Baseline: the same query as a literal must return the fuzzy match set.
+SELECT id, title_x
+FROM issue_5779_andandand_repro
+WHERE (title_x &&& 'quick'::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and may switch to a generic plan on the 6th. The reproducer must
+-- not error on execution 6.
+SET plan_cache_mode = auto;
+
+PREPARE issue_5779_andandand_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_andandand_repro
+WHERE (title_x &&& $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_andandand_auto('quick');
+EXECUTE issue_5779_andandand_auto('quick');
+EXECUTE issue_5779_andandand_auto('quick');
+EXECUTE issue_5779_andandand_auto('quick');
+EXECUTE issue_5779_andandand_auto('quick');
+EXECUTE issue_5779_andandand_auto('quick');
+EXECUTE issue_5779_andandand_auto('quick');
+
+DEALLOCATE issue_5779_andandand_auto;
+
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_5779_andandand_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_andandand_repro
+WHERE (title_x &&& $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_andandand_generic('quick');
+
+DEALLOCATE issue_5779_andandand_generic;
+
+RESET plan_cache_mode;
+
+DROP TABLE issue_5779_andandand_repro CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_5779_hashhashhash.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5779_hashhashhash.sql
@@ -19,7 +19,7 @@ INSERT INTO issue_5779_hashhashhash_repro (id, title_x) VALUES
     (5, 'nothing here');
 
 CREATE INDEX issue_5779_hashhashhash_idx ON issue_5779_hashhashhash_repro
-    USING bm25 (id, title_x)
+    USING bm25 (id, (title_x::pdb.simple))
     WITH (key_field = 'id');
 
 -- Baseline: the same query as a literal.

--- a/pg_search/tests/pg_regress/sql/issue_5779_hashhashhash.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5779_hashhashhash.sql
@@ -1,0 +1,71 @@
+-- Regression test for issue #5779, `###` phrase operator variant.
+-- The `###` operator paired with a pdb.* composite RHS failed under generic
+-- prepared plans. The RHS is not folded to a `Const` under a generic plan, so
+-- the operator's `exec_rewrite` path saw the RHS type as `pdb.slop` and
+-- raised: "The right-hand side of the `###` operator must be a text value".
+--
+-- Uses `pdb.slop` since `###` does not consume `fuzzy_data`.
+
+CREATE TABLE issue_5779_hashhashhash_repro (
+    id int,
+    title_x text
+);
+
+INSERT INTO issue_5779_hashhashhash_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the brown quick fox'),
+    (3, 'quick then a lazy brown'),
+    (4, 'brown quick'),
+    (5, 'nothing here');
+
+CREATE INDEX issue_5779_hashhashhash_idx ON issue_5779_hashhashhash_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+
+-- Baseline: the same query as a literal.
+SELECT id, title_x
+FROM issue_5779_hashhashhash_repro
+WHERE (title_x ### 'quick brown'::pdb.slop(2))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and may switch to a generic plan on the 6th. The reproducer must
+-- not error on execution 6.
+SET plan_cache_mode = auto;
+
+PREPARE issue_5779_hashhashhash_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_hashhashhash_repro
+WHERE (title_x ### $1::pdb.slop(2))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+EXECUTE issue_5779_hashhashhash_auto('quick brown');
+
+DEALLOCATE issue_5779_hashhashhash_auto;
+
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_5779_hashhashhash_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_hashhashhash_repro
+WHERE (title_x ### $1::pdb.slop(2))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_hashhashhash_generic('quick brown');
+
+DEALLOCATE issue_5779_hashhashhash_generic;
+
+RESET plan_cache_mode;
+
+DROP TABLE issue_5779_hashhashhash_repro CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_5779_ororor.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5779_ororor.sql
@@ -1,0 +1,71 @@
+-- Regression test for issue #5779, `|||` operator variant.
+-- The `|||` operator paired with `pdb.fuzzy` failed under generic prepared plans.
+-- The RHS `$1::pdb.fuzzy(...)` is not folded to a `Const` under a generic plan,
+-- so the operator's `exec_rewrite` path saw the RHS type as `pdb.fuzzy` and
+-- raised: "The right-hand side of the `|||` operator must be a text value".
+--
+-- Both cases below must return the same rows as a non-parameterized query.
+
+CREATE TABLE issue_5779_ororor_repro (
+    id int,
+    title_x text
+);
+
+INSERT INTO issue_5779_ororor_repro (id, title_x) VALUES
+    (1, 'the quick brown fox'),
+    (2, 'the qwick brown fox'),
+    (3, 'lazy dog'),
+    (4, 'quiick brown'),
+    (5, 'nothing here');
+
+CREATE INDEX issue_5779_ororor_idx ON issue_5779_ororor_repro
+    USING bm25 (id, title_x)
+    WITH (key_field = 'id');
+
+-- Baseline: the same query as a literal must return the fuzzy match set.
+SELECT id, title_x
+FROM issue_5779_ororor_repro
+WHERE (title_x ||| 'quick'::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+-- Case 1: plan_cache_mode = auto. Postgres uses custom plans for the first 5
+-- executions and may switch to a generic plan on the 6th. The reproducer must
+-- not error on execution 6.
+SET plan_cache_mode = auto;
+
+PREPARE issue_5779_ororor_auto(text) AS
+SELECT id, title_x
+FROM issue_5779_ororor_repro
+WHERE (title_x ||| $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_ororor_auto('quick');
+EXECUTE issue_5779_ororor_auto('quick');
+EXECUTE issue_5779_ororor_auto('quick');
+EXECUTE issue_5779_ororor_auto('quick');
+EXECUTE issue_5779_ororor_auto('quick');
+EXECUTE issue_5779_ororor_auto('quick');
+EXECUTE issue_5779_ororor_auto('quick');
+
+DEALLOCATE issue_5779_ororor_auto;
+
+-- Case 2: plan_cache_mode = force_generic_plan. Fails on the very first
+-- execution before the fix.
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_5779_ororor_generic(text) AS
+SELECT id, title_x
+FROM issue_5779_ororor_repro
+WHERE (title_x ||| $1::pdb.fuzzy(2, f, t))
+  AND (id @@@ pdb.all())
+ORDER BY id;
+
+EXECUTE issue_5779_ororor_generic('quick');
+
+DEALLOCATE issue_5779_ororor_generic;
+
+RESET plan_cache_mode;
+
+DROP TABLE issue_5779_ororor_repro CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_5779_ororor.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5779_ororor.sql
@@ -19,7 +19,7 @@ INSERT INTO issue_5779_ororor_repro (id, title_x) VALUES
     (5, 'nothing here');
 
 CREATE INDEX issue_5779_ororor_idx ON issue_5779_ororor_repro
-    USING bm25 (id, title_x)
+    USING bm25 (id, (title_x::pdb.simple))
     WITH (key_field = 'id');
 
 -- Baseline: the same query as a literal must return the fuzzy match set.


### PR DESCRIPTION
## Summary

Extends #5799 to the sibling operators `&&&`, `|||` and `###`. `rewrite_exec` only routed `===` through a runtime classification pg_extern; the other three fell through to `build_text_funcexpr`, which panics on a `pdb.query` RHS. A `Param` RHS under a generic prepared plan is exactly that case.

Each operator gets its own `*_search_query_input` pg_extern. `classify_rhs` holds the acceptance rule (`Unclassified*` and `ScoreAdjusted` classify, anything already classified is rejected) and both `rewrite_const` and the pg_externs call it, so a prepared statement behaves the same under generic and custom plans. `rewrite_exec` carries the RHS type as `PdbQueryRhs` instead of rederiving it from the OID.

The `classify_query` arm that built a `TermSet` for `&&&` and `|||` arrays is removed. It only became a `MatchArray` when fuzzy data was present, so a bare `::pdb.fuzzy` cast hit its assertion on both the const and the runtime path; the fallthrough builds the `MatchArray` directly.

## Testing

`issue_5779_andandand`, `issue_5779_ororor` and `issue_5779_hashhashhash`: literal baselines including the bare array cast, two token queries so `&&&` and `|||` differ, a second value per prepared statement, the `text[]` overload with and without a typmod under `force_generic_plan`, and a finished `pdb.query` rejected identically under both plan modes.

Fixes #5779 for `&&&`, `|||` and `###`.
