### PR TITLE
chore: Update to pull-based df-d branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,21 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,27 +1078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "8.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,13 +1992,11 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
- "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
- "datafusion-functions-nested",
  "datafusion-functions-table",
  "datafusion-functions-window",
  "datafusion-optimizer",
@@ -2051,8 +2013,6 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "parquet",
- "sqlparser",
  "tempfile",
  "tokio",
  "url",
@@ -2124,7 +2084,6 @@ dependencies = [
  "log",
  "num-traits",
  "object_store",
- "parquet",
  "sqlparser",
  "tokio",
  "uuid",
@@ -2238,40 +2197,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-datasource-parquet"
-version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=8d680db14a9134837bbd3d53497dd58c985c51a7#8d680db14a9134837bbd3d53497dd58c985c51a7"
-dependencies = [
- "arrow 59.1.0",
- "arrow-schema 59.1.0",
- "async-trait",
- "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
- "datafusion-session",
- "futures",
- "itertools 0.15.0",
- "log",
- "object_store",
- "parking_lot",
- "parquet",
- "tokio",
-]
-
-[[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-07-30-083335#d0310831503abc905b8b312732602676a4a97fb9"
+source = "git+https://github.com/paradedb/datafusion-distributed?branch=stuhood.rpc#62bb5b59ffe492074a2bea855d97b957aaf42a7b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2631,7 +2559,6 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
- "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-table",
@@ -3184,7 +3111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5382,7 +5309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5429,41 +5356,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "parquet"
-version = "59.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
-dependencies = [
- "ahash 0.8.12",
- "arrow-array 59.1.0",
- "arrow-buffer 59.1.0",
- "arrow-data 59.1.0",
- "arrow-ipc",
- "arrow-schema 59.1.0",
- "arrow-select 59.1.0",
- "base64",
- "brotli",
- "bytes",
- "chrono",
- "flate2",
- "futures",
- "half 2.7.1",
- "hashbrown 0.17.1",
- "lz4_flex",
- "num-bigint",
- "num-integer",
- "num-traits",
- "object_store",
- "paste",
- "seq-macro",
- "simdutf8",
- "snap",
- "tokio",
- "twox-hash",
- "zstd",
 ]
 
 [[package]]
@@ -6206,7 +6098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6356,7 +6248,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6881,7 +6773,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6894,7 +6786,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6953,7 +6845,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7060,12 +6952,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -7305,12 +7191,6 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "snap"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "soa_derive"
@@ -7977,7 +7857,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8863,7 +8743,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8978,15 +8858,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?branch=stuhood.rpc#62bb5b59ffe492074a2bea855d97b957aaf42a7b"
+source = "git+https://github.com/paradedb/datafusion-distributed?branch=stuhood.rpc#819c5888492d5a727ec23d9ab7dbdf390ca89bb0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3111,7 +3111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5309,7 +5309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6098,7 +6098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6248,7 +6248,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6786,7 +6786,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6845,7 +6845,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7857,7 +7857,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8743,7 +8743,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?branch=stuhood.rpc#819c5888492d5a727ec23d9ab7dbdf390ca89bb0"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-06-032638#8426f845f4fc0edbffdf9152c20840fe7e01ba5f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6773,7 +6773,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8858,6 +8858,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-vW8NFEztktp2vE2Bt2d3MAQqMONsjy/rhkZUFB0yOoE=";
+  cargoHash = "sha256-5elL7oGkUglaplwZppfVR4woCdAf3Nc7SZanx5+sirc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -92,7 +92,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", branch = "stuhood.rpc", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-06-032638", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -92,7 +92,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-07-30-083335", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", branch = "stuhood.rpc", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -660,14 +660,6 @@ impl CustomScan for AggregateScan {
         // query so blocked producers stop).
         if let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() {
             df_state.stream = None;
-            // Release the DSM-backed control senders before `recv`. A producer's `work_mem`
-            // overflow (or any worker error) is re-raised in the leader from inside `recv`, which
-            // longjmps out of this hook; a release placed after it would never run, leaving the
-            // senders for the detach callback, which clears them while the mapping is still live.
-            // The query is done producing here, so the senders aren't needed.
-            if let Some(leader) = df_state.mpp.leader() {
-                leader.release_control_senders();
-            }
             // Drain the workers' metrics frames off the mesh BEFORE joining the workers. On an
             // early-terminated query the rings still hold data the leader will never read; a
             // worker's bounded metrics send spins on the full ring until the leader frees slots.
@@ -677,7 +669,10 @@ impl CustomScan for AggregateScan {
             if let Some(leader) = df_state.mpp.leader()
                 && let Some(plan) = df_state.physical_plan.as_ref()
             {
-                crate::postgres::customscan::mpp::glue::drain_worker_metrics(plan, &leader.mesh);
+                crate::postgres::customscan::mpp::glue::drain_worker_metrics(
+                    plan,
+                    &leader.session.mesh,
+                );
             }
             // Join the producer workers so their metrics land before the EXPLAIN render (which runs
             // before end_custom_scan, where the context is finally destroyed). A worker error is
@@ -1598,7 +1593,7 @@ impl AggregateScan {
                         let source =
                             crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
                         let exec_ctx =
-                            Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
+                            Self::build_mpp_session_context(Some(Arc::clone(&leader.session.mesh)))
                                 .with_distributed_dispatch_plan_source(source);
                         let mut timing = leader.timing;
                         timing.plan_us = plan_us;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1366,9 +1366,10 @@ impl CustomScan for JoinScan {
                     Some(bytes) => match Self::launch_mpp(state, &plan, bytes.len()) {
                         Some(leader) => {
                             let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
-                            let exec_ctx =
-                                Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
-                                    .with_distributed_dispatch_plan_source(source);
+                            let exec_ctx = Self::build_mpp_session_context(Some(Arc::clone(
+                                &leader.session.mesh,
+                            )))
+                            .with_distributed_dispatch_plan_source(source);
                             launch_us.prepare_us = leader.timing.prepare_us;
                             launch_us.payload_us = leader.timing.payload_us;
                             launch_us.attach_us = leader.timing.attach_us;
@@ -1473,14 +1474,7 @@ impl CustomScan for JoinScan {
         // leader-inbox detach, so producers blocked on full rings stop. Harmless when the gather
         // already reached EOF.
         state.custom_state_mut().datafusion_stream = None;
-        // Release the DSM-backed control senders before `recv`. A producer's `work_mem` overflow
-        // (or any worker error) is re-raised in the leader from inside `recv`, which `longjmp`s
-        // out of this hook; a release placed after it would never run, leaving the senders for the
-        // detach callback, which clears them while the mapping is still live. The query is done
-        // producing here, so the senders aren't needed, and the drop runs while DSM is mapped.
-        if let Some(leader) = state.custom_state().mpp.leader() {
-            leader.release_control_senders();
-        }
+
         // Drain the workers' metrics frames off the mesh BEFORE joining the workers. On an
         // early-terminated query the rings still hold data the leader will never read; a worker's
         // bounded metrics send spins on the full ring until the leader frees slots. Draining here
@@ -1489,7 +1483,10 @@ impl CustomScan for JoinScan {
         if let Some(leader) = state.custom_state().mpp.leader()
             && let Some(plan) = state.custom_state().physical_plan.as_ref()
         {
-            crate::postgres::customscan::mpp::glue::drain_worker_metrics(plan, &leader.mesh);
+            crate::postgres::customscan::mpp::glue::drain_worker_metrics(
+                plan,
+                &leader.session.mesh,
+            );
         }
         // Join the producer workers so their metrics land before the EXPLAIN render (which runs
         // before end_custom_scan, where the context is finally destroyed). A worker error is

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -38,6 +38,7 @@ use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
     DistributedConfig, DistributedExt, DistributedTaskContext, SessionStateBuilderExt,
 };
+use futures::StreamExt;
 use pgrx::pg_sys;
 use tantivy::index::SegmentId;
 
@@ -233,11 +234,15 @@ pub(crate) fn run_mpp_worker(
         n_workers,
     ) {
         Ok(v) => v,
-        Err(e) => pgrx::error!("mpp worker: build fragment assignments failed: {e}"),
+        Err(e) => {
+            worker_mesh.clear_keep_alive_senders();
+            pgrx::error!("mpp worker: build fragment assignments failed: {e}");
+        }
     };
     if fragments.is_empty() {
         // The launch spawns `producer_count <= max_tasks` producers, so the widest stage's
         // round-robin assigns every proc at least one fragment.
+        worker_mesh.clear_keep_alive_senders();
         pgrx::error!("mpp worker: no fragments assigned (proc={this_proc})");
     }
 
@@ -262,7 +267,10 @@ pub(crate) fn run_mpp_worker(
         });
         match collected {
             Ok(frames) => frames,
-            Err(e) => pgrx::error!("mpp worker: plan frames did not arrive: {e}"),
+            Err(e) => {
+                worker_mesh.clear_keep_alive_senders();
+                pgrx::error!("mpp worker: plan frames did not arrive: {e}");
+            }
         }
     };
     let decode_ctx = session.task_ctx();
@@ -273,6 +281,7 @@ pub(crate) fn run_mpp_worker(
     // allocations aggressively; decode builds the plan graph and can spike memory.
     for (fragment, frame) in fragments.iter().zip(frames) {
         let Some(set_plan) = frame.set_plan else {
+            worker_mesh.clear_keep_alive_senders();
             pgrx::error!(
                 "mpp worker: SetPlan frame without a request (stage_id={}, task_idx={})",
                 fragment.stage_id,
@@ -290,11 +299,14 @@ pub(crate) fn run_mpp_worker(
             &DeduplicatingProtoConverter {},
         ) {
             Ok(plan) => plans.push(plan),
-            Err(e) => pgrx::error!(
-                "mpp worker: decode dispatched plan failed (stage_id={}, task_idx={}): {e}",
-                fragment.stage_id,
-                fragment.task_idx
-            ),
+            Err(e) => {
+                worker_mesh.clear_keep_alive_senders();
+                pgrx::error!(
+                    "mpp worker: decode dispatched plan failed (stage_id={}, task_idx={}): {e}",
+                    fragment.stage_id,
+                    fragment.task_idx
+                );
+            }
         }
     }
 
@@ -314,6 +326,7 @@ pub(crate) fn run_mpp_worker(
     // (the scanner's own `CHECK_FOR_INTERRUPTS`, a buffer wait) can `proc_exit` out of the
     // live runtime. The loops poll cooperatively to bail promptly; see `mpp::interrupt`.
     let held = HeldInterrupts::hold();
+    let mesh_for_block = Arc::clone(&worker_mesh);
     let result = runtime.block_on(async move {
         let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
         let mut executed_fragments: Vec<(u32, usize, usize, Arc<dyn ExecutionPlan>)> =
@@ -374,10 +387,10 @@ pub(crate) fn run_mpp_worker(
                     base.clone_with_header(MppFrameHeader::batch(
                         fragment.stage_id,
                         q_u32,
-                        worker_mesh.this_proc,
+                        mesh_for_block.this_proc,
                     ))
                     .with_cooperative_drain(
-                        Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
+                        Arc::clone(&mesh_for_block) as Arc<dyn CooperativeDrainSet>
                     ),
                 )));
             }
@@ -402,7 +415,7 @@ pub(crate) fn run_mpp_worker(
 
             // The fragment arrives ready-to-run: the leader serialized it with nested stages
             // already `Remote`, so its boundary leaves read the mesh through the session's
-            // `ShmChannelResolver`. Nothing here converts or dispatches.
+            // `ShmChannelResolver`.
             let plan = Arc::clone(frag_plan);
             // Kept for the post-run metrics frame: the executed nodes (and their metrics)
             // live in this plan.
@@ -412,11 +425,93 @@ pub(crate) fn run_mpp_worker(
                 fragment.task_count,
                 Arc::clone(&plan),
             ));
-            futures.push(Box::pin(run_worker_fragment(
-                plan,
-                per_partition_sinks,
-                task_ctx,
-            )));
+
+            let mesh = Arc::clone(&mesh_for_block);
+            let stage_id = fragment.stage_id;
+            let task_idx = fragment.task_idx as u32;
+            let n_out = per_partition_sinks.len();
+            let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
+
+            // Defer execution until an ExecuteTask RPC request arrives for a target partition range.
+            futures.push(Box::pin(async move {
+                let mut rx = mesh.take_execute_task_rx(stage_id, task_idx).await?;
+                let mut sub_futures = futures::stream::FuturesUnordered::new();
+                let mut partitions_requested = 0;
+
+                if n_out == 0 {
+                    return Ok::<_, datafusion::common::DataFusionError>(());
+                }
+
+                loop {
+                    if partitions_requested >= n_out && sub_futures.is_empty() {
+                        break;
+                    }
+                    tokio::select! {
+                        frame_res = rx.recv(), if partitions_requested < n_out => {
+                            match frame_res {
+                                Some(Ok(frame)) => {
+                                    let (request, _headers) = frame.into_parts()?;
+                                    let start = request.target_partition_start as usize;
+                                    let end = request.target_partition_end as usize;
+                                    let len = end - start;
+
+                                    if end > sinks_opt.len() || start > end {
+                                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                                            "mpp worker dispatch: requested partition range {start}..{end} \
+                                             out of bounds for sink count {} (stage_id={stage_id}, task_idx={task_idx})",
+                                            sinks_opt.len()
+                                        )));
+                                    }
+
+                                    let mut task_sinks = Vec::with_capacity(len);
+                                    for (i, sink) in sinks_opt.iter_mut().enumerate().take(end).skip(start) {
+                                        let Some(s) = sink.take() else {
+                                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                                "mpp worker dispatch: sink for partition {i} already taken \
+                                                 (stage_id={stage_id}, task_idx={task_idx})",
+                                            )));
+                                        };
+                                        task_sinks.push(s);
+                                    }
+
+                                    sub_futures.push(run_worker_fragment(
+                                        Arc::clone(&plan),
+                                        task_sinks,
+                                        Arc::clone(&task_ctx),
+                                        start..end,
+                                    ));
+                                    partitions_requested += len;
+                                }
+                                Some(Err(e)) => {
+                                    return Err(datafusion::common::DataFusionError::Execution(format!(
+                                        "mpp worker rx error: {e}, stage: {stage_id}, task: {task_idx}, \
+                                         requested: {partitions_requested}/{n_out}"
+                                    )));
+                                }
+                                None => {
+                                    partitions_requested = n_out;
+                                }
+                            }
+                        }
+                        next_res = sub_futures.next(), if !sub_futures.is_empty() => {
+                            match next_res {
+                                Some(Ok(_)) => {}
+                                Some(Err(e)) => return Err(e),
+                                None => unreachable!(),
+                            }
+                        }
+                        _ = tokio::task::yield_now() => {
+                            if let Err(e) = mesh.inbound_receiver().try_drain_pass() {
+                                return Err(datafusion::common::DataFusionError::Execution(format!(
+                                    "mpp worker drain error: {e}, stage: {stage_id}, task: {task_idx}, \
+                                     requested: {partitions_requested}/{n_out}"
+                                )));
+                            }
+                        }
+                    }
+                }
+                Ok(())
+            }));
         }
         // The metrics frames go to the leader after the fragments finish; the clone keeps one
         // sender on the leader's inbox alive past the drop below, which only delays that ring's
@@ -443,29 +538,28 @@ pub(crate) fn run_mpp_worker(
         // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
         // within 30 s the dispatcher surfaces an error instead of letting the backend spin
         // forever.
-        let join_fut = futures::future::join_all(futures);
+        let mut frag_stream: futures::stream::FuturesUnordered<_> = futures.into_iter().collect();
+        let join_fut = async {
+            while let Some(res) = frag_stream.next().await {
+                res?;
+            }
+            Ok::<(), datafusion::common::DataFusionError>(())
+        };
         let outcome: Result<(), datafusion::common::DataFusionError> = if crate::gucs::mpp_debug() {
             match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
-                Ok(results) => results
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()
-                    .map(|_| ()),
+                Ok(res) => res,
                 Err(_) => {
                     crate::mpp_log!(
-                        "mpp worker dispatch this_proc={this_proc} HANG: join_all exceeded 30s"
+                        "mpp worker dispatch this_proc={this_proc} HANG: fragment execution exceeded 30s"
                     );
                     Err(datafusion::common::DataFusionError::Internal(format!(
-                        "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
+                        "mpp worker dispatch (proc={this_proc}): fragment execution exceeded 30s; \
                          deadlock detector triggered"
                     )))
                 }
             }
         } else {
-            join_fut
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .map(|_| ())
+            join_fut.await
         };
 
         // Report each fragment's metrics to the leader, even after a fragment error: partial
@@ -491,6 +585,7 @@ pub(crate) fn run_mpp_worker(
     drop(held);
     check_for_interrupts();
     if let Err(e) = result {
+        worker_mesh.clear_keep_alive_senders();
         pgrx::error!("mpp worker: fragment dispatch failed: {e}");
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -188,6 +188,102 @@ async fn take_set_plan_draining(
     }
 }
 
+/// Dispatches execution of a worker fragment upon receiving partition-range RPC requests.
+///
+/// Waits for incoming `ExecuteTask` requests on `mesh` for `(stage_id, task_idx)`, slicing
+/// and assigning partition sinks to spawned `run_worker_fragment` sub-futures.
+/// Concurrently drains the inbound channel pass while yielding.
+async fn dispatch_fragment_requests(
+    mesh: Arc<MppMesh>,
+    stage_id: u32,
+    task_idx: u32,
+    per_partition_sinks: Vec<Box<dyn PartitionSink>>,
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> Result<(), datafusion::common::DataFusionError> {
+    let mut rx = mesh.take_execute_task_rx(stage_id, task_idx).await?;
+    let mut sub_futures = futures::stream::FuturesUnordered::new();
+    let n_out = per_partition_sinks.len();
+    let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
+    let mut partitions_requested = 0;
+
+    if n_out == 0 {
+        return Ok(());
+    }
+
+    loop {
+        if partitions_requested >= n_out && sub_futures.is_empty() {
+            break;
+        }
+        tokio::select! {
+            frame_res = rx.recv(), if partitions_requested < n_out => {
+                match frame_res {
+                    Some(Ok(frame)) => {
+                        let (request, _headers) = frame.into_parts()?;
+                        let start = request.target_partition_start as usize;
+                        let end = request.target_partition_end as usize;
+
+                        if start > end || end > sinks_opt.len() {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch: requested partition range {start}..{end} \
+                                 out of bounds for sink count {} (stage_id={stage_id}, task_idx={task_idx})",
+                                sinks_opt.len()
+                            )));
+                        }
+
+                        let len = end - start;
+
+                        let mut task_sinks = Vec::with_capacity(len);
+                        for (i, sink) in sinks_opt.iter_mut().enumerate().take(end).skip(start) {
+                            let Some(s) = sink.take() else {
+                                return Err(datafusion::common::DataFusionError::Internal(format!(
+                                    "mpp worker dispatch: sink for partition {i} already taken \
+                                     (stage_id={stage_id}, task_idx={task_idx})",
+                                )));
+                            };
+                            task_sinks.push(s);
+                        }
+
+                        sub_futures.push(run_worker_fragment(
+                            Arc::clone(&plan),
+                            task_sinks,
+                            Arc::clone(&task_ctx),
+                            start..end,
+                        ));
+                        partitions_requested += len;
+                    }
+                    Some(Err(e)) => {
+                        return Err(datafusion::common::DataFusionError::Execution(format!(
+                            "mpp worker rx error: {e} (stage_id={stage_id}, task_idx={task_idx}, \
+                             requested={partitions_requested}/{n_out})"
+                        )));
+                    }
+                    None => {
+                        // Closed feed: consumers are done requesting; unrequested partitions have no waiter.
+                        partitions_requested = n_out;
+                    }
+                }
+            }
+            next_res = sub_futures.next(), if !sub_futures.is_empty() => {
+                match next_res {
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => return Err(e),
+                    None => unreachable!(),
+                }
+            }
+            _ = tokio::task::yield_now() => {
+                if let Err(e) = mesh.inbound_receiver().try_drain_pass() {
+                    return Err(datafusion::common::DataFusionError::Execution(format!(
+                        "mpp worker drain error: {e} (stage_id={stage_id}, task_idx={task_idx}, \
+                         requested={partitions_requested}/{n_out})"
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Shape-agnostic body of `exec_mpp_worker`. Runs to completion on the caller's tokio runtime,
 /// pgrx::error!s on fatal failures, returns normally on EOF (the customscan's
 /// `exec_custom_scan` then returns `null_mut()` to signal end-of-stream to PG).
@@ -426,92 +522,14 @@ pub(crate) fn run_mpp_worker(
                 Arc::clone(&plan),
             ));
 
-            let mesh = Arc::clone(&mesh_for_block);
-            let stage_id = fragment.stage_id;
-            let task_idx = fragment.task_idx as u32;
-            let n_out = per_partition_sinks.len();
-            let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
-
-            // Defer execution until an ExecuteTask RPC request arrives for a target partition range.
-            futures.push(Box::pin(async move {
-                let mut rx = mesh.take_execute_task_rx(stage_id, task_idx).await?;
-                let mut sub_futures = futures::stream::FuturesUnordered::new();
-                let mut partitions_requested = 0;
-
-                if n_out == 0 {
-                    return Ok::<_, datafusion::common::DataFusionError>(());
-                }
-
-                loop {
-                    if partitions_requested >= n_out && sub_futures.is_empty() {
-                        break;
-                    }
-                    tokio::select! {
-                        frame_res = rx.recv(), if partitions_requested < n_out => {
-                            match frame_res {
-                                Some(Ok(frame)) => {
-                                    let (request, _headers) = frame.into_parts()?;
-                                    let start = request.target_partition_start as usize;
-                                    let end = request.target_partition_end as usize;
-                                    let len = end - start;
-
-                                    if end > sinks_opt.len() || start > end {
-                                        return Err(datafusion::common::DataFusionError::Internal(format!(
-                                            "mpp worker dispatch: requested partition range {start}..{end} \
-                                             out of bounds for sink count {} (stage_id={stage_id}, task_idx={task_idx})",
-                                            sinks_opt.len()
-                                        )));
-                                    }
-
-                                    let mut task_sinks = Vec::with_capacity(len);
-                                    for (i, sink) in sinks_opt.iter_mut().enumerate().take(end).skip(start) {
-                                        let Some(s) = sink.take() else {
-                                            return Err(datafusion::common::DataFusionError::Internal(format!(
-                                                "mpp worker dispatch: sink for partition {i} already taken \
-                                                 (stage_id={stage_id}, task_idx={task_idx})",
-                                            )));
-                                        };
-                                        task_sinks.push(s);
-                                    }
-
-                                    sub_futures.push(run_worker_fragment(
-                                        Arc::clone(&plan),
-                                        task_sinks,
-                                        Arc::clone(&task_ctx),
-                                        start..end,
-                                    ));
-                                    partitions_requested += len;
-                                }
-                                Some(Err(e)) => {
-                                    return Err(datafusion::common::DataFusionError::Execution(format!(
-                                        "mpp worker rx error: {e}, stage: {stage_id}, task: {task_idx}, \
-                                         requested: {partitions_requested}/{n_out}"
-                                    )));
-                                }
-                                None => {
-                                    partitions_requested = n_out;
-                                }
-                            }
-                        }
-                        next_res = sub_futures.next(), if !sub_futures.is_empty() => {
-                            match next_res {
-                                Some(Ok(_)) => {}
-                                Some(Err(e)) => return Err(e),
-                                None => unreachable!(),
-                            }
-                        }
-                        _ = tokio::task::yield_now() => {
-                            if let Err(e) = mesh.inbound_receiver().try_drain_pass() {
-                                return Err(datafusion::common::DataFusionError::Execution(format!(
-                                    "mpp worker drain error: {e}, stage: {stage_id}, task: {task_idx}, \
-                                     requested: {partitions_requested}/{n_out}"
-                                )));
-                            }
-                        }
-                    }
-                }
-                Ok(())
-            }));
+            futures.push(Box::pin(dispatch_fragment_requests(
+                Arc::clone(&mesh_for_block),
+                fragment.stage_id,
+                fragment.task_idx as u32,
+                per_partition_sinks,
+                plan,
+                task_ctx,
+            )));
         }
         // The metrics frames go to the leader after the fragments finish; the clone keeps one
         // sender on the leader's inbox alive past the drop below, which only delays that ring's
@@ -529,11 +547,11 @@ pub(crate) fn run_mpp_worker(
             "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
             fragments.len()
         );
-        // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
-        // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
-        // futures, leaving their `(stage_id, partition)` sub-buffers stuck at
-        // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
-        // substrate alone (matching reasoning in `run_worker_fragment`).
+        // Fail-fast via FuturesUnordered. Under the pull model, an error in any fragment must
+        // surface immediately so that worker_mesh cleans up keep-alive senders and triggers
+        // pgrx::error! (causing peers to observe Detached status and fail pending buffers).
+        // Waiting for all fragments could cause a hang if a fragment blocks waiting for an RPC
+        // request that will never arrive due to a sibling failure.
         //
         // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
         // within 30 s the dispatcher surfaces an error instead of letting the backend spin

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -20,7 +20,7 @@
 //! The natural-shape MPP path is the same flow for every customscan that opts in: read the
 //! leader's dispatch blob from DSM, decode this proc's per-stage physical subplans (the leader
 //! built and sliced the plan once, so workers don't re-plan), and run each fragment via
-//! [`run_worker_fragment`] + `join_all`. The only customscan-specific pieces are the seed
+//! [`run_worker_fragment`] + `FuturesUnordered`. The only customscan-specific pieces are the seed
 //! `SessionContext` (different `SessionContextProfile`) and where the inputs come from in
 //! per-scan state.
 //!
@@ -48,7 +48,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::PartitionSink;
 use datafusion_distributed::shm::{
     CooperativeDrainSet, InProcessWorkerResolver, MppFrameHeader, MppMesh, MppPartitionSink,
-    MppSender, ShmChannelResolver, collect_task_metrics, proc_for_task, run_worker_fragment,
+    ShmChannelResolver, WorkerSession, collect_task_metrics, proc_for_task, run_worker_fragment,
 };
 use datafusion_proto::physical_plan::DeduplicatingProtoConverter;
 
@@ -72,14 +72,8 @@ pub(crate) struct MppWorkerInputs {
     pub parallel_state: Option<*mut ParallelScanState>,
     /// Total number of sources in the plan. Used to size the codec's per-source segment-ID Vec.
     pub plan_sources_count: usize,
-    /// Leader's dispatch payload (framed per-stage physical subplans), copied out of DSM during
-    /// `worker_setup`.
-    pub plan_bytes: Vec<u8>,
-    /// This worker's `MppMesh` handle.
-    pub worker_mesh: Arc<MppMesh>,
-    /// This worker's outbound senders, keyed by destination `proc_idx`. The dispatcher takes
-    /// ownership; consumers see `Detached` once these drop.
-    pub outbound_senders: Vec<Option<MppSender>>,
+    /// Active worker session handle holding mesh, plan bytes, and outbound senders.
+    pub session: WorkerSession,
 }
 
 /// Build the distributed session context. The leader runs this (mesh = None) to build and slice
@@ -201,7 +195,7 @@ async fn dispatch_fragment_requests(
     plan: Arc<dyn ExecutionPlan>,
     task_ctx: Arc<TaskContext>,
 ) -> Result<(), datafusion::common::DataFusionError> {
-    let mut rx = mesh.take_execute_task_rx(stage_id, task_idx).await?;
+    let mut rx = mesh.take_execute_task_rx(stage_id, task_idx)?;
     let mut sub_futures = futures::stream::FuturesUnordered::new();
     let n_out = per_partition_sinks.len();
     let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
@@ -299,11 +293,11 @@ pub(crate) fn run_mpp_worker(
     let MppWorkerInputs {
         parallel_state,
         plan_sources_count,
-        plan_bytes,
-        worker_mesh,
-        outbound_senders,
+        session: worker_session,
     } = inputs;
 
+    let worker_mesh = &worker_session.mesh;
+    let plan_bytes = &worker_session.plan_bytes;
     let this_proc = worker_mesh.this_proc;
 
     // Build per-source canonical segment ID sets from the populated ParallelScanState.
@@ -323,22 +317,20 @@ pub(crate) fn run_mpp_worker(
     // (it spawns at least 2 producers), so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();
     let (fragments, session) = match fragments_for_worker(
-        &plan_bytes,
+        plan_bytes,
         seed_ctx,
-        Arc::clone(&worker_mesh),
+        Arc::clone(worker_mesh),
         this_proc,
         n_workers,
     ) {
         Ok(v) => v,
         Err(e) => {
-            worker_mesh.clear_keep_alive_senders();
             pgrx::error!("mpp worker: build fragment assignments failed: {e}");
         }
     };
     if fragments.is_empty() {
         // The launch spawns `producer_count <= max_tasks` producers, so the widest stage's
         // round-robin assigns every proc at least one fragment.
-        worker_mesh.clear_keep_alive_senders();
         pgrx::error!("mpp worker: no fragments assigned (proc={this_proc})");
     }
 
@@ -352,7 +344,7 @@ pub(crate) fn run_mpp_worker(
             for fragment in &fragments {
                 frames.push(
                     take_set_plan_draining(
-                        &worker_mesh,
+                        worker_mesh,
                         fragment.stage_id,
                         fragment.task_idx as u32,
                     )
@@ -364,7 +356,6 @@ pub(crate) fn run_mpp_worker(
         match collected {
             Ok(frames) => frames,
             Err(e) => {
-                worker_mesh.clear_keep_alive_senders();
                 pgrx::error!("mpp worker: plan frames did not arrive: {e}");
             }
         }
@@ -377,7 +368,6 @@ pub(crate) fn run_mpp_worker(
     // allocations aggressively; decode builds the plan graph and can spike memory.
     for (fragment, frame) in fragments.iter().zip(frames) {
         let Some(set_plan) = frame.set_plan else {
-            worker_mesh.clear_keep_alive_senders();
             pgrx::error!(
                 "mpp worker: SetPlan frame without a request (stage_id={}, task_idx={})",
                 fragment.stage_id,
@@ -396,7 +386,6 @@ pub(crate) fn run_mpp_worker(
         ) {
             Ok(plan) => plans.push(plan),
             Err(e) => {
-                worker_mesh.clear_keep_alive_senders();
                 pgrx::error!(
                     "mpp worker: decode dispatched plan failed (stage_id={}, task_idx={}): {e}",
                     fragment.stage_id,
@@ -422,7 +411,7 @@ pub(crate) fn run_mpp_worker(
     // (the scanner's own `CHECK_FOR_INTERRUPTS`, a buffer wait) can `proc_exit` out of the
     // live runtime. The loops poll cooperatively to bail promptly; see `mpp::interrupt`.
     let held = HeldInterrupts::hold();
-    let mesh_for_block = Arc::clone(&worker_mesh);
+    let mesh_for_block = Arc::clone(worker_mesh);
     let result = runtime.block_on(async move {
         let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
         let mut executed_fragments: Vec<(u32, usize, usize, Arc<dyn ExecutionPlan>)> =
@@ -455,7 +444,8 @@ pub(crate) fn run_mpp_worker(
                         proc_for_task(n_workers, task)
                     }
                 };
-                let base = match outbound_senders
+                let base = match worker_session
+                    .outbound_senders()
                     .get(dest_proc as usize)
                     .and_then(|s| s.as_ref())
                 {
@@ -531,24 +521,18 @@ pub(crate) fn run_mpp_worker(
                 task_ctx,
             )));
         }
-        // The metrics frames go to the leader after the fragments finish; the clone keeps one
-        // sender on the leader's inbox alive past the drop below, which only delays that ring's
-        // detach observation, never a per-channel EOF.
-        let metrics_sender_base = outbound_senders
+        // The metrics frames go to the leader after the fragments finish.
+        let metrics_sender_base = worker_session
+            .outbound_senders()
             .first()
             .and_then(|s| s.as_ref())
             .map(|s| s.clone_with_header(MppFrameHeader::task_metrics(0, 0, this_proc)));
-        // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue /
-        // in-proc channel are the per-partition clones owned by the spawned fragments. Without
-        // this, the originals would outlive the futures, the consumer-side drains would never
-        // observe `Detached`, and `execute`'s pull loop would spin forever.
-        drop(outbound_senders);
         crate::mpp_log!(
-            "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
+            "mpp worker dispatch this_proc={this_proc} starting fragment futures on {} fragments",
             fragments.len()
         );
         // Fail-fast via FuturesUnordered. Under the pull model, an error in any fragment must
-        // surface immediately so that worker_mesh cleans up keep-alive senders and triggers
+        // surface immediately so that worker_session drops outbound senders and triggers
         // pgrx::error! (causing peers to observe Detached status and fail pending buffers).
         // Waiting for all fragments could cause a hang if a fragment blocks waiting for an RPC
         // request that will never arrive due to a sibling failure.
@@ -603,7 +587,6 @@ pub(crate) fn run_mpp_worker(
     drop(held);
     check_for_interrupts();
     if let Err(e) = result {
-        worker_mesh.clear_keep_alive_senders();
         pgrx::error!("mpp worker: fragment dispatch failed: {e}");
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -28,8 +28,7 @@
 //!   spawn. Returns the leader's [`MppLeaderState`] which carries the runtime [`MppMesh`]
 //!   handle the customscan installs on its DataFusion `SessionContext`.
 //! - [`worker_setup`] — worker-side mesh attach, called from `run_launched_worker`. Returns
-//!   the worker's [`MppWorkerState`] which carries the worker's outbound
-//!   senders and the deserialized plan bytes the worker runs.
+//!   the [`WorkerSession`] which carries the worker mesh, plan bytes, and outbound senders.
 
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -37,7 +36,7 @@ use std::sync::Arc;
 use pgrx::pg_sys;
 
 use datafusion_distributed::TaskKey;
-use datafusion_distributed::shm::{self, Interrupt, MppMesh, MppSender, Wakeup};
+use datafusion_distributed::shm::{self, Interrupt, LeaderSession, MppMesh, Wakeup, WorkerSession};
 use datafusion_proto::physical_plan::DefaultPhysicalProtoConverter;
 
 use crate::gucs::mpp_queue_size as gucs_mpp_queue_size;
@@ -134,41 +133,11 @@ impl MppLaunchTiming {
     }
 }
 
-/// The leader's control senders behind their shared lock. The scan state and mesh cancel path
-/// share this `Arc`; `DsmDetachState` retains another reference so the detach callback can clear
-/// the stored senders while the DSM is still mapped.
-pub type ControlSenders = std::sync::Mutex<Vec<Option<MppSender>>>;
-
-/// State retained by PostgreSQL until DSM detach. The callback marks the shared mesh dead before
-/// clearing stored senders, so escaped sender clones can later drop without touching unmapped DSM.
-struct DsmDetachState {
-    mesh: Arc<MppMesh>,
-    control_senders: Arc<ControlSenders>,
-}
-
 /// Returned to the leader from [`leader_setup`]. The customscan stashes this on its execution
 /// state and consults it during `exec_custom_scan`.
-///
-/// The leader is consumer-only: it gathers fragments from worker procs but doesn't host a
-/// producer fragment itself. Its outbound senders are dropped inside `leader_setup`.
 pub struct MppLeaderState {
-    /// Runtime mesh handle. Install on the leader's `SessionContext` via
-    /// `with_extension(Arc::clone(&mesh))` so `ShmChannelResolver` can find
-    /// it at execute time.
-    pub mesh: Arc<MppMesh>,
-    /// The leader's outbound senders, one per peer inbox; the control-plane path for `SetPlan`
-    /// frames and stream cancel messages. Held for the query's lifetime so no ring observes a
-    /// sender count of zero before every worker attaches (the rings latch `detached` permanently at
-    /// zero).
-    ///
-    /// While the mesh is live, dropping one of these decrements a counter inside its DSM ring.
-    /// [`MppLeaderState::release_control_senders`] clears them from `shutdown_custom_scan` on the
-    /// success path. [`release_control_senders_on_detach`] covers every other path — abort, and a
-    /// `proc_exit` from `pg_terminate_backend` that skips shutdown — by marking the mesh dead and
-    /// clearing this vector before PG unmaps the segment. Escaped sender clones can then drop
-    /// safely without accessing DSM. The scan state's own drop runs after detach and must find
-    /// this vector empty.
-    pub control_senders: Arc<ControlSenders>,
+    /// Active leader session handle holding the runtime mesh and control senders.
+    pub session: LeaderSession,
     /// The builder handle owning the launched producer workers. The leader controls the launch, so
     /// it owns the teardown too: `end_custom_scan` takes this and calls `wait_for_finish` to join
     /// the workers and destroy the parallel context. `None` until `launch` installs it on the
@@ -215,7 +184,7 @@ pub unsafe fn leader_setup(
     // because this runs synchronously on the leader backend from `launch_mpp`, before any
     // tokio runtime spins up.
     let t_setup = crate::gucs::mpp_trace().then(std::time::Instant::now);
-    let attach = unsafe {
+    let session = unsafe {
         shm::leader_setup(
             coordinate,
             n_procs,
@@ -224,111 +193,60 @@ pub unsafe fn leader_setup(
             wakeup,
             token,
             interrupt,
-            // The leader ships `SetPlan` frames (and later, work units) through these senders.
-            // `MppLeaderState` holds them for the query's lifetime, which keeps the rings'
-            // sender count above zero across every worker attach.
-            /* attach_senders */
-            true,
+            /* attach_senders */ true,
         )
     }
     .map_err(|e| e.to_string())?;
-    let mesh = attach.mesh;
     if let Some(t) = t_setup {
         pgrx::warning!(
             "mpp trace: leader_setup (ring create + self attach) took {:.3} ms",
             t.elapsed().as_secs_f64() * 1000.0
         );
     }
-    let control_senders = Arc::new(std::sync::Mutex::new(attach.outbound_senders));
-    // Hand the senders to the mesh too, so its early-termination cancel can reach the producers.
-    // The mesh shares this `Arc`, so clearing either view releases both before the DSM unmaps.
-    mesh.set_cancel_senders(Arc::clone(&control_senders));
-    // Released before the DSM unmaps via [`release_control_senders_on_detach`], registered by `launch`.
     Ok(MppLeaderState {
-        mesh,
-        control_senders,
+        session,
         finish: None,
         timing: MppLaunchTiming::default(),
     })
 }
 
-/// `on_dsm_detach` callback that invalidates the leader's mesh handles and releases its stored
-/// DSM-backed control senders while the MPP segment is still mapped.
+/// `on_dsm_detach` callback that invalidates the leader's mesh handles while the MPP segment is still mapped.
 ///
 /// While the mesh is live, dropping a sender decrements an atomic inside its DSM ring. The
-/// callback first marks every handle dead and then clears the stored senders while the mapping is
-/// live; an escaped clone can subsequently drop without touching DSM. `on_dsm_detach` runs on
-/// every teardown path. A transaction-abort callback can't replace it: it fires after
-/// `AtEOXact_Parallel` has already detached the DSM, and a backend FATAL skips
-/// `shutdown_custom_scan` entirely.
-///
-/// `arg` is the detach-state `Arc` converted into a raw pointer at registration;
-/// [`Arc::from_raw`] reclaims that reference exactly once. The success path may already have
-/// emptied the sender vector, in which case clearing it again is a no-op.
+/// callback marks every handle dead while the mapping is live; an escaped clone can subsequently drop
+/// without touching DSM. `on_dsm_detach` runs on every teardown path.
 #[pgrx::pg_guard]
-unsafe extern "C-unwind" fn release_control_senders_on_detach(
+unsafe extern "C-unwind" fn mark_mesh_detached_on_dsm_detach(
     _seg: *mut pg_sys::dsm_segment,
     arg: pg_sys::Datum,
 ) {
-    let state = unsafe { Arc::from_raw(arg.cast_mut_ptr::<DsmDetachState>()) };
-    release_control_senders_on_detach_impl(&state);
-}
-
-fn release_control_senders_on_detach_impl(state: &DsmDetachState) {
-    // `send_set_plan` can retain a sender clone after releasing the vector lock. Invalidate every
-    // handle before clearing the known senders so escaped clones no-op if dropped after DSM unmaps.
-    state.mesh.mark_detached();
-
-    // Tolerate a poisoned mutex rather than panic across the C boundary; the Vec data is still
-    // valid to clear.
-    let mut guard = state
-        .control_senders
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    // The current sender drop path is panic-free. `catch_unwind` contains any future panic so it
-    // cannot unwind through PostgreSQL's C teardown.
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        guard.clear();
-    }));
+    let mesh = unsafe { Arc::from_raw(arg.cast_mut_ptr::<MppMesh>()) };
+    mesh.mark_detached();
 }
 
 impl MppLeaderState {
-    /// Register the DSM detach cleanup for the leader mesh liveness flag and senders. PostgreSQL
-    /// stores the raw pointer; [`release_control_senders_on_detach`] turns it back into the same
+    /// Register the DSM detach cleanup for the leader mesh liveness flag. PostgreSQL
+    /// stores the raw pointer; [`mark_mesh_detached_on_dsm_detach`] turns it back into the same
     /// `Arc` and drops it.
     ///
     /// # Safety
-    /// `seg` must be the live DSM segment that owns the ring memory targeted by
-    /// `self.control_senders`.
+    /// `seg` must be the live DSM segment that owns the ring memory.
     pub unsafe fn register_control_senders_on_detach(&self, seg: *mut pg_sys::dsm_segment) {
-        let state = Arc::new(DsmDetachState {
-            mesh: Arc::clone(&self.mesh),
-            control_senders: Arc::clone(&self.control_senders),
-        });
+        let mesh_ptr = Arc::into_raw(Arc::clone(&self.session.mesh));
         unsafe {
             pg_sys::on_dsm_detach(
                 seg,
-                Some(release_control_senders_on_detach),
-                pg_sys::Datum::from(Arc::into_raw(state) as *mut c_void),
+                Some(mark_mesh_detached_on_dsm_detach),
+                pg_sys::Datum::from(mesh_ptr as *mut c_void),
             );
         }
-    }
-
-    /// Drop the DSM-backed control senders while the mapping is still attached. Called from
-    /// `shutdown_custom_scan` on the success path; [`release_control_senders_on_detach`] (registered
-    /// via `on_dsm_detach`) covers every other teardown path. Idempotent.
-    pub fn release_control_senders(&self) {
-        // Unlike the detach callback, a poisoned lock panics here on purpose: this runs on the
-        // success path inside the executor, where poison means a real bug and an ERROR is safe
-        // to raise. The callback can't afford that mid-`dsm_detach`.
-        self.control_senders.lock().unwrap().clear();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_distributed::shm::{MppFrameHeader, NoInterrupt};
+    use datafusion_distributed::shm::NoInterrupt;
     use std::sync::atomic::Ordering;
 
     struct NoopWakeup;
@@ -343,7 +261,7 @@ mod tests {
         // alive through the final drop.
         let region_bytes = shm::dsm_region_bytes(3, 64 * 1024, 0).unwrap();
         let mut region = vec![0_u64; region_bytes.div_ceil(std::mem::size_of::<u64>())];
-        let attach = unsafe {
+        let session = unsafe {
             shm::leader_setup(
                 region.as_mut_ptr().cast(),
                 3,
@@ -356,29 +274,13 @@ mod tests {
             )
             .unwrap()
         };
-        // Model the sender clone `send_set_plan` can retain after releasing the control-sender
-        // lock; clearing the stored vector does not release this clone.
-        let delayed_set_plan_sender = attach
-            .outbound_senders
-            .iter()
-            .flatten()
-            .next()
-            .unwrap()
-            .clone_with_header(MppFrameHeader::set_plan(0, 0, 0));
-        let mesh = attach.mesh;
-        let state = DsmDetachState {
-            mesh: Arc::clone(&mesh),
-            control_senders: Arc::new(std::sync::Mutex::new(attach.outbound_senders)),
-        };
+        let mesh = session.mesh;
+        mesh.mark_detached();
 
-        release_control_senders_on_detach_impl(&state);
-
-        assert!(state.control_senders.lock().unwrap().is_empty());
         assert!(
             !mesh.detached_flag().load(Ordering::Acquire),
             "DSM detach must invalidate mesh handles before delayed SetPlan senders can drop"
         );
-        drop(delayed_set_plan_sender);
     }
 }
 
@@ -422,29 +324,6 @@ impl datafusion_distributed::DispatchPlanSource for StagePlanDispatchSource {
     }
 }
 
-/// Returned to a worker from [`worker_setup`]. The customscan reads the plan bytes, runs the
-/// plan, and pushes resulting batches through `outbound_senders`.
-pub struct MppWorkerState {
-    /// `outbound_senders[proc_idx]` is the sender that writes to peer `proc_idx`'s inbox.
-    /// The entry at `proc_idx == this_proc` is the self-loop in-proc channel installed by
-    /// `worker_setup` (since DSM MPSC inboxes have only one receiver per ring, the worker
-    /// can't be both producer and consumer on the shm_mq inbox path).
-    ///
-    /// Each fragment's per-partition output sender is keyed by
-    /// `outbound_senders[proc_for_task(n_workers, consumer_task)]`. Each `MppSender` wraps an
-    /// `Arc<dyn BatchChannelSender>` so callers can `clone_with_header` to multiplex
-    /// `(stage_id, partition)` channels onto one inbox.
-    pub outbound_senders: Vec<Option<MppSender>>,
-    /// Leader's dispatch payload (framed per-stage physical subplans), copied out of DSM. The
-    /// worker decodes it into its fragment assignments via `mpp::dispatch::expand_to_assignments`.
-    pub plan_bytes: Vec<u8>,
-    /// Worker's MppMesh. The single `inbound_receiver` pulls frames addressed to this
-    /// proc from both the DSM MPSC inbox and the in-proc self-loop channel; demux by
-    /// `(sender_proc, stage_id, partition)` happens inside the handle's channel-buffer
-    /// registry. Read by the multi-fragment dispatcher driven by `mpp::host::exec_mpp_worker`.
-    pub mesh: Arc<MppMesh>,
-}
-
 /// Body of `initialize_worker_custom_scan`. Reads the header, attaches as
 /// sender on this worker's slot row, copies the plan bytes out of DSM.
 ///
@@ -455,7 +334,7 @@ pub unsafe fn worker_setup(
     coordinate: *mut c_void,
     region_total: usize,
     worker_number: i32,
-) -> Result<MppWorkerState, String> {
+) -> Result<WorkerSession, String> {
     if worker_number < 0 {
         return Err("mpp: worker_number < 0".into());
     }
@@ -470,7 +349,7 @@ pub unsafe fn worker_setup(
     // Same backend-thread story as `leader_setup`: this runs on the parallel-worker backend
     // before tokio starts.
     let t_setup = crate::gucs::mpp_trace().then(std::time::Instant::now);
-    let attach =
+    let session =
         unsafe { shm::worker_setup(coordinate, region_total, proc_idx, wakeup, token, interrupt) }
             .map_err(|e| e.to_string())?;
     if let Some(t) = t_setup {
@@ -480,11 +359,7 @@ pub unsafe fn worker_setup(
         );
     }
 
-    Ok(MppWorkerState {
-        outbound_senders: attach.outbound_senders,
-        plan_bytes: attach.plan_bytes,
-        mesh: attach.mesh,
-    })
+    Ok(session)
 }
 
 /// Merge the worker fragments' `TaskMetrics` frames into an executed `DistributedExec` plan for

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -142,7 +142,7 @@ pub type ControlSenders = std::sync::Mutex<Vec<Option<MppSender>>>;
 /// State retained by PostgreSQL until DSM detach. The callback marks the shared mesh dead before
 /// clearing stored senders, so escaped sender clones can later drop without touching unmapped DSM.
 struct DsmDetachState {
-    alive: shm::AliveFlag,
+    mesh: Arc<MppMesh>,
     control_senders: Arc<ControlSenders>,
 }
 
@@ -277,9 +277,7 @@ unsafe extern "C-unwind" fn release_control_senders_on_detach(
 fn release_control_senders_on_detach_impl(state: &DsmDetachState) {
     // `send_set_plan` can retain a sender clone after releasing the vector lock. Invalidate every
     // handle before clearing the known senders so escaped clones no-op if dropped after DSM unmaps.
-    state
-        .alive
-        .store(false, std::sync::atomic::Ordering::Release);
+    state.mesh.mark_detached();
 
     // Tolerate a poisoned mutex rather than panic across the C boundary; the Vec data is still
     // valid to clear.
@@ -304,7 +302,7 @@ impl MppLeaderState {
     /// `self.control_senders`.
     pub unsafe fn register_control_senders_on_detach(&self, seg: *mut pg_sys::dsm_segment) {
         let state = Arc::new(DsmDetachState {
-            alive: self.mesh.detached_flag(),
+            mesh: Arc::clone(&self.mesh),
             control_senders: Arc::clone(&self.control_senders),
         });
         unsafe {
@@ -369,7 +367,7 @@ mod tests {
             .clone_with_header(MppFrameHeader::set_plan(0, 0, 0));
         let mesh = attach.mesh;
         let state = DsmDetachState {
-            alive: mesh.detached_flag(),
+            mesh: Arc::clone(&mesh),
             control_senders: Arc::new(std::sync::Mutex::new(attach.outbound_senders)),
         };
 

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -167,7 +167,7 @@ fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> Se
     let region_bytes = unsafe { region_total(region_ptr) };
     let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
     let worker = match unsafe { worker_setup(region_ptr, region_bytes, worker_number) } {
-        Ok(w) => w,
+        Ok(session) => session,
         Err(e) => pgrx::error!("mpp worker: worker_setup failed: {e}"),
     };
 
@@ -182,9 +182,7 @@ fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> Se
     let inputs = MppWorkerInputs {
         parallel_state: Some(scan_ptr),
         plan_sources_count,
-        plan_bytes: worker.plan_bytes,
-        worker_mesh: worker.mesh,
-        outbound_senders: worker.outbound_senders,
+        session: worker,
     };
 
     let runtime = match tokio::runtime::Builder::new_current_thread()

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -881,11 +881,10 @@ impl ExecutionPlan for PgSearchScanPlan {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        // TODO: The datafusion-distributed fork currently calls `execute` for ALL partitions in
-        // `run_worker_fragment`, even though this variant was only assigned to process a single
-        // partition. We should triage whether `run_worker_fragment` should be accessing all
-        // partitions, or only assigned partitions for a task. Until then, returning an empty
-        // stream for non-assigned partitions satisfies the fragment execution without crashing.
+        // Under DataFusion Distributed execution, upstream stage operators (such as `RepartitionExec`)
+        // call `execute(p)` for all partition indices `p` in the stage's requested partition range.
+        // For partitions where `p != assigned`, we return an empty stream so multi-partition
+        // stage pipelines can pull and repartition data without failing.
         if let Some(assigned) = self.assigned_partition
             && partition != assigned
         {
@@ -1225,14 +1224,14 @@ impl<T: Stream<Item = Result<RecordBatch>>> RecordBatchStream for UnsafeSendStre
 /// available workers.
 pub(crate) fn pg_search_scan_desired_task_count(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<datafusion::error::Result<DesiredTaskCountEventResponse>> {
     let _ = ev.plan.downcast_ref::<PgSearchScanPlan>()?;
     let partition_count = ev.plan.properties().output_partitioning().partition_count();
     // `maximum` rather than `desired`: `partition_count` is already clamped to the number
     // of physical index segments (when range sampling is disabled). A single segment cannot
     // be concurrently scanned by multiple workers, so scaling the stage past it would just
     // starve tasks with useless setup work (like building empty hash tables) for zero rows.
-    Some(DesiredTaskCountEventResponse::maximum(partition_count))
+    Some(Ok(DesiredTaskCountEventResponse::maximum(partition_count)))
 }
 
 /// Replaces a `PgSearchScanPlan` leaf with per-task variants once its stage's task


### PR DESCRIPTION
## What

Incorporate https://github.com/paradedb/datafusion-distributed/pull/62 to move our `WorkerChannel` from push based to pull based (RPC).

## Why

Although it does not result in a drop in total lines of code, moving to a pull-based model (where the data for a stage/task/partition is only sent in response to a request) better aligns with how the canonical `df-d` implementation does things. It also eases the implementation of https://github.com/paradedb/paradedb/pull/5809.

## Tests

Existing tests.