### PR TITLE
ci: surface pg_regress diffs instead of burying them in the Postgres log

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -305,7 +305,19 @@ jobs:
           # with a non-zero status code on failure. We catch this failure to print the diffs
           # so they show up in CI, and then manually exit with an error.
           cargo pgrx regress --package pg_search pg${{ matrix.pg_version }} --auto || {
-            git diff
+            git diff | tee regress.diff
+            # Also write the diffs to the job summary. The Postgres log dump at the end of
+            # this job runs to tens of thousands of lines, which is enough to push these
+            # diffs out of the tail of the log that the API will hand back, so the summary
+            # is the only place they are reliably reachable. Cap the excerpt: the summary
+            # has a 1 MiB budget and is dropped wholesale if we blow it.
+            {
+              echo "### pg_regress diffs (PG ${{ matrix.pg_version }})"
+              echo
+              echo "\`\`\`diff"
+              head -c 900000 regress.diff
+              echo "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }
 
@@ -334,9 +346,39 @@ jobs:
           path: coverage-*.lcov
           retention-days: 1
 
+      # Print only the tail. These logs routinely run past 50k lines, and dumping all of
+      # them buries whatever the failing step reported far enough up the log that the
+      # Actions API will no longer return it. The full log goes up as an artifact below
+      # whenever the job fails, so nothing is actually lost.
       - name: Print the Postgres Logs
         if: always()
-        run: cat ~/.pgrx/${{ matrix.pg_version}}.log
+        env:
+          MAX_LINES: 2000
+        run: |
+          LOG=~/.pgrx/${{ matrix.pg_version }}.log
+          if [ ! -f "$LOG" ]; then
+            echo "(log file not present)"
+            exit 0
+          fi
+          cp "$LOG" postgres-${{ matrix.pg_version }}.log
+          TOTAL=$(wc -l < "$LOG")
+          if [ "$TOTAL" -gt "$MAX_LINES" ]; then
+            echo "===== last ${MAX_LINES} of ${TOTAL} lines; full log in the postgres-log-* artifact ====="
+          fi
+          tail -n "$MAX_LINES" "$LOG"
+
+      - name: Upload Postgres Log Artifact
+        if: failure()
+        env:
+          # Same runs-on s3-cache workaround as the coverage upload above.
+          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
+          ACTIONS_CACHE_SERVICE_V2: ""
+        uses: actions/upload-artifact@v7
+        with:
+          name: postgres-log-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}
+          path: postgres-${{ matrix.pg_version }}.log
+          retention-days: 1
+          if-no-files-found: ignore
 
   upload-coverage:
     name: Upload Combined Coverage to Codecov


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Three changes to the `Test pg_search` workflow:

- The regress step now also writes its promoted diffs to `$GITHUB_STEP_SUMMARY`, capped at 900 KB (the summary has a 1 MiB budget and is dropped wholesale if you exceed it).
- `Print the Postgres Logs` prints the last 2000 lines rather than the whole file, with a header saying how much was elided.
- On job failure, the full Postgres log is uploaded as a `postgres-log-<pg_version>-<pg_impl>-<arch>` artifact.

## Why

When a regression test fails, the regress step prints the diffs `cargo pgrx regress --auto` promoted into the working tree — and then the job dumps the entire Postgres log, which routinely runs past 50k lines. The Actions log API only returns the tail of a job log, so that dump reliably pushes the diffs out of reach. The failure then reads as "pg_regress failed" with no indication of which test differed or how.

This came up diagnosing #5896: the actual failure was a single spurious blank line in one expected file, but recovering that one-line diff meant reconstructing the test's behaviour against a local Postgres instead of just reading it off the job.

The two halves are complementary. The job summary is reachable regardless of log length, so it fixes the diagnosis path outright; the tail keeps the inline log readable for everything else. Uploading the full log on failure means the cap costs nothing — the whole file is still one download away when someone genuinely needs to trace backend activity across a run.

## How

The regress step tees `git diff` to `regress.diff` and appends a fenced excerpt to the step summary before exiting non-zero, so the inline print is unchanged and the summary is purely additive.

The log step guards on the file existing (it is absent for some matrix legs), copies it into the workspace so `actions/upload-artifact` can pick it up by relative path, and tails it. The upload reuses the `ACTIONS_RESULTS_URL` / `ACTIONS_CACHE_SERVICE_V2` override already documented on the coverage upload in this file — runs-on's `extras=s3-cache` proxies that variable, and without pinning it back the artifact POSTs to the cache proxy instead of GitHub. It sets `if-no-files-found: ignore` so a missing log never turns a real failure into a confusing artifact error.

## Tests

Both shell snippets were exercised locally against a synthetic 5000-line log and a sample diff, covering the log-larger-than-cap, log-smaller-than-cap, and log-absent paths, plus the summary block's markdown output. `prettier --check` passes on the workflow file.

Beyond that this is CI-only and self-verifying: the diff-surfacing path is exercised the next time a regression test fails, and the tail plus artifact upload are visible on this PR's own `Test pg_search` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUFs5eThWsMu5yA8DjKhaF

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUFs5eThWsMu5yA8DjKhaF)_