### PR TITLE
fix(tokenizers): restrict typmod cache to SELECT for PUBLIC

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -338,18 +338,6 @@ jobs:
         if: always()
         run: cat ~/.pgrx/${{ matrix.pg_version}}.log
 
-      # TEMPORARY (remove before merge): the regression diffs printed by the
-      # regress step above are buried under tens of thousands of lines of
-      # Postgres log, which makes them unreadable from the log tail. Re-print
-      # them last so they are the final thing in the job log.
-      - name: Re-print pg_regress diffs on failure
-        if: matrix.pg_impl == 'pgrx' && failure()
-        run: |
-          echo "=== changed expected files ==="
-          git diff --stat
-          echo "=== diffs ==="
-          git diff
-
   upload-coverage:
     name: Upload Combined Coverage to Codecov
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -338,6 +338,18 @@ jobs:
         if: always()
         run: cat ~/.pgrx/${{ matrix.pg_version}}.log
 
+      # TEMPORARY (remove before merge): the regression diffs printed by the
+      # regress step above are buried under tens of thousands of lines of
+      # Postgres log, which makes them unreadable from the log tail. Re-print
+      # them last so they are the final thing in the job log.
+      - name: Re-print pg_regress diffs on failure
+        if: matrix.pg_impl == 'pgrx' && failure()
+        run: |
+          echo "=== changed expected files ==="
+          git diff --stat
+          echo "=== diffs ==="
+          git diff
+
   upload-coverage:
     name: Upload Combined Coverage to Codecov
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -2737,7 +2737,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -6882,7 +6882,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -7279,7 +7279,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -7442,7 +7442,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.25.1"
+version = "0.25.2"
 edition = "2024"
 license = "AGPL-3.0"
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-NOpBNt0yJpIbMWMJsaRQf6ATShlXcJeXtg5koPDfpCw=";
+  cargoHash = "sha256-c/8q98psE65INoUILh5VsXZPdX1u4Y3Aq0sSnr/ZJ0o=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -29,10 +29,8 @@ GRANT SELECT ON SEQUENCE paradedb._typmod_cache_id_seq TO PUBLIC;
 -- The body below is identical to the one in
 -- pg_search/src/api/tokenizers/typmod/mod.rs. Only the header is spelled
 -- differently (`pg_catalog.int4` rather than `integer`, and the options after
--- the body rather than before it), to match what SchemaBot generates for this
--- change so that check_migration_diff.py sees the same statements. The one
--- place this deviates from SchemaBot's suggestion is `SECURITY DEFINER`, which
--- it renders as `security = 1`, which does not parse.
+-- the body rather than before it), matching what SchemaBot generates for this
+-- change so that check_migration_diff.py sees the same statements.
 DROP FUNCTION IF EXISTS paradedb._save_typmod(typmod_in text[]);
 CREATE OR REPLACE FUNCTION paradedb._save_typmod(typmod_in text[]) RETURNS pg_catalog.int4 AS $$
 DECLARE
@@ -58,4 +56,4 @@ BEGIN
 
     RETURN v_id;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER STRICT VOLATILE PARALLEL UNSAFE SET search_path TO 'pg_catalog', 'pg_temp';
