### PR TITLE
ci: bump the Citus compatibility tests to 13.3.0 and 14.1.0

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Build & install Citus 13 (PG 15)
         if: matrix.pg_version == 15
         env:
-          CITUS_VERSION: v13.0.1
+          CITUS_VERSION: v13.3.0
         run: |
           set -euxo pipefail
 
@@ -195,7 +195,7 @@ jobs:
       - name: Build & install Citus 14 (PG 16-18)
         if: matrix.pg_version >= 16
         env:
-          CITUS_VERSION: v14.0.0
+          CITUS_VERSION: v14.1.0
         run: |
           set -euxo pipefail
 

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -20,7 +20,7 @@ Both `citus` and `pg_search` must be added to `shared_preload_libraries` in the 
 ```bash
 # Install Citus first
 curl https://install.citusdata.com/community/deb.sh | sudo bash
-apt-get install -y postgresql-18-citus-14.0
+apt-get install -y postgresql-18-citus-14.1
 
 # Add both extensions to shared_preload_libraries
 sed -i "s/^shared_preload_libraries = .*/shared_preload_libraries = 'citus,pg_search'/" /var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
## What

`test-pg_search.yml` was building Citus **v13.0.1** (PG 15) and **v14.0.0** (PG 16–18) — three and one minor releases behind. The compatibility job was therefore testing against older Citus than anyone installing today would get.

`docs/deploy/citus.mdx` moves to the matching `postgresql-18-citus-14.1` package.

## The support matrix is unchanged

Checked `configure.ac` at both tags rather than assuming: v13.3.0 accepts Postgres 15/16/17 and v14.1.0 accepts 16/17/18, exactly as the comment above the steps says. So the `matrix.pg_version` conditions on the two build steps stay as they are.

## Test

The Citus steps run in this PR's matrix — the compatibility tests are the check.