### PR TITLE
fix(mpp): keep range-partitioned join outputs off the gather boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-06-032638#8426f845f4fc0edbffdf9152c20840fe7e01ba5f"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-08-041610#57dd67ec2f14296c16c864edb367f46f557d3668"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5729,7 +5729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6322,7 +6322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8237,15 +8237,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-c/8q98psE65INoUILh5VsXZPdX1u4Y3Aq0sSnr/ZJ0o=";
+  cargoHash = "sha256-9ZzRKnP/OrJaC1DjID7/5voENxeG2X5l0k2sp3EHFDY=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -92,7 +92,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-06-032638", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-08-041610", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/tests/pg_regress/expected/mpp_range_boundary.out
+++ b/pg_search/tests/pg_regress/expected/mpp_range_boundary.out
@@ -1,0 +1,98 @@
+-- =====================================================================
+-- A co-partitioned (range) join whose output reaches the top gather with
+-- no aggregate or sort in between. The gather becomes a network boundary,
+-- and boundary scaling cannot handle a range layout, so the planner
+-- must break the range with a round-robin repartition under the gather.
+-- The bare LIMIT (early termination) mirrors the benchmark query that
+-- exposed the shape.
+--
+-- Outcomes are collected in a table so the expected output stays stable
+-- across machines and timings.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 8;
+SET max_parallel_workers TO 7;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET paradedb.mpp_queue_size = '64kB';
+CREATE TABLE rb_users    (id bigserial PRIMARY KEY, display_name text, reputation int, about_me text);
+CREATE TABLE rb_posts    (id bigserial PRIMARY KEY, owner_user_id bigint, title text, body text);
+CREATE TABLE rb_comments (id bigserial PRIMARY KEY, post_id bigint, text text, score int);
+CREATE INDEX rb_users_idx ON rb_users USING bm25 (id, display_name, reputation)
+WITH (key_field='id', partition_by='id', text_fields='{"display_name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"reputation":{"fast":true}}');
+CREATE INDEX rb_posts_idx ON rb_posts USING bm25 (id, owner_user_id, title)
+WITH (key_field='id', partition_by='id,owner_user_id', text_fields='{"title":{"fast":true}}', numeric_fields='{"owner_user_id":{"fast":true}}');
+CREATE INDEX rb_comments_idx ON rb_comments USING bm25 (id, post_id, text, score)
+WITH (key_field='id', partition_by='post_id', text_fields='{"text":{"fast":true}}', numeric_fields='{"post_id":{"fast":true},"score":{"fast":true}}');
+-- Eight segments per index, kilobyte-scale payloads so batches dwarf the ring.
+SET paradedb.global_mutable_segment_rows = 0;
+DO $$
+DECLARE
+    s int;
+BEGIN
+    FOR s IN 0..7 LOOP
+        INSERT INTO rb_users (display_name, reputation, about_me)
+        SELECT 'user_' || g, 50 + (g % 100), repeat('a', 2000) || g FROM generate_series(s * 1250 + 1, (s + 1) * 1250) g;
+        INSERT INTO rb_posts (owner_user_id, title, body)
+        SELECT 1 + (g % 10000), 'error in build ' || g, repeat('b', 2000) || g FROM generate_series(s * 2500 + 1, (s + 1) * 2500) g;
+        INSERT INTO rb_comments (post_id, text, score)
+        SELECT 1 + (g % 20000), 'question about stuff ' || repeat('c', 1000) || g, g % 10 FROM generate_series(s * 5000 + 1, (s + 1) * 5000) g;
+    END LOOP;
+END $$;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE rb_users;
+ANALYZE rb_posts;
+ANALYZE rb_comments;
+CREATE TABLE rb_outcome (line text);
+SET statement_timeout = '120s';
+-- Whether the co-partitioned join reports its range layout or a range-satisfied
+-- hash up to the gather depends on the sampled split points, so only the
+-- outcome is asserted: the query must neither error nor hang. On the range
+-- outcome, the run fails without the repartition under the gather.
+DO $$
+DECLARE
+    r record;
+    launched boolean := false;
+    ranged boolean := false;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF)
+        SELECT * FROM rb_users u
+        JOIN rb_posts p ON u.id = p.owner_user_id
+        JOIN rb_comments c ON c.post_id = p.id
+        WHERE u.id @@@ pdb.all() AND u.reputation > 100 AND p.title @@@ ''error'' AND c.text @@@ ''question''
+        LIMIT 5'
+    LOOP
+        launched := launched OR r."QUERY PLAN" LIKE '%MPP Launch:%';
+        ranged := ranged OR r."QUERY PLAN" LIKE '%partition=%';
+    END LOOP;
+    INSERT INTO rb_outcome VALUES ('limit-5 explain analyze: mpp=' || launched
+        || ' range-scans=' || ranged);
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO rb_outcome VALUES ('limit-5 explain analyze: ERROR ' || SQLERRM);
+END $$;
+-- The limit must terminate the query early and still return its five rows.
+DO $$
+DECLARE
+    n bigint;
+BEGIN
+    SELECT count(*) INTO n FROM (
+        SELECT u.id FROM rb_users u
+        JOIN rb_posts p ON u.id = p.owner_user_id
+        JOIN rb_comments c ON c.post_id = p.id
+        WHERE u.id @@@ pdb.all() AND u.reputation > 100 AND p.title @@@ 'error' AND c.text @@@ 'question'
+        LIMIT 5
+    ) q;
+    INSERT INTO rb_outcome VALUES ('limit-5 rows: ' || n);
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO rb_outcome VALUES ('limit-5 rows: ERROR ' || SQLERRM);
+END $$;
+SET statement_timeout = 0;
+SELECT * FROM rb_outcome ORDER BY line;
+                        line                        
+----------------------------------------------------
+ limit-5 explain analyze: mpp=true range-scans=true
+ limit-5 rows: 5
+(2 rows)
+

