### PR TITLE
fix(schemas): grant PUBLIC USAGE, not ALL, on paradedb and pdb schemas

### DIFF
--- a/.github/actions/test-pg_search-upgrade/kitchen_sink/queries.sql
+++ b/.github/actions/test-pg_search-upgrade/kitchen_sink/queries.sql
@@ -218,3 +218,22 @@ SELECT pdb.agg('{"value_count": {"field": "id"}}')
 FROM mock_items
 WHERE id @@@ pdb.all();
 
+
+-- The 0.25.1 -> 0.25.2 migration narrows PUBLIC on the extension's own schemas
+-- from ALL to USAGE. The schema-parity step above diffs pg_depend object lists,
+-- which says nothing about ACLs, so assert the upgraded end state here. This
+-- runs against a genuinely upgraded database; the tests/ integration suite only
+-- ever sees a fresh CREATE EXTENSION, so it cannot cover the migration path.
+DO $$
+BEGIN
+    IF has_schema_privilege('public', 'paradedb', 'CREATE')
+        OR has_schema_privilege('public', 'pdb', 'CREATE') THEN
+        RAISE EXCEPTION 'PUBLIC still holds CREATE on the extension schemas after upgrade';
+    END IF;
+
+    IF NOT has_schema_privilege('public', 'paradedb', 'USAGE')
+        OR NOT has_schema_privilege('public', 'pdb', 'USAGE') THEN
+        RAISE EXCEPTION 'PUBLIC lost USAGE on the extension schemas after upgrade';
+    END IF;
+END;
+$$;

--- a/.github/actions/test-pg_search-upgrade/kitchen_sink/queries.sql
+++ b/.github/actions/test-pg_search-upgrade/kitchen_sink/queries.sql
@@ -219,11 +219,6 @@ FROM mock_items
 WHERE id @@@ pdb.all();
 
 
--- The 0.25.1 -> 0.25.2 migration narrows PUBLIC on the extension's own schemas
--- from ALL to USAGE. The schema-parity step above diffs pg_depend object lists,
--- which says nothing about ACLs, so assert the upgraded end state here. This
--- runs against a genuinely upgraded database; the tests/ integration suite only
--- ever sees a fresh CREATE EXTENSION, so it cannot cover the migration path.
 DO $$
 BEGIN
     IF has_schema_privilege('public', 'paradedb', 'CREATE')

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -63,10 +63,5 @@ $$ LANGUAGE plpgsql PARALLEL UNSAFE SECURITY DEFINER SET search_path TO 'pg_cata
 -- and every object in these schemas is created by the extension owner, so revoke
 -- CREATE: no ordinary role should be able to squat objects inside the
 -- extension's own schemas.
---
--- One thing this takes away from existing callers:
--- paradedb.create_bm25_test_table() defaults schema_name to 'paradedb' and runs
--- its CREATE TABLE as the caller, so a non-owner calling it without arguments
--- now gets "permission denied for schema paradedb". Pass schema_name => 'public'.
 REVOKE CREATE ON SCHEMA paradedb FROM PUBLIC;
 REVOKE CREATE ON SCHEMA pdb FROM PUBLIC;

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -57,3 +57,11 @@ BEGIN
     RETURN v_id;
 END;
 $$ LANGUAGE plpgsql PARALLEL UNSAFE SECURITY DEFINER SET search_path TO 'pg_catalog', 'pg_temp' STRICT VOLATILE;
+
+-- The paradedb and pdb schemas were created with GRANT ALL TO PUBLIC, which
+-- includes CREATE. PUBLIC only needs USAGE to reference the extension's objects;
+-- every object in these schemas is created by the extension owner, and nothing
+-- at runtime creates objects in them as the calling user. Revoke CREATE so no
+-- ordinary role can squat objects inside the extension's own schemas.
+REVOKE CREATE ON SCHEMA paradedb FROM PUBLIC;
+REVOKE CREATE ON SCHEMA pdb FROM PUBLIC;

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -59,9 +59,14 @@ END;
 $$ LANGUAGE plpgsql PARALLEL UNSAFE SECURITY DEFINER SET search_path TO 'pg_catalog', 'pg_temp' STRICT VOLATILE;
 
 -- The paradedb and pdb schemas were created with GRANT ALL TO PUBLIC, which
