### PR TITLE
refactor: use explicit tokio drivers instead of enable_all

### DIFF
--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -86,7 +86,7 @@ bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
 decimal-bytes = "0.4.2"
 paste = "1.0.15"
 typetag = "0.2"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["rt", "time"] }
 bytes = { version = "1", features = ["serde"] }
 # Here and the equivalent in our datafusion-distributed fork will need to be updated in sync so that
 # both point to the same datafusion ref.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -840,7 +840,7 @@ impl AggregateScan {
         // builds it lazily on first `exec_custom_scan` call; MPP serializes
         // it at begin time so the launch can size the dispatch payload.
         let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
+            .enable_time()
             .build()
         {
             Ok(rt) => rt,
@@ -1546,7 +1546,7 @@ impl AggregateScan {
         // First call: build and execute the DataFusion plan
         if first_call {
             let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
+                .enable_time()
                 .build()
                 .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e));
 

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -567,7 +567,7 @@ pub fn merge_worker_metrics(
 
     plan.downcast_ref::<DistributedExec>()?;
     let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
+        .enable_time()
         .build()
         .ok()?;
     runtime

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -188,7 +188,7 @@ fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> Se
     };
 
     let runtime = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
+        .enable_time()
         .build()
     {
         Ok(rt) => rt,


### PR DESCRIPTION
## What

Replace `enable_all()` with explicit `enable_time()` at the four Tokio runtime construction sites in `pg_search`, and declare the `tokio/time` feature explicitly in `pg_search/Cargo.toml`.

## Why

- Driver least‑privilege: `enable_all()` installs both the I/O and time drivers. DataFusion execution runs entirely in‑process, so the I/O driver is never used. Enabling only `time` matches how `pg_search` actually uses Tokio (the two `tokio::time::timeout` call sites in `mpp/glue.rs` and `mpp/exec_worker.rs`).

- Explicit feature: Those `tokio::time::timeout` uses currently compile only via Cargo feature unification (another dependency happens to enable `tokio/time`). Declaring the feature on our own dependency makes the requirement explicit, stable, and easier to reason about.

- No signal‑handler implications: `enable_all()` does not install signal handlers — Tokio’s signal driver registers lazily on first `tokio::signal` use, which we never call — so this change does not alter PostgreSQL’s `SIGTERM`/`SIGINT` handling in any way.

- Targeted precursor to #5707: This is a small, behavior‑preserving change that cleans up the driver configuration ahead of the process‑scoped runtime consolidation in #5707, which refactors these same sites onto a shared `LazyLock<Runtime>`.

## How

- `pg_search/Cargo.toml`  
  - `tokio = { version = "1", features = ["rt"] }` → `tokio = { version = "1", features = ["rt", "time"] }`

- `aggregatescan/mod.rs`  
  - `stash_mpp_plan_bytes`, `exec_datafusion_aggregate`: `.enable_all()` → `.enable_time()`.

- `mpp/glue.rs`  
  - `merge_worker_metrics`: `.enable_all()` → `.enable_time()`.

- `mpp/launch.rs`  
  - `run_launched_worker`: `.enable_all()` → `.enable_time()`.

Failure‑handling behavior at each site is deliberately unchanged (`warn`‑and‑skip‑MPP, `pgrx::error!`, `.ok()? -> None`, `expect`/`unwrap`); this PR is drivers‑only.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy -p pg_search --all-targets -- -D warnings`
- Manual:
  - Aggregate and MPP queries still plan and execute.
  - `EXPLAIN ANALYZE VERBOSE` on an MPP plan still renders worker metrics (exercises `merge_worker_metrics`, the only behavior‑relevant site).
  - CI’s `cargo pgrx pg18` build covers the runtime instantiation path.