--- a/pg_search/tests/pg_regress/sql/mpp_range_boundary.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_range_boundary.sql
@@ -1,0 +1,101 @@
+-- =====================================================================
+-- A co-partitioned (range) join whose output reaches the top gather with
+-- no aggregate or sort in between. The gather becomes a network boundary,
+-- and boundary scaling cannot handle a range layout, so the planner
+-- must break the range with a round-robin repartition under the gather.
+-- The bare LIMIT (early termination) mirrors the benchmark query that
+-- exposed the shape.
+--
+-- Outcomes are collected in a table so the expected output stays stable
+-- across machines and timings.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 8;
+SET max_parallel_workers TO 7;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET paradedb.mpp_queue_size = '64kB';
+
+CREATE TABLE rb_users    (id bigserial PRIMARY KEY, display_name text, reputation int, about_me text);
+CREATE TABLE rb_posts    (id bigserial PRIMARY KEY, owner_user_id bigint, title text, body text);
+CREATE TABLE rb_comments (id bigserial PRIMARY KEY, post_id bigint, text text, score int);
+
+CREATE INDEX rb_users_idx ON rb_users USING bm25 (id, display_name, reputation)
+WITH (key_field='id', partition_by='id', text_fields='{"display_name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"reputation":{"fast":true}}');
+CREATE INDEX rb_posts_idx ON rb_posts USING bm25 (id, owner_user_id, title)
+WITH (key_field='id', partition_by='id,owner_user_id', text_fields='{"title":{"fast":true}}', numeric_fields='{"owner_user_id":{"fast":true}}');
+CREATE INDEX rb_comments_idx ON rb_comments USING bm25 (id, post_id, text, score)
+WITH (key_field='id', partition_by='post_id', text_fields='{"text":{"fast":true}}', numeric_fields='{"post_id":{"fast":true},"score":{"fast":true}}');
+
+-- Eight segments per index, kilobyte-scale payloads so batches dwarf the ring.
+SET paradedb.global_mutable_segment_rows = 0;
+DO $$
+DECLARE
+    s int;
+BEGIN
+    FOR s IN 0..7 LOOP
+        INSERT INTO rb_users (display_name, reputation, about_me)
+        SELECT 'user_' || g, 50 + (g % 100), repeat('a', 2000) || g FROM generate_series(s * 1250 + 1, (s + 1) * 1250) g;
+        INSERT INTO rb_posts (owner_user_id, title, body)
+        SELECT 1 + (g % 10000), 'error in build ' || g, repeat('b', 2000) || g FROM generate_series(s * 2500 + 1, (s + 1) * 2500) g;
+        INSERT INTO rb_comments (post_id, text, score)
+        SELECT 1 + (g % 20000), 'question about stuff ' || repeat('c', 1000) || g, g % 10 FROM generate_series(s * 5000 + 1, (s + 1) * 5000) g;
+    END LOOP;
+END $$;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE rb_users;
+ANALYZE rb_posts;
+ANALYZE rb_comments;
+
+CREATE TABLE rb_outcome (line text);
+SET statement_timeout = '120s';
+
+-- Whether the co-partitioned join reports its range layout or a range-satisfied
+-- hash up to the gather depends on the sampled split points, so only the
+-- outcome is asserted: the query must neither error nor hang. On the range
+-- outcome, the run fails without the repartition under the gather.
+DO $$
+DECLARE
+    r record;
+    launched boolean := false;
+    ranged boolean := false;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF)
+        SELECT * FROM rb_users u
+        JOIN rb_posts p ON u.id = p.owner_user_id
+        JOIN rb_comments c ON c.post_id = p.id
+        WHERE u.id @@@ pdb.all() AND u.reputation > 100 AND p.title @@@ ''error'' AND c.text @@@ ''question''
+        LIMIT 5'
+    LOOP
+        launched := launched OR r."QUERY PLAN" LIKE '%MPP Launch:%';
+        ranged := ranged OR r."QUERY PLAN" LIKE '%partition=%';
+    END LOOP;
+    INSERT INTO rb_outcome VALUES ('limit-5 explain analyze: mpp=' || launched
+        || ' range-scans=' || ranged);
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO rb_outcome VALUES ('limit-5 explain analyze: ERROR ' || SQLERRM);
+END $$;
+
+-- The limit must terminate the query early and still return its five rows.
+DO $$
+DECLARE
+    n bigint;
+BEGIN
+    SELECT count(*) INTO n FROM (
+        SELECT u.id FROM rb_users u
+        JOIN rb_posts p ON u.id = p.owner_user_id
+        JOIN rb_comments c ON c.post_id = p.id
+        WHERE u.id @@@ pdb.all() AND u.reputation > 100 AND p.title @@@ 'error' AND c.text @@@ 'question'
+        LIMIT 5
+    ) q;
+    INSERT INTO rb_outcome VALUES ('limit-5 rows: ' || n);
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO rb_outcome VALUES ('limit-5 rows: ERROR ' || SQLERRM);
+END $$;
+SET statement_timeout = 0;
+
+SELECT * FROM rb_outcome ORDER BY line;


