### PR TITLE
docs: ORM examples for hybrid search with RRF

### DIFF
--- a/.github/scripts/smoke_test_code_snippets.sh
+++ b/.github/scripts/smoke_test_code_snippets.sh
@@ -127,6 +127,7 @@ if [[ $ORMS =~ "django" ]]; then
   echo "Installing Django ParadeDB client from PyPI..."
   PIP_DISABLE_PIP_VERSION_CHECK=1 "$PYTHON_BIN" -m pip install --quiet --upgrade \
     "django-paradedb==0.12.0" \
+    "django-cte>=2.0" \
     "psycopg[binary]"
 
   while IFS= read -r snippet_file; do

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -214,7 +214,7 @@ To start you'll need a [Django](https://www.djangoproject.com/) project with [Ps
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install django psycopg 'django-cte>=2.0' django-paradedb==0.12.0
+pip install django psycopg django-paradedb==0.12.0
 python3 -m django startproject myproject .
 python3 manage.py startapp myapp
 ```

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -214,7 +214,7 @@ To start you'll need a [Django](https://www.djangoproject.com/) project with [Ps
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install django psycopg django-paradedb==0.12.0
+pip install django psycopg 'django-cte>=2.0' django-paradedb==0.12.0
 python3 -m django startproject myproject .
 python3 manage.py startapp myapp
 ```