+$$ LANGUAGE plpgsql PARALLEL UNSAFE SECURITY DEFINER SET search_path TO 'pg_catalog', 'pg_temp' STRICT VOLATILE;

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -1,0 +1,47 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.2'" to load this file. \quit
+
+-- 0.25.1 -> 0.25.2: harden the tokenizer typmod cache permissions.
+--
+-- paradedb._typmod_cache and its sequence were previously created with
+-- `GRANT ALL ... TO PUBLIC`. That is broader than the extension needs: ordinary
+-- roles only read the table (via SPI in load_typmod) and insert through the
+-- SECURITY DEFINER function paradedb._save_typmod. The extra UPDATE/DELETE/
+-- TRUNCATE and sequence-write privileges let any role silently repoint or orphan
+-- the typmod IDs that other users' ParadeDB indexes resolve their tokenizer
+-- configuration through. Narrow PUBLIC down to SELECT and keep all writes with
+-- the table owner.
+REVOKE ALL ON TABLE paradedb._typmod_cache FROM PUBLIC;
+REVOKE ALL ON SEQUENCE paradedb._typmod_cache_id_seq FROM PUBLIC;
+GRANT SELECT ON TABLE paradedb._typmod_cache TO PUBLIC;
+
+-- Pin the SECURITY DEFINER function's search_path so its resolution can't be
+-- redirected by a caller-controlled search_path. The body only touches the
+-- schema-qualified paradedb._typmod_cache plus pg_catalog operators.
+CREATE OR REPLACE FUNCTION paradedb._save_typmod(typmod_in text[])
+RETURNS integer SECURITY DEFINER STRICT VOLATILE PARALLEL UNSAFE
+SET search_path = pg_catalog, pg_temp
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_id integer;
+BEGIN
+    INSERT INTO paradedb._typmod_cache (typmod)
+    VALUES (typmod_in)
+    ON CONFLICT (typmod) DO NOTHING
+    RETURNING id INTO v_id;
+
+    IF v_id IS NOT NULL THEN
+        RETURN v_id;
+    END IF;
+
+    -- someone else inserted it concurrently, go read it again
+    SELECT id INTO v_id
+    FROM paradedb._typmod_cache
+    WHERE typmod = typmod_in;
+
+    IF v_id IS NULL THEN
+        RAISE EXCEPTION 'typmod "%" not found after upsert', typmod_in;
+    END IF;
+
+    RETURN v_id;
+END;
+$$;

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -25,4 +25,37 @@ GRANT SELECT ON SEQUENCE paradedb._typmod_cache_id_seq TO PUBLIC;
 -- redirected by a caller-controlled search_path. The body only touches the
 -- schema-qualified paradedb._typmod_cache plus pg_catalog operators, so pinning
 -- it leaves behaviour unchanged.
-ALTER FUNCTION paradedb._save_typmod(text[]) SET search_path = pg_catalog, pg_temp;
+--
+-- The body below is identical to the one in
+-- pg_search/src/api/tokenizers/typmod/mod.rs. Only the header is spelled
+-- differently (`pg_catalog.int4` rather than `integer`, and the options after
+-- the body rather than before it), to match what SchemaBot generates for this
+-- change so that check_migration_diff.py sees the same statements. The one
+-- place this deviates from SchemaBot's suggestion is `SECURITY DEFINER`, which
+-- it renders as `security = 1`, which does not parse.
+DROP FUNCTION IF EXISTS paradedb._save_typmod(typmod_in text[]);
+CREATE OR REPLACE FUNCTION paradedb._save_typmod(typmod_in text[]) RETURNS pg_catalog.int4 AS $$
+DECLARE
+    v_id integer;
+BEGIN
+    INSERT INTO paradedb._typmod_cache (typmod)
+    VALUES (typmod_in)
+    ON CONFLICT (typmod) DO NOTHING
+    RETURNING id INTO v_id;
+
+    IF v_id IS NOT NULL THEN
+        RETURN v_id;
+    END IF;
+
+    -- someone else inserted it concurrently, go read it again
+    SELECT id INTO v_id
+    FROM paradedb._typmod_cache
+    WHERE typmod = typmod_in;
+
+    IF v_id IS NULL THEN
+        RAISE EXCEPTION 'typmod "%" not found after upsert', typmod_in;
+    END IF;
+
+    RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STRICT VOLATILE PARALLEL UNSAFE SET search_path TO 'pg_catalog', 'pg_temp';

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -14,34 +14,8 @@ REVOKE ALL ON TABLE paradedb._typmod_cache FROM PUBLIC;
 REVOKE ALL ON SEQUENCE paradedb._typmod_cache_id_seq FROM PUBLIC;
 GRANT SELECT ON TABLE paradedb._typmod_cache TO PUBLIC;
 
--- Pin the SECURITY DEFINER function's search_path so its resolution can't be
+-- Pin the SECURITY DEFINER function's search_path so its name resolution can't be
 -- redirected by a caller-controlled search_path. The body only touches the
