### PR TITLE
chore: upgrade strum to 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,7 +2953,7 @@ dependencies = [
  "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -4263,7 +4263,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.27.2",
  "syn 2.0.119",
  "thiserror 2.0.19",
 ]
@@ -4736,8 +4736,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "unicode-blocks",
  "unicode-normalization",
  "unicode-segmentation",
@@ -4787,8 +4787,8 @@ dependencies = [
  "rkyv 0.8.17",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "tar",
  "thiserror 2.0.19",
  "tokio",
@@ -5655,7 +5655,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "stable_deref_trait",
- "strum",
+ "strum 0.28.0",
  "superkmeans-rs",
  "tantivy",
  "tantivy-fst",
@@ -7744,7 +7744,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -7752,6 +7761,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -8109,7 +8130,7 @@ dependencies = [
  "serde_json",
  "soa_derive",
  "sqlx",
- "strum",
+ "strum 0.28.0",
  "tantivy",
  "tempfile",
  "time",
@@ -8260,8 +8281,8 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "tantivy",
  "tantivy-jieba",
  "tracing",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-njHDlL+LlRD5g656yqDRPnW2wiY9uVK7dReYqfDt1NE=";
+  cargoHash = "sha256-MDGWODMU6MtnscnROUcBXrpg4XRhrIn0TBNyohJh/LE=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -58,7 +58,7 @@ tantivy.workspace = true
 thiserror = "2.0.18"
 ordered-float = "5.3.0"
 uuid = "1.23.1"
-strum = { version = "0.27.2" }
+strum = { version = "0.28.0" }
 serde_path_to_error = "0.1.20"
 bincode = { version = "2.0.1", features = [
   "serde",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,7 +37,7 @@ sqlx = { version = "0.9.0", features = [
   "uuid",
   "chrono",
 ] }
-strum = { version = "0.27.2", features = ["derive"] }
+strum = { version = "0.28.0", features = ["derive"] }
 tantivy.workspace = true
 tempfile = "3.27.0"
 time = { version = "0.3.47", features = ["serde"] }

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -21,8 +21,8 @@ serde = "1.0.228"
 serde_json = "1.0.149"
 tantivy.workspace = true
 tracing = "0.1.44"
-strum_macros = "0.27.2"
-strum = { version = "0.27.2", features = ["derive"] }
+strum_macros = "0.28.0"
+strum = { version = "0.28.0", features = ["derive"] }
 tantivy-jieba = { workspace = true }
 emojis = "0.8.2"
 icu_properties = "2.2.0"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Bumps `strum` and `strum_macros` from `0.27.2` to `0.28.0` in `pg_search`, `tests` and `tokenizers`. No source changes were needed.

Fifth of the major-version dependency upgrades, done one at a time (after #5843 sysinfo, #5844 syn, #5849 rstest, #5853 proptest-derive).

## Why

Broadest remaining upgrade — it's the only one touching three crates.

## How

### The documented breaking changes don't apply

`0.28.0`'s one behavioral break is that **`EnumString` now implements `From<&str>` instead of `TryFrom<&str>`** for enums with a `#[strum(default)]` variant ([#476](https://github.com/Peternator7/strum/pull/476)).

Nothing here derives `EnumString`, and there are zero uses of `#[strum(default)]` or `EnumDiscriminants`. The `strum::ParseError` → `core::fmt::Display` change ([#477](https://github.com/Peternator7/strum/pull/477)) is also unused — the `ParseError` matches in this workspace are `std::net::AddrParseError` and tantivy's `QueryParserError`, not strum's. MSRV moves to 1.71, well under our pinned 1.97.1.

The derive surface actually in use is narrow: `VariantNames` (3), `AsRefStr` (3), `EnumIter` (2), `Display` (2), `IntoEnumIterator` (1), with only `serialize_all = "snake_case"` and two `serialize = "..."` overrides.

### What actually needed checking: the derived strings are public API

`SearchTokenizer` derives `VariantNames` + `AsRefStr` under `serialize_all = "snake_case"`, and `SearchTokenizer::VARIANTS` is returned **directly by the `paradedb.tokenizers()` SQL function**:

```rust
pub fn tokenizers() -> TableIterator<'static, (name!(tokenizer, String),)> {
    TableIterator::new(SearchTokenizer::VARIANTS.iter().map(|t| (t.to_string(),)).collect::<Vec<_>>())
}
```

So a change in how strum renders variants like `ICUTokenizer`, `EdgeNgram`, `WhiteSpace` or `ChineseLinderaDeprecated` would be a **user-visible break**, silently changing accepted tokenizer names.

A replica of both derived enums — same attributes, same 23 variants, in their real tuple/struct/unit shapes — was compiled under 0.27.2 and 0.28.0. Identical output:

```
VARIANTS = ["default", "keyword", "keyword_deprecated", "raw", "literal_normalized",
            "white_space", "regex_tokenizer", "chinese_compatible", "source_code",
            "ngram", "edge_ngram", "chinese_lindera_deprecated", "chinese_lindera",
            "japanese_lindera_deprecated", "japanese_lindera", "korean_lindera_deprecated",
            "korean_lindera", "icu", "jieba", "lindera_deprecated", "lindera",
            "unicode_words_deprecated", "unicode_words"]
```

`as_ref()` for every variant shape (including both `serialize = "..."` overrides), `LinderaLanguage::VARIANTS`, and `EnumIter` ordering all matched too.

## ⚠️ This temporarily duplicates strum in the graph

`lindera 1.5.1` pins `strum = "^0.27.2"`, so its subtree keeps 0.27.2 while our crates move to 0.28.0:

```
strum v0.28.0          strum v0.27.2
├── pg_search          ├── lindera v1.5.1
└── tokenizers         └── lindera-dictionary v1.5.1
```

Cost is one extra `strum` + `strum_macros` compile. No `phf` pull-in, since that feature stays off.

**This resolves itself with the lindera upgrade** — `lindera 4.0.1` requires `strum 0.28.0`, so landing that collapses the duplicate. The two upgrades are complementary; if you'd rather not carry the duplication at all, this one could wait until after lindera.

## Tests

All three crates reach lindera, whose build script downloads dictionaries from `lindera.dev` — a host blocked by egress policy in my environment — so none can be compiled locally. The matrix jobs on this PR are what compile them.

- equivalence harness above — identical derived names under 0.27.2 and 0.28.0
- `cargo fmt --all -- --check` — clean

## Remaining

| crate | current → latest | note |
|---|---|---|
| `lindera` | 1.5.1 → 4.0.1 | also collapses the strum duplication above; but 4.0 dropped the `compress` feature, so embedded dictionaries become raw `include_bytes!` — a `.so` size vs. startup trade-off worth measuring, plus segmentation output needs checking |
| `bincode` | 2.0.1 → 3.0.0 | touches an on-disk encoding |
| `cmd_lib` | 1.9.6 → 2.0.0 | |
| `emojis` | 0.8.2 → 0.9.0 | |

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEm6G1qKw694BQQqb9HBiU)_