--- a/docs/documentation/hybrid/rrf.mdx
+++ b/docs/documentation/hybrid/rrf.mdx
@@ -79,7 +79,7 @@ const text = db.$with("text").as(
   db
     .select({
       id: mockItems.id,
-      rank: sql<number>`rank() over (order by ${score} desc, ${mockItems.id})`.as(
+      rank: sql`rank() over (order by ${score} desc, ${mockItems.id})`.as(
         "rank",
       ),
     })
@@ -93,9 +93,7 @@ const vector = db.$with("vector").as(
   db
     .select({
       id: mockItems.id,
-      rank: sql<number>`rank() over (order by ${distance}, ${mockItems.id})`.as(
-        "rank",
-      ),
+      rank: sql`rank() over (order by ${distance}, ${mockItems.id})`.as("rank"),
     })
     .from(mockItems)
     .where(search.all(mockItems.id))
@@ -108,13 +106,13 @@ const weighted = db.$with("weighted").as(
     db
       .select({
         id: text.id,
-        weight: sql<number>`1.0 / (60 + ${text.rank})`.as("weight"),
+        weight: sql`1.0 / (60 + ${text.rank})`.as("weight"),
       })
       .from(text),
     db
       .select({
         id: vector.id,
-        weight: sql<number>`0.7 / (60 + ${vector.rank})`.as("weight"),
+        weight: sql`0.7 / (60 + ${vector.rank})`.as("weight"),
       })
       .from(vector),
   ),
@@ -124,7 +122,7 @@ const fused = db.$with("fused").as(
   db
     .select({
       id: weighted.id,
-      score: sql<number>`sum(${weighted.weight})`.as("score"),
+      score: sql`sum(${weighted.weight})`.as("score"),
     })
     .from(weighted)
     .groupBy(weighted.id),
@@ -331,6 +329,18 @@ var results = text
 ```
 
 </CodeGroup>
+
+<Note>
+  The Django version depends on
+  [django-cte](https://pypi.org/project/django-cte/) `2.0` or above, installed
+  in [Configuring Your Environment](/documentation/getting-started/environment).
+  Rails' `paradedb_arel` returns the gem's Arel expression builder, so the same
+  score and distance nodes can be shared between each window and its `ORDER BY`.
+  The EF Core version runs the two branches as separate queries and fuses them
+  in application code, since LINQ cannot express CTEs or window functions — wrap
+  the two reads in a transaction if they must see the same snapshot, or execute
+  the SQL version in a single statement with `FromSql`.
+</Note>
 
 The `1.0` and `0.7` are the per-branch weights, here valuing text matches over vector ones, and `60` is `k`.
 

--- a/docs/documentation/hybrid/rrf.mdx
+++ b/docs/documentation/hybrid/rrf.mdx
@@ -332,13 +332,6 @@ var results = text
 
 </CodeGroup>
 
-<Note>
-  LINQ has no CTE or window function support, so the EF Core version runs the
-  two branches as separate queries and fuses them in application code. Each
-  branch is still accelerated by ParadeDB, and because the tiebreaker makes each
-  branch's order total, the list position used for fusion equals `RANK()`.
-</Note>
-
 The `1.0` and `0.7` are the per-branch weights, here valuing text matches over vector ones, and `60` is `k`.
 
 The two `WHERE` clauses differ because each branch retrieves by its own method. `description ||| 'running shoes'` is the text branch's query. The vector branch's query is the query vector in its `ORDER BY`, so its `WHERE` is [`pdb.all()`](/documentation/vector/querying), meaning every row is eligible. To narrow either branch, add [filters](/documentation/filtering) to both, so that each is drawing from the same set of eligible rows.

--- a/docs/documentation/hybrid/rrf.mdx
+++ b/docs/documentation/hybrid/rrf.mdx
@@ -66,7 +66,278 @@ ORDER BY f.score DESC, m.id
 LIMIT 5;
 ```
 
+```ts Drizzle
+import { desc, eq, sql } from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core";
+import { search } from "@paradedb/drizzle-paradedb";
+
+const queryEmbedding = [1, 2, 3, 4, 5, 6, 7, 8];
+const score = search.score(mockItems.id);
+const distance = search.cosineDistance(mockItems.embedding, queryEmbedding);
+
+const text = db.$with("text").as(
+  db
+    .select({
+      id: mockItems.id,
+      rank: sql<number>`rank() over (order by ${score} desc, ${mockItems.id})`.as(
+        "rank",
+      ),
+    })
+    .from(mockItems)
+    .where(search.matchAny(mockItems.description, "running shoes"))
+    .orderBy(desc(score), mockItems.id)
+    .limit(20),
+);
+
+const vector = db.$with("vector").as(
+  db
+    .select({
+      id: mockItems.id,
+      rank: sql<number>`rank() over (order by ${distance}, ${mockItems.id})`.as(
+        "rank",
+      ),
+    })
+    .from(mockItems)
+    .where(search.all(mockItems.id))
+    .orderBy(distance, mockItems.id)
+    .limit(20),
+);
+
+const weighted = db.$with("weighted").as(
+  unionAll(
+    db
+      .select({
+        id: text.id,
+        weight: sql<number>`1.0 / (60 + ${text.rank})`.as("weight"),
+      })
+      .from(text),
+    db
+      .select({
+        id: vector.id,
+        weight: sql<number>`0.7 / (60 + ${vector.rank})`.as("weight"),
+      })
+      .from(vector),
+  ),
+);
+
+const fused = db.$with("fused").as(
+  db
+    .select({
+      id: weighted.id,
+      score: sql<number>`sum(${weighted.weight})`.as("score"),
+    })
+    .from(weighted)
+    .groupBy(weighted.id),
+);
+
+await db
+  .with(text, vector, weighted, fused)
+  .select({
+    id: mockItems.id,
+    description: mockItems.description,
+    score: fused.score,
+  })
+  .from(fused)
+  .innerJoin(mockItems, eq(mockItems.id, fused.id))
+  .orderBy(desc(fused.score), mockItems.id)
+  .limit(5);
+```
+
+```python Django
+from django.db.models import F, FloatField, Sum, Value, Window
+from django.db.models.expressions import ExpressionWrapper
+from django.db.models.functions import Cast, Rank
+from django_cte import CTE, with_cte
+
+from paradedb import All, MatchAny, ParadeDB, Score
+from paradedb.vector import CosineDistance
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+
+text = CTE(
+    MockItem.objects.filter(description=ParadeDB(MatchAny('running shoes')))
+    .annotate(score=Score())
+    .annotate(rank=Window(expression=Rank(), order_by=[F('score').desc(), 'id']))
+    .order_by('-score', 'id')
+    .values('id', 'rank')[:20],
+    name='text',
+)
+
+vector = CTE(
+    MockItem.objects.filter(id=ParadeDB(All()))
+    .annotate(distance=CosineDistance('embedding', query_embedding))
+    .annotate(rank=Window(expression=Rank(), order_by=[F('distance').asc(), 'id']))
+    .order_by('distance', 'id')
+    .values('id', 'rank')[:20],
+    name='vector',
+)
+
+
+def rrf_weight(weight):
+    return ExpressionWrapper(
+        Value(weight) / (Value(60.0) + Cast(F('rank'), FloatField())),
+        output_field=FloatField(),
+    )
+
+
+weighted = CTE(
+    text.queryset()
+    .annotate(weight=rrf_weight(1.0))
+    .values('id', 'weight')
+    .union(
+        vector.queryset().annotate(weight=rrf_weight(0.7)).values('id', 'weight'),
+        all=True,
+    ),
+    name='weighted',
+)
+
+fused = CTE(
+    weighted.queryset().values('id').annotate(score=Sum('weight')),
+    name='fused',
+)
+
+with_cte(
+    text,
+    vector,
+    weighted,
+    fused,
+    select=fused.join(MockItem, id=fused.col.id)
+    .annotate(score=fused.col.score)
+    .order_by('-score', 'id')[:5],
+)
+```
+
+```python SQLAlchemy
+from sqlalchemy import func, select, union_all
+from sqlalchemy.orm import Session
+from paradedb.sqlalchemy import pdb, search, vector
+
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+score = pdb.score(MockItem.id)
+distance = vector.cosine_distance(MockItem.embedding, query_embedding)
+
+text = (
+    select(
+        MockItem.id,
+        func.rank().over(order_by=(score.desc(), MockItem.id)).label("rank"),
+    )
+    .where(search.match_any(MockItem.description, "running shoes"))
+    .order_by(score.desc(), MockItem.id)
+    .limit(20)
+    .cte("text")
+)
+
+vec = (
+    select(
+        MockItem.id,
+        func.rank().over(order_by=(distance, MockItem.id)).label("rank"),
+    )
+    .where(search.all(MockItem.id))
+    .order_by(distance, MockItem.id)
+    .limit(20)
+    .cte("vector")
+)
+
+weighted = union_all(
+    select(text.c.id, (1.0 / (60 + text.c.rank)).label("weight")),
+    select(vec.c.id, (0.7 / (60 + vec.c.rank)).label("weight")),
+).subquery("u")
+
+fused = (
+    select(weighted.c.id, func.sum(weighted.c.weight).label("score"))
+    .group_by(weighted.c.id)
+    .cte("fused")
+)
+
+stmt = (
+    select(MockItem.id, MockItem.description, fused.c.score)
+    .join_from(fused, MockItem, MockItem.id == fused.c.id)
+    .order_by(fused.c.score.desc(), MockItem.id)
+    .limit(5)
+)
+
+with Session(engine) as session:
+    session.execute(stmt).all()
+```
+
+```ruby Rails
+query_embedding = [1, 2, 3, 4, 5, 6, 7, 8]
+id = MockItem.arel_table[:id]
+score = MockItem.paradedb_arel.score(:id)
+distance = MockItem.paradedb_arel.cosine_distance(:embedding, query_embedding)
+
+text = MockItem.search(:description)
+               .match_any("running shoes")
+               .select(id, Arel::Nodes::NamedFunction.new("RANK", [])
+                 .over(Arel::Nodes::Window.new.order(score.desc, id))
+                 .as("rank"))
+               .order(score.desc, id)
+               .limit(20)
+
+vector = MockItem.nearest(:embedding, query_embedding, metric: :cosine)
+                 .select(id, Arel::Nodes::NamedFunction.new("RANK", [])
+                   .over(Arel::Nodes::Window.new.order(distance, id))
+                   .as("rank"))
+                 .order(:id)
+                 .limit(20)
+
+weighted = [
+  MockItem.from("text").select("text.id", "1.0 / (60 + text.rank) AS weight"),
+  MockItem.from("vector").select("vector.id", "0.7 / (60 + vector.rank) AS weight")
+]
+
+fused = MockItem.from("weighted")
+                .select("weighted.id", "SUM(weighted.weight) AS score")
+                .group("weighted.id")
+
+MockItem.with(text: text, vector: vector, weighted: weighted, fused: fused)
+        .from("fused")
+        .joins("JOIN mock_items ON mock_items.id = fused.id")
+        .select("mock_items.id", "mock_items.description", "fused.score")
+        .order("fused.score DESC, mock_items.id")
+        .limit(5)
+```
+
+```cs EF Core
+var queryEmbedding = new float[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+var text = await dbContext
+    .MockItems.Where(item => EF.Functions.MatchAny(item.Description, "running shoes"))
+    .OrderByDescending(item => EF.Functions.Score(item.Id))
+    .ThenBy(item => item.Id)
+    .Select(item => new { item.Id, item.Description })
+    .Take(20)
+    .ToListAsync();
+
+var vector = await dbContext
+    .MockItems.Where(item => EF.Functions.All(item.Id))
+    .OrderBy(item => EF.Functions.CosineDistance(item.Embedding, queryEmbedding))
+    .ThenBy(item => item.Id)
+    .Select(item => new { item.Id, item.Description })
+    .Take(20)
+    .ToListAsync();
+
+var results = text
+    .Select((item, index) => (item.Id, item.Description, Weight: 1.0 / (60 + index + 1)))
+    .Concat(
+        vector.Select((item, index) => (item.Id, item.Description, Weight: 0.7 / (60 + index + 1)))
+    )
+    .GroupBy(row => row.Id)
+    .Select(group => (group.Key, group.First().Description, Score: group.Sum(row => row.Weight)))
+    .OrderByDescending(row => row.Score)
+    .ThenBy(row => row.Key)
+    .Take(5)
+    .ToList();
+```
+
 </CodeGroup>
+
+<Note>
+  LINQ has no CTE or window function support, so the EF Core version runs the
+  two branches as separate queries and fuses them in application code. Each
+  branch is still accelerated by ParadeDB, and because the tiebreaker makes each
+  branch's order total, the list position used for fusion equals `RANK()`.
+</Note>
 
 The `1.0` and `0.7` are the per-branch weights, here valuing text matches over vector ones, and `60` is `k`.
 

--- a/docs/documentation/hybrid/rrf.mdx
+++ b/docs/documentation/hybrid/rrf.mdx
@@ -330,18 +330,6 @@ var results = text
 
 </CodeGroup>
 
-<Note>
-  The Django version depends on
-  [django-cte](https://pypi.org/project/django-cte/) `2.0` or above, installed
-  in [Configuring Your Environment](/documentation/getting-started/environment).
-  Rails' `paradedb_arel` returns the gem's Arel expression builder, so the same
-  score and distance nodes can be shared between each window and its `ORDER BY`.
-  The EF Core version runs the two branches as separate queries and fuses them
-  in application code, since LINQ cannot express CTEs or window functions — wrap
-  the two reads in a transaction if they must see the same snapshot, or execute
-  the SQL version in a single statement with `FromSql`.
-</Note>
-
 The `1.0` and `0.7` are the per-branch weights, here valuing text matches over vector ones, and `60` is `k`.
 
 The two `WHERE` clauses differ because each branch retrieves by its own method. `description ||| 'running shoes'` is the text branch's query. The vector branch's query is the query vector in its `ORDER BY`, so its `WHERE` is [`pdb.all()`](/documentation/vector/querying), meaning every row is eligible. To narrow either branch, add [filters](/documentation/filtering) to both, so that each is drawing from the same set of eligible rows.


### PR DESCRIPTION
## What

Adds Drizzle, Django, SQLAlchemy, Rails, and EF Core tabs to the RRF code block on the [hybrid search page](https://docs.paradedb.com/documentation/hybrid/rrf), following #5865.

## Why

The RRF page only had a SQL example.

Every snippet was run against pg_search 0.25.1 and returns identical rows and scores to the SQL block, with `TopKScanExecState` on both branches. The Drizzle/Django/SQLAlchemy/Rails versions build the same single CTE query; EF Core runs the two branches as separate accelerated queries and fuses in application code (LINQ has no CTE/window support), with a note explaining why the result is equivalent.