### PR TITLE
docs: ORM examples for vector search and index build options

### DIFF
--- a/.github/scripts/django_snippet_harness.py
+++ b/.github/scripts/django_snippet_harness.py
@@ -13,6 +13,7 @@ from django.contrib.postgres.fields import ArrayField, IntegerRangeField
 from django.db import models
 
 from paradedb.queryset import ParadeDBManager
+from paradedb.vector import VectorField
 
 DATABASES = {
     "default": {
@@ -59,6 +60,7 @@ class MockItem(models.Model):
     last_updated_date = models.DateField(null=True)
     latest_available_time = models.TimeField(null=True)
     weight_range = IntegerRangeField(null=True)
+    embedding = VectorField(dimensions=8, null=True)
 
     objects = ParadeDBManager()
 

--- a/.github/scripts/drizzle_snippet_harness.ts
+++ b/.github/scripts/drizzle_snippet_harness.ts
@@ -10,6 +10,7 @@ import {
   text as pgText,
   timestamp as pgTimestamp,
   varchar as pgVarchar,
+  vector as pgVector,
 } from "drizzle-orm/pg-core";
 
 const connectionString =
@@ -34,6 +35,7 @@ const mockItems = definePgTable("mock_items", {
   createdAt: pgTimestamp("created_at"),
   metadata: pgJsonb("metadata"),
   weightRange: int4range("weight_range"),
+  embedding: pgVector("embedding", { dimensions: 8 }),
 });
 
 const orders = definePgTable("orders", {

--- a/.github/scripts/efcore_snippet_harness.cs
+++ b/.github/scripts/efcore_snippet_harness.cs
@@ -40,6 +40,7 @@ public sealed class SnippetDbContext(DbContextOptions<SnippetDbContext> options)
             entity.Property(item => item.CreatedAt).HasColumnName("created_at");
             entity.Property(item => item.Metadata).HasColumnName("metadata").HasColumnType("jsonb");
             entity.Property(item => item.WeightRange).HasColumnName("weight_range");
+            entity.Property(item => item.Embedding).HasColumnName("embedding").HasColumnType("vector(8)");
         });
 
         modelBuilder.Entity<ArrayDemo>(entity =>
@@ -73,6 +74,7 @@ public sealed class MockItem
     public DateTime CreatedAt { get; set; }
     public string Metadata { get; set; } = "{}";
     public NpgsqlRange<int> WeightRange { get; set; }
+    public float[]? Embedding { get; set; }
 }
 
 public sealed class ArrayDemo

--- a/.github/scripts/extract_code_snippets.py
+++ b/.github/scripts/extract_code_snippets.py
@@ -21,6 +21,8 @@ IGNORED_CODEGROUPS = {
     # CodeGroup is used here to switch between Chinese, Korean, and Japanese
     # not SQL vs ORMs
     "documentation__tokenizers__available-tokenizers__lindera__group-001",
+    # Non-executable fragments showing the distance metric spelling per ORM
+    "documentation__indexing__indexing-vectors__group-002",
 }
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent

--- a/.github/scripts/smoke_test_code_snippets.sh
+++ b/.github/scripts/smoke_test_code_snippets.sh
@@ -126,7 +126,7 @@ if [[ $ORMS =~ "django" ]]; then
 
   echo "Installing Django ParadeDB client from PyPI..."
   PIP_DISABLE_PIP_VERSION_CHECK=1 "$PYTHON_BIN" -m pip install --quiet --upgrade \
-    "django-paradedb==0.10.0" \
+    "django-paradedb==0.12.0" \
     "psycopg[binary]"
 
   while IFS= read -r snippet_file; do
@@ -163,7 +163,7 @@ if [[ $ORMS =~ "rails" ]]; then
   echo "Installing rails-paradedb from RubyGems..."
   GEM_HOME="$RUBY_GEM_HOME" GEM_PATH="$RUBY_GEM_HOME" \
     gem install --silent --no-document --install-dir "$RUBY_GEM_HOME" \
-    "rails-paradedb:0.9.0" \
+    "rails-paradedb:0.11.0" \
     "pg"
 
   while IFS= read -r snippet_file; do
@@ -171,7 +171,7 @@ if [[ $ORMS =~ "rails" ]]; then
 
     drop_snippet_indexes
 
-    if ! grep -Fq 'add_bm25_index' "$snippet_file"; then
+    if ! grep -Fq 'add_paradedb_index' "$snippet_file"; then
       create_snippet_indexes
     fi
 
@@ -207,7 +207,7 @@ if [[ $ORMS =~ "sqlalchemy" ]]; then
 
   echo "Installing SQLAlchemy ParadeDB client from PyPI..."
   PIP_DISABLE_PIP_VERSION_CHECK=1 "$PYTHON_BIN" -m pip install --quiet --upgrade \
-    "sqlalchemy-paradedb==0.8.0" \
+    "sqlalchemy-paradedb==0.10.0" \
     "psycopg[binary]"
 
   while IFS= read -r snippet_file; do
@@ -242,7 +242,7 @@ drizzle_fail_count=0
 if [[ $ORMS =~ "drizzle" ]]; then
   echo "Installing @paradedb/drizzle-paradedb from npm..."
   npm --prefix "$JAVASCRIPT_ENV_DIR" install --silent \
-    "@paradedb/drizzle-paradedb@0.2.0" \
+    "@paradedb/drizzle-paradedb@0.4.0" \
     "drizzle-orm" \
     "postgres" \
     "tsx"
@@ -253,7 +253,7 @@ if [[ $ORMS =~ "drizzle" ]]; then
     run_psql_file "${SCRIPT_DIR}/bootstrap_code_snippet_tables.sql"
     drop_snippet_indexes
 
-    if ! grep -Fq 'bm25Index' "$snippet_file"; then
+    if ! grep -Fq 'paradedbIndex' "$snippet_file"; then
       create_snippet_indexes
     fi
 
@@ -284,7 +284,7 @@ if [[ $ORMS =~ "efcore" ]]; then
   echo "Installing ParadeDB.EntityFrameworkCore from NuGet..."
   dotnet new console --framework net10.0 --output "$CSHARP_ENV_DIR" >/dev/null
   dotnet add "$CSHARP_ENV_DIR" package ParadeDB.EntityFrameworkCore \
-    --version 0.1.2 \
+    --version 0.3.0 \
     >/dev/null
   dotnet restore "$CSHARP_ENV_DIR" -p:NuGetAudit=false >/dev/null
 

--- a/.github/scripts/sqlalchemy_snippet_harness.py
+++ b/.github/scripts/sqlalchemy_snippet_harness.py
@@ -23,6 +23,8 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE, JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
+from paradedb.sqlalchemy.vector import Vector
+
 
 def build_database_url() -> str:
     """Build a SQLAlchemy connection string for the docs verification database."""
@@ -61,6 +63,7 @@ class MockItem(Base):
     last_updated_date: Mapped[Any] = mapped_column(Date, nullable=True)
     latest_available_time: Mapped[Any] = mapped_column(Time, nullable=True)
     weight_range: Mapped[Any] = mapped_column(INT4RANGE, nullable=True)
+    embedding: Mapped[Any] = mapped_column(Vector(8), nullable=True)
 
 
 class Order(Base):

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -67,7 +67,7 @@ To get started, create a TypeScript project with [Drizzle](https://orm.drizzle.t
 ```bash
 npm init -y
 npm pkg set type=module
-npm install drizzle-orm@1.0.0-rc.2 drizzle-kit@1.0.0-rc.2 postgres @paradedb/drizzle-paradedb@0.2.0 tsx
+npm install drizzle-orm@1.0.0-rc.2 drizzle-kit@1.0.0-rc.2 postgres @paradedb/drizzle-paradedb@0.4.0 tsx
 ```
 
 Create a `db.ts` file with your database connection and a schema for ParadeDB's built-in test table:
@@ -88,6 +88,7 @@ import {
   time,
   timestamp,
   varchar,
+  vector,
 } from "drizzle-orm/pg-core";
 
 export const client = postgres(
@@ -110,13 +111,15 @@ export const mockItems = pgTable(
     weightRange: customType<{ data: string }>({
       dataType: () => "int4range",
     })("weight_range"),
+    embedding: vector("embedding", { dimensions: 8 }),
   },
   (table) => [
     indexing
-      .bm25Index("search_idx")
+      .paradedbIndex("search_idx")
       .on(
         table.id,
         table.description,
+        indexing.vectorField(table.embedding, "cosine"),
         table.category,
         table.rating,
         table.inStock,
@@ -129,6 +132,8 @@ export const mockItems = pgTable(
   ],
 );
 ```
+
+Note that this includes text, vector, and metadata fields.
 
 <Note>
   As a general rule of thumb, any columns that you want to filter, `GROUP BY`,
@@ -209,7 +214,7 @@ To start you'll need a [Django](https://www.djangoproject.com/) project with [Ps
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install django psycopg django-paradedb==0.10.0
+pip install django psycopg django-paradedb==0.12.0
 python3 -m django startproject myproject .
 python3 manage.py startapp myapp
 ```
@@ -241,9 +246,10 @@ We can now add a model for ParadeDB's built-in test table and ParadeDB index:
 from django.db import models
 
 from django.contrib.postgres.fields import IntegerRangeField
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 from paradedb.queryset import ParadeDBManager
 from paradedb.search import Tokenizer
+from paradedb.vector import VectorField
 
 
 class MockItem(models.Model):
@@ -256,17 +262,19 @@ class MockItem(models.Model):
     last_updated_date = models.DateField(null=True, blank=True)
     latest_available_time = models.TimeField(null=True, blank=True)
     weight_range = IntegerRangeField(null=True, blank=True)
+    embedding = VectorField(dimensions=8, null=True, blank=True)
 
     objects = ParadeDBManager()
 
     class Meta:
         db_table = "mock_items"
         indexes = [
-            BM25Index(
+            ParadeDBIndex(
                 fields={
                     "id": {},
                     "description": {"tokenizer": Tokenizer.unicode_words()},
-                    "category": {"tokenizer": Tokenizer.literal()},
+                    "embedding": {"metric": "cosine"},
+                    "category": {},
                     "rating": {},
                     "in_stock": {},
                     "metadata": {"json_fields": {"fast": True}},
@@ -280,6 +288,8 @@ class MockItem(models.Model):
             ),
         ]
 ```
+
+Note that this includes text, vector, and metadata fields.
 
 <Note>
   As a general rule of thumb, any columns that you want to filter, `GROUP BY`,
@@ -327,7 +337,7 @@ To get started, install [SQLAlchemy](https://www.sqlalchemy.org/), [Alembic](htt
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install sqlalchemy psycopg alembic sqlalchemy-paradedb==0.8.0
+pip install sqlalchemy psycopg alembic sqlalchemy-paradedb==0.10.0
 ```
 
 Initialize Alembic:
@@ -355,6 +365,7 @@ from sqlalchemy.dialects.postgresql import INT4RANGE, JSONB, Range
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from paradedb.sqlalchemy import indexing
+from paradedb.sqlalchemy.vector import Vector
 
 
 class Base(DeclarativeBase):
@@ -374,24 +385,28 @@ class MockItem(Base):
     last_updated_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     latest_available_time: Mapped[time | None] = mapped_column(Time, nullable=True)
     weight_range: Mapped[Range[int] | None] = mapped_column(INT4RANGE, nullable=True)
+    embedding: Mapped[list[float] | None] = mapped_column(Vector(8), nullable=True)
 
 
 Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.description),
-    indexing.BM25Field(MockItem.category),
-    indexing.BM25Field(MockItem.rating),
-    indexing.BM25Field(MockItem.in_stock),
-    indexing.BM25Field(MockItem.metadata_),
-    indexing.BM25Field(MockItem.created_at),
-    indexing.BM25Field(MockItem.last_updated_date),
-    indexing.BM25Field(MockItem.latest_available_time),
-    indexing.BM25Field(MockItem.weight_range),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.VectorField(MockItem.embedding, metric="cosine"),
+    indexing.ParadeDBField(MockItem.category),
+    indexing.ParadeDBField(MockItem.rating),
+    indexing.ParadeDBField(MockItem.in_stock),
+    indexing.ParadeDBField(MockItem.metadata_),
+    indexing.ParadeDBField(MockItem.created_at),
+    indexing.ParadeDBField(MockItem.last_updated_date),
+    indexing.ParadeDBField(MockItem.latest_available_time),
+    indexing.ParadeDBField(MockItem.weight_range),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 ```
+
+Note that this includes text, vector, and metadata fields.
 
 <Note>
   As a general rule of thumb, any columns that you want to filter, `GROUP BY`,
@@ -545,14 +560,14 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Upgrade schema."""
     # ### commands auto generated by Alembic - please adjust! ###
-    op.create_bm25_index('search_idx', 'mock_items', ['id', 'description', 'category', 'rating', 'in_stock', 'metadata', 'created_at', 'last_updated_date', 'latest_available_time', 'weight_range'], key_field='id', table_schema='public')
+    op.create_paradedb_index('search_idx', 'mock_items', ['id', 'description', 'embedding vector_cosine_ops', 'category', 'rating', 'in_stock', 'metadata', 'created_at', 'last_updated_date', 'latest_available_time', 'weight_range'], key_field='id', table_schema='public')
     # ### end Alembic commands ###
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     # ### commands auto generated by Alembic - please adjust! ###
-    op.drop_bm25_index('search_idx', if_exists=True, schema='public')
+    op.drop_paradedb_index('search_idx', if_exists=True, schema='public')
     # ### end Alembic commands ###
 ```
 
@@ -585,7 +600,7 @@ cd paradedb
 Add the [rails-paradedb](https://rubygems.org/gems/rails-paradedb) gem to your `Gemfile`:
 
 ```ruby Gemfile
-gem "rails-paradedb", "0.9.0", require: "parade_db"
+gem "rails-paradedb", "0.11.0", require: "parade_db"
 ```
 
 Then install it:
@@ -651,6 +666,7 @@ class MockItemIndex < ParadeDB::Index
   self.fields = {
     id: nil,
     description: nil,
+    embedding: { metric: :cosine },
     category: nil,
     rating: nil,
     in_stock: nil,
@@ -662,6 +678,8 @@ class MockItemIndex < ParadeDB::Index
   }
 end
 ```
+
+Note that this includes text, vector, and metadata fields.
 
 <Note>
   As a general rule of thumb, any columns that you want to filter, `GROUP BY`,
@@ -689,7 +707,7 @@ def up
 end
 
 def down
-  remove_bm25_index :mock_items, name: :search_idx, if_exists: true
+  remove_paradedb_index :mock_items, name: :search_idx, if_exists: true
 end
 ```
 
@@ -716,7 +734,7 @@ dotnet new tool-manifest
 dotnet tool install dotnet-ef
 dotnet add package Microsoft.EntityFrameworkCore.Design
 dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
-dotnet add package ParadeDB.EntityFrameworkCore --version 0.1.2
+dotnet add package ParadeDB.EntityFrameworkCore --version 0.3.0
 ```
 
 <Note>
@@ -742,6 +760,7 @@ Replace `Program.cs` with a DbContext, model, and query scratchpad for ParadeDB'
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using NpgsqlTypes;
+using ParadeDB.EntityFrameworkCore;
 using ParadeDB.EntityFrameworkCore.Extensions;
 
 await using var dbContext = new AppDbContext();
@@ -808,10 +827,12 @@ public sealed class AppDbContext : DbContext
             entity.Property(item => item.LastUpdatedDate).HasColumnName("last_updated_date").HasColumnType("date");
             entity.Property(item => item.LatestAvailableTime).HasColumnName("latest_available_time").HasColumnType("time");
             entity.Property(item => item.WeightRange).HasColumnName("weight_range").HasColumnType("int4range");
+            entity.Property(item => item.Embedding).HasColumnName("embedding").HasColumnType("vector(8)");
 
             entity
-                .HasBm25Index("search_idx", item => item.Id)
+                .HasParadeDbIndex("search_idx", item => item.Id)
                 .HasField(item => item.Description)
+                .HasField(item => item.Embedding, VectorMetric.Cosine)
                 .HasField(item => item.Category)
                 .HasField(item => item.Rating)
                 .HasField(item => item.InStock)
@@ -836,8 +857,11 @@ public sealed class MockItem
     public DateOnly? LastUpdatedDate { get; set; }
     public TimeOnly? LatestAvailableTime { get; set; }
     public NpgsqlRange<int>? WeightRange { get; set; }
+    public float[]? Embedding { get; set; }
 }
 ```
+
+Note that this includes text, vector, and metadata fields.
 
 <Note>
   As a general rule of thumb, any columns that you want to filter, `GROUP BY`,

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -296,23 +296,81 @@ LIMIT 5;
 ```
 
 ```ts Drizzle
-// Vector search support for Drizzle is coming very soon.
+import { and, gt } from "drizzle-orm";
+import { search } from "@paradedb/drizzle-paradedb";
+
+const queryEmbedding = [1, 2, 3, 4, 5, 6, 7, 8];
+
+await db
+  .select({
+    description: mockItems.description,
+    embedding: mockItems.embedding,
+  })
+  .from(mockItems)
+  .where(
+    and(
+      search.matchAny(mockItems.description, "running shoes"),
+      gt(mockItems.rating, 2),
+    ),
+  )
+  .orderBy(search.cosineDistance(mockItems.embedding, queryEmbedding))
+  .limit(5);
 ```
 
 ```python Django
-# Vector search support for Django is coming very soon.
+from paradedb import MatchAny, ParadeDB
+from paradedb.vector import CosineDistance
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.objects.filter(
+    description=ParadeDB(MatchAny('running shoes')),
+    rating__gt=2
+).order_by(
+    CosineDistance('embedding', query_embedding)
+).values('description', 'embedding')[:5]
 ```
 
 ```python SQLAlchemy
-# Vector search support for SQLAlchemy is coming very soon.
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from paradedb.sqlalchemy import search, vector
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+stmt = (
+    select(MockItem.description, MockItem.embedding)
+    .where(search.match_any(MockItem.description, "running shoes"), MockItem.rating > 2)
+    .order_by(vector.cosine_distance(MockItem.embedding, query_embedding))
+    .limit(5)
+)
+
+with Session(engine) as session:
+    session.execute(stmt).all()
 ```
 
 ```ruby Rails
-# Vector search support for Rails is coming very soon.
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.search(:description)
+        .match_any("running shoes")
+        .where(rating: 3..)
+        .nearest(:embedding, query_embedding, metric: :cosine)
+        .select(:description, :embedding)
+        .limit(5)
 ```
 
 ```cs EF Core
-// Vector search support for EF Core is coming very soon.
+var queryEmbedding = new float[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+await dbContext
+    .MockItems.Where(item =>
+        EF.Functions.MatchAny(item.Description, "running shoes") && item.Rating > 2
+    )
+    .OrderBy(item => EF.Functions.CosineDistance(item.Embedding, queryEmbedding))
+    .Select(item => new { item.Description, item.Embedding })
+    .Take(5)
+    .ToListAsync();
 ```
 
 </CodeGroup>

--- a/docs/documentation/indexing/columnar.mdx
+++ b/docs/documentation/indexing/columnar.mdx
@@ -20,18 +20,18 @@ WITH (key_field = 'id');
 import { indexing } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(mockItems.id, mockItems.description, mockItems.rating);
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {},
@@ -49,10 +49,10 @@ from paradedb.sqlalchemy import indexing
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.description),
-    indexing.BM25Field(MockItem.rating),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(MockItem.rating),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -61,7 +61,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -75,7 +75,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description)
     .HasField(e => e.Rating);
 ```
@@ -95,10 +95,10 @@ WITH (key_field = 'id');
 import { indexing, tokenizer } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
-    indexing.bm25Field(
+    indexing.paradedbField(
       mockItems.description,
       tokenizer.unicodeWords({ columnar: true }),
     ),
@@ -108,13 +108,13 @@ indexing
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 from paradedb.search import Tokenizer
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {
@@ -136,13 +136,13 @@ from paradedb.sqlalchemy import indexing, tokenizer
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(
         MockItem.description,
         tokenizer=tokenizer.unicode_words(options={"columnar": True}),
     ),
-    indexing.BM25Field(MockItem.rating),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.rating),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -151,7 +151,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -167,7 +167,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description, Tokenizer.Unicode(new() { ["columnar"] = true }))
     .HasField(e => e.Rating);
 ```

--- a/docs/documentation/indexing/create-index.mdx
+++ b/docs/documentation/indexing/create-index.mdx
@@ -18,18 +18,18 @@ WITH (key_field='id');
 import { indexing } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(mockItems.id, mockItems.description, mockItems.category);
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {},
@@ -47,10 +47,10 @@ from paradedb.sqlalchemy import indexing
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.description),
-    indexing.BM25Field(MockItem.category),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(MockItem.category),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -59,7 +59,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -73,7 +73,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description)
     .HasField(e => e.Category);
 ```
@@ -126,7 +126,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.remove_bm25_index(:mock_items, name: :search_idx)
+ActiveRecord::Base.connection.remove_paradedb_index(:mock_items, name: :search_idx)
 ```
 
 ```cs EF Core
@@ -154,23 +154,23 @@ WITH (key_field='id');
 import { indexing, tokenizer } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
-    indexing.bm25Field(mockItems.description, tokenizer.icu()),
+    indexing.paradedbField(mockItems.description, tokenizer.icu()),
     mockItems.category,
   );
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 from paradedb.search import Tokenizer
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {"tokenizer": Tokenizer.icu()},
@@ -188,13 +188,13 @@ from paradedb.sqlalchemy import indexing, tokenizer
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(
         MockItem.description,
         tokenizer=tokenizer.icu(),
     ),
-    indexing.BM25Field(MockItem.category),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.category),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -203,7 +203,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -217,7 +217,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description, Tokenizer.Icu())
     .HasField(e => e.Category);
 ```
@@ -238,7 +238,7 @@ WITH (key_field='id');
 import { indexing } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
     mockItems.description,
@@ -253,12 +253,12 @@ indexing
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {},
@@ -281,15 +281,15 @@ from paradedb.sqlalchemy import indexing
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.description),
-    indexing.BM25Field(MockItem.category),
-    indexing.BM25Field(MockItem.rating),
-    indexing.BM25Field(MockItem.in_stock),
-    indexing.BM25Field(MockItem.created_at),
-    indexing.BM25Field(MockItem.metadata_),
-    indexing.BM25Field(MockItem.weight_range),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(MockItem.category),
+    indexing.ParadeDBField(MockItem.rating),
+    indexing.ParadeDBField(MockItem.in_stock),
+    indexing.ParadeDBField(MockItem.created_at),
+    indexing.ParadeDBField(MockItem.metadata_),
+    indexing.ParadeDBField(MockItem.weight_range),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -298,7 +298,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -317,7 +317,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description)
     .HasField(e => e.Category)
     .HasField(e => e.Rating)
@@ -370,10 +370,10 @@ WITH (key_field='id');
 import { indexing, tokenizer } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
-    indexing.bm25Field(
+    indexing.paradedbField(
       mockItems.description,
       tokenizer.simple({ stemmer: "english" }),
     ),
@@ -383,13 +383,13 @@ indexing
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 from paradedb.search import Tokenizer
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {
@@ -411,13 +411,13 @@ from paradedb.sqlalchemy import indexing, tokenizer
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(
         MockItem.description,
         tokenizer=tokenizer.simple(options={"stemmer": "english"}),
     ),
-    indexing.BM25Field(MockItem.category),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.category),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -426,7 +426,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -442,7 +442,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description, Tokenizer.Simple(new() { ["stemmer"] = "english" }))
     .HasField(e => e.Category);
 ```

--- a/docs/documentation/indexing/indexing-arrays.mdx
+++ b/docs/documentation/indexing/indexing-arrays.mdx
@@ -24,17 +24,17 @@ WITH (key_field = 'id');
 ```ts Drizzle
 import { indexing } from "@paradedb/drizzle-paradedb";
 
-indexing.bm25Index("search_idx").on(arrayDemo.id, arrayDemo.categories);
+indexing.paradedbIndex("search_idx").on(arrayDemo.id, arrayDemo.categories);
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         ArrayDemo,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "categories": {},
@@ -51,9 +51,9 @@ from paradedb.sqlalchemy import indexing
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(ArrayDemo.id),
-    indexing.BM25Field(ArrayDemo.categories),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(ArrayDemo.id),
+    indexing.ParadeDBField(ArrayDemo.categories),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -62,7 +62,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :array_demo,
   fields: {
     id: {},
@@ -75,7 +75,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<ArrayDemo>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Categories);
 ```
 
@@ -108,22 +108,22 @@ WITH (key_field = 'id');
 import { indexing, tokenizer } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     arrayDemo.id,
-    indexing.bm25Field(arrayDemo.categories, tokenizer.literal()),
+    indexing.paradedbField(arrayDemo.categories, tokenizer.literal()),
   );
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 from paradedb.search import Tokenizer
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         ArrayDemo,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "categories": {"tokenizer": Tokenizer.literal()},
@@ -140,9 +140,9 @@ from paradedb.sqlalchemy import indexing, tokenizer
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(ArrayDemo.id),
-    indexing.BM25Field(ArrayDemo.categories, tokenizer=tokenizer.literal()),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(ArrayDemo.id),
+    indexing.ParadeDBField(ArrayDemo.categories, tokenizer=tokenizer.literal()),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -151,7 +151,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :array_demo,
   fields: {
     id: {},
@@ -164,7 +164,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<ArrayDemo>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Categories, Tokenizer.Literal());
 ```
 

--- a/docs/documentation/indexing/indexing-expressions.mdx
+++ b/docs/documentation/indexing/indexing-expressions.mdx
@@ -22,10 +22,10 @@ import { sql } from "drizzle-orm";
 import { indexing, tokenizer } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
-    indexing.bm25Field(
+    indexing.paradedbField(
       sql`${mockItems.description} || ' ' || ${mockItems.category}`,
       tokenizer.simple({ alias: "description_concat" }),
     ),
@@ -35,13 +35,13 @@ indexing
 ```python Django
 from django.db import connection, models
 from django.db.models import F, Func, Value
-from paradedb.indexes import BM25Index, IndexExpression
+from paradedb.indexes import ParadeDBIndex, IndexExpression
 from paradedb.search import Tokenizer
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={"id": {}},
             expressions=[
                 IndexExpression(
@@ -71,12 +71,12 @@ from paradedb.sqlalchemy import indexing, tokenizer
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(
         MockItem.description + " " + MockItem.category,
         tokenizer=tokenizer.simple(options={"alias": "description_concat"}),
     ),
-    postgresql_using="bm25",
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -85,7 +85,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -100,7 +100,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(
         "description || ' ' || category",
         Tokenizer.Simple(new() { ["alias"] = "description_concat" })
@@ -147,7 +147,7 @@ import { sql } from "drizzle-orm";
 import { indexing, search } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
     mockItems.description,
@@ -158,12 +158,12 @@ indexing
 ```python Django
 from django.db import connection
 from django.db.models import F
-from paradedb.indexes import BM25Index, IndexExpression
+from paradedb.indexes import ParadeDBIndex, IndexExpression
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={"id": {}, "description": {}},
             expressions=[
                 IndexExpression(
@@ -183,12 +183,12 @@ from paradedb.sqlalchemy import indexing, pdb
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.description),
-    indexing.BM25Field(
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(
         pdb.alias(MockItem.rating + 1, "rating"),
     ),
-    postgresql_using="bm25",
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -197,7 +197,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -211,7 +211,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description)
     .HasField("rating + 1", new FieldAlias("rating"));
 ```

--- a/docs/documentation/indexing/indexing-json.mdx
+++ b/docs/documentation/indexing/indexing-json.mdx
@@ -17,17 +17,17 @@ WITH (key_field='id');
 ```ts Drizzle
 import { indexing } from "@paradedb/drizzle-paradedb";
 
-indexing.bm25Index("search_idx").on(mockItems.id, mockItems.metadata);
+indexing.paradedbIndex("search_idx").on(mockItems.id, mockItems.metadata);
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "metadata": {},
@@ -44,9 +44,9 @@ from paradedb.sqlalchemy import indexing
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.metadata_),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.metadata_),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -55,7 +55,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -68,7 +68,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Metadata);
 ```
 
@@ -95,22 +95,22 @@ WITH (key_field='id');
 import { indexing, tokenizer } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
-    indexing.bm25Field(mockItems.metadata, tokenizer.ngram(2, 3)),
+    indexing.paradedbField(mockItems.metadata, tokenizer.ngram(2, 3)),
   );
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 from paradedb.search import Tokenizer
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "metadata": {
@@ -129,12 +129,12 @@ from paradedb.sqlalchemy import indexing, tokenizer
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(
         MockItem.metadata_,
         tokenizer=tokenizer.ngram(2, 3),
     ),
-    postgresql_using="bm25",
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -143,7 +143,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -156,7 +156,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Metadata, Tokenizer.Ngram(2, 3));
 ```
 
@@ -176,10 +176,10 @@ WITH (key_field='id');
 import { indexing, tokenizer } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(
     mockItems.id,
-    indexing.bm25Field(
+    indexing.paradedbField(
       indexing.jsonText(mockItems.metadata, "color"),
       tokenizer.ngram(2, 3),
     ),
@@ -188,13 +188,13 @@ indexing
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 from paradedb.search import Tokenizer
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "metadata": {
@@ -217,12 +217,12 @@ from paradedb.sqlalchemy import expr, indexing, tokenizer
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(
         expr.json_text(MockItem.metadata_, "color"),
         tokenizer=tokenizer.ngram(2, 3),
     ),
-    postgresql_using="bm25",
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
 )
 
@@ -231,7 +231,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -244,7 +244,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField("metadata->>'color'", Tokenizer.Ngram(2, 3));
 ```
 

--- a/docs/documentation/indexing/indexing-partial.mdx
+++ b/docs/documentation/indexing/indexing-partial.mdx
@@ -23,7 +23,7 @@ import { isNotNull } from "drizzle-orm";
 import { indexing } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx")
+  .paradedbIndex("search_idx")
   .on(mockItems.id, mockItems.description, mockItems.category)
   .where(isNotNull(mockItems.description));
 ```
@@ -31,12 +31,12 @@ indexing
 ```python Django
 from django.db import connection
 from django.db.models import Q
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 
 with connection.schema_editor() as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {},
@@ -55,10 +55,10 @@ from paradedb.sqlalchemy import indexing
 
 idx = Index(
     "search_idx",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.description),
-    indexing.BM25Field(MockItem.category),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(MockItem.category),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
     postgresql_where=MockItem.description.is_not(None),
 )
@@ -68,7 +68,7 @@ with engine.begin() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -83,7 +83,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx", e => e.Id)
+    .HasParadeDbIndex("search_idx", e => e.Id)
     .HasField(e => e.Description)
     .HasField(e => e.Category)
     .HasFilter("description IS NOT NULL");

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -115,9 +115,9 @@ embedding vector_ip_ops      -- inner product
 ```
 
 ```ts Drizzle
-indexing.vectorField(mockItems.embedding, "l2")      // L2 (default)
-indexing.vectorField(mockItems.embedding, "cosine")  // cosine
-indexing.vectorField(mockItems.embedding, "ip")      // inner product
+indexing.vectorField(mockItems.embedding, "l2"); // L2 (default)
+indexing.vectorField(mockItems.embedding, "cosine"); // cosine
+indexing.vectorField(mockItems.embedding, "ip"); // inner product
 ```
 
 ```python Django

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -31,29 +31,120 @@ WITH (key_field='id');
 ```
 
 ```ts Drizzle
-// Vector search support for Drizzle is coming very soon.
+import { indexing } from "@paradedb/drizzle-paradedb";
+
+indexing
+  .paradedbIndex("search_idx")
+  .on(
+    mockItems.id,
+    mockItems.description,
+    mockItems.category,
+    indexing.vectorField(mockItems.embedding, "cosine"),
+  );
 ```
 
 ```python Django
-# Vector search support for Django is coming very soon.
+from django.db import connection
+from paradedb.indexes import ParadeDBIndex
+
+with connection.schema_editor() as schema_editor:
+    schema_editor.add_index(
+        MockItem,
+        ParadeDBIndex(
+            fields={
+                "id": {},
+                "description": {},
+                "category": {},
+                "embedding": {"metric": "cosine"},
+            },
+            key_field="id",
+            name="search_idx",
+        ),
+    )
 ```
 
 ```python SQLAlchemy
-# Vector search support for SQLAlchemy is coming very soon.
+from sqlalchemy import Index
+from paradedb.sqlalchemy import indexing
+
+idx = Index(
+    "search_idx",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(MockItem.category),
+    indexing.VectorField(MockItem.embedding, metric="cosine"),
+    postgresql_using="paradedb",
+    postgresql_with={"key_field": "id"},
+)
+
+with engine.begin() as conn:
+    idx.create(conn)
 ```
 
 ```ruby Rails
-# Vector search support for Rails is coming very soon.
+ActiveRecord::Base.connection.add_paradedb_index(
+  :mock_items,
+  fields: {
+    id: {},
+    description: {},
+    category: {},
+    embedding: { metric: :cosine }
+  },
+  key_field: :id,
+  name: :search_idx
+)
 ```
 
 ```cs EF Core
-// Vector search support for EF Core is coming very soon.
+modelBuilder.Entity<MockItem>()
+    .HasParadeDbIndex("search_idx", e => e.Id)
+    .HasField(e => e.Description)
+    .HasField(e => e.Category)
+    .HasField(e => e.Embedding, VectorMetric.Cosine);
 ```
 
 </CodeGroup>
 
 The desired distance function is encoded into the index definition, and cannot be changed without reindexing.
-Use `vector_l2_ops` for L2 distance, `vector_ip_ops` for inner product, or `vector_cosine_ops` for cosine distance.
+
+<CodeGroup>
+```sql SQL
+embedding vector_l2_ops      -- L2 (default)
+embedding vector_cosine_ops  -- cosine
+embedding vector_ip_ops      -- inner product
+```
+
+```ts Drizzle
+indexing.vectorField(mockItems.embedding, "l2")      // L2 (default)
+indexing.vectorField(mockItems.embedding, "cosine")  // cosine
+indexing.vectorField(mockItems.embedding, "ip")      // inner product
+```
+
+```python Django
+"embedding": {"metric": "l2"}      # L2 (default)
+"embedding": {"metric": "cosine"}  # cosine
+"embedding": {"metric": "ip"}      # inner product
+```
+
+```python SQLAlchemy
+indexing.VectorField(MockItem.embedding, metric="l2")      # L2 (default)
+indexing.VectorField(MockItem.embedding, metric="cosine")  # cosine
+indexing.VectorField(MockItem.embedding, metric="ip")      # inner product
+```
+
+```ruby Rails
+embedding: { metric: :l2 }      # L2 (default)
+embedding: { metric: :cosine }  # cosine
+embedding: { metric: :ip }      # inner product
+```
+
+```cs EF Core
+.HasField(e => e.Embedding, VectorMetric.L2)            // L2 (default)
+.HasField(e => e.Embedding, VectorMetric.Cosine)        // cosine
+.HasField(e => e.Embedding, VectorMetric.InnerProduct)  // inner product
+```
+
+</CodeGroup>
 
 <Note>
   Only pgvector's `vector` type is supported. The `halfvec`, `sparsevec`, and
@@ -81,23 +172,98 @@ WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, clu
 ```
 
 ```ts Drizzle
-// Vector search support for Drizzle is coming very soon.
+import { indexing } from "@paradedb/drizzle-paradedb";
+
+indexing
+  .paradedbIndex("search_idx", {
+    centroidRatio: 0.01,
+    trainingSamplesPerCentroid: 32,
+    clusterReplication: 1,
+  })
+  .on(
+    mockItems.id,
+    mockItems.description,
+    mockItems.category,
+    indexing.vectorField(mockItems.embedding, "cosine"),
+  );
 ```
 
 ```python Django
-# Vector search support for Django is coming very soon.
+from django.db import connection
+from paradedb.indexes import ParadeDBIndex
+
+with connection.schema_editor() as schema_editor:
+    schema_editor.add_index(
+        MockItem,
+        ParadeDBIndex(
+            fields={
+                "id": {},
+                "description": {},
+                "category": {},
+                "embedding": {"metric": "cosine"},
+            },
+            key_field="id",
+            name="search_idx",
+            centroid_ratio=0.01,
+            training_samples_per_centroid=32,
+            cluster_replication=1,
+        ),
+    )
 ```
 
 ```python SQLAlchemy
-# Vector search support for SQLAlchemy is coming very soon.
+from sqlalchemy import Index
+from paradedb.sqlalchemy import indexing
+
+idx = Index(
+    "search_idx",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(MockItem.category),
+    indexing.VectorField(MockItem.embedding, metric="cosine"),
+    postgresql_using="paradedb",
+    postgresql_with={
+        "key_field": "id",
+        **indexing.VectorIndexOptions(
+            centroid_ratio=0.01,
+            training_samples_per_centroid=32,
+            cluster_replication=1,
+        ),
+    },
+)
+
+with engine.begin() as conn:
+    idx.create(conn)
 ```
 
 ```ruby Rails
-# Vector search support for Rails is coming very soon.
+ActiveRecord::Base.connection.add_paradedb_index(
+  :mock_items,
+  fields: {
+    id: {},
+    description: {},
+    category: {},
+    embedding: { metric: :cosine }
+  },
+  key_field: :id,
+  name: :search_idx,
+  index_options: {
+    centroid_ratio: 0.01,
+    training_samples_per_centroid: 32,
+    cluster_replication: 1
+  }
+)
 ```
 
 ```cs EF Core
-// Vector search support for EF Core is coming very soon.
+modelBuilder.Entity<MockItem>()
+    .HasParadeDbIndex("search_idx", e => e.Id)
+    .HasField(e => e.Description)
+    .HasField(e => e.Category)
+    .HasField(e => e.Embedding, VectorMetric.Cosine)
+    .HasCentroidRatio(0.01)
+    .HasTrainingSamplesPerCentroid(32)
+    .HasClusterReplication(1);
 ```
 
 </CodeGroup>

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -33,14 +33,17 @@ WITH (key_field='id');
 ```ts Drizzle
 import { indexing } from "@paradedb/drizzle-paradedb";
 
-indexing
-  .paradedbIndex("search_idx")
-  .on(
-    mockItems.id,
-    mockItems.description,
-    mockItems.category,
-    indexing.vectorField(mockItems.embedding, "cosine"),
-  );
+// In the pgTable definition:
+(table) => [
+  indexing
+    .paradedbIndex("search_idx")
+    .on(
+      table.id,
+      table.description,
+      table.category,
+      indexing.vectorField(table.embedding, "cosine"),
+    ),
+];
 ```
 
 ```python Django
@@ -174,18 +177,21 @@ WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, clu
 ```ts Drizzle
 import { indexing } from "@paradedb/drizzle-paradedb";
 
-indexing
-  .paradedbIndex("search_idx", {
-    centroidRatio: 0.01,
-    trainingSamplesPerCentroid: 32,
-    clusterReplication: 1,
-  })
-  .on(
-    mockItems.id,
-    mockItems.description,
-    mockItems.category,
-    indexing.vectorField(mockItems.embedding, "cosine"),
-  );
+// In the pgTable definition:
+(table) => [
+  indexing
+    .paradedbIndex("search_idx", {
+      centroidRatio: 0.01,
+      trainingSamplesPerCentroid: 32,
+      clusterReplication: 1,
+    })
+    .on(
+      table.id,
+      table.description,
+      table.category,
+      indexing.vectorField(table.embedding, "cosine"),
+    ),
+];
 ```
 
 ```python Django

--- a/docs/documentation/indexing/reindexing.mdx
+++ b/docs/documentation/indexing/reindexing.mdx
@@ -27,19 +27,19 @@ WITH (key_field = 'id');
 import { indexing } from "@paradedb/drizzle-paradedb";
 
 indexing
-  .bm25Index("search_idx_v2")
+  .paradedbIndex("search_idx_v2")
   .on(mockItems.id, mockItems.description, mockItems.category)
   .concurrently();
 ```
 
 ```python Django
 from django.db import connection
-from paradedb.indexes import BM25Index
+from paradedb.indexes import ParadeDBIndex
 
 with connection.schema_editor(atomic=False) as schema_editor:
     schema_editor.add_index(
         MockItem,
-        BM25Index(
+        ParadeDBIndex(
             fields={
                 "id": {},
                 "description": {},
@@ -58,10 +58,10 @@ from paradedb.sqlalchemy import indexing
 
 idx = Index(
     "search_idx_v2",
-    indexing.BM25Field(MockItem.id),
-    indexing.BM25Field(MockItem.description),
-    indexing.BM25Field(MockItem.category),
-    postgresql_using="bm25",
+    indexing.ParadeDBField(MockItem.id),
+    indexing.ParadeDBField(MockItem.description),
+    indexing.ParadeDBField(MockItem.category),
+    postgresql_using="paradedb",
     postgresql_with={"key_field": "id"},
     postgresql_concurrently=True,
 )
@@ -72,7 +72,7 @@ with engine.connect() as conn:
 ```
 
 ```ruby Rails
-ActiveRecord::Base.connection.add_bm25_index(
+ActiveRecord::Base.connection.add_paradedb_index(
   :mock_items,
   fields: {
     id: {},
@@ -87,7 +87,7 @@ ActiveRecord::Base.connection.add_bm25_index(
 
 ```cs EF Core
 modelBuilder.Entity<MockItem>()
-    .HasBm25Index("search_idx_v2", e => e.Id)
+    .HasParadeDbIndex("search_idx_v2", e => e.Id)
     .HasField(e => e.Description)
     .HasField(e => e.Category)
     .IsCreatedConcurrently();

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -29,26 +29,75 @@ LIMIT 5;
 ```
 
 ```ts Drizzle
-// Vector search support for Drizzle is coming very soon.
+import { search } from "@paradedb/drizzle-paradedb";
+
+const queryEmbedding = [1, 2, 3, 4, 5, 6, 7, 8];
+
+await db
+  .select({ id: mockItems.id, description: mockItems.description })
+  .from(mockItems)
+  .where(search.all(mockItems.id))
+  .orderBy(search.cosineDistance(mockItems.embedding, queryEmbedding))
+  .limit(5);
 ```
 
 ```python Django
-# Vector search support for Django is coming very soon.
+from paradedb import All, ParadeDB
+from paradedb.vector import CosineDistance
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.objects.filter(
+    id=ParadeDB(All())
+).order_by(
+    CosineDistance('embedding', query_embedding)
+).values('id', 'description')[:5]
 ```
 
 ```python SQLAlchemy
-# Vector search support for SQLAlchemy is coming very soon.
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from paradedb.sqlalchemy import search, vector
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+stmt = (
+    select(MockItem.id, MockItem.description)
+    .where(search.all(MockItem.id))
+    .order_by(vector.cosine_distance(MockItem.embedding, query_embedding))
+    .limit(5)
+)
+
+with Session(engine) as session:
+    session.execute(stmt).all()
 ```
 
 ```ruby Rails
-# Vector search support for Rails is coming very soon.
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.nearest(:embedding, query_embedding, metric: :cosine)
+        .select(:id, :description)
+        .limit(5)
 ```
 
 ```cs EF Core
-// Vector search support for EF Core is coming very soon.
+var queryEmbedding = new float[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+await dbContext
+    .MockItems.Where(item => EF.Functions.All(item.Id))
+    .OrderBy(item => EF.Functions.CosineDistance(item.Embedding, queryEmbedding))
+    .Select(item => new { item.Id, item.Description })
+    .Take(5)
+    .ToListAsync();
 ```
 
 </CodeGroup>
+
+<Note>
+  Rails' `nearest` adds the match-all predicate automatically when the relation
+  has no other search predicate, and defaults the metric to the one the index
+  was built with.
+</Note>
 
 The `<=>` operator computes cosine distance, so this returns the five rows whose embeddings are nearest the query vector `[1, 2, 3, 4, 5, 6, 7, 8]`.
 
@@ -76,23 +125,68 @@ LIMIT 5;
 ```
 
 ```ts Drizzle
-// Vector search support for Drizzle is coming very soon.
+import { search } from "@paradedb/drizzle-paradedb";
+
+const queryEmbedding = [1, 2, 3, 4, 5, 6, 7, 8];
+
+await db
+  .select({ id: mockItems.id, description: mockItems.description })
+  .from(mockItems)
+  .where(search.term(mockItems.category, "footwear"))
+  .orderBy(search.cosineDistance(mockItems.embedding, queryEmbedding))
+  .limit(5);
 ```
 
 ```python Django
-# Vector search support for Django is coming very soon.
+from paradedb import ParadeDB, Term
+from paradedb.vector import CosineDistance
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.objects.filter(
+    category=ParadeDB(Term('footwear'))
+).order_by(
+    CosineDistance('embedding', query_embedding)
+).values('id', 'description')[:5]
 ```
 
 ```python SQLAlchemy
-# Vector search support for SQLAlchemy is coming very soon.
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from paradedb.sqlalchemy import search, vector
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+stmt = (
+    select(MockItem.id, MockItem.description)
+    .where(search.term(MockItem.category, "footwear"))
+    .order_by(vector.cosine_distance(MockItem.embedding, query_embedding))
+    .limit(5)
+)
+
+with Session(engine) as session:
+    session.execute(stmt).all()
 ```
 
 ```ruby Rails
-# Vector search support for Rails is coming very soon.
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.search(:category)
+        .term("footwear")
+        .nearest(:embedding, query_embedding, metric: :cosine)
+        .select(:id, :description)
+        .limit(5)
 ```
 
 ```cs EF Core
-// Vector search support for EF Core is coming very soon.
+var queryEmbedding = new float[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+await dbContext
+    .MockItems.Where(item => EF.Functions.Term(item.Category, "footwear"))
+    .OrderBy(item => EF.Functions.CosineDistance(item.Embedding, queryEmbedding))
+    .Select(item => new { item.Id, item.Description })
+    .Take(5)
+    .ToListAsync();
 ```
 
 </CodeGroup>
@@ -106,15 +200,88 @@ LIMIT 5;
 
 ## Deterministic Results
 
+<Note>Tiebreaker columns require version `0.25.1` and above.</Note>
+
 Rows whose embeddings are equidistant from the query vector are returned in an arbitrary order. When the `LIMIT` cuts through such a group, which of the tied rows come back can change between runs. Add a tiebreaker column after the distance to make the order stable:
 
-```sql
+<CodeGroup>
+```sql SQL
 SELECT id, description
 FROM mock_items
 WHERE id @@@ pdb.all()
 ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]', id
 LIMIT 5;
 ```
+
+```ts Drizzle
+import { search } from "@paradedb/drizzle-paradedb";
+
+const queryEmbedding = [1, 2, 3, 4, 5, 6, 7, 8];
+
+await db
+  .select({ id: mockItems.id, description: mockItems.description })
+  .from(mockItems)
+  .where(search.all(mockItems.id))
+  .orderBy(
+    search.cosineDistance(mockItems.embedding, queryEmbedding),
+    mockItems.id,
+  )
+  .limit(5);
+```
+
+```python Django
+from paradedb import All, ParadeDB
+from paradedb.vector import CosineDistance
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.objects.filter(
+    id=ParadeDB(All())
+).order_by(
+    CosineDistance('embedding', query_embedding), 'id'
+).values('id', 'description')[:5]
+```
+
+```python SQLAlchemy
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from paradedb.sqlalchemy import search, vector
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+stmt = (
+    select(MockItem.id, MockItem.description)
+    .where(search.all(MockItem.id))
+    .order_by(vector.cosine_distance(MockItem.embedding, query_embedding), MockItem.id)
+    .limit(5)
+)
+
+with Session(engine) as session:
+    session.execute(stmt).all()
+```
+
+```ruby Rails
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+MockItem.nearest(:embedding, query_embedding, metric: :cosine)
+        .order(:id)
+        .select(:id, :description)
+        .limit(5)
+```
+
+```cs EF Core
+var queryEmbedding = new float[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+await dbContext
+    .MockItems.Where(item => EF.Functions.All(item.Id))
+    .OrderBy(item => EF.Functions.CosineDistance(item.Embedding, queryEmbedding))
+    .ThenBy(item => item.Id)
+    .Select(item => new { item.Id, item.Description })
+    .Take(5)
+    .ToListAsync();
+```
+
+</CodeGroup>
 
 The tiebreaker is applied only within a group of equal distances, so it never changes which rows are nearest. Multiple tiebreakers and `DESC` are both supported, and every tiebreaker column must be in the ParadeDB index to keep the Top K optimization.
 


### PR DESCRIPTION
# Description

Updates the docs for the ORM releases that ship the paradedb rename, native vector search, and the vector index build options (sqlalchemy 0.10.0, django 0.12.0, rails 0.11.0, drizzle 0.4.0, efcore 0.3.0):

- Version pins bumped in the environment setup.
- bm25-named ORM APIs renamed to their paradedb names across the indexing pages.
- `embedding` column added to every environment accordion, mirroring the SQL tab.
- "Coming very soon" vector placeholders replaced with real code in getting started, indexing vectors, and querying vectors, including the index-options and tiebreaker examples.

Every ORM snippet was run against a live ParadeDB (0.25.0 for queries, a 0.25.1-candidate build for the tiebreaker) and produces the same results as the SQL tab.