### PR TITLE
feat(vector): bounds gate + work budget + result-anchored base replace epsilon (0.25.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -2911,7 +2911,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -7912,7 +7912,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -8088,7 +8088,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8144,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "bitpacking",
 ]
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8167,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8200,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8212,7 +8212,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8225,7 +8225,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=eadcfaf293c91cd69fec2e009ca20818688dc5fe#eadcfaf293c91cd69fec2e009ca20818688dc5fe"
+source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b5724c290c2bafd785f03#c97fc25d7dbac9218d0b5724c290c2bafd785f03"
 dependencies = [
  "serde",
 ]
@@ -8308,7 +8308,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -8476,7 +8476,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 license = "AGPL-3.0"
 
@@ -58,7 +58,7 @@ debug-assertions = false
 inherits = "dev"
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "eadcfaf293c91cd69fec2e009ca20818688dc5fe", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "c97fc25d7dbac9218d0b5724c290c2bafd785f03", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -71,7 +71,7 @@ pgrx-tests = "=0.19.0"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "eadcfaf293c91cd69fec2e009ca20818688dc5fe" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c97fc25d7dbac9218d0b5724c290c2bafd785f03" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/benchmarks/datasets/cohere/config.toml
+++ b/benchmarks/datasets/cohere/config.toml
@@ -48,6 +48,3 @@ vchord_probes_1pct_off = "CASE {{ dataset_size }} WHEN 1000000 THEN 420 WHEN 100
 vchord_probes_1pct_on = "CASE {{ dataset_size }} WHEN 1000000 THEN 420 WHEN 10000000 THEN 1200 ELSE greatest(1, round(0.21 * (CASE WHEN {{ dataset_size }} < 2000000 THEN 2000 WHEN {{ dataset_size }} < 100000000 THEN 10000 ELSE 80000 END))::int) END"
 
 pg_search_max_probe = "0.05"
-pg_search_probe_epsilon_unfiltered = "0.4"
-pg_search_probe_epsilon_10pct = "0.45"
-pg_search_probe_epsilon_1pct = "0.65"

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_10pct.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_10pct.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe }}; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_10pct }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe }}; SELECT _id, title FROM cohere_wiki
 WHERE text @@@ current_setting('cohere.titles_10pct')
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_1pct.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_1pct.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe }}; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_1pct }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe }}; SELECT _id, title FROM cohere_wiki
 WHERE text @@@ current_setting('cohere.titles_1pct')
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/benchmarks/datasets/cohere/queries/pg_search/knn_top10_unfiltered.sql
+++ b/benchmarks/datasets/cohere/queries/pg_search/knn_top10_unfiltered.sql
@@ -1,4 +1,4 @@
-SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe }}; SET paradedb.vector_cluster_probe_epsilon={{ pg_search_probe_epsilon_unfiltered }}; SELECT _id, title FROM cohere_wiki
+SET paradedb.vector_cluster_max_probe={{ pg_search_max_probe }}; SELECT _id, title FROM cohere_wiki
 WHERE _id @@@ paradedb.all()
 ORDER BY emb <=> current_setting('cohere.qvec')::vector(1024)
 LIMIT 10;

--- a/docs/documentation/vector/tuning.mdx
+++ b/docs/documentation/vector/tuning.mdx
@@ -4,25 +4,22 @@ description: Trade recall against latency for vector search
 canonical: https://docs.paradedb.com/documentation/vector/tuning
 ---
 
-Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. Two session-level settings control this tradeoff:
+Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. One session-level setting controls this tradeoff:
 
 ```sql
-SET paradedb.vector_cluster_probe_epsilon = 0.5;
 SET paradedb.vector_cluster_max_probe = 0.02;
 ```
 
-<ParamField body="paradedb.vector_cluster_probe_epsilon" default={0.5}>
-  The primary recall driver. A higher epsilon improves recall by probing more
-  clusters at the expense of higher latency. Think of epsilon as an early
-  termination value, where lower epsilon terminates early more aggressively.
-  When tuning this value, we recommend sweeping in increments of `0.1`. Must be
-  between `0.0` and `100.0`.
-</ParamField>
-
 <ParamField body="paradedb.vector_cluster_max_probe" default={0.02}>