--- schema-qualified paradedb._typmod_cache plus pg_catalog operators.
-CREATE OR REPLACE FUNCTION paradedb._save_typmod(typmod_in text[])
-RETURNS integer SECURITY DEFINER STRICT VOLATILE PARALLEL UNSAFE
-SET search_path = pg_catalog, pg_temp
-LANGUAGE plpgsql AS $$
-DECLARE
-    v_id integer;
-BEGIN
-    INSERT INTO paradedb._typmod_cache (typmod)
-    VALUES (typmod_in)
-    ON CONFLICT (typmod) DO NOTHING
-    RETURNING id INTO v_id;
-
-    IF v_id IS NOT NULL THEN
-        RETURN v_id;
-    END IF;
-
-    -- someone else inserted it concurrently, go read it again
-    SELECT id INTO v_id
-    FROM paradedb._typmod_cache
-    WHERE typmod = typmod_in;
-
-    IF v_id IS NULL THEN
-        RAISE EXCEPTION 'typmod "%" not found after upsert', typmod_in;
-    END IF;
-
-    RETURN v_id;
-END;
-$$;
+-- schema-qualified paradedb._typmod_cache plus pg_catalog operators, so pinning
+-- it leaves behaviour unchanged.
+ALTER FUNCTION paradedb._save_typmod(text[]) SET search_path = pg_catalog, pg_temp;

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -10,9 +10,16 @@
 -- the typmod IDs that other users' ParadeDB indexes resolve their tokenizer
 -- configuration through. Narrow PUBLIC down to SELECT and keep all writes with
 -- the table owner.
+--
+-- SELECT stays on the sequence as well: both relations are registered with
+-- pg_extension_config_dump, so pg_dump reads the sequence's last_value directly
+-- and a non-owner dump role would otherwise fail. SELECT on a sequence does not
+-- permit nextval/setval, which is where the hardening actually matters; the
+-- sequence is only ever advanced from inside _save_typmod, as its owner.
 REVOKE ALL ON TABLE paradedb._typmod_cache FROM PUBLIC;
 REVOKE ALL ON SEQUENCE paradedb._typmod_cache_id_seq FROM PUBLIC;
 GRANT SELECT ON TABLE paradedb._typmod_cache TO PUBLIC;
+GRANT SELECT ON SEQUENCE paradedb._typmod_cache_id_seq TO PUBLIC;
 
 -- Pin the SECURITY DEFINER function's search_path so its name resolution can't be
 -- redirected by a caller-controlled search_path. The body only touches the

--- a/pg_search/src/api/tokenizers/typmod/mod.rs
+++ b/pg_search/src/api/tokenizers/typmod/mod.rs
@@ -623,7 +623,6 @@ GRANT SELECT ON TABLE paradedb._typmod_cache TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION paradedb._save_typmod(typmod_in text[])
 RETURNS integer SECURITY DEFINER STRICT VOLATILE PARALLEL UNSAFE
-SET search_path = pg_catalog, pg_temp
 LANGUAGE plpgsql AS $$
 DECLARE
     v_id integer;
@@ -649,6 +648,13 @@ BEGIN
     RETURN v_id;
 END;
 $$;
+
+-- Pin the SECURITY DEFINER function's search_path so its name resolution can't be
+-- redirected by a caller-controlled search_path. The body only touches the
+-- schema-qualified paradedb._typmod_cache plus pg_catalog operators. This is a
+-- separate ALTER rather than a SET clause on the CREATE above so that upgrades
+-- can apply the same one-line statement without recreating the function.
+ALTER FUNCTION paradedb._save_typmod(text[]) SET search_path = pg_catalog, pg_temp;
 "#,
     name = "typmod_cache"
 );

