### PR TITLE
feat: (experiment do not review) SQ4 quantize centroids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5465,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7865,7 +7865,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "bitpacking",
 ]
@@ -7929,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8039,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
+source = "git+https://github.com/paradedb/tantivy.git?rev=70fc8cc677f5cd38f75ece7eae8ee998129eceb1#70fc8cc677f5cd38f75ece7eae8ee998129eceb1"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ debug-assertions = false
 inherits = "dev"
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "c97fc25d7dbac9218d0b5724c290c2bafd785f03", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "70fc8cc677f5cd38f75ece7eae8ee998129eceb1", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -71,7 +71,7 @@ pgrx-tests = "=0.19.2"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c97fc25d7dbac9218d0b5724c290c2bafd785f03" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "70fc8cc677f5cd38f75ece7eae8ee998129eceb1" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-njHDlL+LlRD5g656yqDRPnW2wiY9uVK7dReYqfDt1NE=";
+  cargoHash = "sha256-sNB4DXQIB2vIDGuFdFSaUaVx5IiL+3YwyjDVdjQ3GFk=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/vector/clusterer.rs
+++ b/pg_search/src/vector/clusterer.rs
@@ -213,10 +213,8 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
         centroids: &IvfCentroids,
     ) -> tantivy::Result<Vec<u32>> {
         let IvfVectors::F32(vectors) = vectors;
-        let IvfCentroids::F32(centroids) = centroids;
         let dim = options.dim();
         let vector_matrix = vectors.matrix;
-        let centroid_matrix = centroids;
         if vector_matrix.dims != dim {
             return Err(TantivyError::InvalidArgument(format!(
                 "vector dimensionality mismatch: expected {dim}, got {}",
@@ -237,27 +235,50 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
                 vector_matrix.values.len()
             )));
         }
-        if centroid_matrix.rows == 0 {
+        let num_centroids = centroids.rows();
+        if num_centroids == 0 {
             return Err(TantivyError::InvalidArgument(
                 "cannot assign with zero centroids".to_string(),
             ));
         }
-        if centroid_matrix.dims != dim {
+        if centroids.dims() != dim {
             return Err(TantivyError::InvalidArgument(format!(
                 "centroid dimensionality mismatch: expected {dim}, got {}",
-                centroid_matrix.dims
-            )));
-        }
-        if centroid_matrix.values.len() != centroid_matrix.rows * dim {
-            return Err(TantivyError::InvalidArgument(format!(
-                "centroid value count mismatch: expected {}, got {}",
-                centroid_matrix.rows * dim,
-                centroid_matrix.values.len()
+                centroids.dims()
             )));
         }
         if vector_matrix.rows == 0 {
             return Ok(Vec::new());
         }
+
+        // SuperKMeans scores against a flat f32 matrix, so SQ4 centroids
+        // (what tantivy hands to `assign` from format V3 on) decode into a
+        // transient buffer per batch — for `F32` the values are borrowed
+        // directly. Decoding per call keeps this instance stateless across
+        // the concurrent merges that share it; scoring the codes natively
+        // in superkmeans (or a safely-keyed decode cache) is the follow-up
+        // if the decode ever shows up in merge profiles.
+        let decoded: Vec<f32>;
+        let centroid_values: &[f32] = match centroids {
+            IvfCentroids::F32(matrix) => {
+                if matrix.values.len() != num_centroids * dim {
+                    return Err(TantivyError::InvalidArgument(format!(
+                        "centroid value count mismatch: expected {}, got {}",
+                        num_centroids * dim,
+                        matrix.values.len()
+                    )));
+                }
+                matrix.values.as_slice()
+            }
+            _ => {
+                let mut buf = vec![0f32; num_centroids * dim];
+                for row in 0..num_centroids {
+                    centroids.decode_row_into(row, &mut buf[row * dim..][..dim]);
+                }
+                decoded = buf;
+                decoded.as_slice()
+            }
+        };
 
         let angular = matches!(options.metric(), Metric::Cosine | Metric::Dot);
 
@@ -275,7 +296,7 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
                     let mut config = self.config.clone();
                     config.base.angular = angular;
                     let clusterer = Arc::new(HierarchicalSuperKMeans::with_config(
-                        centroid_matrix.rows,
+                        num_centroids,
                         dim,
                         config,
                     ));
@@ -291,11 +312,7 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
         // Primary (nearest-centroid) assignment via superkmeans, angular-aware
         // for cosine/dot. One cluster per vector — no replication. `n_centroids`
         // is derived from the centroid slice length.
-        let primaries = clusterer.assign(
-            vector_matrix.values,
-            centroid_matrix.values.as_slice(),
-            vector_matrix.rows,
-        );
+        let primaries = clusterer.assign(vector_matrix.values, centroid_values, vector_matrix.rows);
         Ok(primaries)
     }
 }


### PR DESCRIPTION
## What

Adapts to [paradedb/tantivy#197](https://github.com/paradedb/tantivy/pull/197): tantivy now SQ4-compresses trained IVF centroids at merge time — the routing RNG trains on the quantized set, only the packed codes are stored (`.centroids` V3), and the f32 centroid matrix is dropped immediately after training. Centroid footprint (merge working set + on-disk/page-cache) drops 8×.

## Changes

- Bump the pinned tantivy rev to the SQ4 branch head.
- `SuperKMeansIvfClusterer::assign` now receives `IvfCentroids::Sq4 { codes, params, rows }`. SuperKMeans scores against a flat f32 matrix, so the codes decode into a transient buffer per assign batch; `F32` centroids (the pre-V3 shape) are still borrowed directly. Validation moves to the codec-agnostic `rows()`/`dims()` accessors.

## Notes

- The per-batch decode keeps the clusterer stateless across the concurrent merges that share it. If the decode ever shows in merge profiles, the follow-ups are scoring the codes natively in superkmeans (tantivy exports `Sq4Arena`/`Sq4Scorer` + kernels) or a safely-keyed decode cache.
- `train` is unchanged — it still returns f32 centroids; tantivy owns quantization.
- Depends on paradedb/tantivy#197 landing; the rev should be re-pinned to the merge commit once it does.