-  A control for tail latency. This setting enforces a ceiling on how many clusters a query may probe. For instance, at the default value of `0.02`, at most 2% of clusters are probed. Must be between `0.000001` and `1.0`, where `1.0` effectively means "no ceiling."
+  The recall/latency driver: a ceiling on how much probe work a query may
+  spend, expressed as a fraction of each segment's clusters. For instance, at
+  the default value of `0.02`, at most 2% of a segment's cluster-scan work is
+  spent. Must be between `0.000001` and `1.0`, where `1.0` allows an
+  exhaustive scan.
 
-Note that setting this value to `1.0` does not equal exhaustive search, since the epsilon value still drives early termination.
+Within the ceiling, clusters that provably cannot improve the current top-K
+are skipped automatically using per-cluster bounds stored in the index; this
+skipping never reduces recall, so raising the ceiling only ever improves it.
 
 </ParamField>
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-px3JpX3EWKN/ca12xZZ1ryxczl0qf42OtDUBgsGItLA=";
+  cargoHash = "sha256-X1irb57zQs8HqrodHGljwsmUvTHjOVgDSaKd9apk1gA=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-M/zKfYPrgzkRHKdspRzf3PHREsZVKjJynWqtAy3955o=";
+  cargoHash = "sha256-px3JpX3EWKN/ca12xZZ1ryxczl0qf42OtDUBgsGItLA=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.25.0--0.25.1.sql
+++ b/pg_search/sql/pg_search--0.25.0--0.25.1.sql
@@ -1,0 +1,4 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.1'" to load this file. \quit
+
+-- 0.25.0 -> 0.25.1: no schema changes (epsilon GUC removal and the
+-- bounds_scope reloption are not schema objects).

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -216,16 +216,6 @@ pub fn vector_cluster_max_probe() -> f32 {
     VECTOR_CLUSTER_MAX_PROBE.get() as f32
 }
 
-/// Query-time pruning factor for tantivy's `AdaptiveProbeParams`: how far
-/// past the best centroid the IVF probe loop keeps probing clusters. Lower
-/// epsilon probes fewer clusters, decreasing latency at the expense of
-/// recall. Default `0.5`.
-static VECTOR_CLUSTER_PROBE_EPSILON: GucSetting<f64> = GucSetting::<f64>::new(0.5);
-
-pub fn vector_cluster_probe_epsilon() -> f32 {
-    VECTOR_CLUSTER_PROBE_EPSILON.get() as f32
-}
-
 /// Doc-count boundary at which a merged segment's vector storage switches
 /// from flat (exact scan) to IVF (clustered). Captured into the index's
 /// stored `IndexSettings` at CREATE INDEX time, so it applies to every merge