--- a/pg_search/src/api/tokenizers/typmod/mod.rs
+++ b/pg_search/src/api/tokenizers/typmod/mod.rs
@@ -611,11 +611,19 @@ extension_sql!(
 CREATE TABLE paradedb._typmod_cache(id SERIAL NOT NULL PRIMARY KEY, typmod text[] NOT NULL UNIQUE);
 SELECT pg_catalog.pg_extension_config_dump('paradedb._typmod_cache', '');
 SELECT pg_catalog.pg_extension_config_dump('paradedb._typmod_cache_id_seq', '');
-GRANT ALL ON TABLE paradedb._typmod_cache TO PUBLIC;
-GRANT ALL ON SEQUENCE paradedb._typmod_cache_id_seq TO PUBLIC;
+
+-- The typmod cache is shared extension state that every user's ParadeDB indexes
+-- resolve their tokenizer configuration through. Ordinary roles only ever read
+-- it (via SPI in load_typmod) and insert into it through the SECURITY DEFINER
+-- function paradedb._save_typmod below, so grant no more than SELECT to PUBLIC.
+-- Writes (INSERT/UPDATE/DELETE/TRUNCATE) and sequence access stay with the
+-- table owner; letting PUBLIC mutate rows would let any role silently repoint
+-- or orphan the typmod IDs that other users' indexes depend on.
+GRANT SELECT ON TABLE paradedb._typmod_cache TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION paradedb._save_typmod(typmod_in text[])
 RETURNS integer SECURITY DEFINER STRICT VOLATILE PARALLEL UNSAFE
+SET search_path = pg_catalog, pg_temp
 LANGUAGE plpgsql AS $$
 DECLARE
     v_id integer;

--- a/pg_search/src/api/tokenizers/typmod/mod.rs
+++ b/pg_search/src/api/tokenizers/typmod/mod.rs
@@ -616,13 +616,23 @@ SELECT pg_catalog.pg_extension_config_dump('paradedb._typmod_cache_id_seq', '');
 -- resolve their tokenizer configuration through. Ordinary roles only ever read
 -- it (via SPI in load_typmod) and insert into it through the SECURITY DEFINER
 -- function paradedb._save_typmod below, so grant no more than SELECT to PUBLIC.
--- Writes (INSERT/UPDATE/DELETE/TRUNCATE) and sequence access stay with the
--- table owner; letting PUBLIC mutate rows would let any role silently repoint
--- or orphan the typmod IDs that other users' indexes depend on.
+-- Writes (INSERT/UPDATE/DELETE/TRUNCATE) stay with the table owner; letting
+-- PUBLIC mutate rows would let any role silently repoint or orphan the typmod
+-- IDs that other users' indexes depend on.
+--
+-- Both relations are registered with pg_extension_config_dump above, so pg_dump
+-- reads the sequence's last_value directly. SELECT on a sequence permits that
+-- but not nextval/setval, so PUBLIC keeps enough to dump and nothing more; the
+-- sequence is only ever advanced from inside _save_typmod, as its owner.
 GRANT SELECT ON TABLE paradedb._typmod_cache TO PUBLIC;
+GRANT SELECT ON SEQUENCE paradedb._typmod_cache_id_seq TO PUBLIC;
 
+-- search_path is pinned so this SECURITY DEFINER function's name resolution
+-- can't be redirected by a caller-controlled search_path. The body only touches
+-- the schema-qualified paradedb._typmod_cache plus pg_catalog operators.
 CREATE OR REPLACE FUNCTION paradedb._save_typmod(typmod_in text[])
 RETURNS integer SECURITY DEFINER STRICT VOLATILE PARALLEL UNSAFE
+SET search_path = pg_catalog, pg_temp
 LANGUAGE plpgsql AS $$
 DECLARE
     v_id integer;
@@ -648,13 +658,6 @@ BEGIN
     RETURN v_id;
 END;
 $$;
-
--- Pin the SECURITY DEFINER function's search_path so its name resolution can't be
--- redirected by a caller-controlled search_path. The body only touches the
--- schema-qualified paradedb._typmod_cache plus pg_catalog operators. This is a
--- separate ALTER rather than a SET clause on the CREATE above so that upgrades
--- can apply the same one-line statement without recreating the function.
-ALTER FUNCTION paradedb._save_typmod(text[]) SET search_path = pg_catalog, pg_temp;
 "#,
     name = "typmod_cache"
 );

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod_cache.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod_cache.out
@@ -1,4 +1,5 @@
 DELETE FROM paradedb._typmod_cache WHERE typmod = ARRAY['66', '77'];
