### PR TITLE
chore: point opencc-jieba-rs at main and dedup the jieba chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,15 +1289,6 @@ dependencies = [
 
 [[package]]
 name = "cedarwood"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "cedarwood"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0524a528a6a0288df1863c3c20fe92c301875b4941e7b6c4b394ab08c5a4c55"
@@ -3611,15 +3602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4327,37 +4309,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jieba-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c676b32a471d3cfae8dac2ad2f8334cd52e53377733cca8c1fb0a5062fec192"
-dependencies = [
- "phf_codegen 0.11.3",
-]
-
-[[package]]
-name = "jieba-macros"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34904340bc65749a9e9a02fcc7f3368e675427c18447b9bbe02df52c15c9a36a"
 dependencies = [
- "phf_codegen 0.13.1",
-]
-
-[[package]]
-name = "jieba-rs"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dd552bbb95d578520ee68403bf8aaf0dbbb2ce55b0854d019f9350ad61040a"
-dependencies = [
- "cedarwood 0.4.6",
- "derive_builder",
- "fxhash",
- "include-flate",
- "jieba-macros 0.7.1",
- "lazy_static",
- "ordered-float 4.6.0",
- "phf 0.11.3",
- "regex",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -4367,9 +4323,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb5bdea4dc241d589e179f39d2a778f31490f3370aa2f626223dbd930ebc5c9d"
 dependencies = [
  "bytecount",
- "cedarwood 0.5.0",
+ "cedarwood",
  "include-flate",
- "jieba-macros 0.10.3",
+ "jieba-macros",
+ "ordered-float",
  "phf 0.13.1",
  "regex",
  "rustc-hash",
@@ -5348,10 +5305,10 @@ checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 [[package]]
 name = "opencc-jieba-rs"
 version = "0.8.0"
-source = "git+https://github.com/paradedb/opencc-jieba-rs?branch=paradedb.no-msrv#55f037922075f1d8eea80202e3b00e4f5301801e"
+source = "git+https://github.com/paradedb/opencc-jieba-rs?branch=main#1bee2628bcae67a955caa5e91b740d170f5615d0"
 dependencies = [
  "include-flate",
- "jieba-rs 0.7.4",
+ "jieba-rs",
  "rayon",
  "rayon-core",
  "regex",
@@ -5408,15 +5365,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-float"
@@ -5612,7 +5560,7 @@ dependencies = [
  "log",
  "macros",
  "once_cell",
- "ordered-float 5.3.0",
+ "ordered-float",
  "parking_lot",
  "paste",
  "pgrx",
@@ -5778,15 +5726,6 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
@@ -5806,32 +5745,12 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_codegen"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
+ "phf_generator",
  "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.7",
 ]
 
 [[package]]
@@ -5842,15 +5761,6 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -7965,7 +7875,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3392170e86f1c387170aba7d171a466ffdc98a8b55b006e19ac64b123a7b690a"
 dependencies = [
- "jieba-rs 0.10.3",
+ "jieba-rs",
  "lazy_static",
  "tantivy-tokenizer-api 0.7.0",
 ]
@@ -7977,7 +7887,7 @@ source = "git+https://github.com/paradedb/tantivy.git?rev=c97fc25d7dbac9218d0b57
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "ordered-float 5.3.0",
+ "ordered-float",
  "serde",
  "serde_json",
 ]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-XDBCNBNeCm60s4REag87bP6tUer3vEZZG3cMHJfxc+w=";
+  cargoHash = "sha256-vW8NFEztktp2vE2Bt2d3MAQqMONsjy/rhkZUFB0yOoE=";
 
   inherit cargo-pgrx postgresql;
 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -30,8 +30,7 @@ unicode-segmentation = "1.13.2"
 icu_segmenter = "2.2.0"
 # We use a fork of opencc-jieba-rs to remove the exact-version dependency pins (e.g., include-flate = "=0.3.0")
 # that were introduced for MSRV reasons, which otherwise conflict with our newer dependencies.
-# The fork also bumps jieba-rs to 0.10, matching tantivy-jieba so we compile one jieba chain rather than two;
-# that half is proposed upstream in laisuk/opencc-jieba-rs#1.
+# The fork also bumps jieba-rs to 0.10, matching tantivy-jieba so we compile one jieba chain rather than two.
 opencc-jieba-rs = { git = "https://github.com/paradedb/opencc-jieba-rs", branch = "main" }
 
 [dev-dependencies]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -30,7 +30,9 @@ unicode-segmentation = "1.13.2"
 icu_segmenter = "2.2.0"
 # We use a fork of opencc-jieba-rs to remove the exact-version dependency pins (e.g., include-flate = "=0.3.0")
 # that were introduced for MSRV reasons, which otherwise conflict with our newer dependencies.
-opencc-jieba-rs = { git = "https://github.com/paradedb/opencc-jieba-rs", branch = "paradedb.no-msrv" }
+# The fork also bumps jieba-rs to 0.10, matching tantivy-jieba so we compile one jieba chain rather than two;
+# that half is proposed upstream in laisuk/opencc-jieba-rs#1.
+opencc-jieba-rs = { git = "https://github.com/paradedb/opencc-jieba-rs", branch = "main" }
 
 [dev-dependencies]
 rstest = "0.26.1"


### PR DESCRIPTION
## What

Tracks `main` on our `opencc-jieba-rs` fork instead of the `paradedb.no-msrv` branch, and refreshes the lock. The fork's work has been consolidated onto `main` (`1bee262`), which now also carries [paradedb/opencc-jieba-rs#1](https://github.com/paradedb/opencc-jieba-rs/pull/1) — the `jieba-rs` 0.7.4 -> 0.10.3 bump.

## Why it matters

The fork pinned `jieba-rs` 0.7.4 while `tantivy-jieba` 0.20.0 uses 0.10.3. Being semver-incompatible, we compiled both chains. Aligning them removes **9 crates from the lock and adds none**, 867 -> 858:

```
- cedarwood 0.4.6          - phf 0.11.3
- fxhash 0.2.1             - phf_codegen 0.11.3
- jieba-macros 0.7.1       - phf_generator 0.11.3
- jieba-rs 0.7.4           - phf_shared 0.11.3
- ordered-float 4.6.0
```

`phf` drops from three versions in the tree to two as a side effect — the 0.11.3 chain was reachable only from `jieba-rs` 0.7.4.

## Verification

- `cargo check -p tokenizers --all-features` — clean, and resolves a single `jieba-rs v0.10.3`.
- `cargo test -p tokenizers --all-features` — 77 passed, 0 failed. That includes the tests that actually exercise the OpenCC path: `chinese_convert::test_jieba_with_convert`, `test_t2s_conversion`, `test_s2t_conversion`, and the `manager::test_jieba_tokenizer_*` cases.

Upstream in the fork, `cargo test --workspace --all-features` reported 125 passed / 6 ignored both before and after the bump, with the exact-sequence `assert_eq!` on user-dictionary segmentation unchanged — so segmentation output is identical, not merely still green.

## Note on the fork

`jieba-rs` 0.10 changed `Jieba::cut` and friends to return `Vec<Token<'a>>` rather than `Vec<&'a str>`, so this was a real port rather than a version-string edit; the details are in the fork PR. The jieba half is proposed upstream in [laisuk/opencc-jieba-rs#1](https://github.com/laisuk/opencc-jieba-rs/pull/1), though it raises their MSRV to 1.85, so it may not be accepted. The `include-flate` pin removal that the fork exists for is unaffected either way.

`paradedb.no-msrv` is left in place for now and can be deleted once this merges.