### PR TITLE
fix: declare BaseScan heap-filter and PostgresExpression nodes via custom_exprs

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -1249,9 +1249,27 @@ impl CustomScan for BaseScan {
                     .set_exec_method_type(ExecMethodType::Normal);
             }
 
+            // #5727: collect heap-filter and PostgresExpression nodes so we can
+            // hand them to `custom_exprs` below. `finalize_plan` walks that field
+            // for Param references; without it, `Gather.initParam` omits InitPlan
+            // outputs and parallel workers execute with empty param slots.
+            let expr_nodes = builder
+                .custom_private_mut()
+                .query_mut()
+                .as_mut()
+                .map(|q| q.collect_expression_nodes())
+                .unwrap_or_default();
+
             let mut scan = builder.build();
             if !subplan_quals.is_empty() {
                 scan.scan.plan.qual = subplan_quals.into_pg();
+            }
+            if !expr_nodes.is_empty() {
+                let mut expr_list = PgList::<pg_sys::Node>::new();
+                for node in expr_nodes {
+                    expr_list.push(node);
+                }
+                scan.custom_exprs = expr_list.into_pg();
             }
             scan
         }

--- a/pg_search/src/postgres/customscan/basescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/basescan/privdat.rs
@@ -265,6 +265,10 @@ impl PrivateData {
         &self.query
     }
 
+    pub fn query_mut(&mut self) -> &mut Option<SearchQueryInput> {
+        &mut self.query
+    }
+
     pub fn limit_offset(&self) -> &Option<LimitOffset> {
         &self.limit_offset
     }

--- a/pg_search/src/postgres/customscan/solve_expr.rs
+++ b/pg_search/src/postgres/customscan/solve_expr.rs
@@ -52,6 +52,33 @@ impl SearchQueryInput {
         found
     }
 
+    /// Collects raw `Expr*` pointers for every PostgreSQL expression referenced
+    /// by heap filters or PostgresExpression variants in this query tree.
+    ///
+    /// Used to populate `CustomScan.custom_exprs` so `finalize_plan`'s
+    /// param-dependency walker sees InitPlan references (issue #5727).
+    pub fn collect_expression_nodes(&mut self) -> Vec<*mut pg_sys::Node> {
+        let mut nodes = Vec::new();
+        self.visit(&mut |sqi| match sqi {
+            SearchQueryInput::HeapFilter { field_filters, .. } => {
+                for filter in field_filters.iter() {
+                    let node = unsafe { filter.get_expression_node() };
+                    if !node.is_null() {
+                        nodes.push(node);
+                    }
+                }
+            }
+            SearchQueryInput::PostgresExpression { expr } => {
+                let node = expr.node();
+                if !node.is_null() {
+                    nodes.push(node);
+                }
+            }
+            _ => {}
+        });
+        nodes
+    }
+
     pub fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) -> usize {
         let mut cnt = 0;
         self.visit(&mut |sqi| {

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -688,3 +688,69 @@ fn pdb_agg_with_parameterized_json(mut conn: PgConnection) {
     "DEALLOCATE agg_g".execute(&mut conn);
     "RESET plan_cache_mode".execute(&mut conn);
 }
+
+/// Regression for #5727. Base Scan below a Gather with a heap filter that
+/// references an InitPlan (uncorrelated scalar subquery) output silently
+/// returned wrong results because the basescan left `CustomScan.custom_exprs`
+/// empty, so `finalize_plan` never saw the Param reference and
+/// `SerializeParamExecParams` never shipped the InitPlan value to workers.
+#[rstest]
+fn parallel_with_initplan_param_in_heap_filter(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS bsp_pages;
+    DROP TABLE IF EXISTS bsp_files;
+
+    CREATE TABLE bsp_files (
+        id SERIAL PRIMARY KEY,
+        title TEXT,
+        content TEXT
+    );
+
+    CREATE TABLE bsp_pages (
+        id SERIAL PRIMARY KEY,
+        file_id INTEGER,
+        page_text TEXT,
+        size_bytes INTEGER
+    );
+
+    INSERT INTO bsp_files (title, content)
+    SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+    FROM generate_series(1, 200) AS g;
+
+    INSERT INTO bsp_pages (file_id, page_text, size_bytes)
+    SELECT (g % 200) + 1, 'Page text for page ' || g, (g * 17) % 4096
+    FROM generate_series(1, 1000) AS g;
+
+    CREATE INDEX bsp_files_idx ON bsp_files USING bm25 (id, title, content)
+    WITH (key_field = 'id', text_fields = '{"title": {"fast": true}, "content": {}}');
+
+    ANALYZE bsp_files;
+    ANALYZE bsp_pages;
+    "#
+    .execute(&mut conn);
+
+    "SET paradedb.enable_join_custom_scan TO off".execute(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO off".execute(&mut conn);
+    "SET parallel_setup_cost TO 0".execute(&mut conn);
+    "SET parallel_tuple_cost TO 0".execute(&mut conn);
+    "SET min_parallel_table_scan_size TO 0".execute(&mut conn);
+    "SET max_parallel_workers_per_gather TO 4".execute(&mut conn);
+
+    let query = "SELECT count(*) FROM bsp_files f JOIN bsp_pages p ON f.id = p.file_id \
+                 WHERE f.content @@@ 'Section' \
+                   AND length(f.title) > (SELECT min(length(title)) + 1 FROM bsp_files)";
+
+    "SET parallel_leader_participation TO on".execute(&mut conn);
+    let (leader_on,) = query.fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(
+        leader_on, 505,
+        "parallel_leader_participation=on: expected 505, got {leader_on}"
+    );
+
+    "SET parallel_leader_participation TO off".execute(&mut conn);
+    let (leader_off,) = query.fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(
+        leader_off, 505,
+        "parallel_leader_participation=off: expected 505, got {leader_off}"
+    );
+}


### PR DESCRIPTION
Fixes #5727.

BaseScan left `custom_exprs` NULL, so `finalize_plan` (subselect.c) never
saw the Param references buried inside `SearchQueryInput::HeapFilter` and
`SearchQueryInput::PostgresExpression`. `Gather.initParam` therefore
dropped InitPlan-derived `PARAM_EXEC`, and worker heap filters ran with
empty param slots (silent wrong results).

Collect the `Expr*` pointers and splice into `scan.custom_exprs` in
`plan_custom_path`, mirroring `aggregatescan/mod.rs:343-350`.

Related: #5445 (same class in JoinScan).