### PR TITLE
chore: upgrade proptest-derive to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6295,9 +6295,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
+checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-px3JpX3EWKN/ca12xZZ1ryxczl0qf42OtDUBgsGItLA=";
+  cargoHash = "sha256-njHDlL+LlRD5g656yqDRPnW2wiY9uVK7dReYqfDt1NE=";
 
   inherit cargo-pgrx postgresql;
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -46,5 +46,5 @@ tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
 uuid = "1.23.1"
 num-traits = "0.2.19"
 proptest = "1.11.0"
-proptest-derive = "0.6.0"
+proptest-derive = "0.8.0"
 env_logger = "0.11.10"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Bumps `proptest-derive` from `0.6.0` to `0.8.0` in `tests`, the only crate that uses it. No source changes were needed; the lockfile moves only `proptest-derive`.

Fourth of the major-version dependency upgrades, done one at a time (after #5843 sysinfo, #5844 syn, #5849 rstest).

**Note:** `proptest` itself is already current at `1.11.0` — this is the derive crate, which versions separately.

## Why

Two majors behind (0.6 → 0.7 → 0.8), and it's the lowest-risk item left: it's test-only, so the blast radius is test compilation and generated-value distribution rather than production behavior.

## How

Both intervening releases are **MSRV bumps and nothing else**:

| release | breaking change |
|---|---|
| 0.7.0 | MSRV → 1.82.0 ([#605](https://github.com/proptest-rs/proptest/pull/605)) |
| 0.8.0 | MSRV → 1.84.0 ([#612](https://github.com/proptest-rs/proptest/pull/612)) |

No API changes listed. Our pinned toolchain is `1.97.1`, so both are satisfied.

A changelog saying "MSRV only" isn't worth much on its own — the rstest 0.26 upgrade in #5849 carried an undocumented breaking change that only the compiler found. So the derive output was compared directly instead.

A harness covering **every `derive(Arbitrary)` shape this workspace uses** was run under both versions with a fixed ChaCha seed:

- unit-variant enums (`JoinType`, `Operator`, `ComparisonOp`, `TokenizerType`)
- tuple variants (`Action::Insert(Message)`)
- struct variants (`Action::Update { .. }`)
- named-field structs (`IndexConfig`)
- `#[proptest(strategy = "any::<prop::sample::Index>()")]` on **both** a named field and a tuple field — the only derive attribute used anywhere in the repo

All six types generated **byte-identical value sequences** across 25 draws each. So the derived strategies are unchanged, and existing proptest regression seeds stay meaningful — which is the part that would actually hurt if it had shifted.

## Tests

- equivalence harness above — identical output under 0.6.0 and 0.8.0
- `cargo fmt --all -- --check` — clean

The `tests` crate cannot be compiled in my environment: it reaches lindera, whose build script downloads dictionaries from `lindera.dev`, a host blocked by egress policy here. The matrix jobs on this PR are what actually compile it.

## Remaining

| crate | current → latest | note |
|---|---|---|
| `lindera` | 1.5.1 → 4.0.1 | 4.0 dropped the `compress` feature — embedded dictionaries become raw `include_bytes!`, a `.so` size vs. startup trade-off worth measuring, plus segmentation output needs checking |
| `bincode` | 2.0.1 → 3.0.0 | touches an on-disk encoding |
| `strum`/`strum_macros` | 0.27.2 → 0.28.0 | |
| `cmd_lib` | 1.9.6 → 2.0.0 | |
| `emojis` | 0.8.2 → 0.9.0 | |

All route through lindera-dependent crates, so none can be built locally while `lindera.dev` is blocked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEm6G1qKw694BQQqb9HBiU)_