### PR TITLE
chore: refresh the Nix lock and pre-commit hooks

### DIFF
--- a/.github/actions/benchmark-queries/compare_baseline.py
+++ b/.github/actions/benchmark-queries/compare_baseline.py
@@ -166,11 +166,13 @@ def write_alert_report(path, suite, baseline, alerts):
     lines = [
         f"## :warning: Possible performance regression vs `{baseline['commit']['id'][:7]}`",
         "",
-        "Percentile series with paired per-query samples alert when the bootstrapped "
-        "one-sided lower 95% bound of the paired percentile ratio exceeds "
-        f"{EFFECT_FLOOR:.2f}x. Without samples, a series alerts when its 95% CI sits "
-        f"entirely above the baseline's and the value regressed >{EFFECT_FLOOR:.2f}x; "
-        f"without CIs, when the value regressed >{FALLBACK_RATIO:.2f}x.",
+        (
+            "Percentile series with paired per-query samples alert when the bootstrapped "
+            "one-sided lower 95% bound of the paired percentile ratio exceeds "
+            f"{EFFECT_FLOOR:.2f}x. Without samples, a series alerts when its 95% CI sits "
+            f"entirely above the baseline's and the value regressed >{EFFECT_FLOOR:.2f}x; "
+            f"without CIs, when the value regressed >{FALLBACK_RATIO:.2f}x."
+        ),
         "",
         f"### {suite}",
         "",

--- a/.github/scripts/check_migration_diff.py
+++ b/.github/scripts/check_migration_diff.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Check if all schema changes from pg-schema-diff are present in the migration file.
 Compares SQL statements in an order-independent way since pg-schema-diff output order
 is non-deterministic. Comments are stripped for comparison.
 """
 
-import sys
 import re
+import sys
 
 
 def normalize_array_defaults(stmt):

--- a/.github/scripts/django_snippet_harness.py
+++ b/.github/scripts/django_snippet_harness.py
@@ -11,7 +11,6 @@ import django
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField, IntegerRangeField
 from django.db import models
-
 from paradedb.queryset import ParadeDBManager
 
 DATABASES = {

--- a/.github/scripts/extract_code_snippets.py
+++ b/.github/scripts/extract_code_snippets.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 """Extract verification snippets from docs CodeGroups."""
 
-from pathlib import Path
 import re
 import shutil
 import sys
+from pathlib import Path
 
-
-CODEGROUP_PATTERN = re.compile(r"<CodeGroup[ >].*?</CodeGroup>", re.S)
-FENCE_PATTERN = re.compile(r"^```([^\n]*)\n(.*?)^```[ \t]*$", re.M | re.S)
+CODEGROUP_PATTERN = re.compile(r"<CodeGroup[ >].*?</CodeGroup>", re.DOTALL)
+FENCE_PATTERN = re.compile(r"^```([^\n]*)\n(.*?)^```[ \t]*$", re.MULTILINE | re.DOTALL)
 TARGET_SUFFIXES = {
     "sql": "sql",
     "django": "py",

--- a/.github/scripts/sqlalchemy_snippet_harness.py
+++ b/.github/scripts/sqlalchemy_snippet_harness.py
@@ -87,9 +87,9 @@ class ArrayDemo(Base):
 engine = create_engine(DATABASE_URL, future=True)
 
 __all__ = [
-    "Base",
     "DATABASE_URL",
     "ArrayDemo",
+    "Base",
     "MockItem",
     "Order",
     "engine",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
         args: ["-i", "2", "-ci"]
@@ -46,7 +46,7 @@ repos:
       - id: shellcheck
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.47.0
+    rev: v0.49.1
     hooks:
       - id: markdownlint
 
@@ -65,14 +65,14 @@ repos:
       - id: cargo-check
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: v4.0.4
+    rev: v4.0.6
     hooks:
       - id: pylint
         args:

--- a/flake.lock
+++ b/flake.lock
@@ -8,12 +8,12 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1769929675,
-        "narHash": "sha256-EBpe7sXCPLs+qVePXbA7kc+Kmpmp0pWysEpjjEWTK+E=",
-        "rev": "78d518f5ca32a86dc767de481160dbae640c70cf",
-        "revCount": 2542,
+        "lastModified": 1782900513,
+        "narHash": "sha256-GHrsl1+ysDFgmDQtQSqWS7TiYD2Q58VlwLvnf1+crJM=",
+        "rev": "16810aa8f4ad89ca480b1513774e8b6f485fe368",
+        "revCount": 2708,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2542%2Brev-78d518f5ca32a86dc767de481160dbae640c70cf/019c1851-0ed1-7f81-b175-8e8bbad651e6/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2708%2Brev-16810aa8f4ad89ca480b1513774e8b6f485fe368/019f1d68-8b55-7783-bed1-d5926f21ae52/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -22,12 +22,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
-        "revCount": 1004030,
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "revCount": 1047536,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1004030%2Brev-64c08a7ca051951c8eae34e3e3cb1e202fe36786/019e5fd8-b716-7e01-9710-e44ec43dc50b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1047536%2Brev-e72e4f299401a3689d4b3d5fc6496b11db7064eb/019fcd00-1d90-79a2-acd8-54111cc4b057/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -43,11 +43,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1769857242,
-        "narHash": "sha256-3eKpRRzKz0KzY7CJzRXFm4POwEqbuTohyQ2ajI/zKvg=",
+        "lastModified": 1782864348,
+        "narHash": "sha256-NVYhLbaefeIUftPlo3kS6qr0xd8eFJRodEiaHrvFKR4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "17304e9c7e11d26139672d3d77aa498b1cae0d69",
+        "rev": "0d381ca097a8e0375a19387874d952c0a230ac4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Nix

`flake.lock` was the stalest thing in the repo — nixpkgs from 23 May, fenix and rust-analyzer-src from late January. This is `nix flake update`:

| input | from | to |
|---|---|---|
| nixpkgs | `64c08a7` (2026-05-23) | `e72e4f2` (2026-08-04) |
| fenix | `78d518f` (2026-01-31) | `16810aa` (2026-07-01) |
| rust-analyzer-src | `17304e9` (2026-01-31) | `0d381ca` (2026-06-30) |

**How this was produced, since it matters for review:** I have no nix on this machine, so the lock was written by computing the NAR hashes directly rather than by running `nix flake update`. Before trusting that, I checked the implementation reproduces hashes nix itself had already written — the existing fenix tarball input and the existing rust-analyzer-src GitHub input both came out byte-identical, as did fenix's own recorded hash for the new rust-analyzer-src rev. `lastModified` is the commit date (verified against the current entries), `revCount` and the pinned URLs come from FlakeHub's resolution of the `0.1` ranges. The nix job runs on `flake.lock` changes, so CI is the real check — if any hash were wrong it would fail loudly rather than quietly.

**Separate issue this turned up:** the overlay takes `fenix.packages.<system>.stable`, which is 1.93.0 on the old lock and 1.96.1 on the new one — while `rust-toolchain.toml` pins **1.97.1**. So the devshell has never matched the pin, and still doesn't. `fromToolchainFile { file = ./rust-toolchain.toml; }` would close it permanently; happy to do that as a follow-up, but it is a behaviour change rather than an update, so it is not in here.

## pre-commit

`prek autoupdate`: shfmt `v3.12.0-2` → `v3.13.1-1`, markdownlint-cli `v0.47.0` → `v0.49.1`, ruff `v0.15.0` → `v0.16.1`, pylint `v4.0.4` → `v4.0.6`.

ruff 0.16 finds nine things across the four Python helpers — import ordering, a redundant `# -*- coding: utf-8 -*-`, `re.S` → `re.DOTALL`, `__all__` ordering. Eight it fixes itself. The ninth is ISC004 in `compare_baseline.py`: an implicit string concatenation sitting directly in a list, which reads as a missing comma — parenthesised by hand. No behaviour changes.

## Test

`prek run --all-files` passes on every hook. shellcheck is the one exception and only locally — it runs in docker, which isn't up on this machine; CI covers it.