### PR TITLE
chore: Upgrade to `0.25.1`

### DIFF
--- a/docs/changelog/0.25.1.mdx
+++ b/docs/changelog/0.25.1.mdx
@@ -1,0 +1,76 @@
+---
+title: 0.25.1
+noindex: true
+---
+
+<Warning>
+  **Breaking change:** `0.25.1` replaces the vector search engine's epsilon
+  recall knob with a proof-based bounds gate. The
+  `paradedb.vector_cluster_probe_epsilon` GUC has been removed, and vector
+  indexes built with `0.25.0` must be rebuilt with `REINDEX` after upgrading.
+</Warning>
+
+## New Features 🎉
+
+### Faster Vector Search, One Less Knob
+
+Vector search now uses a proof-based bounds gate with a work budget, which skips clusters that provably cannot
+contribute to the result. This cuts tail latency by up to 6x and produces much tighter recall/latency confidence
+intervals.
+
+Because the gate is proof-based, there is no longer a recall knob to misconfigure: `paradedb.vector_cluster_max_probe`,
+the work-budget ceiling, is now the only [recall/latency setting](/documentation/vector/tuning).
+
+### Deterministic Vector Search Results
+
+Tiebreaker columns can now follow the distance in `ORDER BY`, making [vector search results deterministic](/documentation/vector/querying#deterministic-results)
+when embeddings are equidistant from the query vector:
+
+```sql
+SELECT id, description
+FROM mock_items
+WHERE id @@@ pdb.all()
+ORDER BY embedding <=> '[1, 2, 3, 4, 5, 6, 7, 8]', id
+LIMIT 5;
+```
+
+### Vector Search in Hybrid Queries
+
+The vector arm of [reciprocal rank fusion](/documentation/hybrid/rrf) queries is now pushed down into the ParadeDB
+index, accelerating hybrid search.
+
+### ORM Support for Vector Search
+
+The ParadeDB ORM integrations have been updated for the `paradedb` index naming, native vector search, and the
+vector index build options:
+
+- [sqlalchemy-paradedb](https://pypi.org/project/sqlalchemy-paradedb/) `0.10.0`
+- [django-paradedb](https://pypi.org/project/django-paradedb/) `0.12.0`
+- [rails-paradedb](https://rubygems.org/gems/rails-paradedb) `0.11.0`
+- [@paradedb/drizzle-paradedb](https://www.npmjs.com/package/@paradedb/drizzle-paradedb) `0.4.0`
+- [ParadeDB.EntityFrameworkCore](https://www.nuget.org/packages/ParadeDB.EntityFrameworkCore) `0.3.0`
+
+### LEFT, RIGHT, and FULL Joins
+
+JoinScan now supports `LEFT`, `RIGHT`, and `FULL` joins, extending the join shapes that execute inside the
+ParadeDB index.
+
+## Performance Improvements 🚀
+
+- Vector index builds hand training vectors to the clusterer by value, halving training memory.
+- Vector index build parallelism is capped at 4 workers to prevent memory spikes on large builds.
+- A new `paradedb.vector_clustering_threshold` GUC (default `500`) sets the segment size at which vector storage
+  switches from flat to clustered.
+- MPP workers now launch plan-first, sized from the plan's task fragments, and the default ring size was lowered
+  to 8MB.
+- Range partitioning is now wired into join planning.
+
+## Stability Improvements 💪
+
+- AggregateScan join predicates are now normalized and validated.
+- Fixed a spurious `datetime_fields` error.
+- Dynamic filters now survive across MPP fragments.
+- The extension Docker image now ships `pg_search`'s non-base shared libraries.
+- Multi-valued fields are now disallowed in `partition_by` and `sort_by`.
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.25.1).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -38,7 +38,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.25.0-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.25.1-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -6,7 +6,7 @@ canonical: https://docs.paradedb.com/deploy/self-hosted/extension
 
 <Note>
   We recommend running ParadeDB Enterprise, not Community, in production to
-  maximize uptime. See [overview](/deploy/overview#self-hosted).
+  maximize uptime. See [overview](/deploy/overview#self-hosted-paradedb).
 </Note>
 
 If you already self-manage Postgres, you may prefer to install ParadeDB directly within your self-managed
@@ -29,8 +29,8 @@ instructions](https://github.com/pgvector/pgvector?tab=readme-ov-file#installati
 ParadeDB provides prebuilt binaries of our extension for Postgres 15+ on:
 
 - Debian 12 (Bookworm) and 13 (Trixie)
-- Ubuntu 22.04 (Jammy) and 24.04 (Noble)
-- macOS 14 (Sonoma) and 15 (Sequoia)
+- Ubuntu 24.04 (Noble) and 26.04 (Resolute)
+- macOS 15 (Sequoia) and 26 (Tahoe)
 - macOS via [Postgres.app](https://postgresapp.com/extensions/) (PostgreSQL 18)
 - Red Hat Enterprise Linux 9 and 10
 
@@ -41,57 +41,57 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.25.0` with the `pg_search` version you wish to install and
+  You can replace `0.25.1` with the `pg_search` version you wish to install and
   `18` with the version of Postgres you are using.
 </Note>
 
 <CodeGroup>
 
-```bash Ubuntu 24.04
+```bash Ubuntu 26.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/postgresql-18-pg-search_0.25.1-1PARADEDB-resolute_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
-```bash Ubuntu 22.04
+```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/postgresql-18-pg-search_0.25.1-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/postgresql-18-pg-search_0.25.1-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/postgresql-18-pg-search_0.25.0-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/postgresql-18-pg-search_0.25.1-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search_18-0.25.0-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/pg_search_18-0.25.1-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search_18-0.25.0-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/pg_search_18-0.25.1-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
+```
+
+```bash macOS 26 (Tahoe)
+# Available arch version is arm64
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/pg_search@18--0.25.1.arm64_tahoe.pkg" -o ~/Downloads/pg_search.pkg
+sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search@18--0.25.0.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
-sudo installer -pkg ~/Downloads/pg_search.pkg -target /
-```
-
-```bash macOS 14 (Sonoma)
-# Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.0/pg_search@18--0.25.0.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.1/pg_search@18--0.25.1.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -38,7 +38,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.25.0`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.25.1`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -80,10 +80,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.25.0
+docker pull paradedb/paradedb:0.25.1
 ```
 
-The latest version of the Docker image should be `0.25.0`.
+The latest version of the Docker image should be `0.25.1`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -100,7 +100,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.25.0';
+ALTER EXTENSION pg_search UPDATE TO '0.25.1';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.25.0",
+        "version": "v0.25.1",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -356,6 +356,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.25.1",
                   "changelog/0.25.0",
                   "changelog/0.24.3",
                   "changelog/0.24.2",


### PR DESCRIPTION
# Description
Backport of #5872 to `0.25.x`.