### PR TITLE
fix: install lld in the stressgres and proptests images

### DIFF
--- a/docker/Dockerfile.proptests
+++ b/docker/Dockerfile.proptests
@@ -13,6 +13,7 @@ FROM rust:1.97-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build and runtime dependencies. `jq` is used during build to extract
+# the test binary path from cargo's JSON output.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     lld \

--- a/docker/Dockerfile.proptests
+++ b/docker/Dockerfile.proptests
@@ -13,9 +13,12 @@ FROM rust:1.97-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build and runtime dependencies. `jq` is used during build to extract
-# the test binary path from cargo's JSON output.
+# the test binary path from cargo's JSON output. `lld` is required:
+# .cargo/config.toml links Linux targets with `-fuse-ld=lld`, and without it cc
+# fails the link with "cannot find 'ld'".
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    lld \
     pkg-config \
     libpq-dev \
     libssl-dev \

--- a/docker/Dockerfile.proptests
+++ b/docker/Dockerfile.proptests
@@ -13,9 +13,6 @@ FROM rust:1.97-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build and runtime dependencies. `jq` is used during build to extract
-# the test binary path from cargo's JSON output. `lld` is required:
-# .cargo/config.toml links Linux targets with `-fuse-ld=lld`, and without it cc
-# fails the link with "cannot find 'ld'".
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     lld \

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -18,8 +18,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build and runtime dependencies. Upgrade existing OS packages first so
 # we pick up the latest Debian security fixes regardless of the base layer's age.
-# `lld` is required: .cargo/config.toml links Linux targets with `-fuse-ld=lld`,
-# and without it cc fails the link with "cannot find 'ld'".
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
     lld \

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -18,8 +18,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build and runtime dependencies. Upgrade existing OS packages first so
 # we pick up the latest Debian security fixes regardless of the base layer's age.
+# `lld` is required: .cargo/config.toml links Linux targets with `-fuse-ld=lld`,
+# and without it cc fails the link with "cannot find 'ld'".
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
+    lld \
     pkg-config \
     libpq-dev \
     libssl-dev \


### PR DESCRIPTION
## What

#5811 moved Linux linking to LLD via `.cargo/config.toml`, and installed it everywhere it was needed — the CI workflows, the benchmark cluster action, nix — but not the two Dockerfiles that compile Rust. Both build from a plain `rust:1.97-slim` base, so cc has no `ld.lld` to hand:

```
= note: collect2: fatal error: cannot find 'ld'
        compilation terminated.
error: could not compile `stressgres` (bin "stressgres")
```

[Failing run.](https://github.com/paradedb/paradedb/actions/runs/31033170493/job/92398640885)

`docker/Dockerfile.stressgres` and `docker/Dockerfile.proptests` are the only two images that run cargo; everything else installs a prebuilt `.deb`. Only stressgres has failed so far because that is the workload that has been built since; proptests takes the same path and would fail the same way.

## Why the flag reaches the link at all

The stressgres image sets its sancov flags through `CARGO_TARGET_<triple>_RUSTFLAGS`. Cargo *joins* that with the `target.'cfg(target_os="linux")'` rustflags rather than replacing them, so `-fuse-ld=lld` lands on the link regardless of what the Dockerfile sets — visible as the last argument of the failing `cc` invocation.

## Testing

Reproduced the exact error on `rust:1.97-slim-trixie` with only `build-essential` installed, then confirmed `lld` fixes it:

```
/usr/bin/ld.lld
Debian LLD 19.1.7 (compatible with GNU linkers)
```

Both base images (`rust:1.97-slim-trixie`, `rust:1.97-slim`) resolve to Debian 13 trixie and get `ld.lld` from the `lld` package. A full local `docker build` of the stressgres image on arm64 — the arch that failed in CI — is running; I'll confirm here when it lands. CI builds both images on this PR regardless.

https://claude.ai/code/session_01KQhwr6bHiCeu9Ssr9shzvn