### PR TITLE
fix(mpp): bound the worker's wait for partition requests and poll for cancels

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -157,6 +157,13 @@ static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// a raw per-inbox byte count.
 static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(8 * 1024 * 1024);
 
+/// Longest a worker fragment waits for its next partition-execution request with none
+/// of its partitions running. Consumers issue every request while building their
+/// streams, so the wait is normally over in milliseconds; a stall this long means a
+/// consumer stopped requesting and the fragment (and the leader waiting on it) would
+/// otherwise wait forever. `0` disables the guard.
+static MPP_REQUEST_TIMEOUT: GucSetting<i32> = GucSetting::<i32>::new(300);
+
 /// The maximum size of an InList that can be pushed down to a TermSet Query.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
     GucSetting::<i32>::new(16 * 1024 * 1024);
@@ -625,6 +632,22 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_request_timeout",
+        c"Longest an MPP worker fragment waits for its next partition request",
+        c"Bounds how long an MPP worker fragment waits for the next partition-execution \
+          request while none of its partitions are running. Consumers issue every \
+          request while building their streams, so the wait is normally over in \
+          milliseconds; a stall this long means a consumer stopped requesting and the \
+          query would otherwise hang. Accepts standard Postgres time units. 0 disables \
+          the guard.",
+        &MPP_REQUEST_TIMEOUT,
+        0,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::UNIT_S,
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -828,6 +851,10 @@ pub fn mpp_trace() -> bool {
 
 pub fn mpp_queue_size() -> usize {
     MPP_QUEUE_SIZE.get() as usize
+}
+
+pub fn mpp_request_timeout_secs() -> i32 {
+    MPP_REQUEST_TIMEOUT.get()
 }
 
 pub fn hash_join_inlist_pushdown_max_size() -> i32 {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -55,7 +55,9 @@ use datafusion_proto::physical_plan::DeduplicatingProtoConverter;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
 use crate::postgres::customscan::mpp::glue::producer_worker_cap;
-use crate::postgres::customscan::mpp::interrupt::{HeldInterrupts, check_for_interrupts};
+use crate::postgres::customscan::mpp::interrupt::{
+    HeldInterrupts, cancel_pending, check_for_interrupts, interrupted,
+};
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::utils::ExprContextGuard;
 use crate::scan::execution_plan::{
@@ -205,6 +207,14 @@ async fn dispatch_fragment_requests(
         return Ok(());
     }
 
+    // Consumers issue every request while building their streams, so a fragment with
+    // nothing running normally waits milliseconds for its next request. A stall this
+    // long means a consumer stopped requesting (a planning or routing bug), and
+    // without the bound this fragment and the leader waiting on it hang forever.
+    let stall_secs = crate::gucs::mpp_request_timeout_secs();
+    let stall_duration = std::time::Duration::from_secs(stall_secs.max(0) as u64);
+    let mut stall_deadline = tokio::time::Instant::now() + stall_duration;
+
     loop {
         if partitions_requested >= n_out && sub_futures.is_empty() {
             break;
@@ -245,6 +255,7 @@ async fn dispatch_fragment_requests(
                             start..end,
                         ));
                         partitions_requested += len;
+                        stall_deadline = tokio::time::Instant::now() + stall_duration;
                     }
                     Some(Err(e)) => {
                         return Err(datafusion::common::DataFusionError::Execution(format!(
@@ -264,8 +275,23 @@ async fn dispatch_fragment_requests(
                     Some(Err(e)) => return Err(e),
                     None => unreachable!(),
                 }
+                stall_deadline = tokio::time::Instant::now() + stall_duration;
+            }
+            _ = tokio::time::sleep_until(stall_deadline),
+                if stall_secs > 0 && partitions_requested < n_out && sub_futures.is_empty() => {
+                return Err(datafusion::common::DataFusionError::Execution(format!(
+                    "mpp worker dispatch: no ExecuteTask request for {stall_secs}s \
+                     (stage_id={stage_id}, task_idx={task_idx}, \
+                     requested={partitions_requested}/{n_out}); a consumer stopped \
+                     requesting this task's partitions"
+                )));
             }
             _ = tokio::task::yield_now() => {
+                // Interrupts are held for the whole dispatcher, so a cancel or a
+                // backend-die only ends this wait if the loop polls for it.
+                if cancel_pending() {
+                    return Err(interrupted());
+                }
                 if let Err(e) = mesh.inbound_receiver().try_drain_pass() {
                     return Err(datafusion::common::DataFusionError::Execution(format!(
                         "mpp worker drain error: {e} (stage_id={stage_id}, task_idx={task_idx}, \


### PR DESCRIPTION
## What

This PR bounds the MPP worker's wait for partition requests and makes it poll for cancels.

## Why

`dispatch_fragment_requests` parks in `rx.recv()` until consumers have requested every partition. Interrupts are held for the whole dispatcher and nothing in this wait polls for a pending cancel or die, so a parked fragment ignores `statement_timeout`, query cancel, and `SIGTERM`. In addition, when a consumer stops requesting (a planning or routing bug, like the range-at-boundary misroute behind the #5892 benchmark hang), nothing bounds the wait. The fragment never finishes and the leader waits on the worker forever.

## How

- The drain arm polls `cancel_pending()` and bails with `interrupted()`, like the other cooperative loops.
- A new `paradedb.mpp_request_timeout` GUC (default 300s, `0` disables) bounds how long a fragment waits for its next request while none of its partitions run. Consumers issue every request while building their streams, so this wait normally ends in milliseconds. A stall that long means the query would otherwise hang.

I think any finite default beats a six-hour benchmark timeout, but the value is open for discussion.

## Tests

Existing tests.
