### PR TITLE
test: un-ignore bm25_partial_index_hybrid

### DIFF
--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -766,10 +766,6 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
     assert_eq!(rows.len(), 6);
 }
 
-// TODO: This test is currently ignored because hybrid plans did not reliably trigger the custom
-// scan on a partial BM25 index. The issue this pointed at (#2747) has since been closed, so the
-// test should be re-run and un-ignored if it now passes.
-#[ignore]
 #[rstest]
 fn bm25_partial_index_hybrid(mut conn: PgConnection) {
     r#"


### PR DESCRIPTION
## What

Removes `#[ignore]` from `bm25_partial_index_hybrid` in `tests/tests/bm25_search.rs`, along with the TODO that explained it.

## Why

The comment said the test was ignored because hybrid plans did not reliably trigger the custom scan on a partial BM25 index, tracked by #2747 — and that the test should be re-run and un-ignored if it now passes. #2747 is closed, so I ran it.

## It passes

Verified locally against PostgreSQL 18.4 with the extension installed:

```
running 1 test
test bm25_partial_index_hybrid ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 47 filtered out
```

Then the whole file, since the test creates `mock_items` and a partial `search_idx` and could in principle disturb its neighbours:

```
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

It doesn't — each test gets its own `_sqlx_test_*` database. Note the suite now reports **0 ignored** for this file.

CI covers the combinations I could not run locally: PG 15–18 across both the system and pgrx builds, with pgvector installed for each, which this test needs for its `vector` column.