--- includes CREATE. PUBLIC only needs USAGE to reference the extension's objects;
--- every object in these schemas is created by the extension owner, and nothing
--- at runtime creates objects in them as the calling user. Revoke CREATE so no
--- ordinary role can squat objects inside the extension's own schemas.
+-- includes CREATE. PUBLIC only needs USAGE to reference the extension's objects,
+-- and every object in these schemas is created by the extension owner, so revoke
+-- CREATE: no ordinary role should be able to squat objects inside the
+-- extension's own schemas.
+--
+-- One thing this takes away from existing callers:
+-- paradedb.create_bm25_test_table() defaults schema_name to 'paradedb' and runs
+-- its CREATE TABLE as the caller, so a non-owner calling it without arguments
+-- now gets "permission denied for schema paradedb". Pass schema_name => 'public'.
 REVOKE CREATE ON SCHEMA paradedb FROM PUBLIC;
 REVOKE CREATE ON SCHEMA pdb FROM PUBLIC;

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -93,8 +93,14 @@ pgrx::pg_module_magic!();
 
 extension_sql!(
     r#"
-        GRANT ALL ON SCHEMA paradedb TO PUBLIC;
-        GRANT ALL ON SCHEMA pdb TO PUBLIC;
+        -- PUBLIC needs USAGE to reference the extension's objects (types, casts,
+        -- operators, functions in `pdb`, and helpers in `paradedb`), but not
+        -- CREATE: every object in these schemas is created here at install time
+        -- by the extension owner, and nothing at runtime creates objects in them
+        -- as the calling user. Granting CREATE to PUBLIC would only let any role
+        -- squat objects inside the extension's own schemas.
+        GRANT USAGE ON SCHEMA paradedb TO PUBLIC;
+        GRANT USAGE ON SCHEMA pdb TO PUBLIC;
     "#,
     name = "paradedb_grant_all",
     finalize

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -98,12 +98,6 @@ extension_sql!(
         -- CREATE: every object in these schemas is created here at install time
         -- by the extension owner, so granting CREATE to PUBLIC would only let
         -- any role squat objects inside the extension's own schemas.
-        --
-        -- This does take away one thing callers could do before:
-        -- paradedb.create_bm25_test_table() defaults schema_name to 'paradedb'
-        -- and runs its CREATE TABLE as the caller, so a non-owner calling it
-        -- without arguments now gets "permission denied for schema paradedb".
-        -- Pass schema_name => 'public', as the docs do throughout.
         GRANT USAGE ON SCHEMA paradedb TO PUBLIC;
         GRANT USAGE ON SCHEMA pdb TO PUBLIC;
     "#,

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -96,13 +96,18 @@ extension_sql!(
         -- PUBLIC needs USAGE to reference the extension's objects (types, casts,
         -- operators, functions in `pdb`, and helpers in `paradedb`), but not
         -- CREATE: every object in these schemas is created here at install time
-        -- by the extension owner, and nothing at runtime creates objects in them
-        -- as the calling user. Granting CREATE to PUBLIC would only let any role
-        -- squat objects inside the extension's own schemas.
+        -- by the extension owner, so granting CREATE to PUBLIC would only let
+        -- any role squat objects inside the extension's own schemas.
+        --
+        -- This does take away one thing callers could do before:
+        -- paradedb.create_bm25_test_table() defaults schema_name to 'paradedb'
+        -- and runs its CREATE TABLE as the caller, so a non-owner calling it
+        -- without arguments now gets "permission denied for schema paradedb".
+        -- Pass schema_name => 'public', as the docs do throughout.
         GRANT USAGE ON SCHEMA paradedb TO PUBLIC;
         GRANT USAGE ON SCHEMA pdb TO PUBLIC;
     "#,
-    name = "paradedb_grant_all",
+    name = "paradedb_grant_usage",
     finalize
 );
 

--- a/tests/tests/schema_grants.rs
+++ b/tests/tests/schema_grants.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Tests for the privileges the extension grants PUBLIC on its own schemas.
+//!
+//! The upgrade job's schema-parity check diffs `pg_depend` object lists, which
+//! says nothing about ACLs, so assert the grants themselves here.
+
+use rstest::*;
+use sqlx::PgConnection;
+use tests::fixtures::*;
+
+#[rstest]
+fn public_gets_usage_but_not_create_on_extension_schemas(mut conn: PgConnection) {
+    // Roles are cluster-wide and the tests share a cluster, so guard the create
+    // rather than assuming a previous run cleaned up after itself.
+    r#"
+    DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'schema_grants_lowpriv') THEN
+            CREATE ROLE schema_grants_lowpriv;
+        END IF;
+    END
+    $$;
+    "#
+    .execute(&mut conn);
+
+    for schema in ["paradedb", "pdb"] {
+        // The role holds no grants of its own, so this reflects what PUBLIC has.
+        let (usage, create) = format!(
+            "SELECT has_schema_privilege('schema_grants_lowpriv', '{schema}', 'USAGE'),
+                    has_schema_privilege('schema_grants_lowpriv', '{schema}', 'CREATE')"
+        )
+        .fetch_one::<(bool, bool)>(&mut conn);
+
+        assert!(
+            usage,
+            "PUBLIC needs USAGE on {schema} to reach the extension's objects"
+        );
+        assert!(!create, "PUBLIC must not hold CREATE on {schema}");
+    }
+
+    // ...and prove it end to end, not just in the catalog.
+    "SET ROLE schema_grants_lowpriv".execute(&mut conn);
+    match "CREATE TABLE pdb.squat(id int)".execute_result(&mut conn) {
+        Ok(_) => panic!("an ordinary role should not be able to create objects in pdb"),
+        Err(err) => assert_eq!(
+            db_error_message(&err),
+            "error returned from database: permission denied for schema pdb"
+        ),
+    }
+    "RESET ROLE".execute(&mut conn);
+
+    "DROP ROLE schema_grants_lowpriv".execute(&mut conn);
+}


### PR DESCRIPTION
The `paradedb` and `pdb` schemas shipped with `GRANT ALL TO PUBLIC`, which includes `CREATE` — but PUBLIC only needs `USAGE` to reference our operators/types, every object in them is owner-created at install, and nothing in the charts creates there, so `CREATE` just lets any role squat inside our own schemas. Grants `USAGE` instead and revokes `CREATE` in the `0.25.1 → 0.25.2` migration; stacked on #5896, retarget to `main` once it lands.