+DELETE FROM paradedb._typmod_cache WHERE typmod = ARRAY['66', '78'];
 BEGIN;
 SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
  text 
@@ -13,10 +14,17 @@ SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
  {}
 (1 row)
 
--- An ordinary role may read the shared typmod cache but must not mutate it:
--- the cache backs every user's ParadeDB index tokenizer configuration, so writes
--- stay with the table owner (inserts go through SECURITY DEFINER _save_typmod).
-CREATE ROLE typmod_cache_lowpriv;
+-- An ordinary role may read the shared typmod cache, and may still add entries
+-- through the SECURITY DEFINER path, but must not mutate it directly: the cache
+-- backs every user's ParadeDB index tokenizer configuration, so direct writes
+-- stay with the table owner.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'typmod_cache_lowpriv') THEN
+        CREATE ROLE typmod_cache_lowpriv;
+    END IF;
+END
+$$;
 SET ROLE typmod_cache_lowpriv;
 SELECT count(*) >= 0 AS can_select FROM paradedb._typmod_cache;
  can_select 
@@ -24,11 +32,32 @@ SELECT count(*) >= 0 AS can_select FROM paradedb._typmod_cache;
  t
 (1 row)
 
+-- pg_dump reads last_value straight off the sequence, so SELECT has to survive
+-- there, but nothing outside _save_typmod may advance it.
+SELECT last_value >= 0 AS can_read_seq FROM paradedb._typmod_cache_id_seq;
+ can_read_seq 
+--------------
+ t
+(1 row)
+
+SELECT nextval('paradedb._typmod_cache_id_seq');
+ERROR:  permission denied for sequence _typmod_cache_id_seq
+INSERT INTO paradedb._typmod_cache (typmod) VALUES (ARRAY['9', '9']);
+ERROR:  permission denied for table _typmod_cache
 UPDATE paradedb._typmod_cache SET typmod = ARRAY['9', '9'];
 ERROR:  permission denied for table _typmod_cache
 DELETE FROM paradedb._typmod_cache;
 ERROR:  permission denied for table _typmod_cache
 TRUNCATE paradedb._typmod_cache;
 ERROR:  permission denied for table _typmod_cache
+-- The supported write path still works for that role. The typmod pair must not
+-- appear earlier in this file: save_typmod memoises per backend, so a reused
+-- pair would never reach SQL and would prove nothing.
+SELECT 'hello, world'::pdb.ngram(66, 78)::text[];
+ text 
+------
+ {}
+(1 row)
+
 RESET ROLE;
-DROP ROLE typmod_cache_lowpriv;
+DROP ROLE IF EXISTS typmod_cache_lowpriv;

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod_cache.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod_cache.out
@@ -13,7 +13,6 @@ SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
  {}
 (1 row)
 
-
 -- An ordinary role may read the shared typmod cache but must not mutate it:
 -- the cache backs every user's ParadeDB index tokenizer configuration, so writes
 -- stay with the table owner (inserts go through SECURITY DEFINER _save_typmod).

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod_cache.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod_cache.out
@@ -13,3 +13,23 @@ SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
  {}
 (1 row)
 
+
+-- An ordinary role may read the shared typmod cache but must not mutate it:
+-- the cache backs every user's ParadeDB index tokenizer configuration, so writes
+-- stay with the table owner (inserts go through SECURITY DEFINER _save_typmod).
+CREATE ROLE typmod_cache_lowpriv;
+SET ROLE typmod_cache_lowpriv;
+SELECT count(*) >= 0 AS can_select FROM paradedb._typmod_cache;
+ can_select 
+------------
+ t
+(1 row)
+
+UPDATE paradedb._typmod_cache SET typmod = ARRAY['9', '9'];
+ERROR:  permission denied for table _typmod_cache
+DELETE FROM paradedb._typmod_cache;
+ERROR:  permission denied for table _typmod_cache
+TRUNCATE paradedb._typmod_cache;
+ERROR:  permission denied for table _typmod_cache
+RESET ROLE;
+DROP ROLE typmod_cache_lowpriv;

