### PR TITLE
fix: skip vector columns in field-less more_like_this

### DIFF
--- a/pg_search/src/query/more_like_this.rs
+++ b/pg_search/src/query/more_like_this.rs
@@ -19,6 +19,7 @@ use crate::api::version::Version;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::types::TantivyValue;
+use crate::schema::SearchFieldType;
 use pgrx::spi::SpiError;
 use tantivy::query::{
     BooleanQuery, EnableScoring, MoreLikeThis as TantivyMoreLikeThis, Query, Weight,
@@ -195,6 +196,9 @@ impl MoreLikeThisQueryBuilder {
                         continue;
                     }
 
+                    let is_vector =
+                        matches!(search_field.field_type(), SearchFieldType::Vector(..));
+
                     if let Some(ref fields) = fields {
                         if !fields.contains(&search_field.field_name().clone().into_inner()) {
                             continue;
@@ -203,9 +207,13 @@ impl MoreLikeThisQueryBuilder {
                         if search_field.is_json() {
                             panic!("json fields are not supported for more_like_this");
                         }
+
+                        if is_vector {
+                            panic!("vector fields are not supported for more_like_this");
+                        }
                     }
 
-                    if categorized.is_json {
+                    if categorized.is_json || is_vector {
                         continue;
                     }
 

--- a/pg_search/tests/pg_regress/expected/more_like_this.out
+++ b/pg_search/tests/pg_regress/expected/more_like_this.out
@@ -135,3 +135,33 @@ SELECT * FROM mlt where id @@@ pdb.more_like_this(100);
 (0 rows)
 
 DROP TABLE mlt;
+-- Field-less more_like_this skips vector columns (issue #5826)
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE TABLE mlt_vec (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    embedding vector(3)
+);
+INSERT INTO mlt_vec (description, embedding) VALUES
+    ('aaa bbb ccc', '[1,2,3]'),
+    ('aaa aaa', '[4,5,6]'),
+    ('ddd eee fff', '[7,8,9]');
+CREATE INDEX ON mlt_vec USING bm25 (id, description, embedding) WITH (key_field = 'id');
+SELECT id, description FROM mlt_vec WHERE id @@@ pdb.more_like_this(1);
+ id | description 
+----+-------------
+  1 | aaa bbb ccc
+  2 | aaa aaa
+(2 rows)
+
+SELECT id, description FROM mlt_vec WHERE id @@@ pdb.more_like_this(1, ARRAY['description']);
+ id | description 
+----+-------------
+  1 | aaa bbb ccc
+  2 | aaa aaa
+(2 rows)
+
+-- Vector not supported
+SELECT id FROM mlt_vec WHERE id @@@ pdb.more_like_this(1, ARRAY['embedding']);
+ERROR:  vector fields are not supported for more_like_this
+DROP TABLE mlt_vec;

--- a/pg_search/tests/pg_regress/sql/more_like_this.sql
+++ b/pg_search/tests/pg_regress/sql/more_like_this.sql
@@ -49,3 +49,26 @@ SELECT * FROM mlt where id @@@ pdb.more_like_this(1, ARRAY['json_field']);
 SELECT * FROM mlt where id @@@ pdb.more_like_this(100);
 
 DROP TABLE mlt;
+
+-- Field-less more_like_this skips vector columns (issue #5826)
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE mlt_vec (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    embedding vector(3)
+);
+
+INSERT INTO mlt_vec (description, embedding) VALUES
+    ('aaa bbb ccc', '[1,2,3]'),
+    ('aaa aaa', '[4,5,6]'),
+    ('ddd eee fff', '[7,8,9]');
+
+CREATE INDEX ON mlt_vec USING bm25 (id, description, embedding) WITH (key_field = 'id');
+
+SELECT id, description FROM mlt_vec WHERE id @@@ pdb.more_like_this(1);
+SELECT id, description FROM mlt_vec WHERE id @@@ pdb.more_like_this(1, ARRAY['description']);
+-- Vector not supported
+SELECT id FROM mlt_vec WHERE id @@@ pdb.more_like_this(1, ARRAY['embedding']);
+
+DROP TABLE mlt_vec;


### PR DESCRIPTION
Field-less `pdb.more_like_this(key_value => ...)` reads every indexed column, and failed with `UnsupportedOid` when the index contained a pgvector column. Vector fields are now skipped (like json fields), and explicitly requesting one errors with a clear message instead.

Fixes #5826