@@ -446,17 +436,6 @@ pub fn init() {
         &VECTOR_CLUSTER_MAX_PROBE,
         0.000001,
         1.0,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_float_guc(
-        c"paradedb.vector_cluster_probe_epsilon",
-        c"SPANN-style pruning factor (ε₂) for vector ORDER BY queries",
-        c"How far past the best centroid the IVF probe loop keeps probing clusters. Lower epsilon probes fewer clusters, decreasing latency at the expense of recall.",
-        &VECTOR_CLUSTER_PROBE_EPSILON,
-        0.0,
-        100.0,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -44,6 +44,7 @@ pub fn index_settings(
         docstore_compress_dedicated_thread: false,
         codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
         vector_clustering_threshold: crate::gucs::vector_clustering_threshold(),
+        vector_bounds_scope: options.bounds_scope(),
         ..IndexSettings::default()
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -970,7 +970,6 @@ impl SearchIndexReader {
                     .and_offset(offset)
                     .order_by_similarity(tantivy_field, query_vector)
                     .with_adaptive_params(AdaptiveProbeParams {
-                        epsilon: crate::gucs::vector_cluster_probe_epsilon(),
                         max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
                         ..Default::default()
                     });

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -33,6 +33,7 @@ use pgrx::pg_sys::AsPgCStr;
 use pgrx::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
+use tantivy::vector::BoundsScope;
 use tokenizers::manager::SearchTokenizerFilters;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
 /* ADDING OPTIONS
@@ -183,6 +184,23 @@ extern "C-unwind" fn validate_search_tokenizer(value: *const std::os::raw::c_cha
         .unwrap_or_else(|| panic!("invalid search_tokenizer: '{s}'"));
 }
 
+/// The only legal `bounds_scope`: the merge folds centroid bounds over a
+/// cluster's NATIVE (primary-assignment) members. Captured into the stored
+/// tantivy `IndexSettings` at CREATE INDEX, like the clustering threshold.
+pub(crate) const BOUNDS_SCOPE_NATIVE: &str = "native";
+
+#[pg_guard]
+extern "C-unwind" fn validate_bounds_scope(value: *const std::os::raw::c_char) {
+    if value.is_null() {
+        return;
+    }
+    let cstr = unsafe { core::ffi::CStr::from_ptr(value) };
+    let value = cstr.to_str().expect("`bounds_scope` must be valid UTF-8");
+    if value != BOUNDS_SCOPE_NATIVE {
+        panic!("invalid `bounds_scope`: {value:?}; the only supported value is 'native'");
+    }
+}
+
 #[pg_guard]
 extern "C-unwind" fn validate_layer_sizes(value: *const std::os::raw::c_char) {
     if value.is_null() {
@@ -222,7 +240,7 @@ fn cstr_to_rust_str(value: *const std::os::raw::c_char) -> String {
         .to_string()
 }
 
-const NUM_REL_OPTS: usize = 18;
+const NUM_REL_OPTS: usize = 19;
 #[pg_guard]
 pub unsafe extern "C-unwind" fn amoptions(
     reloptions: pg_sys::Datum,
@@ -325,6 +343,13 @@ pub unsafe extern "C-unwind" fn amoptions(
             optname: "search_tokenizer".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
             offset: std::mem::offset_of!(BM25IndexOptionsData, search_tokenizer_offset) as i32,
+            #[cfg(feature = "pg18")]
+            isset_offset: 0,
+        },
+        pg_sys::relopt_parse_elt {
+            optname: "bounds_scope".as_pg_cstr(),
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, bounds_scope_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
@@ -444,6 +469,10 @@ impl BM25IndexOptions {
 
     pub fn centroid_ratio(&self) -> f32 {
         self.options_data().centroid_ratio()
+    }
+
+    pub fn bounds_scope(&self) -> BoundsScope {
+        self.options_data().bounds_scope()
     }
 
     pub fn training_samples_per_centroid(&self) -> usize {
@@ -805,6 +834,7 @@ struct BM25IndexOptionsData {
     training_samples_per_centroid: i32,
     cluster_replication: i32,
     partition_by_offset: i32,
+    bounds_scope_offset: i32,
 }
 
 impl BM25IndexOptionsData {
@@ -846,6 +876,16 @@ impl BM25IndexOptionsData {
 
     pub fn centroid_ratio(&self) -> f32 {
         self.centroid_ratio as f32
+    }
+
+    /// The stored-bounds scope, validated at option-set time; anything but
+    /// the default reads as `Native` (the only variant).
+    pub fn bounds_scope(&self) -> BoundsScope {
+        let value = self.get_str(self.bounds_scope_offset, BOUNDS_SCOPE_NATIVE.to_string());
+        match value.as_str() {
+            BOUNDS_SCOPE_NATIVE => BoundsScope::Native,
+            other => panic!("invalid stored `bounds_scope`: {other:?}"),
+        }
     }
 
     pub fn training_samples_per_centroid(&self) -> usize {
@@ -1093,6 +1133,15 @@ pub unsafe fn init() {
         "Default search-time tokenizer for text/JSON fields".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_search_tokenizer),
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
+    );
+    pg_sys::add_string_reloption(
+        RELOPT_KIND_PDB,
+        "bounds_scope".as_pg_cstr(),
+        "Which rows a cluster's stored centroid bound covers; only 'native' is supported"
+            .as_pg_cstr(),
+        BOUNDS_SCOPE_NATIVE.as_pg_cstr(),
+        Some(validate_bounds_scope),
         pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_real_reloption(


### PR DESCRIPTION
# Description
Backport of #5819 to `0.25.x`.

Conflict resolutions beyond the straight cherry-pick:
- `Cargo.toml`: took the 0.25.1 version bump but kept `edition = "2021"` (the edition-2024 migration #5804 is not on this branch); `cargo check -p pg_search` passes.
- Cohere benchmark config/queries: kept this branch's param-style harness (main's versions depend on the `[sweeps]` restructure) and dropped the removed epsilon knob; `pg_search_max_probe` is the remaining setting.
- `nix/pg_search.nix`: `cargoHash` needs regeneration — this branch's `Cargo.lock` (0.25.x deps + the tantivy re-pin) matches neither side's hash. Currently set to main's value; the nix build error will report the correct one.