--- a/pg_search/tests/pg_regress/sql/tokenizer-typmod_cache.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-typmod_cache.sql
@@ -3,3 +3,15 @@ BEGIN;
 SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
 ABORT;
 SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
+
+-- An ordinary role may read the shared typmod cache but must not mutate it:
+-- the cache backs every user's ParadeDB index tokenizer configuration, so writes
+-- stay with the table owner (inserts go through SECURITY DEFINER _save_typmod).
+CREATE ROLE typmod_cache_lowpriv;
+SET ROLE typmod_cache_lowpriv;
+SELECT count(*) >= 0 AS can_select FROM paradedb._typmod_cache;
+UPDATE paradedb._typmod_cache SET typmod = ARRAY['9', '9'];
+DELETE FROM paradedb._typmod_cache;
+TRUNCATE paradedb._typmod_cache;
+RESET ROLE;
+DROP ROLE typmod_cache_lowpriv;

--- a/pg_search/tests/pg_regress/sql/tokenizer-typmod_cache.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-typmod_cache.sql
@@ -1,17 +1,34 @@
 DELETE FROM paradedb._typmod_cache WHERE typmod = ARRAY['66', '77'];
+DELETE FROM paradedb._typmod_cache WHERE typmod = ARRAY['66', '78'];
 BEGIN;
 SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
 ABORT;
 SELECT 'hello, world'::pdb.ngram(66, 77)::text[];
 
--- An ordinary role may read the shared typmod cache but must not mutate it:
--- the cache backs every user's ParadeDB index tokenizer configuration, so writes
--- stay with the table owner (inserts go through SECURITY DEFINER _save_typmod).
-CREATE ROLE typmod_cache_lowpriv;
+-- An ordinary role may read the shared typmod cache, and may still add entries
+-- through the SECURITY DEFINER path, but must not mutate it directly: the cache
+-- backs every user's ParadeDB index tokenizer configuration, so direct writes
+-- stay with the table owner.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'typmod_cache_lowpriv') THEN
+        CREATE ROLE typmod_cache_lowpriv;
+    END IF;
+END
+$$;
 SET ROLE typmod_cache_lowpriv;
 SELECT count(*) >= 0 AS can_select FROM paradedb._typmod_cache;
+-- pg_dump reads last_value straight off the sequence, so SELECT has to survive
+-- there, but nothing outside _save_typmod may advance it.
+SELECT last_value >= 0 AS can_read_seq FROM paradedb._typmod_cache_id_seq;
+SELECT nextval('paradedb._typmod_cache_id_seq');
+INSERT INTO paradedb._typmod_cache (typmod) VALUES (ARRAY['9', '9']);
 UPDATE paradedb._typmod_cache SET typmod = ARRAY['9', '9'];
 DELETE FROM paradedb._typmod_cache;
 TRUNCATE paradedb._typmod_cache;
+-- The supported write path still works for that role. The typmod pair must not
+-- appear earlier in this file: save_typmod memoises per backend, so a reused
+-- pair would never reach SQL and would prove nothing.
+SELECT 'hello, world'::pdb.ngram(66, 78)::text[];
 RESET ROLE;
-DROP ROLE typmod_cache_lowpriv;
+DROP ROLE IF EXISTS typmod_cache_lowpriv;


### PR DESCRIPTION
`paradedb._typmod_cache` and its sequence shipped with `GRANT ALL TO PUBLIC`, so any role could `UPDATE`/`DELETE`/`TRUNCATE` the tokenizer config every ParadeDB index resolves through — but reads only need `SELECT` and writes already go through the `SECURITY DEFINER` `_save_typmod`. Narrows the table grant to `SELECT`, drops the sequence grant, pins `_save_typmod`'s search_path, and ships the same in the `0.25.1 → 0.25.2` migration.