### PR TITLE
test(tokenizers): record the Lindera token streams as a golden file

### DIFF
--- a/tokenizers/tests/golden/lindera_tokens.txt
+++ b/tokenizers/tests/golden/lindera_tokens.txt
@@ -1,0 +1,4508 @@
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"，"	7	10	2	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"("	32	33	7	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"包括"	33	39	8	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"符號"	39	45	9	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"與"	45	48	10	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"不標準"	48	57	11	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"的"	57	60	12	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"asci"	60	64	13	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"阿"	64	67	14	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"爾"	67	70	15	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"發"	70	73	16	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"字元"	73	79	17	1
+zh[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=18
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無"	16	19	5	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"的"	22	25	7	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"字"	25	28	8	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"元"	28	31	9	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"("	32	33	10	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"包括"	33	39	11	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"符"	39	42	12	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"號"	42	45	13	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"與"	45	48	14	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"不"	48	51	15	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"標準"	51	57	16	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"的"	57	60	17	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"asci"	60	64	18	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"阿"	64	67	19	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"爾"	67	70	20	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"發"	70	73	21	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"字"	73	76	22	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"元"	76	79	23	1
+ja[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=24
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無效"	16	22	5	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"的"	22	25	6	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"字"	25	28	7	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"元"	28	31	8	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"("	32	33	9	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"包括"	33	39	10	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"符號"	39	45	11	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"與"	45	48	12	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"不"	48	51	13	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"標準"	51	57	14	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"的"	57	60	15	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"asci"	60	64	16	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"阿"	64	67	17	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"爾"	67	70	18	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"發"	70	73	19	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"字"	73	76	20	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"元"	76	79	21	1
+ko[ws=false,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=22
+zh[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+zh[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	count=2
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	1	"もも"	10	16	1	1
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	2	"も"	16	19	2	1
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	3	"もも"	19	25	3	1
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	4	"も"	25	28	4	1
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	5	"の"	28	31	5	1
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	6	"うち"	31	37	6	1
+ja[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	count=7
+ko[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+ko[ws=false,nfkc=false,rf=false]	"すもも もももももものうち"	count=2
+zh[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+zh[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+zh[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+zh[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+zh[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ja[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+ja[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+ja[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+ja[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+ja[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"."	15	16	2	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"멋진"	24	30	4	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"단어"	31	37	5	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	"입니다"	37	46	6	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	"."	46	47	7	1
+ko[ws=false,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=8
+zh[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+zh[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+zh[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	count=2
+ja[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	1	"１"	9	12	1	1
+ja[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	2	"２"	12	15	2	1
+ja[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	3	"３"	15	18	3	1
+ja[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	count=4
+ko[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+ko[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+ko[ws=false,nfkc=false,rf=false]	"ＡＢＣ１２３"	count=2
+zh[ws=false,nfkc=false,rf=false]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=false,rf=false]	"日本語"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=false,rf=false]	"日本語"	count=2
+ja[ws=false,nfkc=false,rf=false]	"日本語"	0	"日本語"	0	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"日本語"	count=1
+ko[ws=false,nfkc=false,rf=false]	"日本語"	0	"日本"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"日本語"	1	"語"	6	9	1	1
+ko[ws=false,nfkc=false,rf=false]	"日本語"	count=2
+zh[ws=false,nfkc=false,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=false,nfkc=false,rf=false]	"韓國"	count=1
+ja[ws=false,nfkc=false,rf=false]	"韓國"	0	"韓"	0	3	0	1
+ja[ws=false,nfkc=false,rf=false]	"韓國"	1	"國"	3	6	1	1
+ja[ws=false,nfkc=false,rf=false]	"韓國"	count=2
+ko[ws=false,nfkc=false,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"韓國"	count=1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+zh[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検索"	28	34	5	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"エンジン"	34	46	6	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"です"	46	52	7	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"。"	52	55	8	1
+ja[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=9
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+ko[ws=false,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"0"	34	35	7	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"."	35	36	8	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"25"	36	38	9	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	38	39	10	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"1"	39	40	11	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"版本"	40	46	12	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"。"	46	49	13	1
+zh[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=14
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"版本"	40	46	14	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ja[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"版本"	40	46	14	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ko[ws=false,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+zh[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+ja[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+ko[ws=false,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+zh[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	0	"leading"	2	9	0	1
+zh[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	1	"and"	10	13	1	1
+zh[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+zh[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	count=3
+ja[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	1	"and"	10	13	1	1
+ja[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ja[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	count=3
+ko[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ko[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	1	"and"	10	13	1	1
+ko[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ko[ws=false,nfkc=false,rf=false]	"  leading and trailing  "	count=3
+zh[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+zh[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	3	"改行"	17	23	3	1
+zh[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	count=4
+ja[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	0	"日本語"	0	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	1	"タブ"	10	16	1	1
+ja[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	2	"改行"	17	23	2	1
+ja[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	count=3
+ko[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+ko[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ko[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	3	"改"	17	20	3	1
+ko[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	4	"行"	20	23	4	1
+ko[ws=false,nfkc=false,rf=false]	"日本語\tタブ\n改行"	count=5
+zh[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+zh[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	count=1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	0	"１"	0	3	0	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	1	"２"	3	6	1	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	2	"３"	6	9	2	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	3	"４"	9	12	3	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	4	"５"	12	15	4	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	5	"６"	15	18	5	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	6	"７"	18	21	6	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	7	"８"	21	24	7	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	8	"９"	24	27	8	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	9	"０"	27	30	9	1
+ja[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	count=10
+ko[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+ko[ws=false,nfkc=false,rf=false]	"１２３４５６７８９０"	count=1
+zh[ws=false,nfkc=false,rf=false]	"３．１４１５９"	0	"３"	0	3	0	1
+zh[ws=false,nfkc=false,rf=false]	"３．１４１５９"	1	"．"	3	6	1	1
+zh[ws=false,nfkc=false,rf=false]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+zh[ws=false,nfkc=false,rf=false]	"３．１４１５９"	count=3
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	0	"３"	0	3	0	1
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	1	"．"	3	6	1	1
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	2	"１"	6	9	2	1
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	3	"４"	9	12	3	1
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	4	"１"	12	15	4	1
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	5	"５"	15	18	5	1
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	6	"９"	18	21	6	1
+ja[ws=false,nfkc=false,rf=false]	"３．１４１５９"	count=7
+ko[ws=false,nfkc=false,rf=false]	"３．１４１５９"	0	"３"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"３．１４１５９"	1	"．"	3	6	1	1
+ko[ws=false,nfkc=false,rf=false]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+ko[ws=false,nfkc=false,rf=false]	"３．１４１５９"	count=3
+zh[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+zh[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	2	"８"	15	18	2	1
+zh[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	4	"４"	21	24	4	1
+zh[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	count=6
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	0	"２"	0	3	0	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	1	"０"	3	6	1	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	2	"２"	6	9	2	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	3	"６"	9	12	3	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	4	"年"	12	15	4	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	5	"８月"	15	21	5	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	6	"４"	21	24	6	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	7	"日"	24	27	7	1
+ja[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	count=8
+ko[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+ko[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+ko[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	2	"８"	15	18	2	1
+ko[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+ko[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	4	"４"	21	24	4	1
+ko[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+ko[ws=false,nfkc=false,rf=false]	"２０２６年８月４日"	count=6
+zh[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	1	"서울"	13	19	1	1
+zh[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	2	"特別"	19	25	2	1
+zh[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	3	"市"	25	28	3	1
+zh[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	count=4
+ja[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ja[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	1	"民"	6	9	1	1
+ja[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	2	"國"	9	12	2	1
+ja[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ja[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	4	"特別"	19	25	4	1
+ja[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	5	"市"	25	28	5	1
+ja[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	count=6
+ko[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	1	"民國"	6	12	1	1
+ko[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+ko[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	3	"特別"	19	25	3	1
+ko[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	4	"市"	25	28	4	1
+ko[ws=false,nfkc=false,rf=false]	"大韓民國 서울特別市"	count=5
+zh[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	count=5
+ja[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	0	"東京"	0	6	0	1
+ja[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	1	"都"	6	9	1	1
+ja[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	2	"渋谷"	9	15	2	1
+ja[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	3	"区"	15	18	3	1
+ja[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	count=4
+ko[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+ko[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+ko[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=false,nfkc=false,rf=false]	"東京都渋谷区"	count=5
+zh[ws=false,nfkc=false,rf=false]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=false,nfkc=false,rf=false]	"中華人民共和國"	count=1
+ja[ws=false,nfkc=false,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ja[ws=false,nfkc=false,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ja[ws=false,nfkc=false,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ja[ws=false,nfkc=false,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ja[ws=false,nfkc=false,rf=false]	"中華人民共和國"	count=4
+ko[ws=false,nfkc=false,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ko[ws=false,nfkc=false,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ko[ws=false,nfkc=false,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ko[ws=false,nfkc=false,rf=false]	"中華人民共和國"	count=4
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	count=8
+ja[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	0	"国際"	0	6	0	1
+ja[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	1	"連合"	6	12	1	1
+ja[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	2	"教育"	12	18	2	1
+ja[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	3	"科学"	18	24	3	1
+ja[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	4	"文化"	24	30	4	1
+ja[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	5	"機関"	30	36	5	1
+ja[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	count=6
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	3	"合"	9	12	3	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	6	"科"	18	21	6	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	8	"文化"	24	30	8	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	9	"機"	30	33	9	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=false,nfkc=false,rf=false]	"国際連合教育科学文化機関"	count=11
+zh[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報処理"	0	12	0	1
+ja[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	1	"推進"	12	18	1	1
+ja[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	2	"機構"	18	24	2	1
+ja[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+ko[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進"	12	18	3	1
+ko[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	4	"機構"	18	24	4	1
+ko[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=false,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	count=1
+ja[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	count=1
+ko[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=false,nfkc=false,rf=false]	"서울대학교병원어린이병원"	count=5
+zh[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公"	39	42	11	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	12	"室"	42	45	12	1
+ja[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公室"	39	45	11	1
+ko[ws=false,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	count=4
+ja[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	0	"検索"	0	6	0	1
+ja[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	count=3
+ko[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=false,nfkc=false,rf=false]	"検索🔍エンジン"	count=4
+zh[ws=false,nfkc=false,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=false,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=false,rf=false]	"検索…エンジン"	2	"…"	6	9	2	1
+zh[ws=false,nfkc=false,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=false,nfkc=false,rf=false]	"検索…エンジン"	count=4
+ja[ws=false,nfkc=false,rf=false]	"検索…エンジン"	0	"検索"	0	6	0	1
+ja[ws=false,nfkc=false,rf=false]	"検索…エンジン"	1	"…"	6	9	1	1
+ja[ws=false,nfkc=false,rf=false]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=false,nfkc=false,rf=false]	"検索…エンジン"	count=3
+ko[ws=false,nfkc=false,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=false,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=false,rf=false]	"検索…エンジン"	2	"…"	6	9	2	1
+ko[ws=false,nfkc=false,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=false,nfkc=false,rf=false]	"検索…エンジン"	count=4
+zh[ws=false,nfkc=false,rf=false]	"①②③"	0	"①②③"	0	9	0	1
+zh[ws=false,nfkc=false,rf=false]	"①②③"	count=1
+ja[ws=false,nfkc=false,rf=false]	"①②③"	0	"①②③"	0	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"①②③"	count=1
+ko[ws=false,nfkc=false,rf=false]	"①②③"	0	"①②③"	0	9	0	1
+ko[ws=false,nfkc=false,rf=false]	"①②③"	count=1
+zh[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ja[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ko[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=false,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=false,nfkc=false,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=false,nfkc=false,rf=false]	"쀍쀎쀏"	count=1
+ja[ws=false,nfkc=false,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=false,nfkc=false,rf=false]	"쀍쀎쀏"	count=1
+ko[ws=false,nfkc=false,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=false,nfkc=false,rf=false]	"쀍쀎쀏"	count=1
+zh[ws=false,nfkc=false,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=false,nfkc=false,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=false,nfkc=false,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=false,nfkc=false,rf=false]	"𠮷野家"	count=3
+ja[ws=false,nfkc=false,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=false,nfkc=false,rf=false]	"𠮷野家"	1	"野家"	4	10	1	1
+ja[ws=false,nfkc=false,rf=false]	"𠮷野家"	count=2
+ko[ws=false,nfkc=false,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=false,nfkc=false,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+ko[ws=false,nfkc=false,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+ko[ws=false,nfkc=false,rf=false]	"𠮷野家"	count=3
+zh[ws=false,nfkc=false,rf=false]	""	<empty>
+ja[ws=false,nfkc=false,rf=false]	""	<empty>
+ko[ws=false,nfkc=false,rf=false]	""	<empty>
+zh[ws=false,nfkc=false,rf=false]	"   "	<empty>
+ja[ws=false,nfkc=false,rf=false]	"   "	<empty>
+ko[ws=false,nfkc=false,rf=false]	"   "	<empty>
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"，"	7	10	2	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"("	32	33	7	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"包括"	33	39	8	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"符號"	39	45	9	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"與"	45	48	10	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"不標準"	48	57	11	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"的"	57	60	12	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"asci"	60	64	13	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"阿"	64	67	14	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"爾"	67	70	15	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"發"	70	73	16	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"字元"	73	79	17	1
+zh[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=18
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"チ"	0	3	0	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"シ"	3	6	1	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"ホウガン"	10	16	4	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"ム"	16	19	5	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"テキ"	22	25	7	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"ジ"	25	28	8	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"モト"	28	31	9	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"("	32	33	10	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"ホウカツ"	33	39	11	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"フ"	39	42	12	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"號"	42	45	13	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"アタエ"	45	48	14	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"フ"	48	51	15	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"ヒョウジュン"	51	57	16	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"テキ"	57	60	17	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"asci"	60	64	18	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"オモネ"	64	67	19	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"シカ"	67	70	20	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"發"	70	73	21	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"ジ"	73	76	22	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"モト"	76	79	23	1
+ja[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=24
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"지"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"포함"	10	16	4	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"무효"	16	22	5	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"적"	22	25	6	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"자"	25	28	7	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"원"	28	31	8	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"*"	32	33	9	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"포괄"	33	39	10	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"부호"	39	45	11	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"여"	45	48	12	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"부"	48	51	13	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"표준"	51	57	14	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"적"	57	60	15	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"asci"	60	64	16	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"아"	64	67	17	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"爾"	67	70	18	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"발"	70	73	19	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"자"	73	76	20	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"원"	76	79	21	1
+ko[ws=false,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=22
+zh[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+zh[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	count=2
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	0	"スモモ"	0	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	1	"モモ"	10	16	1	1
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	2	"モ"	16	19	2	1
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	3	"モモ"	19	25	3	1
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	4	"モ"	25	28	4	1
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	5	"ノ"	28	31	5	1
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	6	"ウチ"	31	37	6	1
+ja[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	count=7
+ko[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+ko[ws=false,nfkc=false,rf=true]	"すもも もももももものうち"	count=2
+zh[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+zh[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+zh[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+zh[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+zh[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ja[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+ja[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+ja[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+ja[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+ja[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"*"	15	16	2	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"멋진"	24	30	4	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"단어"	31	37	5	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	"입니다"	37	46	6	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	"*"	46	47	7	1
+ko[ws=false,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=8
+zh[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+zh[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+zh[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	count=2
+ja[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	0	"エイビーシー"	0	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	1	"イチ"	9	12	1	1
+ja[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	2	"ニ"	12	15	2	1
+ja[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	3	"サン"	15	18	3	1
+ja[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	count=4
+ko[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+ko[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+ko[ws=false,nfkc=false,rf=true]	"ＡＢＣ１２３"	count=2
+zh[ws=false,nfkc=false,rf=true]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=false,rf=true]	"日本語"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=false,rf=true]	"日本語"	count=2
+ja[ws=false,nfkc=false,rf=true]	"日本語"	0	"ニホンゴ"	0	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"日本語"	count=1
+ko[ws=false,nfkc=false,rf=true]	"日本語"	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"日本語"	1	"어"	6	9	1	1
+ko[ws=false,nfkc=false,rf=true]	"日本語"	count=2
+zh[ws=false,nfkc=false,rf=true]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=false,nfkc=false,rf=true]	"韓國"	count=1
+ja[ws=false,nfkc=false,rf=true]	"韓國"	0	"カン"	0	3	0	1
+ja[ws=false,nfkc=false,rf=true]	"韓國"	1	"クニ"	3	6	1	1
+ja[ws=false,nfkc=false,rf=true]	"韓國"	count=2
+ko[ws=false,nfkc=false,rf=true]	"韓國"	0	"한국"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"韓國"	count=1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+zh[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"ハ"	9	12	1	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"ヨウ"	22	25	3	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"ノ"	25	28	4	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"ケンサク"	28	34	5	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"エンジン"	34	46	6	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"デス"	46	52	7	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"。"	52	55	8	1
+ja[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=9
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"용"	22	25	3	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+ko[ws=false,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"0"	34	35	7	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"."	35	36	8	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"25"	36	38	9	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	38	39	10	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"1"	39	40	11	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"版本"	40	46	12	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"。"	46	49	13	1
+zh[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=14
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"ワガ"	0	3	0	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"ザイ"	6	9	2	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"ネン"	13	16	4	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ヌノ"	19	22	6	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"リョウ"	22	25	7	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"ハンポン"	40	46	14	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ja[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"아"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"재"	6	9	2	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"년"	13	16	4	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"판본"	40	46	14	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ko[ws=false,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+zh[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+ja[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"*"	32	33	4	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"*"	54	55	12	1
+ko[ws=false,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+zh[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	0	"leading"	2	9	0	1
+zh[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	1	"and"	10	13	1	1
+zh[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+zh[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	count=3
+ja[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	1	"and"	10	13	1	1
+ja[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ja[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	count=3
+ko[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ko[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	1	"and"	10	13	1	1
+ko[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ko[ws=false,nfkc=false,rf=true]	"  leading and trailing  "	count=3
+zh[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+zh[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	3	"改行"	17	23	3	1
+zh[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	count=4
+ja[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	0	"ニホンゴ"	0	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	1	"タブ"	10	16	1	1
+ja[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	2	"カイギョウ"	17	23	2	1
+ja[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	count=3
+ko[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	1	"어"	6	9	1	1
+ko[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ko[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	3	"改"	17	20	3	1
+ko[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	4	"행"	20	23	4	1
+ko[ws=false,nfkc=false,rf=true]	"日本語\tタブ\n改行"	count=5
+zh[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+zh[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	count=1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	0	"イチ"	0	3	0	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	1	"ニ"	3	6	1	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	2	"サン"	6	9	2	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	3	"ヨン"	9	12	3	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	4	"ゴ"	12	15	4	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	5	"ロク"	15	18	5	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	6	"ナナ"	18	21	6	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	7	"ハチ"	21	24	7	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	8	"キュウ"	24	27	8	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	9	"ゼロ"	27	30	9	1
+ja[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	count=10
+ko[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+ko[ws=false,nfkc=false,rf=true]	"１２３４５６７８９０"	count=1
+zh[ws=false,nfkc=false,rf=true]	"３．１４１５９"	0	"３"	0	3	0	1
+zh[ws=false,nfkc=false,rf=true]	"３．１４１５９"	1	"．"	3	6	1	1
+zh[ws=false,nfkc=false,rf=true]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+zh[ws=false,nfkc=false,rf=true]	"３．１４１５９"	count=3
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	0	"サン"	0	3	0	1
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	1	"．"	3	6	1	1
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	2	"イチ"	6	9	2	1
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	3	"ヨン"	9	12	3	1
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	4	"イチ"	12	15	4	1
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	5	"ゴ"	15	18	5	1
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	6	"キュウ"	18	21	6	1
+ja[ws=false,nfkc=false,rf=true]	"３．１４１５９"	count=7
+ko[ws=false,nfkc=false,rf=true]	"３．１４１５９"	0	"３"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"３．１４１５９"	1	"．"	3	6	1	1
+ko[ws=false,nfkc=false,rf=true]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+ko[ws=false,nfkc=false,rf=true]	"３．１４１５９"	count=3
+zh[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+zh[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	2	"８"	15	18	2	1
+zh[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	4	"４"	21	24	4	1
+zh[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	count=6
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	0	"ニ"	0	3	0	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	1	"ゼロ"	3	6	1	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	2	"ニ"	6	9	2	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	3	"ロク"	9	12	3	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	4	"ネン"	12	15	4	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	5	"ハチガツ"	15	21	5	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	6	"ヨン"	21	24	6	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	7	"ニチ"	24	27	7	1
+ja[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	count=8
+ko[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+ko[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	1	"년"	12	15	1	1
+ko[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	2	"８"	15	18	2	1
+ko[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	3	"월"	18	21	3	1
+ko[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	4	"４"	21	24	4	1
+ko[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	5	"일"	24	27	5	1
+ko[ws=false,nfkc=false,rf=true]	"２０２６年８月４日"	count=6
+zh[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	1	"서울"	13	19	1	1
+zh[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	2	"特別"	19	25	2	1
+zh[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	3	"市"	25	28	3	1
+zh[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	count=4
+ja[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	0	"タイカン"	0	6	0	1
+ja[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	1	"ミン"	6	9	1	1
+ja[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	2	"クニ"	9	12	2	1
+ja[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ja[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	4	"トクベツ"	19	25	4	1
+ja[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	5	"シ"	25	28	5	1
+ja[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	count=6
+ko[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	0	"대한"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	1	"민국"	6	12	1	1
+ko[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+ko[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	3	"특별"	19	25	3	1
+ko[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	4	"시"	25	28	4	1
+ko[ws=false,nfkc=false,rf=true]	"大韓民國 서울特別市"	count=5
+zh[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	count=5
+ja[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	0	"トウキョウ"	0	6	0	1
+ja[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	1	"ト"	6	9	1	1
+ja[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	2	"シブヤ"	9	15	2	1
+ja[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	3	"ク"	15	18	3	1
+ja[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	count=4
+ko[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	0	"동"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	1	"경도"	3	9	1	1
+ko[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	3	"곡"	12	15	3	1
+ko[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=false,nfkc=false,rf=true]	"東京都渋谷区"	count=5
+zh[ws=false,nfkc=false,rf=true]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=false,nfkc=false,rf=true]	"中華人民共和國"	count=1
+ja[ws=false,nfkc=false,rf=true]	"中華人民共和國"	0	"チュウカ"	0	6	0	1
+ja[ws=false,nfkc=false,rf=true]	"中華人民共和國"	1	"ジンミン"	6	12	1	1
+ja[ws=false,nfkc=false,rf=true]	"中華人民共和國"	2	"キョウワ"	12	18	2	1
+ja[ws=false,nfkc=false,rf=true]	"中華人民共和國"	3	"クニ"	18	21	3	1
+ja[ws=false,nfkc=false,rf=true]	"中華人民共和國"	count=4
+ko[ws=false,nfkc=false,rf=true]	"中華人民共和國"	0	"중화"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"中華人民共和國"	1	"인민"	6	12	1	1
+ko[ws=false,nfkc=false,rf=true]	"中華人民共和國"	2	"공화"	12	18	2	1
+ko[ws=false,nfkc=false,rf=true]	"中華人民共和國"	3	"국"	18	21	3	1
+ko[ws=false,nfkc=false,rf=true]	"中華人民共和國"	count=4
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	count=8
+ja[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	0	"コクサイ"	0	6	0	1
+ja[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	1	"レンゴウ"	6	12	1	1
+ja[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	2	"キョウイク"	12	18	2	1
+ja[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	3	"カガク"	18	24	3	1
+ja[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	4	"ブンカ"	24	30	4	1
+ja[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	5	"キカン"	30	36	5	1
+ja[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	count=6
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	1	"제"	3	6	1	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	3	"합"	9	12	3	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	6	"과"	18	21	6	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	8	"문화"	24	30	8	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	9	"기"	30	33	9	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=false,nfkc=false,rf=true]	"国際連合教育科学文化機関"	count=11
+zh[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	0	"ジョウホウショリ"	0	12	0	1
+ja[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	1	"スイシン"	12	18	1	1
+ja[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	2	"キコウ"	18	24	2	1
+ja[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	0	"정보"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	2	"리"	9	12	2	1
+ko[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	3	"추진"	12	18	3	1
+ko[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	4	"기구"	18	24	4	1
+ko[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=false,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	count=1
+ja[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	count=1
+ko[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=false,nfkc=false,rf=true]	"서울대학교병원어린이병원"	count=5
+zh[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	0	"チュウ"	0	3	0	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	2	"ジンミン"	6	12	2	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	3	"キョウワ"	12	18	3	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	4	"コク"	18	21	4	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	5	"コク"	21	24	5	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	7	"イン"	27	30	7	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	8	"シン"	30	33	8	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	11	"オオヤケ"	39	42	11	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	12	"シツ"	42	45	12	1
+ja[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	0	"중"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	2	"인민"	6	12	2	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	3	"공화"	12	18	3	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	7	"원"	27	30	7	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	8	"신"	30	33	8	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	11	"공실"	39	45	11	1
+ko[ws=false,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	count=4
+ja[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	count=3
+ko[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=false,nfkc=false,rf=true]	"検索🔍エンジン"	count=4
+zh[ws=false,nfkc=false,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=false,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=false,rf=true]	"検索…エンジン"	2	"…"	6	9	2	1
+zh[ws=false,nfkc=false,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=false,nfkc=false,rf=true]	"検索…エンジン"	count=4
+ja[ws=false,nfkc=false,rf=true]	"検索…エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=false,nfkc=false,rf=true]	"検索…エンジン"	1	"…"	6	9	1	1
+ja[ws=false,nfkc=false,rf=true]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=false,nfkc=false,rf=true]	"検索…エンジン"	count=3
+ko[ws=false,nfkc=false,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=false,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=false,rf=true]	"検索…エンジン"	2	"*"	6	9	2	1
+ko[ws=false,nfkc=false,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=false,nfkc=false,rf=true]	"検索…エンジン"	count=4
+zh[ws=false,nfkc=false,rf=true]	"①②③"	0	"①②③"	0	9	0	1
+zh[ws=false,nfkc=false,rf=true]	"①②③"	count=1
+ja[ws=false,nfkc=false,rf=true]	"①②③"	0	"①②③"	0	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"①②③"	count=1
+ko[ws=false,nfkc=false,rf=true]	"①②③"	0	"①②③"	0	9	0	1
+ko[ws=false,nfkc=false,rf=true]	"①②③"	count=1
+zh[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"ソウシャ"	18	24	1	1
+ja[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"주자"	18	24	1	1
+ko[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=false,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=false,nfkc=false,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=false,nfkc=false,rf=true]	"쀍쀎쀏"	count=1
+ja[ws=false,nfkc=false,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=false,nfkc=false,rf=true]	"쀍쀎쀏"	count=1
+ko[ws=false,nfkc=false,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=false,nfkc=false,rf=true]	"쀍쀎쀏"	count=1
+zh[ws=false,nfkc=false,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=false,nfkc=false,rf=true]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=false,nfkc=false,rf=true]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=false,nfkc=false,rf=true]	"𠮷野家"	count=3
+ja[ws=false,nfkc=false,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=false,nfkc=false,rf=true]	"𠮷野家"	1	"ノヤ"	4	10	1	1
+ja[ws=false,nfkc=false,rf=true]	"𠮷野家"	count=2
+ko[ws=false,nfkc=false,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=false,nfkc=false,rf=true]	"𠮷野家"	1	"야"	4	7	1	1
+ko[ws=false,nfkc=false,rf=true]	"𠮷野家"	2	"가"	7	10	2	1
+ko[ws=false,nfkc=false,rf=true]	"𠮷野家"	count=3
+zh[ws=false,nfkc=false,rf=true]	""	<empty>
+ja[ws=false,nfkc=false,rf=true]	""	<empty>
+ko[ws=false,nfkc=false,rf=true]	""	<empty>
+zh[ws=false,nfkc=false,rf=true]	"   "	<empty>
+ja[ws=false,nfkc=false,rf=true]	"   "	<empty>
+ko[ws=false,nfkc=false,rf=true]	"   "	<empty>
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	","	7	10	2	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"("	32	33	7	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"包括"	33	39	8	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"符號"	39	45	9	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"與"	45	48	10	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"不標準"	48	57	11	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"的"	57	60	12	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"asci"	60	64	13	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"阿"	64	67	14	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"爾"	67	70	15	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"發"	70	73	16	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"字元"	73	79	17	1
+zh[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=18
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	","	7	10	3	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無"	16	19	5	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"的"	22	25	7	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"字"	25	28	8	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"元"	28	31	9	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"("	32	33	10	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"包括"	33	39	11	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"符"	39	42	12	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"號"	42	45	13	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"與"	45	48	14	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"不"	48	51	15	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"標準"	51	57	16	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"的"	57	60	17	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"asci"	60	64	18	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"阿"	64	67	19	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"爾"	67	70	20	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"發"	70	73	21	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"字"	73	76	22	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"元"	76	79	23	1
+ja[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=24
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	","	7	10	3	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無效"	16	22	5	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"的"	22	25	6	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"字"	25	28	7	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"元"	28	31	8	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"("	32	33	9	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"包括"	33	39	10	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"符號"	39	45	11	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"與"	45	48	12	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"不"	48	51	13	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"標準"	51	57	14	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"的"	57	60	15	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"asci"	60	64	16	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"阿"	64	67	17	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"爾"	67	70	18	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"發"	70	73	19	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"字"	73	76	20	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"元"	76	79	21	1
+ko[ws=false,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=22
+zh[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+zh[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	count=2
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	1	"もも"	10	16	1	1
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	2	"も"	16	19	2	1
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	3	"もも"	19	25	3	1
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	4	"も"	25	28	4	1
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	5	"の"	28	31	5	1
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	6	"うち"	31	37	6	1
+ja[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	count=7
+ko[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+ko[ws=false,nfkc=true,rf=false]	"すもも もももももものうち"	count=2
+zh[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+zh[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+zh[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+zh[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+zh[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ja[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+ja[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+ja[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+ja[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+ja[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"."	15	16	2	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"멋진"	24	30	4	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"단어"	31	37	5	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	"입니다"	37	46	6	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	"."	46	47	7	1
+ko[ws=false,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=8
+zh[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+zh[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+zh[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	count=2
+ja[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ja[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	count=2
+ko[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ko[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ko[ws=false,nfkc=true,rf=false]	"ＡＢＣ１２３"	count=2
+zh[ws=false,nfkc=true,rf=false]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=true,rf=false]	"日本語"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=true,rf=false]	"日本語"	count=2
+ja[ws=false,nfkc=true,rf=false]	"日本語"	0	"日本語"	0	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"日本語"	count=1
+ko[ws=false,nfkc=true,rf=false]	"日本語"	0	"日本"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"日本語"	1	"語"	6	9	1	1
+ko[ws=false,nfkc=true,rf=false]	"日本語"	count=2
+zh[ws=false,nfkc=true,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=false,nfkc=true,rf=false]	"韓國"	count=1
+ja[ws=false,nfkc=true,rf=false]	"韓國"	0	"韓"	0	3	0	1
+ja[ws=false,nfkc=true,rf=false]	"韓國"	1	"國"	3	6	1	1
+ja[ws=false,nfkc=true,rf=false]	"韓國"	count=2
+ko[ws=false,nfkc=true,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"韓國"	count=1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+zh[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検索"	28	34	5	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"エンジン"	34	46	6	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"です"	46	52	7	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"。"	52	55	8	1
+ja[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=9
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+ko[ws=false,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"0"	34	35	7	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"."	35	36	8	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"25"	36	38	9	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	38	39	10	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"1"	39	40	11	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"版本"	40	46	12	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"。"	46	49	13	1
+zh[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=14
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"版本"	40	46	14	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ja[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"版本"	40	46	14	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ko[ws=false,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+zh[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+ja[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+ko[ws=false,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+zh[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	0	"leading"	2	9	0	1
+zh[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	1	"and"	10	13	1	1
+zh[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+zh[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	count=3
+ja[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	1	"and"	10	13	1	1
+ja[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ja[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	count=3
+ko[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ko[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	1	"and"	10	13	1	1
+ko[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ko[ws=false,nfkc=true,rf=false]	"  leading and trailing  "	count=3
+zh[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+zh[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	3	"改行"	17	23	3	1
+zh[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	count=4
+ja[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	0	"日本語"	0	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	1	"タブ"	10	16	1	1
+ja[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	2	"改行"	17	23	2	1
+ja[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	count=3
+ko[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+ko[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ko[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	3	"改"	17	20	3	1
+ko[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	4	"行"	20	23	4	1
+ko[ws=false,nfkc=true,rf=false]	"日本語\tタブ\n改行"	count=5
+zh[ws=false,nfkc=true,rf=false]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+zh[ws=false,nfkc=true,rf=false]	"１２３４５６７８９０"	count=1
+ja[ws=false,nfkc=true,rf=false]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ja[ws=false,nfkc=true,rf=false]	"１２３４５６７８９０"	count=1
+ko[ws=false,nfkc=true,rf=false]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ko[ws=false,nfkc=true,rf=false]	"１２３４５６７８９０"	count=1
+zh[ws=false,nfkc=true,rf=false]	"３．１４１５９"	0	"3"	0	3	0	1
+zh[ws=false,nfkc=true,rf=false]	"３．１４１５９"	1	"."	3	6	1	1
+zh[ws=false,nfkc=true,rf=false]	"３．１４１５９"	2	"14159"	6	21	2	1
+zh[ws=false,nfkc=true,rf=false]	"３．１４１５９"	count=3
+ja[ws=false,nfkc=true,rf=false]	"３．１４１５９"	0	"3"	0	3	0	1
+ja[ws=false,nfkc=true,rf=false]	"３．１４１５９"	1	"."	3	6	1	1
+ja[ws=false,nfkc=true,rf=false]	"３．１４１５９"	2	"14159"	6	21	2	1
+ja[ws=false,nfkc=true,rf=false]	"３．１４１５９"	count=3
+ko[ws=false,nfkc=true,rf=false]	"３．１４１５９"	0	"3"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"３．１４１５９"	1	"."	3	6	1	1
+ko[ws=false,nfkc=true,rf=false]	"３．１４１５９"	2	"14159"	6	21	2	1
+ko[ws=false,nfkc=true,rf=false]	"３．１４１５９"	count=3
+zh[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+zh[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	2	"8"	15	18	2	1
+zh[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	4	"4"	21	24	4	1
+zh[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	count=6
+ja[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ja[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+ja[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ja[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+ja[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ja[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+ja[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	count=6
+ko[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ko[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+ko[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ko[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+ko[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ko[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+ko[ws=false,nfkc=true,rf=false]	"２０２６年８月４日"	count=6
+zh[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	1	"서울"	13	19	1	1
+zh[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	2	"特別"	19	25	2	1
+zh[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	3	"市"	25	28	3	1
+zh[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	count=4
+ja[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ja[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	1	"民"	6	9	1	1
+ja[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	2	"國"	9	12	2	1
+ja[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ja[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	4	"特別"	19	25	4	1
+ja[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	5	"市"	25	28	5	1
+ja[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	count=6
+ko[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	1	"民國"	6	12	1	1
+ko[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+ko[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	3	"特別"	19	25	3	1
+ko[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	4	"市"	25	28	4	1
+ko[ws=false,nfkc=true,rf=false]	"大韓民國 서울特別市"	count=5
+zh[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	count=5
+ja[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	0	"東京"	0	6	0	1
+ja[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	1	"都"	6	9	1	1
+ja[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	2	"渋谷"	9	15	2	1
+ja[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	3	"区"	15	18	3	1
+ja[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	count=4
+ko[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+ko[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+ko[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=false,nfkc=true,rf=false]	"東京都渋谷区"	count=5
+zh[ws=false,nfkc=true,rf=false]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=false,nfkc=true,rf=false]	"中華人民共和國"	count=1
+ja[ws=false,nfkc=true,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ja[ws=false,nfkc=true,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ja[ws=false,nfkc=true,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ja[ws=false,nfkc=true,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ja[ws=false,nfkc=true,rf=false]	"中華人民共和國"	count=4
+ko[ws=false,nfkc=true,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ko[ws=false,nfkc=true,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ko[ws=false,nfkc=true,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ko[ws=false,nfkc=true,rf=false]	"中華人民共和國"	count=4
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	count=8
+ja[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	0	"国際"	0	6	0	1
+ja[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	1	"連合"	6	12	1	1
+ja[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	2	"教育"	12	18	2	1
+ja[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	3	"科学"	18	24	3	1
+ja[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	4	"文化"	24	30	4	1
+ja[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	5	"機関"	30	36	5	1
+ja[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	count=6
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	3	"合"	9	12	3	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	6	"科"	18	21	6	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	8	"文化"	24	30	8	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	9	"機"	30	33	9	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=false,nfkc=true,rf=false]	"国際連合教育科学文化機関"	count=11
+zh[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報処理"	0	12	0	1
+ja[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	1	"推進"	12	18	1	1
+ja[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	2	"機構"	18	24	2	1
+ja[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+ko[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進"	12	18	3	1
+ko[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	4	"機構"	18	24	4	1
+ko[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=false,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	count=1
+ja[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	count=1
+ko[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=false,nfkc=true,rf=false]	"서울대학교병원어린이병원"	count=5
+zh[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公"	39	42	11	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	12	"室"	42	45	12	1
+ja[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公室"	39	45	11	1
+ko[ws=false,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	count=4
+ja[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	0	"検索"	0	6	0	1
+ja[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	count=3
+ko[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=false,nfkc=true,rf=false]	"検索🔍エンジン"	count=4
+zh[ws=false,nfkc=true,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=true,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=true,rf=false]	"検索…エンジン"	2	"..."	6	9	2	1
+zh[ws=false,nfkc=true,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=false,nfkc=true,rf=false]	"検索…エンジン"	count=4
+ja[ws=false,nfkc=true,rf=false]	"検索…エンジン"	0	"検索"	0	6	0	1
+ja[ws=false,nfkc=true,rf=false]	"検索…エンジン"	1	"..."	6	9	1	1
+ja[ws=false,nfkc=true,rf=false]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=false,nfkc=true,rf=false]	"検索…エンジン"	count=3
+ko[ws=false,nfkc=true,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=true,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=true,rf=false]	"検索…エンジン"	2	"..."	6	9	2	1
+ko[ws=false,nfkc=true,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=false,nfkc=true,rf=false]	"検索…エンジン"	count=4
+zh[ws=false,nfkc=true,rf=false]	"①②③"	0	"123"	0	9	0	1
+zh[ws=false,nfkc=true,rf=false]	"①②③"	count=1
+ja[ws=false,nfkc=true,rf=false]	"①②③"	0	"123"	0	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"①②③"	count=1
+ko[ws=false,nfkc=true,rf=false]	"①②③"	0	"123"	0	9	0	1
+ko[ws=false,nfkc=true,rf=false]	"①②③"	count=1
+zh[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ja[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ko[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=false,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=false,nfkc=true,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=false,nfkc=true,rf=false]	"쀍쀎쀏"	count=1
+ja[ws=false,nfkc=true,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=false,nfkc=true,rf=false]	"쀍쀎쀏"	count=1
+ko[ws=false,nfkc=true,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=false,nfkc=true,rf=false]	"쀍쀎쀏"	count=1
+zh[ws=false,nfkc=true,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=false,nfkc=true,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=false,nfkc=true,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=false,nfkc=true,rf=false]	"𠮷野家"	count=3
+ja[ws=false,nfkc=true,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=false,nfkc=true,rf=false]	"𠮷野家"	1	"野家"	4	10	1	1
+ja[ws=false,nfkc=true,rf=false]	"𠮷野家"	count=2
+ko[ws=false,nfkc=true,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=false,nfkc=true,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+ko[ws=false,nfkc=true,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+ko[ws=false,nfkc=true,rf=false]	"𠮷野家"	count=3
+zh[ws=false,nfkc=true,rf=false]	""	<empty>
+ja[ws=false,nfkc=true,rf=false]	""	<empty>
+ko[ws=false,nfkc=true,rf=false]	""	<empty>
+zh[ws=false,nfkc=true,rf=false]	"   "	<empty>
+ja[ws=false,nfkc=true,rf=false]	"   "	<empty>
+ko[ws=false,nfkc=true,rf=false]	"   "	<empty>
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	","	7	10	2	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"("	32	33	7	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"包括"	33	39	8	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"符號"	39	45	9	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"與"	45	48	10	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"不標準"	48	57	11	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"的"	57	60	12	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"asci"	60	64	13	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"阿"	64	67	14	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"爾"	67	70	15	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"發"	70	73	16	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"字元"	73	79	17	1
+zh[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=18
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"チ"	0	3	0	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"シ"	3	6	1	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	","	7	10	3	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"ホウガン"	10	16	4	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"ム"	16	19	5	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"テキ"	22	25	7	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"ジ"	25	28	8	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"モト"	28	31	9	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"("	32	33	10	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"ホウカツ"	33	39	11	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"フ"	39	42	12	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"號"	42	45	13	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"アタエ"	45	48	14	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"フ"	48	51	15	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"ヒョウジュン"	51	57	16	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"テキ"	57	60	17	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"asci"	60	64	18	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"オモネ"	64	67	19	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"シカ"	67	70	20	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"發"	70	73	21	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"ジ"	73	76	22	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"モト"	76	79	23	1
+ja[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=24
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"지"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"*"	7	10	3	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"포함"	10	16	4	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"무효"	16	22	5	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"적"	22	25	6	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"자"	25	28	7	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"원"	28	31	8	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"*"	32	33	9	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"포괄"	33	39	10	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"부호"	39	45	11	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"여"	45	48	12	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"부"	48	51	13	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"표준"	51	57	14	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"적"	57	60	15	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"asci"	60	64	16	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"아"	64	67	17	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"爾"	67	70	18	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"발"	70	73	19	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"자"	73	76	20	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"원"	76	79	21	1
+ko[ws=false,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=22
+zh[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+zh[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	count=2
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	0	"スモモ"	0	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	1	"モモ"	10	16	1	1
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	2	"モ"	16	19	2	1
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	3	"モモ"	19	25	3	1
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	4	"モ"	25	28	4	1
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	5	"ノ"	28	31	5	1
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	6	"ウチ"	31	37	6	1
+ja[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	count=7
+ko[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	1	"もももももものうち"	10	37	1	1
+ko[ws=false,nfkc=true,rf=true]	"すもも もももももものうち"	count=2
+zh[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+zh[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+zh[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+zh[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+zh[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ja[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"매우"	17	23	2	1
+ja[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"멋진"	24	30	3	1
+ja[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"단어입니다"	31	46	4	1
+ja[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"."	46	47	5	1
+ja[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=6
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"*"	15	16	2	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"멋진"	24	30	4	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"단어"	31	37	5	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	"입니다"	37	46	6	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	"*"	46	47	7	1
+ko[ws=false,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=8
+zh[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+zh[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+zh[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	count=2
+ja[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ja[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	count=2
+ko[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ko[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ko[ws=false,nfkc=true,rf=true]	"ＡＢＣ１２３"	count=2
+zh[ws=false,nfkc=true,rf=true]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=true,rf=true]	"日本語"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=true,rf=true]	"日本語"	count=2
+ja[ws=false,nfkc=true,rf=true]	"日本語"	0	"ニホンゴ"	0	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"日本語"	count=1
+ko[ws=false,nfkc=true,rf=true]	"日本語"	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"日本語"	1	"어"	6	9	1	1
+ko[ws=false,nfkc=true,rf=true]	"日本語"	count=2
+zh[ws=false,nfkc=true,rf=true]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=false,nfkc=true,rf=true]	"韓國"	count=1
+ja[ws=false,nfkc=true,rf=true]	"韓國"	0	"カン"	0	3	0	1
+ja[ws=false,nfkc=true,rf=true]	"韓國"	1	"クニ"	3	6	1	1
+ja[ws=false,nfkc=true,rf=true]	"韓國"	count=2
+ko[ws=false,nfkc=true,rf=true]	"韓國"	0	"한국"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"韓國"	count=1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"用"	22	25	3	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+zh[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"ハ"	9	12	1	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"ヨウ"	22	25	3	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"ノ"	25	28	4	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"ケンサク"	28	34	5	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"エンジン"	34	46	6	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"デス"	46	52	7	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"。"	52	55	8	1
+ja[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=9
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	"は"	9	12	1	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"Postgres"	13	21	2	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	"용"	22	25	3	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"の"	25	28	4	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	"検"	28	31	5	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"索"	31	34	6	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"エンジン"	34	46	7	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"です"	46	52	8	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"。"	52	55	9	1
+ko[ws=false,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=10
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"0"	34	35	7	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"."	35	36	8	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"25"	36	38	9	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	38	39	10	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"1"	39	40	11	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"版本"	40	46	12	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"。"	46	49	13	1
+zh[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=14
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"ワガ"	0	3	0	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"ザイ"	6	9	2	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"ネン"	13	16	4	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ヌノ"	19	22	6	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"リョウ"	22	25	7	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"ハンポン"	40	46	14	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ja[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"아"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"재"	6	9	2	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"년"	13	16	4	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"0"	34	35	9	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"."	35	36	10	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"25"	36	38	11	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"."	38	39	12	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"1"	39	40	13	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"판본"	40	46	14	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"。"	46	49	15	1
+ko[ws=false,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=16
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+zh[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	","	32	33	4	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"!"	54	55	12	1
+ja[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	"검색"	10	16	1	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"엔진"	17	23	2	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	"ParadeDB"	24	32	3	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"*"	32	33	4	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	"버전"	34	40	5	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"0"	41	42	6	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"."	42	43	7	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	"25"	43	45	8	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"."	45	46	9	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	"1"	46	47	10	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"출시"	48	54	11	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"*"	54	55	12	1
+ko[ws=false,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=13
+zh[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	0	"leading"	2	9	0	1
+zh[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	1	"and"	10	13	1	1
+zh[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+zh[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	count=3
+ja[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	1	"and"	10	13	1	1
+ja[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ja[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	count=3
+ko[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	0	"leading"	2	9	0	1
+ko[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	1	"and"	10	13	1	1
+ko[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	2	"trailing"	14	22	2	1
+ko[ws=false,nfkc=true,rf=true]	"  leading and trailing  "	count=3
+zh[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+zh[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	3	"改行"	17	23	3	1
+zh[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	count=4
+ja[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	0	"ニホンゴ"	0	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	1	"タブ"	10	16	1	1
+ja[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	2	"カイギョウ"	17	23	2	1
+ja[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	count=3
+ko[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	0	"일본"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	1	"어"	6	9	1	1
+ko[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ko[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	3	"改"	17	20	3	1
+ko[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	4	"행"	20	23	4	1
+ko[ws=false,nfkc=true,rf=true]	"日本語\tタブ\n改行"	count=5
+zh[ws=false,nfkc=true,rf=true]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+zh[ws=false,nfkc=true,rf=true]	"１２３４５６７８９０"	count=1
+ja[ws=false,nfkc=true,rf=true]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ja[ws=false,nfkc=true,rf=true]	"１２３４５６７８９０"	count=1
+ko[ws=false,nfkc=true,rf=true]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ko[ws=false,nfkc=true,rf=true]	"１２３４５６７８９０"	count=1
+zh[ws=false,nfkc=true,rf=true]	"３．１４１５９"	0	"3"	0	3	0	1
+zh[ws=false,nfkc=true,rf=true]	"３．１４１５９"	1	"."	3	6	1	1
+zh[ws=false,nfkc=true,rf=true]	"３．１４１５９"	2	"14159"	6	21	2	1
+zh[ws=false,nfkc=true,rf=true]	"３．１４１５９"	count=3
+ja[ws=false,nfkc=true,rf=true]	"３．１４１５９"	0	"3"	0	3	0	1
+ja[ws=false,nfkc=true,rf=true]	"３．１４１５９"	1	"."	3	6	1	1
+ja[ws=false,nfkc=true,rf=true]	"３．１４１５９"	2	"14159"	6	21	2	1
+ja[ws=false,nfkc=true,rf=true]	"３．１４１５９"	count=3
+ko[ws=false,nfkc=true,rf=true]	"３．１４１５９"	0	"3"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"３．１４１５９"	1	"."	3	6	1	1
+ko[ws=false,nfkc=true,rf=true]	"３．１４１５９"	2	"14159"	6	21	2	1
+ko[ws=false,nfkc=true,rf=true]	"３．１４１５９"	count=3
+zh[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+zh[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	2	"8"	15	18	2	1
+zh[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	4	"4"	21	24	4	1
+zh[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	count=6
+ja[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ja[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	1	"ネン"	12	15	1	1
+ja[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ja[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	3	"ツキ"	18	21	3	1
+ja[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ja[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	5	"ニチ"	24	27	5	1
+ja[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	count=6
+ko[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ko[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	1	"년"	12	15	1	1
+ko[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ko[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	3	"월"	18	21	3	1
+ko[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ko[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	5	"일"	24	27	5	1
+ko[ws=false,nfkc=true,rf=true]	"２０２６年８月４日"	count=6
+zh[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	1	"서울"	13	19	1	1
+zh[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	2	"特別"	19	25	2	1
+zh[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	3	"市"	25	28	3	1
+zh[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	count=4
+ja[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	0	"タイカン"	0	6	0	1
+ja[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	1	"ミン"	6	9	1	1
+ja[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	2	"クニ"	9	12	2	1
+ja[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ja[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	4	"トクベツ"	19	25	4	1
+ja[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	5	"シ"	25	28	5	1
+ja[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	count=6
+ko[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	0	"대한"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	1	"민국"	6	12	1	1
+ko[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+ko[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	3	"특별"	19	25	3	1
+ko[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	4	"시"	25	28	4	1
+ko[ws=false,nfkc=true,rf=true]	"大韓民國 서울特別市"	count=5
+zh[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	count=5
+ja[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	0	"トウキョウ"	0	6	0	1
+ja[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	1	"ト"	6	9	1	1
+ja[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	2	"シブヤ"	9	15	2	1
+ja[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	3	"ク"	15	18	3	1
+ja[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	count=4
+ko[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	0	"동"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	1	"경도"	3	9	1	1
+ko[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	3	"곡"	12	15	3	1
+ko[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=false,nfkc=true,rf=true]	"東京都渋谷区"	count=5
+zh[ws=false,nfkc=true,rf=true]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=false,nfkc=true,rf=true]	"中華人民共和國"	count=1
+ja[ws=false,nfkc=true,rf=true]	"中華人民共和國"	0	"チュウカ"	0	6	0	1
+ja[ws=false,nfkc=true,rf=true]	"中華人民共和國"	1	"ジンミン"	6	12	1	1
+ja[ws=false,nfkc=true,rf=true]	"中華人民共和國"	2	"キョウワ"	12	18	2	1
+ja[ws=false,nfkc=true,rf=true]	"中華人民共和國"	3	"クニ"	18	21	3	1
+ja[ws=false,nfkc=true,rf=true]	"中華人民共和國"	count=4
+ko[ws=false,nfkc=true,rf=true]	"中華人民共和國"	0	"중화"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"中華人民共和國"	1	"인민"	6	12	1	1
+ko[ws=false,nfkc=true,rf=true]	"中華人民共和國"	2	"공화"	12	18	2	1
+ko[ws=false,nfkc=true,rf=true]	"中華人民共和國"	3	"국"	18	21	3	1
+ko[ws=false,nfkc=true,rf=true]	"中華人民共和國"	count=4
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	count=8
+ja[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	0	"コクサイ"	0	6	0	1
+ja[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	1	"レンゴウ"	6	12	1	1
+ja[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	2	"キョウイク"	12	18	2	1
+ja[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	3	"カガク"	18	24	3	1
+ja[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	4	"ブンカ"	24	30	4	1
+ja[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	5	"キカン"	30	36	5	1
+ja[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	count=6
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	1	"제"	3	6	1	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	3	"합"	9	12	3	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	6	"과"	18	21	6	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	8	"문화"	24	30	8	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	9	"기"	30	33	9	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=false,nfkc=true,rf=true]	"国際連合教育科学文化機関"	count=11
+zh[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	0	"ジョウホウショリ"	0	12	0	1
+ja[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	1	"スイシン"	12	18	1	1
+ja[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	2	"キコウ"	18	24	2	1
+ja[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	0	"정보"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	2	"리"	9	12	2	1
+ko[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	3	"추진"	12	18	3	1
+ko[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	4	"기구"	18	24	4	1
+ko[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=false,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	count=1
+ja[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	count=1
+ko[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=false,nfkc=true,rf=true]	"서울대학교병원어린이병원"	count=5
+zh[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	0	"チュウ"	0	3	0	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	2	"ジンミン"	6	12	2	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	3	"キョウワ"	12	18	3	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	4	"コク"	18	21	4	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	5	"コク"	21	24	5	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	7	"イン"	27	30	7	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	8	"シン"	30	33	8	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	11	"オオヤケ"	39	42	11	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	12	"シツ"	42	45	12	1
+ja[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	0	"중"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	2	"인민"	6	12	2	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	3	"공화"	12	18	3	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	7	"원"	27	30	7	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	8	"신"	30	33	8	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	11	"공실"	39	45	11	1
+ko[ws=false,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	count=4
+ja[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	count=3
+ko[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=false,nfkc=true,rf=true]	"検索🔍エンジン"	count=4
+zh[ws=false,nfkc=true,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=false,nfkc=true,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=false,nfkc=true,rf=true]	"検索…エンジン"	2	"..."	6	9	2	1
+zh[ws=false,nfkc=true,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=false,nfkc=true,rf=true]	"検索…エンジン"	count=4
+ja[ws=false,nfkc=true,rf=true]	"検索…エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=false,nfkc=true,rf=true]	"検索…エンジン"	1	"..."	6	9	1	1
+ja[ws=false,nfkc=true,rf=true]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=false,nfkc=true,rf=true]	"検索…エンジン"	count=3
+ko[ws=false,nfkc=true,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=false,nfkc=true,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=false,nfkc=true,rf=true]	"検索…エンジン"	2	"..."	6	9	2	1
+ko[ws=false,nfkc=true,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=false,nfkc=true,rf=true]	"検索…エンジン"	count=4
+zh[ws=false,nfkc=true,rf=true]	"①②③"	0	"123"	0	9	0	1
+zh[ws=false,nfkc=true,rf=true]	"①②③"	count=1
+ja[ws=false,nfkc=true,rf=true]	"①②③"	0	"123"	0	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"①②③"	count=1
+ko[ws=false,nfkc=true,rf=true]	"①②③"	0	"123"	0	9	0	1
+ko[ws=false,nfkc=true,rf=true]	"①②③"	count=1
+zh[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"ソウシャ"	18	24	1	1
+ja[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"주자"	18	24	1	1
+ko[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=false,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=false,nfkc=true,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=false,nfkc=true,rf=true]	"쀍쀎쀏"	count=1
+ja[ws=false,nfkc=true,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=false,nfkc=true,rf=true]	"쀍쀎쀏"	count=1
+ko[ws=false,nfkc=true,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=false,nfkc=true,rf=true]	"쀍쀎쀏"	count=1
+zh[ws=false,nfkc=true,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=false,nfkc=true,rf=true]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=false,nfkc=true,rf=true]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=false,nfkc=true,rf=true]	"𠮷野家"	count=3
+ja[ws=false,nfkc=true,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=false,nfkc=true,rf=true]	"𠮷野家"	1	"ノヤ"	4	10	1	1
+ja[ws=false,nfkc=true,rf=true]	"𠮷野家"	count=2
+ko[ws=false,nfkc=true,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=false,nfkc=true,rf=true]	"𠮷野家"	1	"야"	4	7	1	1
+ko[ws=false,nfkc=true,rf=true]	"𠮷野家"	2	"가"	7	10	2	1
+ko[ws=false,nfkc=true,rf=true]	"𠮷野家"	count=3
+zh[ws=false,nfkc=true,rf=true]	""	<empty>
+ja[ws=false,nfkc=true,rf=true]	""	<empty>
+ko[ws=false,nfkc=true,rf=true]	""	<empty>
+zh[ws=false,nfkc=true,rf=true]	"   "	<empty>
+ja[ws=false,nfkc=true,rf=true]	"   "	<empty>
+ko[ws=false,nfkc=true,rf=true]	"   "	<empty>
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"，"	7	10	2	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	" "	31	32	7	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"("	32	33	8	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"包括"	33	39	9	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"符號"	39	45	10	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"與"	45	48	11	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"不標準"	48	57	12	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"的"	57	60	13	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"asci"	60	64	14	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"阿"	64	67	15	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"爾"	67	70	16	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"發"	70	73	17	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"字元"	73	79	18	1
+zh[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=19
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無"	16	19	5	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"的"	22	25	7	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"字"	25	28	8	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"元"	28	31	9	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	" "	31	32	10	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"("	32	33	11	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"包括"	33	39	12	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"符"	39	42	13	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"號"	42	45	14	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"與"	45	48	15	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"不"	48	51	16	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"標準"	51	57	17	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"的"	57	60	18	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"asci"	60	64	19	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"阿"	64	67	20	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"爾"	67	70	21	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"發"	70	73	22	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"字"	73	76	23	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	24	"元"	76	79	24	1
+ja[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=25
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無效"	16	22	5	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"的"	22	25	6	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"字"	25	28	7	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"元"	28	31	8	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	" "	31	32	9	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"("	32	33	10	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"包括"	33	39	11	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"符號"	39	45	12	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"與"	45	48	13	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"不"	48	51	14	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"標準"	51	57	15	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"的"	57	60	16	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"asci"	60	64	17	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"阿"	64	67	18	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"爾"	67	70	19	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"發"	70	73	20	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"字"	73	76	21	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"元"	76	79	22	1
+ko[ws=true,nfkc=false,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=23
+zh[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	1	" "	9	10	1	1
+zh[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+zh[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	count=3
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	1	" "	9	10	1	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	2	"もも"	10	16	2	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	3	"も"	16	19	3	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	4	"もも"	19	25	4	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	5	"も"	25	28	5	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	6	"の"	28	31	6	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	7	"うち"	31	37	7	1
+ja[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	count=8
+ko[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	1	" "	9	10	1	1
+ko[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+ko[ws=true,nfkc=false,rf=false]	"すもも もももももものうち"	count=3
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+zh[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+ja[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"."	15	16	2	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	" "	16	17	3	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"매우"	17	23	4	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	" "	23	24	5	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	"멋진"	24	30	6	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	" "	30	31	7	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	8	"단어"	31	37	8	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	9	"입니다"	37	46	9	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	10	"."	46	47	10	1
+ko[ws=true,nfkc=false,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=11
+zh[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+zh[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+zh[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	count=2
+ja[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+ja[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	1	"１"	9	12	1	1
+ja[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	2	"２"	12	15	2	1
+ja[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	3	"３"	15	18	3	1
+ja[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	count=4
+ko[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+ko[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+ko[ws=true,nfkc=false,rf=false]	"ＡＢＣ１２３"	count=2
+zh[ws=true,nfkc=false,rf=false]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=false,rf=false]	"日本語"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=false,rf=false]	"日本語"	count=2
+ja[ws=true,nfkc=false,rf=false]	"日本語"	0	"日本語"	0	9	0	1
+ja[ws=true,nfkc=false,rf=false]	"日本語"	count=1
+ko[ws=true,nfkc=false,rf=false]	"日本語"	0	"日本"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"日本語"	1	"語"	6	9	1	1
+ko[ws=true,nfkc=false,rf=false]	"日本語"	count=2
+zh[ws=true,nfkc=false,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=true,nfkc=false,rf=false]	"韓國"	count=1
+ja[ws=true,nfkc=false,rf=false]	"韓國"	0	"韓"	0	3	0	1
+ja[ws=true,nfkc=false,rf=false]	"韓國"	1	"國"	3	6	1	1
+ja[ws=true,nfkc=false,rf=false]	"韓國"	count=2
+ko[ws=true,nfkc=false,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"韓國"	count=1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+zh[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検索"	28	34	8	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"エンジン"	34	46	9	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"です"	46	52	10	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"。"	52	55	11	1
+ja[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=12
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+ko[ws=true,nfkc=false,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	" "	33	34	7	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"0"	34	35	8	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"."	35	36	9	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"25"	36	38	10	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	38	39	11	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"1"	39	40	12	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"版本"	40	46	13	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"。"	46	49	14	1
+zh[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=15
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"版本"	40	46	15	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ja[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"版本"	40	46	15	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ko[ws=true,nfkc=false,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+zh[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+ja[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+ko[ws=true,nfkc=false,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	0	"  "	0	2	0	1
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	1	"leading"	2	9	1	1
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	2	" "	9	10	2	1
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	3	"and"	10	13	3	1
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	4	" "	13	14	4	1
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	6	"  "	22	24	6	1
+zh[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	count=7
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	0	"  "	0	2	0	1
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	2	" "	9	10	2	1
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	3	"and"	10	13	3	1
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	4	" "	13	14	4	1
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	6	"  "	22	24	6	1
+ja[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	count=7
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	0	"  "	0	2	0	1
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	2	" "	9	10	2	1
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	3	"and"	10	13	3	1
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	4	" "	13	14	4	1
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	6	"  "	22	24	6	1
+ko[ws=true,nfkc=false,rf=false]	"  leading and trailing  "	count=7
+zh[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+zh[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+zh[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+zh[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	5	"改行"	17	23	5	1
+zh[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	count=6
+ja[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	0	"日本語"	0	9	0	1
+ja[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	1	"\t"	9	10	1	1
+ja[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ja[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	3	"\n"	16	17	3	1
+ja[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	4	"改行"	17	23	4	1
+ja[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	count=5
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	5	"改"	17	20	5	1
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	6	"行"	20	23	6	1
+ko[ws=true,nfkc=false,rf=false]	"日本語\tタブ\n改行"	count=7
+zh[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+zh[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	count=1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	0	"１"	0	3	0	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	1	"２"	3	6	1	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	2	"３"	6	9	2	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	3	"４"	9	12	3	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	4	"５"	12	15	4	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	5	"６"	15	18	5	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	6	"７"	18	21	6	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	7	"８"	21	24	7	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	8	"９"	24	27	8	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	9	"０"	27	30	9	1
+ja[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	count=10
+ko[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+ko[ws=true,nfkc=false,rf=false]	"１２３４５６７８９０"	count=1
+zh[ws=true,nfkc=false,rf=false]	"３．１４１５９"	0	"３"	0	3	0	1
+zh[ws=true,nfkc=false,rf=false]	"３．１４１５９"	1	"．"	3	6	1	1
+zh[ws=true,nfkc=false,rf=false]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+zh[ws=true,nfkc=false,rf=false]	"３．１４１５９"	count=3
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	0	"３"	0	3	0	1
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	1	"．"	3	6	1	1
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	2	"１"	6	9	2	1
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	3	"４"	9	12	3	1
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	4	"１"	12	15	4	1
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	5	"５"	15	18	5	1
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	6	"９"	18	21	6	1
+ja[ws=true,nfkc=false,rf=false]	"３．１４１５９"	count=7
+ko[ws=true,nfkc=false,rf=false]	"３．１４１５９"	0	"３"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"３．１４１５９"	1	"．"	3	6	1	1
+ko[ws=true,nfkc=false,rf=false]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+ko[ws=true,nfkc=false,rf=false]	"３．１４１５９"	count=3
+zh[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+zh[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	2	"８"	15	18	2	1
+zh[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	4	"４"	21	24	4	1
+zh[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	count=6
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	0	"２"	0	3	0	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	1	"０"	3	6	1	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	2	"２"	6	9	2	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	3	"６"	9	12	3	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	4	"年"	12	15	4	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	5	"８月"	15	21	5	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	6	"４"	21	24	6	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	7	"日"	24	27	7	1
+ja[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	count=8
+ko[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+ko[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+ko[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	2	"８"	15	18	2	1
+ko[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+ko[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	4	"４"	21	24	4	1
+ko[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+ko[ws=true,nfkc=false,rf=false]	"２０２６年８月４日"	count=6
+zh[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	1	" "	12	13	1	1
+zh[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+zh[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	3	"特別"	19	25	3	1
+zh[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	4	"市"	25	28	4	1
+zh[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	count=5
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	1	"民"	6	9	1	1
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	2	"國"	9	12	2	1
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	3	" "	12	13	3	1
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	4	"서울"	13	19	4	1
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	5	"特別"	19	25	5	1
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	6	"市"	25	28	6	1
+ja[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	count=7
+ko[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	1	"民國"	6	12	1	1
+ko[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	2	" "	12	13	2	1
+ko[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ko[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	4	"特別"	19	25	4	1
+ko[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	5	"市"	25	28	5	1
+ko[ws=true,nfkc=false,rf=false]	"大韓民國 서울特別市"	count=6
+zh[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	count=5
+ja[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	0	"東京"	0	6	0	1
+ja[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	1	"都"	6	9	1	1
+ja[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	2	"渋谷"	9	15	2	1
+ja[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	3	"区"	15	18	3	1
+ja[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	count=4
+ko[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+ko[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+ko[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=true,nfkc=false,rf=false]	"東京都渋谷区"	count=5
+zh[ws=true,nfkc=false,rf=false]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=true,nfkc=false,rf=false]	"中華人民共和國"	count=1
+ja[ws=true,nfkc=false,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ja[ws=true,nfkc=false,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ja[ws=true,nfkc=false,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ja[ws=true,nfkc=false,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ja[ws=true,nfkc=false,rf=false]	"中華人民共和國"	count=4
+ko[ws=true,nfkc=false,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ko[ws=true,nfkc=false,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ko[ws=true,nfkc=false,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ko[ws=true,nfkc=false,rf=false]	"中華人民共和國"	count=4
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	count=8
+ja[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	0	"国際"	0	6	0	1
+ja[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	1	"連合"	6	12	1	1
+ja[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	2	"教育"	12	18	2	1
+ja[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	3	"科学"	18	24	3	1
+ja[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	4	"文化"	24	30	4	1
+ja[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	5	"機関"	30	36	5	1
+ja[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	count=6
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	3	"合"	9	12	3	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	6	"科"	18	21	6	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	8	"文化"	24	30	8	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	9	"機"	30	33	9	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=true,nfkc=false,rf=false]	"国際連合教育科学文化機関"	count=11
+zh[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報処理"	0	12	0	1
+ja[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	1	"推進"	12	18	1	1
+ja[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	2	"機構"	18	24	2	1
+ja[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+ko[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進"	12	18	3	1
+ko[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	4	"機構"	18	24	4	1
+ko[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=true,nfkc=false,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	count=1
+ja[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	count=1
+ko[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=true,nfkc=false,rf=false]	"서울대학교병원어린이병원"	count=5
+zh[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公"	39	42	11	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	12	"室"	42	45	12	1
+ja[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公室"	39	45	11	1
+ko[ws=true,nfkc=false,rf=false]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	count=4
+ja[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	0	"検索"	0	6	0	1
+ja[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	count=3
+ko[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=true,nfkc=false,rf=false]	"検索🔍エンジン"	count=4
+zh[ws=true,nfkc=false,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=false,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=false,rf=false]	"検索…エンジン"	2	"…"	6	9	2	1
+zh[ws=true,nfkc=false,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=true,nfkc=false,rf=false]	"検索…エンジン"	count=4
+ja[ws=true,nfkc=false,rf=false]	"検索…エンジン"	0	"検索"	0	6	0	1
+ja[ws=true,nfkc=false,rf=false]	"検索…エンジン"	1	"…"	6	9	1	1
+ja[ws=true,nfkc=false,rf=false]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=true,nfkc=false,rf=false]	"検索…エンジン"	count=3
+ko[ws=true,nfkc=false,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=false,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=false,rf=false]	"検索…エンジン"	2	"…"	6	9	2	1
+ko[ws=true,nfkc=false,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=true,nfkc=false,rf=false]	"検索…エンジン"	count=4
+zh[ws=true,nfkc=false,rf=false]	"①②③"	0	"①②③"	0	9	0	1
+zh[ws=true,nfkc=false,rf=false]	"①②③"	count=1
+ja[ws=true,nfkc=false,rf=false]	"①②③"	0	"①②③"	0	9	0	1
+ja[ws=true,nfkc=false,rf=false]	"①②③"	count=1
+ko[ws=true,nfkc=false,rf=false]	"①②③"	0	"①②③"	0	9	0	1
+ko[ws=true,nfkc=false,rf=false]	"①②③"	count=1
+zh[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ja[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ko[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=true,nfkc=false,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=true,nfkc=false,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=true,nfkc=false,rf=false]	"쀍쀎쀏"	count=1
+ja[ws=true,nfkc=false,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=true,nfkc=false,rf=false]	"쀍쀎쀏"	count=1
+ko[ws=true,nfkc=false,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=true,nfkc=false,rf=false]	"쀍쀎쀏"	count=1
+zh[ws=true,nfkc=false,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=true,nfkc=false,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=true,nfkc=false,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=true,nfkc=false,rf=false]	"𠮷野家"	count=3
+ja[ws=true,nfkc=false,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=true,nfkc=false,rf=false]	"𠮷野家"	1	"野家"	4	10	1	1
+ja[ws=true,nfkc=false,rf=false]	"𠮷野家"	count=2
+ko[ws=true,nfkc=false,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=true,nfkc=false,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+ko[ws=true,nfkc=false,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+ko[ws=true,nfkc=false,rf=false]	"𠮷野家"	count=3
+zh[ws=true,nfkc=false,rf=false]	""	<empty>
+ja[ws=true,nfkc=false,rf=false]	""	<empty>
+ko[ws=true,nfkc=false,rf=false]	""	<empty>
+zh[ws=true,nfkc=false,rf=false]	"   "	<empty>
+ja[ws=true,nfkc=false,rf=false]	"   "	<empty>
+ko[ws=true,nfkc=false,rf=false]	"   "	<empty>
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"，"	7	10	2	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	" "	31	32	7	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"("	32	33	8	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"包括"	33	39	9	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"符號"	39	45	10	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"與"	45	48	11	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"不標準"	48	57	12	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"的"	57	60	13	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"asci"	60	64	14	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"阿"	64	67	15	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"爾"	67	70	16	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"發"	70	73	17	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"字元"	73	79	18	1
+zh[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=19
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"チ"	0	3	0	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"シ"	3	6	1	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"ホウガン"	10	16	4	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"ム"	16	19	5	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"テキ"	22	25	7	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"ジ"	25	28	8	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"モト"	28	31	9	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	" "	31	32	10	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"("	32	33	11	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"ホウカツ"	33	39	12	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"フ"	39	42	13	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"號"	42	45	14	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"アタエ"	45	48	15	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"フ"	48	51	16	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"ヒョウジュン"	51	57	17	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"テキ"	57	60	18	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"asci"	60	64	19	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"オモネ"	64	67	20	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"シカ"	67	70	21	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"發"	70	73	22	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"ジ"	73	76	23	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	24	"モト"	76	79	24	1
+ja[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=25
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"지"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"，"	7	10	3	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"포함"	10	16	4	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"무효"	16	22	5	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"적"	22	25	6	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"자"	25	28	7	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"원"	28	31	8	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	" "	31	32	9	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"*"	32	33	10	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"포괄"	33	39	11	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"부호"	39	45	12	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"여"	45	48	13	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"부"	48	51	14	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"표준"	51	57	15	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"적"	57	60	16	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"asci"	60	64	17	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"아"	64	67	18	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"爾"	67	70	19	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"발"	70	73	20	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"자"	73	76	21	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"원"	76	79	22	1
+ko[ws=true,nfkc=false,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=23
+zh[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	1	" "	9	10	1	1
+zh[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+zh[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	count=3
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	0	"スモモ"	0	9	0	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	1	" "	9	10	1	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	2	"モモ"	10	16	2	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	3	"モ"	16	19	3	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	4	"モモ"	19	25	4	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	5	"モ"	25	28	5	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	6	"ノ"	28	31	6	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	7	"ウチ"	31	37	7	1
+ja[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	count=8
+ko[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	1	" "	9	10	1	1
+ko[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+ko[ws=true,nfkc=false,rf=true]	"すもも もももももものうち"	count=3
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+zh[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+ja[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"*"	15	16	2	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	" "	16	17	3	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"매우"	17	23	4	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	" "	23	24	5	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	"멋진"	24	30	6	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	" "	30	31	7	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	8	"단어"	31	37	8	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	9	"입니다"	37	46	9	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	10	"*"	46	47	10	1
+ko[ws=true,nfkc=false,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=11
+zh[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+zh[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+zh[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	count=2
+ja[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	0	"エイビーシー"	0	9	0	1
+ja[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	1	"イチ"	9	12	1	1
+ja[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	2	"ニ"	12	15	2	1
+ja[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	3	"サン"	15	18	3	1
+ja[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	count=4
+ko[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	0	"ＡＢＣ"	0	9	0	1
+ko[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	1	"１２３"	9	18	1	1
+ko[ws=true,nfkc=false,rf=true]	"ＡＢＣ１２３"	count=2
+zh[ws=true,nfkc=false,rf=true]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=false,rf=true]	"日本語"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=false,rf=true]	"日本語"	count=2
+ja[ws=true,nfkc=false,rf=true]	"日本語"	0	"ニホンゴ"	0	9	0	1
+ja[ws=true,nfkc=false,rf=true]	"日本語"	count=1
+ko[ws=true,nfkc=false,rf=true]	"日本語"	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"日本語"	1	"어"	6	9	1	1
+ko[ws=true,nfkc=false,rf=true]	"日本語"	count=2
+zh[ws=true,nfkc=false,rf=true]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=true,nfkc=false,rf=true]	"韓國"	count=1
+ja[ws=true,nfkc=false,rf=true]	"韓國"	0	"カン"	0	3	0	1
+ja[ws=true,nfkc=false,rf=true]	"韓國"	1	"クニ"	3	6	1	1
+ja[ws=true,nfkc=false,rf=true]	"韓國"	count=2
+ko[ws=true,nfkc=false,rf=true]	"韓國"	0	"한국"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"韓國"	count=1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+zh[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"ハ"	9	12	2	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"ヨウ"	22	25	6	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"ノ"	25	28	7	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"ケンサク"	28	34	8	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"エンジン"	34	46	9	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"デス"	46	52	10	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"。"	52	55	11	1
+ja[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=12
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"용"	22	25	6	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+ko[ws=true,nfkc=false,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	" "	33	34	7	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"0"	34	35	8	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"."	35	36	9	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"25"	36	38	10	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	38	39	11	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"1"	39	40	12	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"版本"	40	46	13	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"。"	46	49	14	1
+zh[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=15
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"ワガ"	0	3	0	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"ザイ"	6	9	2	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"ネン"	13	16	4	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ヌノ"	19	22	6	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"リョウ"	22	25	7	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"ハンポン"	40	46	15	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ja[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"아"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"재"	6	9	2	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"년"	13	16	4	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"판본"	40	46	15	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ko[ws=true,nfkc=false,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+zh[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+ja[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"*"	32	33	7	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"*"	54	55	18	1
+ko[ws=true,nfkc=false,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	0	"  "	0	2	0	1
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	1	"leading"	2	9	1	1
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	2	" "	9	10	2	1
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	3	"and"	10	13	3	1
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	4	" "	13	14	4	1
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	6	"  "	22	24	6	1
+zh[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	count=7
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	0	"  "	0	2	0	1
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	2	" "	9	10	2	1
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	3	"and"	10	13	3	1
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	4	" "	13	14	4	1
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	6	"  "	22	24	6	1
+ja[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	count=7
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	0	"  "	0	2	0	1
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	2	" "	9	10	2	1
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	3	"and"	10	13	3	1
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	4	" "	13	14	4	1
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	6	"  "	22	24	6	1
+ko[ws=true,nfkc=false,rf=true]	"  leading and trailing  "	count=7
+zh[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+zh[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+zh[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+zh[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	5	"改行"	17	23	5	1
+zh[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	count=6
+ja[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	0	"ニホンゴ"	0	9	0	1
+ja[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	1	"\t"	9	10	1	1
+ja[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ja[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	3	"\n"	16	17	3	1
+ja[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	4	"カイギョウ"	17	23	4	1
+ja[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	count=5
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	1	"어"	6	9	1	1
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	5	"改"	17	20	5	1
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	6	"행"	20	23	6	1
+ko[ws=true,nfkc=false,rf=true]	"日本語\tタブ\n改行"	count=7
+zh[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+zh[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	count=1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	0	"イチ"	0	3	0	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	1	"ニ"	3	6	1	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	2	"サン"	6	9	2	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	3	"ヨン"	9	12	3	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	4	"ゴ"	12	15	4	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	5	"ロク"	15	18	5	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	6	"ナナ"	18	21	6	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	7	"ハチ"	21	24	7	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	8	"キュウ"	24	27	8	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	9	"ゼロ"	27	30	9	1
+ja[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	count=10
+ko[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	0	"１２３４５６７８９０"	0	30	0	1
+ko[ws=true,nfkc=false,rf=true]	"１２３４５６７８９０"	count=1
+zh[ws=true,nfkc=false,rf=true]	"３．１４１５９"	0	"３"	0	3	0	1
+zh[ws=true,nfkc=false,rf=true]	"３．１４１５９"	1	"．"	3	6	1	1
+zh[ws=true,nfkc=false,rf=true]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+zh[ws=true,nfkc=false,rf=true]	"３．１４１５９"	count=3
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	0	"サン"	0	3	0	1
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	1	"．"	3	6	1	1
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	2	"イチ"	6	9	2	1
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	3	"ヨン"	9	12	3	1
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	4	"イチ"	12	15	4	1
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	5	"ゴ"	15	18	5	1
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	6	"キュウ"	18	21	6	1
+ja[ws=true,nfkc=false,rf=true]	"３．１４１５９"	count=7
+ko[ws=true,nfkc=false,rf=true]	"３．１４１５９"	0	"３"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"３．１４１５９"	1	"．"	3	6	1	1
+ko[ws=true,nfkc=false,rf=true]	"３．１４１５９"	2	"１４１５９"	6	21	2	1
+ko[ws=true,nfkc=false,rf=true]	"３．１４１５９"	count=3
+zh[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+zh[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	2	"８"	15	18	2	1
+zh[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	4	"４"	21	24	4	1
+zh[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	count=6
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	0	"ニ"	0	3	0	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	1	"ゼロ"	3	6	1	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	2	"ニ"	6	9	2	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	3	"ロク"	9	12	3	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	4	"ネン"	12	15	4	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	5	"ハチガツ"	15	21	5	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	6	"ヨン"	21	24	6	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	7	"ニチ"	24	27	7	1
+ja[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	count=8
+ko[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	0	"２０２６"	0	12	0	1
+ko[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	1	"년"	12	15	1	1
+ko[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	2	"８"	15	18	2	1
+ko[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	3	"월"	18	21	3	1
+ko[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	4	"４"	21	24	4	1
+ko[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	5	"일"	24	27	5	1
+ko[ws=true,nfkc=false,rf=true]	"２０２６年８月４日"	count=6
+zh[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	1	" "	12	13	1	1
+zh[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+zh[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	3	"特別"	19	25	3	1
+zh[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	4	"市"	25	28	4	1
+zh[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	count=5
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	0	"タイカン"	0	6	0	1
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	1	"ミン"	6	9	1	1
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	2	"クニ"	9	12	2	1
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	3	" "	12	13	3	1
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	4	"서울"	13	19	4	1
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	5	"トクベツ"	19	25	5	1
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	6	"シ"	25	28	6	1
+ja[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	count=7
+ko[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	0	"대한"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	1	"민국"	6	12	1	1
+ko[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	2	" "	12	13	2	1
+ko[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ko[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	4	"특별"	19	25	4	1
+ko[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	5	"시"	25	28	5	1
+ko[ws=true,nfkc=false,rf=true]	"大韓民國 서울特別市"	count=6
+zh[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	count=5
+ja[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	0	"トウキョウ"	0	6	0	1
+ja[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	1	"ト"	6	9	1	1
+ja[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	2	"シブヤ"	9	15	2	1
+ja[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	3	"ク"	15	18	3	1
+ja[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	count=4
+ko[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	0	"동"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	1	"경도"	3	9	1	1
+ko[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	3	"곡"	12	15	3	1
+ko[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=true,nfkc=false,rf=true]	"東京都渋谷区"	count=5
+zh[ws=true,nfkc=false,rf=true]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=true,nfkc=false,rf=true]	"中華人民共和國"	count=1
+ja[ws=true,nfkc=false,rf=true]	"中華人民共和國"	0	"チュウカ"	0	6	0	1
+ja[ws=true,nfkc=false,rf=true]	"中華人民共和國"	1	"ジンミン"	6	12	1	1
+ja[ws=true,nfkc=false,rf=true]	"中華人民共和國"	2	"キョウワ"	12	18	2	1
+ja[ws=true,nfkc=false,rf=true]	"中華人民共和國"	3	"クニ"	18	21	3	1
+ja[ws=true,nfkc=false,rf=true]	"中華人民共和國"	count=4
+ko[ws=true,nfkc=false,rf=true]	"中華人民共和國"	0	"중화"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"中華人民共和國"	1	"인민"	6	12	1	1
+ko[ws=true,nfkc=false,rf=true]	"中華人民共和國"	2	"공화"	12	18	2	1
+ko[ws=true,nfkc=false,rf=true]	"中華人民共和國"	3	"국"	18	21	3	1
+ko[ws=true,nfkc=false,rf=true]	"中華人民共和國"	count=4
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	count=8
+ja[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	0	"コクサイ"	0	6	0	1
+ja[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	1	"レンゴウ"	6	12	1	1
+ja[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	2	"キョウイク"	12	18	2	1
+ja[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	3	"カガク"	18	24	3	1
+ja[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	4	"ブンカ"	24	30	4	1
+ja[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	5	"キカン"	30	36	5	1
+ja[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	count=6
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	1	"제"	3	6	1	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	3	"합"	9	12	3	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	6	"과"	18	21	6	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	8	"문화"	24	30	8	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	9	"기"	30	33	9	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=true,nfkc=false,rf=true]	"国際連合教育科学文化機関"	count=11
+zh[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	0	"ジョウホウショリ"	0	12	0	1
+ja[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	1	"スイシン"	12	18	1	1
+ja[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	2	"キコウ"	18	24	2	1
+ja[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	0	"정보"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	2	"리"	9	12	2	1
+ko[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	3	"추진"	12	18	3	1
+ko[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	4	"기구"	18	24	4	1
+ko[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=true,nfkc=false,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	count=1
+ja[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	count=1
+ko[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=true,nfkc=false,rf=true]	"서울대학교병원어린이병원"	count=5
+zh[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	0	"チュウ"	0	3	0	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	2	"ジンミン"	6	12	2	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	3	"キョウワ"	12	18	3	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	4	"コク"	18	21	4	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	5	"コク"	21	24	5	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	7	"イン"	27	30	7	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	8	"シン"	30	33	8	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	11	"オオヤケ"	39	42	11	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	12	"シツ"	42	45	12	1
+ja[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	0	"중"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	2	"인민"	6	12	2	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	3	"공화"	12	18	3	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	7	"원"	27	30	7	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	8	"신"	30	33	8	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	11	"공실"	39	45	11	1
+ko[ws=true,nfkc=false,rf=true]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	count=4
+ja[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	count=3
+ko[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=true,nfkc=false,rf=true]	"検索🔍エンジン"	count=4
+zh[ws=true,nfkc=false,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=false,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=false,rf=true]	"検索…エンジン"	2	"…"	6	9	2	1
+zh[ws=true,nfkc=false,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=true,nfkc=false,rf=true]	"検索…エンジン"	count=4
+ja[ws=true,nfkc=false,rf=true]	"検索…エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=true,nfkc=false,rf=true]	"検索…エンジン"	1	"…"	6	9	1	1
+ja[ws=true,nfkc=false,rf=true]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=true,nfkc=false,rf=true]	"検索…エンジン"	count=3
+ko[ws=true,nfkc=false,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=false,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=false,rf=true]	"検索…エンジン"	2	"*"	6	9	2	1
+ko[ws=true,nfkc=false,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=true,nfkc=false,rf=true]	"検索…エンジン"	count=4
+zh[ws=true,nfkc=false,rf=true]	"①②③"	0	"①②③"	0	9	0	1
+zh[ws=true,nfkc=false,rf=true]	"①②③"	count=1
+ja[ws=true,nfkc=false,rf=true]	"①②③"	0	"①②③"	0	9	0	1
+ja[ws=true,nfkc=false,rf=true]	"①②③"	count=1
+ko[ws=true,nfkc=false,rf=true]	"①②③"	0	"①②③"	0	9	0	1
+ko[ws=true,nfkc=false,rf=true]	"①②③"	count=1
+zh[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"ソウシャ"	18	24	1	1
+ja[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"주자"	18	24	1	1
+ko[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=true,nfkc=false,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=true,nfkc=false,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=true,nfkc=false,rf=true]	"쀍쀎쀏"	count=1
+ja[ws=true,nfkc=false,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=true,nfkc=false,rf=true]	"쀍쀎쀏"	count=1
+ko[ws=true,nfkc=false,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=true,nfkc=false,rf=true]	"쀍쀎쀏"	count=1
+zh[ws=true,nfkc=false,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=true,nfkc=false,rf=true]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=true,nfkc=false,rf=true]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=true,nfkc=false,rf=true]	"𠮷野家"	count=3
+ja[ws=true,nfkc=false,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=true,nfkc=false,rf=true]	"𠮷野家"	1	"ノヤ"	4	10	1	1
+ja[ws=true,nfkc=false,rf=true]	"𠮷野家"	count=2
+ko[ws=true,nfkc=false,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=true,nfkc=false,rf=true]	"𠮷野家"	1	"야"	4	7	1	1
+ko[ws=true,nfkc=false,rf=true]	"𠮷野家"	2	"가"	7	10	2	1
+ko[ws=true,nfkc=false,rf=true]	"𠮷野家"	count=3
+zh[ws=true,nfkc=false,rf=true]	""	<empty>
+ja[ws=true,nfkc=false,rf=true]	""	<empty>
+ko[ws=true,nfkc=false,rf=true]	""	<empty>
+zh[ws=true,nfkc=false,rf=true]	"   "	<empty>
+ja[ws=true,nfkc=false,rf=true]	"   "	<empty>
+ko[ws=true,nfkc=false,rf=true]	"   "	<empty>
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	","	7	10	2	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	" "	31	32	7	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"("	32	33	8	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"包括"	33	39	9	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"符號"	39	45	10	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"與"	45	48	11	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"不標準"	48	57	12	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"的"	57	60	13	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"asci"	60	64	14	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"阿"	64	67	15	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"爾"	67	70	16	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"發"	70	73	17	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"字元"	73	79	18	1
+zh[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=19
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	","	7	10	3	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無"	16	19	5	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"的"	22	25	7	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"字"	25	28	8	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"元"	28	31	9	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	" "	31	32	10	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"("	32	33	11	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"包括"	33	39	12	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"符"	39	42	13	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"號"	42	45	14	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"與"	45	48	15	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"不"	48	51	16	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"標準"	51	57	17	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"的"	57	60	18	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"asci"	60	64	19	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"阿"	64	67	20	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"爾"	67	70	21	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"發"	70	73	22	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"字"	73	76	23	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	24	"元"	76	79	24	1
+ja[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=25
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	","	7	10	3	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"包含"	10	16	4	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"無效"	16	22	5	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"的"	22	25	6	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"字"	25	28	7	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"元"	28	31	8	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	" "	31	32	9	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"("	32	33	10	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"包括"	33	39	11	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"符號"	39	45	12	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"與"	45	48	13	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"不"	48	51	14	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"標準"	51	57	15	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"的"	57	60	16	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"asci"	60	64	17	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"阿"	64	67	18	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"爾"	67	70	19	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"發"	70	73	20	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"字"	73	76	21	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"元"	76	79	22	1
+ko[ws=true,nfkc=true,rf=false]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=23
+zh[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	1	" "	9	10	1	1
+zh[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+zh[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	count=3
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	1	" "	9	10	1	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	2	"もも"	10	16	2	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	3	"も"	16	19	3	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	4	"もも"	19	25	4	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	5	"も"	25	28	5	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	6	"の"	28	31	6	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	7	"うち"	31	37	7	1
+ja[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	count=8
+ko[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	1	" "	9	10	1	1
+ko[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+ko[ws=true,nfkc=true,rf=false]	"すもも もももももものうち"	count=3
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+zh[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+ja[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	2	"."	15	16	2	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	3	" "	16	17	3	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	4	"매우"	17	23	4	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	5	" "	23	24	5	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	6	"멋진"	24	30	6	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	7	" "	30	31	7	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	8	"단어"	31	37	8	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	9	"입니다"	37	46	9	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	10	"."	46	47	10	1
+ko[ws=true,nfkc=true,rf=false]	"일본입니다. 매우 멋진 단어입니다."	count=11
+zh[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+zh[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+zh[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	count=2
+ja[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ja[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ja[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	count=2
+ko[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ko[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ko[ws=true,nfkc=true,rf=false]	"ＡＢＣ１２３"	count=2
+zh[ws=true,nfkc=true,rf=false]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=true,rf=false]	"日本語"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=true,rf=false]	"日本語"	count=2
+ja[ws=true,nfkc=true,rf=false]	"日本語"	0	"日本語"	0	9	0	1
+ja[ws=true,nfkc=true,rf=false]	"日本語"	count=1
+ko[ws=true,nfkc=true,rf=false]	"日本語"	0	"日本"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"日本語"	1	"語"	6	9	1	1
+ko[ws=true,nfkc=true,rf=false]	"日本語"	count=2
+zh[ws=true,nfkc=true,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=true,nfkc=true,rf=false]	"韓國"	count=1
+ja[ws=true,nfkc=true,rf=false]	"韓國"	0	"韓"	0	3	0	1
+ja[ws=true,nfkc=true,rf=false]	"韓國"	1	"國"	3	6	1	1
+ja[ws=true,nfkc=true,rf=false]	"韓國"	count=2
+ko[ws=true,nfkc=true,rf=false]	"韓國"	0	"韓國"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"韓國"	count=1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+zh[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検索"	28	34	8	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"エンジン"	34	46	9	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"です"	46	52	10	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"。"	52	55	11	1
+ja[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=12
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+ko[ws=true,nfkc=true,rf=false]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	" "	33	34	7	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"0"	34	35	8	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"."	35	36	9	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"25"	36	38	10	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	38	39	11	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"1"	39	40	12	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"版本"	40	46	13	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"。"	46	49	14	1
+zh[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=15
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"版本"	40	46	15	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ja[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"在"	6	9	2	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"年"	13	16	4	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"版本"	40	46	15	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ko[ws=true,nfkc=true,rf=false]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+zh[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+ja[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+ko[ws=true,nfkc=true,rf=false]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	0	"  "	0	2	0	1
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	1	"leading"	2	9	1	1
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	2	" "	9	10	2	1
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	3	"and"	10	13	3	1
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	4	" "	13	14	4	1
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	6	"  "	22	24	6	1
+zh[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	count=7
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	0	"  "	0	2	0	1
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	2	" "	9	10	2	1
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	3	"and"	10	13	3	1
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	4	" "	13	14	4	1
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	6	"  "	22	24	6	1
+ja[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	count=7
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	0	"  "	0	2	0	1
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	2	" "	9	10	2	1
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	3	"and"	10	13	3	1
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	4	" "	13	14	4	1
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	6	"  "	22	24	6	1
+ko[ws=true,nfkc=true,rf=false]	"  leading and trailing  "	count=7
+zh[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+zh[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+zh[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+zh[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	5	"改行"	17	23	5	1
+zh[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	count=6
+ja[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	0	"日本語"	0	9	0	1
+ja[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	1	"\t"	9	10	1	1
+ja[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ja[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	3	"\n"	16	17	3	1
+ja[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	4	"改行"	17	23	4	1
+ja[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	count=5
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	5	"改"	17	20	5	1
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	6	"行"	20	23	6	1
+ko[ws=true,nfkc=true,rf=false]	"日本語\tタブ\n改行"	count=7
+zh[ws=true,nfkc=true,rf=false]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+zh[ws=true,nfkc=true,rf=false]	"１２３４５６７８９０"	count=1
+ja[ws=true,nfkc=true,rf=false]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ja[ws=true,nfkc=true,rf=false]	"１２３４５６７８９０"	count=1
+ko[ws=true,nfkc=true,rf=false]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ko[ws=true,nfkc=true,rf=false]	"１２３４５６７８９０"	count=1
+zh[ws=true,nfkc=true,rf=false]	"３．１４１５９"	0	"3"	0	3	0	1
+zh[ws=true,nfkc=true,rf=false]	"３．１４１５９"	1	"."	3	6	1	1
+zh[ws=true,nfkc=true,rf=false]	"３．１４１５９"	2	"14159"	6	21	2	1
+zh[ws=true,nfkc=true,rf=false]	"３．１４１５９"	count=3
+ja[ws=true,nfkc=true,rf=false]	"３．１４１５９"	0	"3"	0	3	0	1
+ja[ws=true,nfkc=true,rf=false]	"３．１４１５９"	1	"."	3	6	1	1
+ja[ws=true,nfkc=true,rf=false]	"３．１４１５９"	2	"14159"	6	21	2	1
+ja[ws=true,nfkc=true,rf=false]	"３．１４１５９"	count=3
+ko[ws=true,nfkc=true,rf=false]	"３．１４１５９"	0	"3"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"３．１４１５９"	1	"."	3	6	1	1
+ko[ws=true,nfkc=true,rf=false]	"３．１４１５９"	2	"14159"	6	21	2	1
+ko[ws=true,nfkc=true,rf=false]	"３．１４１５９"	count=3
+zh[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+zh[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	2	"8"	15	18	2	1
+zh[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	4	"4"	21	24	4	1
+zh[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	count=6
+ja[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ja[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+ja[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ja[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+ja[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ja[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+ja[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	count=6
+ko[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ko[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	1	"年"	12	15	1	1
+ko[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ko[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	3	"月"	18	21	3	1
+ko[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ko[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	5	"日"	24	27	5	1
+ko[ws=true,nfkc=true,rf=false]	"２０２６年８月４日"	count=6
+zh[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	1	" "	12	13	1	1
+zh[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+zh[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	3	"特別"	19	25	3	1
+zh[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	4	"市"	25	28	4	1
+zh[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	count=5
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	1	"民"	6	9	1	1
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	2	"國"	9	12	2	1
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	3	" "	12	13	3	1
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	4	"서울"	13	19	4	1
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	5	"特別"	19	25	5	1
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	6	"市"	25	28	6	1
+ja[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	count=7
+ko[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	0	"大韓"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	1	"民國"	6	12	1	1
+ko[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	2	" "	12	13	2	1
+ko[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ko[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	4	"特別"	19	25	4	1
+ko[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	5	"市"	25	28	5	1
+ko[ws=true,nfkc=true,rf=false]	"大韓民國 서울特別市"	count=6
+zh[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	count=5
+ja[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	0	"東京"	0	6	0	1
+ja[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	1	"都"	6	9	1	1
+ja[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	2	"渋谷"	9	15	2	1
+ja[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	3	"区"	15	18	3	1
+ja[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	count=4
+ko[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	0	"東"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	1	"京都"	3	9	1	1
+ko[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	3	"谷"	12	15	3	1
+ko[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=true,nfkc=true,rf=false]	"東京都渋谷区"	count=5
+zh[ws=true,nfkc=true,rf=false]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=true,nfkc=true,rf=false]	"中華人民共和國"	count=1
+ja[ws=true,nfkc=true,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ja[ws=true,nfkc=true,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ja[ws=true,nfkc=true,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ja[ws=true,nfkc=true,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ja[ws=true,nfkc=true,rf=false]	"中華人民共和國"	count=4
+ko[ws=true,nfkc=true,rf=false]	"中華人民共和國"	0	"中華"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"中華人民共和國"	1	"人民"	6	12	1	1
+ko[ws=true,nfkc=true,rf=false]	"中華人民共和國"	2	"共和"	12	18	2	1
+ko[ws=true,nfkc=true,rf=false]	"中華人民共和國"	3	"國"	18	21	3	1
+ko[ws=true,nfkc=true,rf=false]	"中華人民共和國"	count=4
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	count=8
+ja[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	0	"国際"	0	6	0	1
+ja[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	1	"連合"	6	12	1	1
+ja[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	2	"教育"	12	18	2	1
+ja[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	3	"科学"	18	24	3	1
+ja[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	4	"文化"	24	30	4	1
+ja[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	5	"機関"	30	36	5	1
+ja[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	count=6
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	3	"合"	9	12	3	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	6	"科"	18	21	6	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	8	"文化"	24	30	8	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	9	"機"	30	33	9	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=true,nfkc=true,rf=false]	"国際連合教育科学文化機関"	count=11
+zh[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報処理"	0	12	0	1
+ja[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	1	"推進"	12	18	1	1
+ja[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	2	"機構"	18	24	2	1
+ja[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+ko[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	3	"推進"	12	18	3	1
+ko[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	4	"機構"	18	24	4	1
+ko[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=true,nfkc=true,rf=false]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	count=1
+ja[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	count=1
+ko[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=true,nfkc=true,rf=false]	"서울대학교병원어린이병원"	count=5
+zh[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公"	39	42	11	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	12	"室"	42	45	12	1
+ja[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	0	"中"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	2	"人民"	6	12	2	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	3	"共和"	12	18	3	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	7	"院"	27	30	7	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	8	"新"	30	33	8	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	11	"公室"	39	45	11	1
+ko[ws=true,nfkc=true,rf=false]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	count=4
+ja[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	0	"検索"	0	6	0	1
+ja[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	count=3
+ko[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=true,nfkc=true,rf=false]	"検索🔍エンジン"	count=4
+zh[ws=true,nfkc=true,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=true,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=true,rf=false]	"検索…エンジン"	2	"..."	6	9	2	1
+zh[ws=true,nfkc=true,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=true,nfkc=true,rf=false]	"検索…エンジン"	count=4
+ja[ws=true,nfkc=true,rf=false]	"検索…エンジン"	0	"検索"	0	6	0	1
+ja[ws=true,nfkc=true,rf=false]	"検索…エンジン"	1	"..."	6	9	1	1
+ja[ws=true,nfkc=true,rf=false]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=true,nfkc=true,rf=false]	"検索…エンジン"	count=3
+ko[ws=true,nfkc=true,rf=false]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=true,rf=false]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=true,rf=false]	"検索…エンジン"	2	"..."	6	9	2	1
+ko[ws=true,nfkc=true,rf=false]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=true,nfkc=true,rf=false]	"検索…エンジン"	count=4
+zh[ws=true,nfkc=true,rf=false]	"①②③"	0	"123"	0	9	0	1
+zh[ws=true,nfkc=true,rf=false]	"①②③"	count=1
+ja[ws=true,nfkc=true,rf=false]	"①②③"	0	"123"	0	9	0	1
+ja[ws=true,nfkc=true,rf=false]	"①②③"	count=1
+ko[ws=true,nfkc=true,rf=false]	"①②③"	0	"123"	0	9	0	1
+ko[ws=true,nfkc=true,rf=false]	"①②③"	count=1
+zh[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ja[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏者"	18	24	1	1
+ko[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=true,nfkc=true,rf=false]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=true,nfkc=true,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=true,nfkc=true,rf=false]	"쀍쀎쀏"	count=1
+ja[ws=true,nfkc=true,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=true,nfkc=true,rf=false]	"쀍쀎쀏"	count=1
+ko[ws=true,nfkc=true,rf=false]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=true,nfkc=true,rf=false]	"쀍쀎쀏"	count=1
+zh[ws=true,nfkc=true,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=true,nfkc=true,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=true,nfkc=true,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=true,nfkc=true,rf=false]	"𠮷野家"	count=3
+ja[ws=true,nfkc=true,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=true,nfkc=true,rf=false]	"𠮷野家"	1	"野家"	4	10	1	1
+ja[ws=true,nfkc=true,rf=false]	"𠮷野家"	count=2
+ko[ws=true,nfkc=true,rf=false]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=true,nfkc=true,rf=false]	"𠮷野家"	1	"野"	4	7	1	1
+ko[ws=true,nfkc=true,rf=false]	"𠮷野家"	2	"家"	7	10	2	1
+ko[ws=true,nfkc=true,rf=false]	"𠮷野家"	count=3
+zh[ws=true,nfkc=true,rf=false]	""	<empty>
+ja[ws=true,nfkc=true,rf=false]	""	<empty>
+ko[ws=true,nfkc=true,rf=false]	""	<empty>
+zh[ws=true,nfkc=true,rf=false]	"   "	<empty>
+ja[ws=true,nfkc=true,rf=false]	"   "	<empty>
+ko[ws=true,nfkc=true,rf=false]	"   "	<empty>
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"地址"	0	6	0	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"1"	6	7	1	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	","	7	10	2	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"包含"	10	16	3	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"無效"	16	22	4	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"的"	22	25	5	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"字元"	25	31	6	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	" "	31	32	7	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"("	32	33	8	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"包括"	33	39	9	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"符號"	39	45	10	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"與"	45	48	11	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"不標準"	48	57	12	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"的"	57	60	13	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"asci"	60	64	14	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"阿"	64	67	15	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"爾"	67	70	16	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"發"	70	73	17	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"字元"	73	79	18	1
+zh[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=19
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"チ"	0	3	0	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"シ"	3	6	1	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	","	7	10	3	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"ホウガン"	10	16	4	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"ム"	16	19	5	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"效"	19	22	6	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"テキ"	22	25	7	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"ジ"	25	28	8	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	"モト"	28	31	9	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	" "	31	32	10	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"("	32	33	11	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"ホウカツ"	33	39	12	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"フ"	39	42	13	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"號"	42	45	14	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"アタエ"	45	48	15	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"フ"	48	51	16	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"ヒョウジュン"	51	57	17	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"テキ"	57	60	18	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"asci"	60	64	19	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"オモネ"	64	67	20	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"シカ"	67	70	21	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"發"	70	73	22	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	23	"ジ"	73	76	23	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	24	"モト"	76	79	24	1
+ja[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=25
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	0	"지"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	1	"址"	3	6	1	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	2	"1"	6	7	2	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	3	"*"	7	10	3	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	4	"포함"	10	16	4	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	5	"무효"	16	22	5	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	6	"적"	22	25	6	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	7	"자"	25	28	7	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	8	"원"	28	31	8	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	9	" "	31	32	9	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	10	"*"	32	33	10	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	11	"포괄"	33	39	11	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	12	"부호"	39	45	12	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	13	"여"	45	48	13	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	14	"부"	48	51	14	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	15	"표준"	51	57	15	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	16	"적"	57	60	16	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	17	"asci"	60	64	17	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	18	"아"	64	67	18	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	19	"爾"	67	70	19	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	20	"발"	70	73	20	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	21	"자"	73	76	21	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	22	"원"	76	79	22	1
+ko[ws=true,nfkc=true,rf=true]	"地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元"	count=23
+zh[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+zh[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	1	" "	9	10	1	1
+zh[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+zh[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	count=3
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	0	"スモモ"	0	9	0	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	1	" "	9	10	1	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	2	"モモ"	10	16	2	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	3	"モ"	16	19	3	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	4	"モモ"	19	25	4	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	5	"モ"	25	28	5	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	6	"ノ"	28	31	6	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	7	"ウチ"	31	37	7	1
+ja[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	count=8
+ko[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	0	"すもも"	0	9	0	1
+ko[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	1	" "	9	10	1	1
+ko[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	2	"もももももものうち"	10	37	2	1
+ko[ws=true,nfkc=true,rf=true]	"すもも もももももものうち"	count=3
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+zh[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본입니다"	0	15	0	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"."	15	16	1	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	" "	16	17	2	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	"매우"	17	23	3	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	" "	23	24	4	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	"멋진"	24	30	5	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	" "	30	31	6	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	"단어입니다"	31	46	7	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	8	"."	46	47	8	1
+ja[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=9
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	1	"입니다"	6	15	1	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	2	"*"	15	16	2	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	3	" "	16	17	3	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	4	"매우"	17	23	4	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	5	" "	23	24	5	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	6	"멋진"	24	30	6	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	7	" "	30	31	7	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	8	"단어"	31	37	8	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	9	"입니다"	37	46	9	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	10	"*"	46	47	10	1
+ko[ws=true,nfkc=true,rf=true]	"일본입니다. 매우 멋진 단어입니다."	count=11
+zh[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+zh[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+zh[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	count=2
+ja[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ja[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ja[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	count=2
+ko[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	0	"ABC"	0	9	0	1
+ko[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	1	"123"	9	18	1	1
+ko[ws=true,nfkc=true,rf=true]	"ＡＢＣ１２３"	count=2
+zh[ws=true,nfkc=true,rf=true]	"日本語"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=true,rf=true]	"日本語"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=true,rf=true]	"日本語"	count=2
+ja[ws=true,nfkc=true,rf=true]	"日本語"	0	"ニホンゴ"	0	9	0	1
+ja[ws=true,nfkc=true,rf=true]	"日本語"	count=1
+ko[ws=true,nfkc=true,rf=true]	"日本語"	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"日本語"	1	"어"	6	9	1	1
+ko[ws=true,nfkc=true,rf=true]	"日本語"	count=2
+zh[ws=true,nfkc=true,rf=true]	"韓國"	0	"韓國"	0	6	0	1
+zh[ws=true,nfkc=true,rf=true]	"韓國"	count=1
+ja[ws=true,nfkc=true,rf=true]	"韓國"	0	"カン"	0	3	0	1
+ja[ws=true,nfkc=true,rf=true]	"韓國"	1	"クニ"	3	6	1	1
+ja[ws=true,nfkc=true,rf=true]	"韓國"	count=2
+ko[ws=true,nfkc=true,rf=true]	"韓國"	0	"한국"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"韓國"	count=1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"用"	22	25	6	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+zh[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"ハ"	9	12	2	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"ヨウ"	22	25	6	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"ノ"	25	28	7	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"ケンサク"	28	34	8	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"エンジン"	34	46	9	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"デス"	46	52	10	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"。"	52	55	11	1
+ja[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=12
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	0	"ParadeDB"	0	8	0	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	1	" "	8	9	1	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	2	"は"	9	12	2	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	3	" "	12	13	3	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	4	"Postgres"	13	21	4	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	5	" "	21	22	5	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	6	"용"	22	25	6	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	7	"の"	25	28	7	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	8	"検"	28	31	8	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	9	"索"	31	34	9	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	10	"エンジン"	34	46	10	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	11	"です"	46	52	11	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	12	"。"	52	55	12	1
+ko[ws=true,nfkc=true,rf=true]	"ParadeDB は Postgres 用の検索エンジンです。"	count=13
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"我们"	0	6	0	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"在"	6	9	1	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"2026"	9	13	2	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"年"	13	16	3	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"发布"	16	22	4	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"了"	22	25	5	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ParadeDB"	25	33	6	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	" "	33	34	7	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"0"	34	35	8	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	"."	35	36	9	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"25"	36	38	10	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	38	39	11	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"1"	39	40	12	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"版本"	40	46	13	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"。"	46	49	14	1
+zh[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=15
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"ワガ"	0	3	0	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"ザイ"	6	9	2	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"ネン"	13	16	4	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"ヌノ"	19	22	6	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"リョウ"	22	25	7	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"ハンポン"	40	46	15	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ja[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	0	"아"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	1	"们"	3	6	1	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	2	"재"	6	9	2	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	3	"2026"	9	13	3	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	4	"년"	13	16	4	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	5	"发"	16	19	5	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	6	"布"	19	22	6	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	7	"了"	22	25	7	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	8	"ParadeDB"	25	33	8	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	9	" "	33	34	9	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	10	"0"	34	35	10	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	11	"."	35	36	11	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	12	"25"	36	38	12	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	13	"."	38	39	13	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	14	"1"	39	40	14	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	15	"판본"	40	46	15	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	16	"。"	46	49	16	1
+ko[ws=true,nfkc=true,rf=true]	"我们在2026年发布了ParadeDB 0.25.1版本。"	count=17
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+zh[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	","	32	33	7	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"!"	54	55	18	1
+ja[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	0	"한국어"	0	9	0	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	1	" "	9	10	1	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	2	"검색"	10	16	2	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	3	" "	16	17	3	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	4	"엔진"	17	23	4	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	5	" "	23	24	5	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	6	"ParadeDB"	24	32	6	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	7	"*"	32	33	7	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	8	" "	33	34	8	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	9	"버전"	34	40	9	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	10	" "	40	41	10	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	11	"0"	41	42	11	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	12	"."	42	43	12	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	13	"25"	43	45	13	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	14	"."	45	46	14	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	15	"1"	46	47	15	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	16	" "	47	48	16	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	17	"출시"	48	54	17	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	18	"*"	54	55	18	1
+ko[ws=true,nfkc=true,rf=true]	"한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!"	count=19
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	0	"  "	0	2	0	1
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	1	"leading"	2	9	1	1
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	2	" "	9	10	2	1
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	3	"and"	10	13	3	1
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	4	" "	13	14	4	1
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	6	"  "	22	24	6	1
+zh[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	count=7
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	0	"  "	0	2	0	1
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	2	" "	9	10	2	1
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	3	"and"	10	13	3	1
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	4	" "	13	14	4	1
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	6	"  "	22	24	6	1
+ja[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	count=7
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	0	"  "	0	2	0	1
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	1	"leading"	2	9	1	1
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	2	" "	9	10	2	1
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	3	"and"	10	13	3	1
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	4	" "	13	14	4	1
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	5	"trailing"	14	22	5	1
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	6	"  "	22	24	6	1
+ko[ws=true,nfkc=true,rf=true]	"  leading and trailing  "	count=7
+zh[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	0	"日本"	0	6	0	1
+zh[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	1	"語"	6	9	1	1
+zh[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+zh[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+zh[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+zh[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	5	"改行"	17	23	5	1
+zh[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	count=6
+ja[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	0	"ニホンゴ"	0	9	0	1
+ja[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	1	"\t"	9	10	1	1
+ja[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	2	"タブ"	10	16	2	1
+ja[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	3	"\n"	16	17	3	1
+ja[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	4	"カイギョウ"	17	23	4	1
+ja[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	count=5
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	0	"일본"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	1	"어"	6	9	1	1
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	2	"\t"	9	10	2	1
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	3	"タブ"	10	16	3	1
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	4	"\n"	16	17	4	1
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	5	"改"	17	20	5	1
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	6	"행"	20	23	6	1
+ko[ws=true,nfkc=true,rf=true]	"日本語\tタブ\n改行"	count=7
+zh[ws=true,nfkc=true,rf=true]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+zh[ws=true,nfkc=true,rf=true]	"１２３４５６７８９０"	count=1
+ja[ws=true,nfkc=true,rf=true]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ja[ws=true,nfkc=true,rf=true]	"１２３４５６７８９０"	count=1
+ko[ws=true,nfkc=true,rf=true]	"１２３４５６７８９０"	0	"1234567890"	0	30	0	1
+ko[ws=true,nfkc=true,rf=true]	"１２３４５６７８９０"	count=1
+zh[ws=true,nfkc=true,rf=true]	"３．１４１５９"	0	"3"	0	3	0	1
+zh[ws=true,nfkc=true,rf=true]	"３．１４１５９"	1	"."	3	6	1	1
+zh[ws=true,nfkc=true,rf=true]	"３．１４１５９"	2	"14159"	6	21	2	1
+zh[ws=true,nfkc=true,rf=true]	"３．１４１５９"	count=3
+ja[ws=true,nfkc=true,rf=true]	"３．１４１５９"	0	"3"	0	3	0	1
+ja[ws=true,nfkc=true,rf=true]	"３．１４１５９"	1	"."	3	6	1	1
+ja[ws=true,nfkc=true,rf=true]	"３．１４１５９"	2	"14159"	6	21	2	1
+ja[ws=true,nfkc=true,rf=true]	"３．１４１５９"	count=3
+ko[ws=true,nfkc=true,rf=true]	"３．１４１５９"	0	"3"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"３．１４１５９"	1	"."	3	6	1	1
+ko[ws=true,nfkc=true,rf=true]	"３．１４１５９"	2	"14159"	6	21	2	1
+ko[ws=true,nfkc=true,rf=true]	"３．１４１５９"	count=3
+zh[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+zh[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	1	"年"	12	15	1	1
+zh[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	2	"8"	15	18	2	1
+zh[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	3	"月"	18	21	3	1
+zh[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	4	"4"	21	24	4	1
+zh[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	5	"日"	24	27	5	1
+zh[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	count=6
+ja[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ja[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	1	"ネン"	12	15	1	1
+ja[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ja[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	3	"ツキ"	18	21	3	1
+ja[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ja[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	5	"ニチ"	24	27	5	1
+ja[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	count=6
+ko[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	0	"2026"	0	12	0	1
+ko[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	1	"년"	12	15	1	1
+ko[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	2	"8"	15	18	2	1
+ko[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	3	"월"	18	21	3	1
+ko[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	4	"4"	21	24	4	1
+ko[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	5	"일"	24	27	5	1
+ko[ws=true,nfkc=true,rf=true]	"２０２６年８月４日"	count=6
+zh[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	0	"大韓民國"	0	12	0	1
+zh[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	1	" "	12	13	1	1
+zh[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	2	"서울"	13	19	2	1
+zh[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	3	"特別"	19	25	3	1
+zh[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	4	"市"	25	28	4	1
+zh[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	count=5
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	0	"タイカン"	0	6	0	1
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	1	"ミン"	6	9	1	1
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	2	"クニ"	9	12	2	1
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	3	" "	12	13	3	1
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	4	"서울"	13	19	4	1
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	5	"トクベツ"	19	25	5	1
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	6	"シ"	25	28	6	1
+ja[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	count=7
+ko[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	0	"대한"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	1	"민국"	6	12	1	1
+ko[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	2	" "	12	13	2	1
+ko[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	3	"서울"	13	19	3	1
+ko[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	4	"특별"	19	25	4	1
+ko[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	5	"시"	25	28	5	1
+ko[ws=true,nfkc=true,rf=true]	"大韓民國 서울特別市"	count=6
+zh[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	0	"東"	0	3	0	1
+zh[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	1	"京都"	3	9	1	1
+zh[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+zh[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	3	"谷"	12	15	3	1
+zh[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+zh[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	count=5
+ja[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	0	"トウキョウ"	0	6	0	1
+ja[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	1	"ト"	6	9	1	1
+ja[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	2	"シブヤ"	9	15	2	1
+ja[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	3	"ク"	15	18	3	1
+ja[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	count=4
+ko[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	0	"동"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	1	"경도"	3	9	1	1
+ko[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	2	"渋"	9	12	2	1
+ko[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	3	"곡"	12	15	3	1
+ko[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	4	"区"	15	18	4	1
+ko[ws=true,nfkc=true,rf=true]	"東京都渋谷区"	count=5
+zh[ws=true,nfkc=true,rf=true]	"中華人民共和國"	0	"中華人民共和國"	0	21	0	1
+zh[ws=true,nfkc=true,rf=true]	"中華人民共和國"	count=1
+ja[ws=true,nfkc=true,rf=true]	"中華人民共和國"	0	"チュウカ"	0	6	0	1
+ja[ws=true,nfkc=true,rf=true]	"中華人民共和國"	1	"ジンミン"	6	12	1	1
+ja[ws=true,nfkc=true,rf=true]	"中華人民共和國"	2	"キョウワ"	12	18	2	1
+ja[ws=true,nfkc=true,rf=true]	"中華人民共和國"	3	"クニ"	18	21	3	1
+ja[ws=true,nfkc=true,rf=true]	"中華人民共和國"	count=4
+ko[ws=true,nfkc=true,rf=true]	"中華人民共和國"	0	"중화"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"中華人民共和國"	1	"인민"	6	12	1	1
+ko[ws=true,nfkc=true,rf=true]	"中華人民共和國"	2	"공화"	12	18	2	1
+ko[ws=true,nfkc=true,rf=true]	"中華人民共和國"	3	"국"	18	21	3	1
+ko[ws=true,nfkc=true,rf=true]	"中華人民共和國"	count=4
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	1	"際"	3	6	1	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	2	"連合"	6	12	2	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	3	"教育"	12	18	3	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	4	"科学"	18	24	4	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	5	"文化"	24	30	5	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	6	"機"	30	33	6	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	7	"関"	33	36	7	1
+zh[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	count=8
+ja[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	0	"コクサイ"	0	6	0	1
+ja[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	1	"レンゴウ"	6	12	1	1
+ja[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	2	"キョウイク"	12	18	2	1
+ja[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	3	"カガク"	18	24	3	1
+ja[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	4	"ブンカ"	24	30	4	1
+ja[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	5	"キカン"	30	36	5	1
+ja[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	count=6
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	0	"国"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	1	"제"	3	6	1	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	2	"連"	6	9	2	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	3	"합"	9	12	3	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	4	"教"	12	15	4	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	5	"育"	15	18	5	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	6	"과"	18	21	6	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	7	"学"	21	24	7	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	8	"문화"	24	30	8	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	9	"기"	30	33	9	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	10	"関"	33	36	10	1
+ko[ws=true,nfkc=true,rf=true]	"国際連合教育科学文化機関"	count=11
+zh[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	0	"情報"	0	6	0	1
+zh[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+zh[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	2	"理"	9	12	2	1
+zh[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	3	"推進機"	12	21	3	1
+zh[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	4	"構"	21	24	4	1
+zh[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+zh[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+ja[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	0	"ジョウホウショリ"	0	12	0	1
+ja[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	1	"スイシン"	12	18	1	1
+ja[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	2	"キコウ"	18	24	2	1
+ja[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	3	"セキュリティ"	24	42	3	1
+ja[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	4	"センター"	42	54	4	1
+ja[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	count=5
+ko[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	0	"정보"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	1	"処"	6	9	1	1
+ko[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	2	"리"	9	12	2	1
+ko[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	3	"추진"	12	18	3	1
+ko[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	4	"기구"	18	24	4	1
+ko[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	5	"セキュリティセンター"	24	54	5	1
+ko[ws=true,nfkc=true,rf=true]	"情報処理推進機構セキュリティセンター"	count=6
+zh[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+zh[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	count=1
+ja[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	0	"서울대학교병원어린이병원"	0	36	0	1
+ja[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	count=1
+ko[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	0	"서울"	0	6	0	1
+ko[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	1	"대학교"	6	15	1	1
+ko[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	2	"병원"	15	21	2	1
+ko[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	3	"어린이"	21	30	3	1
+ko[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	4	"병원"	30	36	4	1
+ko[ws=true,nfkc=true,rf=true]	"서울대학교병원어린이병원"	count=5
+zh[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	0	"中华人民共和国"	0	21	0	1
+zh[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	1	"国务院新闻办公室"	21	45	1	1
+zh[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	count=2
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	0	"チュウ"	0	3	0	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	2	"ジンミン"	6	12	2	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	3	"キョウワ"	12	18	3	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	4	"コク"	18	21	4	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	5	"コク"	21	24	5	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	7	"イン"	27	30	7	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	8	"シン"	30	33	8	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	11	"オオヤケ"	39	42	11	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	12	"シツ"	42	45	12	1
+ja[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	count=13
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	0	"중"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	1	"华"	3	6	1	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	2	"인민"	6	12	2	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	3	"공화"	12	18	3	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	4	"国"	18	21	4	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	5	"国"	21	24	5	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	6	"务"	24	27	6	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	7	"원"	27	30	7	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	8	"신"	30	33	8	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	9	"闻"	33	36	9	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	10	"办"	36	39	10	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	11	"공실"	39	45	11	1
+ko[ws=true,nfkc=true,rf=true]	"中华人民共和国国务院新闻办公室"	count=12
+zh[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+zh[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+zh[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	count=4
+ja[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	1	"🔍"	6	10	1	1
+ja[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	2	"エンジン"	10	22	2	1
+ja[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	count=3
+ko[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	2	"🔍"	6	10	2	1
+ko[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	3	"エンジン"	10	22	3	1
+ko[ws=true,nfkc=true,rf=true]	"検索🔍エンジン"	count=4
+zh[ws=true,nfkc=true,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+zh[ws=true,nfkc=true,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+zh[ws=true,nfkc=true,rf=true]	"検索…エンジン"	2	"..."	6	9	2	1
+zh[ws=true,nfkc=true,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+zh[ws=true,nfkc=true,rf=true]	"検索…エンジン"	count=4
+ja[ws=true,nfkc=true,rf=true]	"検索…エンジン"	0	"ケンサク"	0	6	0	1
+ja[ws=true,nfkc=true,rf=true]	"検索…エンジン"	1	"..."	6	9	1	1
+ja[ws=true,nfkc=true,rf=true]	"検索…エンジン"	2	"エンジン"	9	21	2	1
+ja[ws=true,nfkc=true,rf=true]	"検索…エンジン"	count=3
+ko[ws=true,nfkc=true,rf=true]	"検索…エンジン"	0	"検"	0	3	0	1
+ko[ws=true,nfkc=true,rf=true]	"検索…エンジン"	1	"索"	3	6	1	1
+ko[ws=true,nfkc=true,rf=true]	"検索…エンジン"	2	"..."	6	9	2	1
+ko[ws=true,nfkc=true,rf=true]	"検索…エンジン"	3	"エンジン"	9	21	3	1
+ko[ws=true,nfkc=true,rf=true]	"検索…エンジン"	count=4
+zh[ws=true,nfkc=true,rf=true]	"①②③"	0	"123"	0	9	0	1
+zh[ws=true,nfkc=true,rf=true]	"①②③"	count=1
+ja[ws=true,nfkc=true,rf=true]	"①②③"	0	"123"	0	9	0	1
+ja[ws=true,nfkc=true,rf=true]	"①②③"	count=1
+ko[ws=true,nfkc=true,rf=true]	"①②③"	0	"123"	0	9	0	1
+ko[ws=true,nfkc=true,rf=true]	"①②③"	count=1
+zh[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+zh[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"奏"	18	21	1	1
+zh[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"者"	21	24	2	1
+zh[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	3	"ヴィヴァルディ"	24	45	3	1
+zh[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=4
+ja[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ja[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"ソウシャ"	18	24	1	1
+ja[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ja[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+ko[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	0	"ヴァイオリン"	0	18	0	1
+ko[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	1	"주자"	18	24	1	1
+ko[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	2	"ヴィヴァルディ"	24	45	2	1
+ko[ws=true,nfkc=true,rf=true]	"ヴァイオリン奏者ヴィヴァルディ"	count=3
+zh[ws=true,nfkc=true,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+zh[ws=true,nfkc=true,rf=true]	"쀍쀎쀏"	count=1
+ja[ws=true,nfkc=true,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ja[ws=true,nfkc=true,rf=true]	"쀍쀎쀏"	count=1
+ko[ws=true,nfkc=true,rf=true]	"쀍쀎쀏"	0	"쀍쀎쀏"	0	9	0	1
+ko[ws=true,nfkc=true,rf=true]	"쀍쀎쀏"	count=1
+zh[ws=true,nfkc=true,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+zh[ws=true,nfkc=true,rf=true]	"𠮷野家"	1	"野"	4	7	1	1
+zh[ws=true,nfkc=true,rf=true]	"𠮷野家"	2	"家"	7	10	2	1
+zh[ws=true,nfkc=true,rf=true]	"𠮷野家"	count=3
+ja[ws=true,nfkc=true,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ja[ws=true,nfkc=true,rf=true]	"𠮷野家"	1	"ノヤ"	4	10	1	1
+ja[ws=true,nfkc=true,rf=true]	"𠮷野家"	count=2
+ko[ws=true,nfkc=true,rf=true]	"𠮷野家"	0	"𠮷"	0	4	0	1
+ko[ws=true,nfkc=true,rf=true]	"𠮷野家"	1	"야"	4	7	1	1
+ko[ws=true,nfkc=true,rf=true]	"𠮷野家"	2	"가"	7	10	2	1
+ko[ws=true,nfkc=true,rf=true]	"𠮷野家"	count=3
+zh[ws=true,nfkc=true,rf=true]	""	<empty>
+ja[ws=true,nfkc=true,rf=true]	""	<empty>
+ko[ws=true,nfkc=true,rf=true]	""	<empty>
+zh[ws=true,nfkc=true,rf=true]	"   "	<empty>
+ja[ws=true,nfkc=true,rf=true]	"   "	<empty>
+ko[ws=true,nfkc=true,rf=true]	"   "	<empty>

--- a/tokenizers/tests/lindera_golden.rs
+++ b/tokenizers/tests/lindera_golden.rs
@@ -1,0 +1,227 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Golden token-stream test for the Lindera tokenizers.
+//!
+//! The unit tests in `tokenizers::lindera` assert a handful of tokens each,
+//! which is enough to prove an option is wired up but not enough to notice a
+//! dictionary or segmentation change. This test records the *entire* token
+//! stream — text, byte offsets, position and position length — for every
+//! tokenizer and option combination over a fixed CJK corpus, and compares it
+//! against a checked-in golden file.
+//!
+//! The point is index compatibility. A lindera bump, a dictionary rebuild or a
+//! change to the filter chain that shifts tokenization silently invalidates
+//! every BM25 index built with the previous version, and the diff of this file
+//! is the evidence of what moved. A change here is not automatically a bug —
+//! but it must be a deliberate, reviewed decision rather than a surprise.
+//!
+//! Regenerate after an intended change with:
+//!
+//! ```sh
+//! UPDATE_LINDERA_GOLDEN=1 cargo test -p tokenizers --test lindera_golden
+//! ```
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use tantivy::tokenizer::{TokenStream, Tokenizer};
+use tokenizers::lindera::{
+    LinderaChineseTokenizer, LinderaJapaneseTokenizer, LinderaKoreanTokenizer,
+};
+
+/// Inputs chosen to cover the cases where tokenization is most likely to move:
+/// out-of-vocabulary words, script boundaries, width variants, and long
+/// compounds where the Viterbi path has room to pick differently.
+const CORPUS: &[&str] = &[
+    // The inputs used by the unit tests in `tokenizers::lindera`.
+    "地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元",
+    "すもも もももももものうち",
+    "일본입니다. 매우 멋진 단어입니다.",
+    "ＡＢＣ１２３",
+    "日本語",
+    "韓國",
+    // Mixed script, latin, digits, punctuation.
+    "ParadeDB は Postgres 用の検索エンジンです。",
+    "我们在2026年发布了ParadeDB 0.25.1版本。",
+    "한국어 검색 엔진 ParadeDB, 버전 0.25.1 출시!",
+    // Whitespace shapes.
+    "  leading and trailing  ",
+    "日本語\tタブ\n改行",
+    // Numerals, units, half and full width.
+    "１２３４５６７８９０",
+    "３．１４１５９",
+    "２０２６年８月４日",
+    // Hanja and kanji shared across dictionaries.
+    "大韓民國 서울特別市",
+    "東京都渋谷区",
+    "中華人民共和國",
+    // Long compounds, where the Viterbi path is most likely to shift.
+    "国際連合教育科学文化機関",
+    "情報処理推進機構セキュリティセンター",
+    "서울대학교병원어린이병원",
+    "中华人民共和国国务院新闻办公室",
+    // Emoji and symbols interleaved with CJK.
+    "検索🔍エンジン",
+    "検索…エンジン",
+    "①②③",
+    // Rare and out-of-vocabulary words, which exercise the unknown-word handler
+    // and therefore the reading-form filter's treatment of it.
+    "ヴァイオリン奏者ヴィヴァルディ",
+    "쀍쀎쀏",
+    "𠮷野家",
+    // Empty and whitespace-only.
+    "",
+    "   ",
+];
+
+fn golden_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/golden/lindera_tokens.txt")
+}
+
+/// Append every token of `text` to `out`, one per line, prefixed by `label` so
+/// each record identifies the tokenizer and option set that produced it.
+fn dump<T: Tokenizer>(out: &mut String, label: &str, tokenizer: &mut T, text: &str) {
+    if text.trim().is_empty() {
+        // Matches the short-circuit in the tokenizer itself.
+        writeln!(out, "{label}\t{text:?}\t<empty>").unwrap();
+        return;
+    }
+
+    let mut stream = tokenizer.token_stream(text);
+    let mut count = 0;
+    while stream.advance() {
+        let token = stream.token();
+        writeln!(
+            out,
+            "{label}\t{text:?}\t{count}\t{:?}\t{}\t{}\t{}\t{}",
+            token.text, token.offset_from, token.offset_to, token.position, token.position_length
+        )
+        .unwrap();
+        count += 1;
+    }
+    writeln!(out, "{label}\t{text:?}\tcount={count}").unwrap();
+}
+
+fn token_dump() -> String {
+    let mut out = String::new();
+
+    for &keep_whitespace in &[false, true] {
+        for &nfkc in &[false, true] {
+            for &reading_form in &[false, true] {
+                let opts = format!("ws={keep_whitespace},nfkc={nfkc},rf={reading_form}");
+
+                // Chinese (cc-cedict) has no reading field, so the Chinese
+                // tokenizer takes no reading_form option; it is dumped under
+                // every option set anyway, which asserts that it does not move
+                // when the others do.
+                let mut zh = LinderaChineseTokenizer::with_options(keep_whitespace, nfkc);
+                let mut ja =
+                    LinderaJapaneseTokenizer::with_options(keep_whitespace, nfkc, reading_form);
+                let mut ko =
+                    LinderaKoreanTokenizer::with_options(keep_whitespace, nfkc, reading_form);
+
+                for text in CORPUS {
+                    dump(&mut out, &format!("zh[{opts}]"), &mut zh, text);
+                    dump(&mut out, &format!("ja[{opts}]"), &mut ja, text);
+                    dump(&mut out, &format!("ko[{opts}]"), &mut ko, text);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// The first few differing lines, with their line numbers, so a failure names
+/// what moved instead of dumping four thousand lines into the test output.
+fn describe_difference(expected: &str, actual: &str) -> String {
+    const MAX_REPORTED: usize = 10;
+
+    let expected: Vec<&str> = expected.lines().collect();
+    let actual: Vec<&str> = actual.lines().collect();
+
+    let mut report = String::new();
+    let mut differing = 0;
+
+    for (line, (expected, actual)) in expected.iter().zip(actual.iter()).enumerate() {
+        if expected == actual {
+            continue;
+        }
+        differing += 1;
+        if differing <= MAX_REPORTED {
+            writeln!(
+                report,
+                "line {}:\n  golden: {expected}\n  actual: {actual}",
+                line + 1
+            )
+            .unwrap();
+        }
+    }
+
+    if differing > MAX_REPORTED {
+        writeln!(
+            report,
+            "... and {} more differing lines",
+            differing - MAX_REPORTED
+        )
+        .unwrap();
+    }
+
+    if expected.len() != actual.len() {
+        writeln!(
+            report,
+            "token record count changed: golden has {} lines, actual has {}",
+            expected.len(),
+            actual.len()
+        )
+        .unwrap();
+    }
+
+    report
+}
+
+#[test]
+fn lindera_token_streams_match_golden() {
+    let actual = token_dump();
+    let path = golden_path();
+
+    if std::env::var_os("UPDATE_LINDERA_GOLDEN").is_some() {
+        std::fs::create_dir_all(path.parent().expect("golden path has a parent"))
+            .expect("golden directory must be creatable");
+        std::fs::write(&path, &actual).expect("golden file must be writable");
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "golden file {} could not be read ({e}); regenerate it with \
+             UPDATE_LINDERA_GOLDEN=1 cargo test -p tokenizers --test lindera_golden",
+            path.display()
+        )
+    });
+
+    assert!(
+        expected == actual,
+        "Lindera tokenization no longer matches the golden file.\n\n{}\n\
+         Indexes built with the previous tokenization will not match queries \
+         parsed with this one. If the change is intended, regenerate the golden \
+         file with:\n\n    UPDATE_LINDERA_GOLDEN=1 cargo test -p tokenizers \
+         --test lindera_golden\n\nand review the resulting diff as part of the change.",
+        describe_difference(&expected, &actual)
+    );
+}


### PR DESCRIPTION
## What

Records the full token stream — text, byte offsets, position, position length — for the Chinese, Japanese and Korean Lindera tokenizers across all eight `keep_whitespace`/NFKC/`reading_form` combinations over a 29-string corpus, and compares it against a checked-in golden file (`tokenizers/tests/golden/lindera_tokens.txt`, 4508 records).

## Why

The unit tests in `tokenizers::lindera` assert a handful of tokens each. That is enough to prove an option is wired up and nothing more — none of them would notice a dictionary rebuild or a segmentation change. Tokenization decides what is written into a BM25 index, so a shift there invalidates every index built with the previous version, and it does so quietly: queries simply stop matching.

A diff in this file is not automatically a bug. It is a statement that indexes built before the change no longer agree with queries parsed after it, which is a decision to be reviewed rather than something to discover in production. On a mismatch the test names the differing records and prints the regeneration command:

```sh
UPDATE_LINDERA_GOLDEN=1 cargo test -p tokenizers --test lindera_golden
```

The corpus targets where segmentation is most likely to move: out-of-vocabulary words, script and width boundaries, emoji, half/full-width numerals, Hanja shared across dictionaries, and long compounds where the Viterbi path has room to pick differently.

## It has already earned its keep

This harness is what turned up [lindera/lindera#853](https://github.com/lindera/lindera/pull/853). Under lindera 4.0.1, **614 of these 4508 records become a literal `*`** — a dead `UNK` guard in the reading-form filters lets the MeCab placeholder be substituted into the surface form of every unknown word. With `reading_form` off the two versions are byte-identical, which is why a smaller test would have missed it entirely.

Recorded here against **1.5.1**, which is what we ship. The 4.x bump stays held until that fix is released upstream.

## Test

`cargo test -p tokenizers --test lindera_golden` — passes; CI already runs `cargo test --package tokenizers`. Runtime is ~3s.