### PR DESCRIPTION
## What

This PR pins the `datafusion-distributed` rev that breaks a range layout under the distributed gather, and adds a regress test for the query shape that hit it.

## Why

With `partition_by` on join keys, the co-partitioned join can report `Partitioning::Range` up to the top gather when nothing above it reshuffles: a bare `LIMIT`, no aggregate, no sort. Boundary scaling has no rule for a range layout: debug builds hit an assert, release builds misroute the consumer and the query hangs. Both #5892 benchmark runs died this way on `join_hierarchical_content-no-scores-large`, the one suite query with that shape.

## How

The fix lives upstream (paradedb/datafusion-distributed#67): `scale_partitioning` maps a range layout to `UnknownPartitioning` with the scaled count, so the boundary and the coalesce consumer agree on the partition set and the rows never move. This PR carries the pin and the regress coverage; earlier revisions carried a `pg_search` physical-optimizer rule, then an upstream planner pass, before the boundary mapping made both unnecessary.

## Tests

- New `mpp_range_boundary` regress test: `partition_by` indexes, a 3-way co-partitioned join, `SELECT *` with a bare `LIMIT 5` under `EXPLAIN ANALYZE`. Without the pinned fix it hangs in release builds; with it, the query completes and returns the right rows.
- MPP regress green: `mpp_smoke`, `mpp_joinscan`, `mpp_worker_sizing`, plus the new test.
