### PR TITLE
refactor: rename `create_bm25_test_table` to `create_paradedb_test_table`

### DIFF
--- a/.github/scripts/bootstrap_code_snippet_tables.sql
+++ b/.github/scripts/bootstrap_code_snippet_tables.sql
@@ -4,12 +4,12 @@ DROP TABLE IF EXISTS orders CASCADE;
 DROP TABLE IF EXISTS mock_items CASCADE;
 DROP TABLE IF EXISTS array_demo CASCADE;
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'orders',
   table_type => 'Orders'

--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run ParadeDB example queries
         run: |
-          psql -h localhost -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
+          psql -h localhost -U testuser -d testdb -c "CALL paradedb.create_paradedb_test_table(schema_name => 'public', table_name => 'mock_items');"
           psql -h localhost -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
           psql -h localhost -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
           psql -h localhost -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"

--- a/docs/deploy/ci/gitlab-ci.mdx
+++ b/docs/deploy/ci/gitlab-ci.mdx
@@ -17,7 +17,7 @@ paradedb-in-gitlab-ci:
     POSTGRES_DB: testdb
     POSTGRES_HOST_AUTH_METHOD: trust
   script:
-    - psql -h "postgres" -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
+    - psql -h "postgres" -U testuser -d testdb -c "CALL paradedb.create_paradedb_test_table(schema_name => 'public', table_name => 'mock_items');"
     - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
     - psql -h "postgres" -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
     - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -12,7 +12,7 @@ ParadeDB comes with a helpful procedure that creates a table populated with mock
 you get started. Run the following command to create this table.
 
 ```sql
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );
@@ -183,7 +183,7 @@ Create and populate `mock_items`:
 
 ```ts
 await db.execute(sql`
-  CALL paradedb.create_bm25_test_table(
+  CALL paradedb.create_paradedb_test_table(
     schema_name => 'public',
     table_name => 'mock_items'
   )
@@ -317,7 +317,7 @@ from django.db import connection
 
 with connection.cursor() as cursor:
     cursor.execute("""
-        CALL paradedb.create_bm25_test_table(
+        CALL paradedb.create_paradedb_test_table(
           schema_name => 'public',
           table_name  => 'mock_items_tmp'
         );
@@ -509,7 +509,7 @@ def upgrade() -> None:
     """Upgrade schema."""
     op.execute(
         """
-        CALL paradedb.create_bm25_test_table(
+        CALL paradedb.create_paradedb_test_table(
           schema_name => 'public',
           table_name => 'mock_items'
         )
@@ -633,7 +633,7 @@ Update the generated migration to create `mock_items`:
 ```ruby db/migrate/*_create_mock_items_table.rb
 def up
   execute <<~SQL
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -885,7 +885,7 @@ Open the generated migration in `Migrations/*_CreateMockItems.cs` and add this s
 
 ```cs
 migrationBuilder.Sql("""
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name  => 'mock_items_tmp'
     );

--- a/docs/documentation/joins/overview.mdx
+++ b/docs/documentation/joins/overview.mdx
@@ -45,7 +45,7 @@ If any checks fail, ParadeDB will emit a `NOTICE` explaining why and fall back t
 To demonstrate, let's create a second table called `orders` that can be joined with `mock_items`:
 
 ```sql
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'orders',
   table_type => 'Orders'

--- a/docs/documentation/sorting/score.mdx
+++ b/docs/documentation/sorting/score.mdx
@@ -170,7 +170,7 @@ While BM25 scores will be returned as long as `description` is indexed, includin
 First, let's create a second table called `orders` that can be joined with `mock_items`:
 
 ```sql
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'orders',
   table_type => 'Orders'

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -82,6 +82,6 @@ AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';
 -- signature and behaviour are unchanged, including the 'bm25_test_table'
 -- default table name, so an existing call that passes no table_name still
 -- creates exactly the same table.
-DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(varchar, varchar, paradedb.TestTable);
+DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(table_name pg_catalog."varchar", schema_name pg_catalog."varchar", table_type paradedb.testtable);
 CREATE OR REPLACE PROCEDURE paradedb.create_paradedb_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
 LANGUAGE c AS 'MODULE_PATHNAME', 'create_paradedb_test_table_wrapper';

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -75,3 +75,13 @@ CREATE  FUNCTION "term_search_query_input"(
 IMMUTABLE STRICT PARALLEL SAFE
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';
+
+-- Rename paradedb.create_bm25_test_table to paradedb.create_paradedb_test_table.
+-- The bm25 name predates the access method rename to `paradedb`, and this
+-- procedure was one of the last user-facing identifiers still carrying it. The
+-- signature and behaviour are unchanged, including the 'bm25_test_table'
+-- default table name, so an existing call that passes no table_name still
+-- creates exactly the same table.
+DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(varchar, varchar, paradedb.TestTable);
+CREATE OR REPLACE PROCEDURE paradedb.create_paradedb_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
+LANGUAGE c AS 'MODULE_PATHNAME', 'create_paradedb_test_table_wrapper';

--- a/pg_search/src/bootstrap/test_table.rs
+++ b/pg_search/src/bootstrap/test_table.rs
@@ -56,10 +56,10 @@ type MockDeliveryRow = (
 );
 
 #[pg_extern(sql = "
-CREATE OR REPLACE PROCEDURE paradedb.create_bm25_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
+CREATE OR REPLACE PROCEDURE paradedb.create_paradedb_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
 LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
 ", requires = [ TestTable ])]
-fn create_bm25_test_table(
+fn create_paradedb_test_table(
     table_name: Option<&str>,
     schema_name: Option<&str>,
     table_type: Option<TestTable>,

--- a/pg_search/tests/pg_regress/common/recursive_estimates_setup.sql
+++ b/pg_search/tests/pg_regress/common/recursive_estimates_setup.sql
@@ -7,7 +7,7 @@
 -- Create dedicated schema and table for recursive estimates tests (isolated from other tests)
 CREATE SCHEMA IF NOT EXISTS recursive_test;
 DROP TABLE IF EXISTS recursive_test.estimate_items CASCADE;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'recursive_test',
         table_name => 'estimate_items'
      );

--- a/pg_search/tests/pg_regress/expected/aggregate_topk.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_topk.out
@@ -7,7 +7,7 @@ SET paradedb.enable_columnar_exec = true;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- Create test table
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
     schema_name => 'public',
     table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/aliased_text_expression_resolution.out
+++ b/pg_search/tests/pg_regress/expected/aliased_text_expression_resolution.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/aliased_text_expression_topk_orderby.out
+++ b/pg_search/tests/pg_regress/expected/aliased_text_expression_topk_orderby.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/cte-tokenizer-cast.out
+++ b/pg_search/tests/pg_regress/expected/cte-tokenizer-cast.out
@@ -5,7 +5,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 -- Test CTE queries with tokenizer cast in index definition
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/expensive_estimate.out
+++ b/pg_search/tests/pg_regress/expected/expensive_estimate.out
@@ -7,7 +7,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/index_json_expression.out
+++ b/pg_search/tests/pg_regress/expected/index_json_expression.out
@@ -5,7 +5,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 SET paradedb.enable_aggregate_custom_scan TO on;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/index_layer_info.out
+++ b/pg_search/tests/pg_regress/expected/index_layer_info.out
@@ -4,11 +4,11 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_1'
 );
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_2'
 );
@@ -49,7 +49,7 @@ SELECT * FROM paradedb.combined_layer_sizes('mock_items_2_idx');
  {102400,1048576,10485760,104857600,1048576000,10485760000}
 (1 row)
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_not_ready'
 );

--- a/pg_search/tests/pg_regress/expected/inline_tokenizer_casts.out
+++ b/pg_search/tests/pg_regress/expected/inline_tokenizer_casts.out
@@ -15,7 +15,7 @@ SET paradedb.enable_columnar_exec = true;
 --
 -- Also covers the pre-existing fuzzy/slop -> boost chain casts and the
 -- newly added fuzzy/slop -> const chain casts.
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_2932.out
+++ b/pg_search/tests/pg_regress/expected/issue_2932.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_3050.out
+++ b/pg_search/tests/pg_regress/expected/issue_3050.out
@@ -5,7 +5,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 SET paradedb.enable_aggregate_custom_scan TO on;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_3051.out
+++ b/pg_search/tests/pg_regress/expected/issue_3051.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_3196.out
+++ b/pg_search/tests/pg_regress/expected/issue_3196.out
@@ -5,7 +5,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 SET paradedb.enable_aggregate_custom_scan TO on;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_3256.out
+++ b/pg_search/tests/pg_regress/expected/issue_3256.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_3298.out
+++ b/pg_search/tests/pg_regress/expected/issue_3298.out
@@ -5,7 +5,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 SET paradedb.enable_aggregate_custom_scan TO on;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_3300.out
+++ b/pg_search/tests/pg_regress/expected/issue_3300.out
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS issue3300;
 DROP TABLE IF EXISTS allowed_categories;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'issue3300'
      );

--- a/pg_search/tests/pg_regress/expected/issue_3890.out
+++ b/pg_search/tests/pg_regress/expected/issue_3890.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_4070.out
+++ b/pg_search/tests/pg_regress/expected/issue_4070.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/issue_4610.out
+++ b/pg_search/tests/pg_regress/expected/issue_4610.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/json_operator.out
+++ b/pg_search/tests/pg_regress/expected/json_operator.out
@@ -5,7 +5,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 DROP TABLE IF EXISTS mock_items;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/misconfigured_configs.out
+++ b/pg_search/tests/pg_regress/expected/misconfigured_configs.out
@@ -1,5 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/not-paradedb_all.out
+++ b/pg_search/tests/pg_regress/expected/not-paradedb_all.out
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS notpdball;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'notpdball'
      );

--- a/pg_search/tests/pg_regress/expected/operators.out
+++ b/pg_search/tests/pg_regress/expected/operators.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/parse.out
+++ b/pg_search/tests/pg_regress/expected/parse.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/partial_index_score_fix.out
+++ b/pg_search/tests/pg_regress/expected/partial_index_score_fix.out
@@ -127,7 +127,7 @@ DROP TABLE partial_test;
 -- Test case for partial index with category predicate
 -- ============================================================
 -- Setup test table
-CALL paradedb.create_bm25_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');
 -- Create partial index with predicate WHERE category = 'Electronics'
 CREATE INDEX partial_idx ON paradedb.test_partial_index
 USING bm25 (id, description, category, rating)

--- a/pg_search/tests/pg_regress/expected/prepared_statement_score.out
+++ b/pg_search/tests/pg_regress/expected/prepared_statement_score.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/reciprocal_rank_fusion.out
+++ b/pg_search/tests/pg_regress/expected/reciprocal_rank_fusion.out
@@ -6,12 +6,12 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 -- Create test tables
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_rrf',
   table_type => 'Items'
 );
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'orders_rrf',
   table_type => 'Orders'

--- a/pg_search/tests/pg_regress/expected/recursive_estimates.out
+++ b/pg_search/tests/pg_regress/expected/recursive_estimates.out
@@ -15,7 +15,7 @@ SET paradedb.enable_columnar_exec = true;
 -- Create dedicated schema and table for recursive estimates tests (isolated from other tests)
 CREATE SCHEMA IF NOT EXISTS recursive_test;
 DROP TABLE IF EXISTS recursive_test.estimate_items CASCADE;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'recursive_test',
         table_name => 'estimate_items'
      );

--- a/pg_search/tests/pg_regress/expected/setup.out
+++ b/pg_search/tests/pg_regress/expected/setup.out
@@ -11,7 +11,7 @@ $$;
 -- Also set it for the current session, in case any subsequent setup steps rely on it
 SET max_parallel_workers_per_gather = 2;
 DROP TABLE IF EXISTS mock_items_issue_2528;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_issue_2528'
 );
@@ -23,7 +23,7 @@ CREATE INDEX search_idx_issue_2528 ON mock_items_issue_2528 USING bm25 (id, desc
 -- we add a new column, "sku", to the table, and populate it with a unique UUID per row
 --
 CREATE SCHEMA IF NOT EXISTS regress;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'regress',
         table_name => 'mock_items'
      );

--- a/pg_search/tests/pg_regress/expected/tokenize_fast_field.out
+++ b/pg_search/tests/pg_regress/expected/tokenize_fast_field.out
@@ -5,7 +5,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 SET paradedb.enable_aggregate_custom_scan TO on;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
     schema_name => 'public',
     table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -12,7 +12,7 @@ SET paradedb.enable_columnar_exec = true;
 -- Verifies that ORDER BY <expr> LIMIT N uses TopN scan when <expr> was
 -- used to build the BM25 index, not just for the hardcoded patterns
 -- (pdb.score(), lower(), plain col).
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/topk-lower-text.out
+++ b/pg_search/tests/pg_regress/expected/topk-lower-text.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/topk_scores.out
+++ b/pg_search/tests/pg_regress/expected/topk_scores.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/expected/topk_validation.out
+++ b/pg_search/tests/pg_regress/expected/topk_validation.out
@@ -8,7 +8,7 @@ SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
 -- Create test table with appropriate data
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'test_products'
 );

--- a/pg_search/tests/pg_regress/sql/aggregate_topk.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_topk.sql
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- Create test table
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
     schema_name => 'public',
     table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/aliased_text_expression_resolution.sql
+++ b/pg_search/tests/pg_regress/sql/aliased_text_expression_resolution.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/aliased_text_expression_topk_orderby.sql
+++ b/pg_search/tests/pg_regress/sql/aliased_text_expression_topk_orderby.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/cte-tokenizer-cast.sql
+++ b/pg_search/tests/pg_regress/sql/cte-tokenizer-cast.sql
@@ -1,7 +1,7 @@
 \i common/common_setup.sql
 
 -- Test CTE queries with tokenizer cast in index definition
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/expensive_estimate.sql
+++ b/pg_search/tests/pg_regress/sql/expensive_estimate.sql
@@ -4,7 +4,7 @@
 
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/index_json_expression.sql
+++ b/pg_search/tests/pg_regress/sql/index_json_expression.sql
@@ -2,7 +2,7 @@
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/index_layer_info.sql
+++ b/pg_search/tests/pg_regress/sql/index_layer_info.sql
@@ -1,11 +1,11 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_1'
 );
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_2'
 );
@@ -22,7 +22,7 @@ SELECT relname, layer_size FROM pdb.index_layer_info WHERE relname = 'mock_items
 SELECT * FROM paradedb.combined_layer_sizes('mock_items_1_idx');
 SELECT * FROM paradedb.combined_layer_sizes('mock_items_2_idx');
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_not_ready'
 );

--- a/pg_search/tests/pg_regress/sql/inline_tokenizer_casts.sql
+++ b/pg_search/tests/pg_regress/sql/inline_tokenizer_casts.sql
@@ -12,7 +12,7 @@
 -- Also covers the pre-existing fuzzy/slop -> boost chain casts and the
 -- newly added fuzzy/slop -> const chain casts.
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_2932.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2932.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_3050.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3050.sql
@@ -2,7 +2,7 @@
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_3051.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3051.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_3196.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3196.sql
@@ -2,7 +2,7 @@
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_3256.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3256.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_3298.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3298.sql
@@ -2,7 +2,7 @@
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_3300.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3300.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS issue3300;
 DROP TABLE IF EXISTS allowed_categories;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'issue3300'
      );

--- a/pg_search/tests/pg_regress/sql/issue_3890.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3890.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_4070.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4070.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/issue_4610.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4610.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/json_operator.sql
+++ b/pg_search/tests/pg_regress/sql/json_operator.sql
@@ -1,7 +1,7 @@
 \i common/common_setup.sql
 
 DROP TABLE IF EXISTS mock_items;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/misconfigured_configs.sql
+++ b/pg_search/tests/pg_regress/sql/misconfigured_configs.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/not-paradedb_all.sql
+++ b/pg_search/tests/pg_regress/sql/not-paradedb_all.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS notpdball;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'notpdball'
      );

--- a/pg_search/tests/pg_regress/sql/operators.sql
+++ b/pg_search/tests/pg_regress/sql/operators.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/parse.sql
+++ b/pg_search/tests/pg_regress/sql/parse.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/partial_index_score_fix.sql
+++ b/pg_search/tests/pg_regress/sql/partial_index_score_fix.sql
@@ -84,7 +84,7 @@ DROP TABLE partial_test;
 -- ============================================================
 
 -- Setup test table
-CALL paradedb.create_bm25_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');
 
 -- Create partial index with predicate WHERE category = 'Electronics'
 CREATE INDEX partial_idx ON paradedb.test_partial_index

--- a/pg_search/tests/pg_regress/sql/prepared_statement_score.sql
+++ b/pg_search/tests/pg_regress/sql/prepared_statement_score.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/reciprocal_rank_fusion.sql
+++ b/pg_search/tests/pg_regress/sql/reciprocal_rank_fusion.sql
@@ -3,12 +3,12 @@
 \i common/common_setup.sql
 
 -- Create test tables
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_rrf',
   table_type => 'Items'
 );
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'orders_rrf',
   table_type => 'Orders'

--- a/pg_search/tests/pg_regress/sql/setup.sql
+++ b/pg_search/tests/pg_regress/sql/setup.sql
@@ -13,7 +13,7 @@ $$;
 SET max_parallel_workers_per_gather = 2;
 
 DROP TABLE IF EXISTS mock_items_issue_2528;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items_issue_2528'
 );
@@ -27,7 +27,7 @@ CREATE INDEX search_idx_issue_2528 ON mock_items_issue_2528 USING bm25 (id, desc
 -- we add a new column, "sku", to the table, and populate it with a unique UUID per row
 --
 CREATE SCHEMA IF NOT EXISTS regress;
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
         schema_name => 'regress',
         table_name => 'mock_items'
      );

--- a/pg_search/tests/pg_regress/sql/tokenize_fast_field.sql
+++ b/pg_search/tests/pg_regress/sql/tokenize_fast_field.sql
@@ -2,7 +2,7 @@
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
     schema_name => 'public',
     table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/topk-indexed-expressions.sql
+++ b/pg_search/tests/pg_regress/sql/topk-indexed-expressions.sql
@@ -9,7 +9,7 @@ SET paradedb.enable_columnar_exec = true;
 -- used to build the BM25 index, not just for the hardcoded patterns
 -- (pdb.score(), lower(), plain col).
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/topk-lower-text.sql
+++ b/pg_search/tests/pg_regress/sql/topk-lower-text.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/topk_scores.sql
+++ b/pg_search/tests/pg_regress/sql/topk_scores.sql
@@ -1,6 +1,6 @@
 \i common/common_setup.sql
 
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );

--- a/pg_search/tests/pg_regress/sql/topk_validation.sql
+++ b/pg_search/tests/pg_regress/sql/topk_validation.sql
@@ -5,7 +5,7 @@
 \i common/common_setup.sql
 
 -- Create test table with appropriate data
-CALL paradedb.create_bm25_test_table(
+CALL paradedb.create_paradedb_test_table(
   schema_name => 'public',
   table_name => 'test_products'
 );

--- a/tests/src/fixtures/tables/deliveries.rs
+++ b/tests/src/fixtures/tables/deliveries.rs
@@ -41,7 +41,7 @@ impl DeliveriesTable {
 
 static DELIVERIES_TABLE_SETUP: &str = r#"
 BEGIN;
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'deliveries',
         table_type => 'Deliveries'

--- a/tests/src/fixtures/tables/simple_products.rs
+++ b/tests/src/fixtures/tables/simple_products.rs
@@ -51,7 +51,7 @@ impl SimpleProductsTable {
 
 static SIMPLE_PRODUCTS_TABLE_SETUP: &str = r#"
 BEGIN;
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CREATE INDEX bm25_search_bm25_index
     ON paradedb.bm25_search

--- a/tests/tests/aggregate.rs
+++ b/tests/tests/aggregate.rs
@@ -23,7 +23,7 @@ use tests::fixtures::*;
 #[rstest]
 fn test_aggregate_with_mvcc(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
     CREATE INDEX idxbm25_search ON paradedb.bm25_search
     USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
     WITH (
@@ -72,7 +72,7 @@ fn test_aggregate_with_mvcc(mut conn: PgConnection) {
 #[rstest]
 fn test_aggregate_without_mvcc(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
     CREATE INDEX idxbm25_search ON paradedb.bm25_search
     USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
     WITH (

--- a/tests/tests/aggregate_custom_scan.rs
+++ b/tests/tests/aggregate_custom_scan.rs
@@ -155,7 +155,7 @@ fn test_group_by_null_bucket(mut conn: PgConnection) {
 
 #[rstest]
 fn test_no_bm25_index(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'no_bm25', schema_name => 'paradedb');"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'no_bm25', schema_name => 'paradedb');"
         .execute(&mut conn);
 
     "SET paradedb.enable_aggregate_custom_scan TO on;".execute(&mut conn);

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -445,7 +445,7 @@ fn snippet_text_array(mut conn: PgConnection) {
 #[rstest]
 fn hybrid_with_single_result(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -516,7 +516,7 @@ fn update_non_indexed_column(mut conn: PgConnection) -> Result<()> {
     // drop the embedding column (and rewrite the heap to reclaim its space) to keep the tuple
     // layout free of the vector column.
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'public');
+    CALL paradedb.create_paradedb_test_table(table_name => 'mock_items', schema_name => 'public');
     ALTER TABLE mock_items DROP COLUMN embedding;
     "#
     .execute(&mut conn);
@@ -670,7 +670,7 @@ async fn json_nested_arrays(mut conn: PgConnection) {
 fn bm25_partial_index_search(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
-    "CALL paradedb.create_bm25_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');".execute(&mut conn);
+    "CALL paradedb.create_paradedb_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');".execute(&mut conn);
 
     let ret = r#"
     CREATE INDEX partial_idx ON paradedb.test_partial_index
@@ -769,7 +769,7 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
 #[rstest]
 fn bm25_partial_index_hybrid(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -884,7 +884,7 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
 fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
-    "CALL paradedb.create_bm25_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');".execute(&mut conn);
+    "CALL paradedb.create_paradedb_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');".execute(&mut conn);
 
     // Ensure report error when predicate is invalid
     // unknown column
@@ -939,7 +939,7 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
 fn bm25_partial_index_alter_and_drop(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
-    "CALL paradedb.create_bm25_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');".execute(&mut conn);
+    "CALL paradedb.create_paradedb_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');".execute(&mut conn);
 
     r#"
     CREATE INDEX partial_idx ON paradedb.test_partial_index
@@ -1140,7 +1140,7 @@ fn json_match(mut conn: PgConnection) {
 
 #[rstest]
 fn json_range(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');"
         .execute(&mut conn);
     "CREATE INDEX bm25_search_idx ON paradedb.bm25_search
     USING bm25 (id, metadata)
@@ -1188,7 +1188,7 @@ fn json_range(mut conn: PgConnection) {
 
 #[rstest]
 fn test_customers_table(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(
+    "CALL paradedb.create_paradedb_test_table(
         table_name => 'customers',
         schema_name => 'public',
         table_type => 'Customers'

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -298,13 +298,13 @@ where a.description @@@ 'bear' OR b.description @@@ 'teddy bear';"#
 #[rstest]
 fn add_scores_across_joins_issue1753(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'public');
+    CALL paradedb.create_paradedb_test_table(table_name => 'mock_items', schema_name => 'public');
 
     CREATE INDEX search_idx ON mock_items
     USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
     WITH (key_field='id');
 
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'orders',
       table_type => 'Orders'
@@ -333,9 +333,9 @@ fn add_scores_across_joins_issue1753(mut conn: PgConnection) {
 #[rstest]
 fn scores_survive_joins(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'a', schema_name => 'public');
-    CALL paradedb.create_bm25_test_table(table_name => 'b', schema_name => 'public');
-    CALL paradedb.create_bm25_test_table(table_name => 'c', schema_name => 'public');
+    CALL paradedb.create_paradedb_test_table(table_name => 'a', schema_name => 'public');
+    CALL paradedb.create_paradedb_test_table(table_name => 'b', schema_name => 'public');
+    CALL paradedb.create_paradedb_test_table(table_name => 'c', schema_name => 'public');
 
     CREATE INDEX idxa ON a USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time) WITH (key_field='id');
     CREATE INDEX idxb ON b USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time) WITH (key_field='id');
@@ -366,7 +366,7 @@ fn scores_survive_joins(mut conn: PgConnection) {
 #[rstest]
 fn join_issue_1776(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
           schema_name => 'public',
           table_name => 'mock_items'
         );
@@ -375,7 +375,7 @@ fn join_issue_1776(mut conn: PgConnection) {
     USING bm25 (id, description, category, rating, in_stock, metadata, created_at)
     WITH (key_field='id');
 
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
           schema_name => 'public',
           table_name => 'orders',
           table_type => 'Orders'
@@ -410,7 +410,7 @@ fn join_issue_1776(mut conn: PgConnection) {
 #[rstest]
 fn join_issue_1826(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
           schema_name => 'public',
           table_name => 'mock_items'
         );
@@ -419,7 +419,7 @@ fn join_issue_1826(mut conn: PgConnection) {
     USING bm25 (id, description, category, rating, in_stock, metadata, created_at)
     WITH (key_field='id');
 
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
           schema_name => 'public',
           table_name => 'orders',
           table_type => 'Orders'
@@ -538,7 +538,7 @@ fn cte_issue_1951(mut conn: PgConnection) {
 #[rstest]
 fn without_operator_guc(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'public');
+    CALL paradedb.create_paradedb_test_table(table_name => 'mock_items', schema_name => 'public');
 
     CREATE INDEX search_idx ON mock_items
     USING bm25 (id, description, rating)
@@ -1229,7 +1229,7 @@ fn join_with_string_fast_fields_issue_2505(mut conn: PgConnection) {
 #[rstest]
 fn custom_scan_respects_parentheses_issue2526(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'public');
+    CALL paradedb.create_paradedb_test_table(table_name => 'mock_items', schema_name => 'public');
 
     CREATE INDEX search_idx ON mock_items
     USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -27,7 +27,7 @@ use tests::fixtures::*;
 #[rstest]
 fn quickstart(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     )
@@ -98,7 +98,7 @@ fn quickstart(mut conn: PgConnection) {
     assert_eq!(rows[0].0, "White jogging shoes");
 
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'orders',
         table_type => 'Orders'
@@ -230,7 +230,7 @@ fn quickstart(mut conn: PgConnection) {
 #[rstest]
 fn full_text_search(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -411,7 +411,7 @@ fn full_text_search(mut conn: PgConnection) {
     assert_eq!(rows.len(), 3);
 
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'orders',
         table_type => 'Orders'
@@ -546,7 +546,7 @@ fn full_text_search(mut conn: PgConnection) {
 #[rstest]
 fn match_query(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -656,7 +656,7 @@ fn match_query(mut conn: PgConnection) {
 #[rstest]
 fn term_level_queries(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1071,7 +1071,7 @@ fn term_level_queries(mut conn: PgConnection) {
 #[rstest]
 fn phrase_level_queries(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1174,7 +1174,7 @@ fn phrase_level_queries(mut conn: PgConnection) {
 #[rstest]
 fn json_queries(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1239,7 +1239,7 @@ fn json_arrays(mut conn: PgConnection) {
     // 1) Create the mock_items test table with ParadeDB helper
     //
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1316,7 +1316,7 @@ fn json_arrays(mut conn: PgConnection) {
 #[rstest]
 fn custom_enum(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1380,7 +1380,7 @@ fn custom_enum(mut conn: PgConnection) {
 #[rstest]
 fn compound_queries(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1797,7 +1797,7 @@ fn compound_queries(mut conn: PgConnection) {
 #[rstest]
 fn specialized_queries(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1867,7 +1867,7 @@ fn specialized_queries(mut conn: PgConnection) {
 #[rstest]
 fn autocomplete(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -1968,7 +1968,7 @@ fn autocomplete(mut conn: PgConnection) {
 #[rstest]
 fn hybrid_search(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2066,15 +2066,15 @@ fn hybrid_search(mut conn: PgConnection) {
 }
 
 #[rstest]
-fn create_bm25_test_tables(mut conn: PgConnection) {
+fn create_paradedb_test_tables(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'orders',
         table_type => 'Orders'
     );
 
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'parts',
         table_type => 'Parts'
@@ -2100,7 +2100,7 @@ fn create_bm25_test_tables(mut conn: PgConnection) {
 #[rstest]
 fn concurrent_indexing(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2137,7 +2137,7 @@ fn concurrent_indexing(mut conn: PgConnection) {
 #[rstest]
 fn schema(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2168,7 +2168,7 @@ fn schema(mut conn: PgConnection) {
 #[rstest]
 fn index_size(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2189,7 +2189,7 @@ fn index_size(mut conn: PgConnection) {
 #[rstest]
 fn field_configuration(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2308,7 +2308,7 @@ fn field_configuration(mut conn: PgConnection) {
 #[rstest]
 fn available_tokenizers(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2519,7 +2519,7 @@ fn available_tokenizers(mut conn: PgConnection) {
 #[rstest]
 fn token_filters(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2569,7 +2569,7 @@ fn token_filters(mut conn: PgConnection) {
 #[rstest]
 fn fast_fields(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -2606,7 +2606,7 @@ fn fast_fields(mut conn: PgConnection) {
 #[rstest]
 fn record(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );

--- a/tests/tests/expression.rs
+++ b/tests/tests/expression.rs
@@ -23,7 +23,7 @@ use tests::fixtures::*;
 #[rstest]
 fn expression_paradedb_func(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb');
 
     CREATE INDEX index_config_index ON paradedb.index_config
         USING bm25 (id, (lower(description)::pdb.simple)) WITH (key_field='id');
@@ -45,7 +45,7 @@ fn expression_paradedb_func(mut conn: PgConnection) {
 #[rstest]
 fn expression_paradedb_op(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb');
 
     CREATE INDEX index_config_index ON paradedb.index_config
         USING bm25 (id, ((description || ' with cats')::pdb.simple)) WITH (key_field='id');

--- a/tests/tests/fast_fields.rs
+++ b/tests/tests/fast_fields.rs
@@ -25,7 +25,7 @@ use tests::fixtures::*;
 #[rstest]
 fn plans_numeric_fast_field(mut conn: PgConnection) {
     r#"
-CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 CREATE INDEX idxbm25_search ON paradedb.bm25_search
 USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
 WITH (
@@ -52,7 +52,7 @@ WITH (
 #[rstest]
 fn plans_many_numeric_fast_fields(mut conn: PgConnection) {
     r#"
-CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 CREATE INDEX idxbm25_search ON paradedb.bm25_search
 USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
 WITH (
@@ -79,7 +79,7 @@ WITH (
 #[rstest]
 fn plans_many_numeric_fast_fields_with_score(mut conn: PgConnection) {
     r#"
-CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 CREATE INDEX idxbm25_search ON paradedb.bm25_search
 USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
 WITH (
@@ -107,7 +107,7 @@ WITH (
 #[rstest]
 fn plans_string_fast_field(mut conn: PgConnection) {
     r#"
-CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 CREATE INDEX idxbm25_search ON paradedb.bm25_search
 USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
 WITH (
@@ -135,7 +135,7 @@ SET paradedb.enable_aggregate_custom_scan = false;
 #[rstest]
 fn does_plan_string_fast_field(mut conn: PgConnection) {
     r#"
-CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 CREATE INDEX idxbm25_search ON paradedb.bm25_search
 USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
 WITH (
@@ -161,7 +161,7 @@ WITH (
 #[rstest]
 fn numeric_fast_field_in_window_func(mut conn: PgConnection) {
     r#"
-CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 CREATE INDEX idxbm25_search ON paradedb.bm25_search
 USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
 WITH (

--- a/tests/tests/heap.rs
+++ b/tests/tests/heap.rs
@@ -22,7 +22,7 @@ use tests::fixtures::*;
 #[rstest]
 fn mvcc_heap_filter(mut conn: PgConnection) {
     r#"
-        CALL paradedb.create_bm25_test_table(table_name => 'heap_and_clauses_table', schema_name => 'public');
+        CALL paradedb.create_paradedb_test_table(table_name => 'heap_and_clauses_table', schema_name => 'public');
 
         CREATE INDEX heap_and_clauses_idx ON heap_and_clauses_table
         USING bm25 (id, description)
@@ -53,7 +53,7 @@ fn mvcc_heap_filter(mut conn: PgConnection) {
 #[rstest]
 fn mvcc_snippet(mut conn: PgConnection) {
     r#"
-        CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'public');
+        CALL paradedb.create_paradedb_test_table(table_name => 'mock_items', schema_name => 'public');
         
         CREATE INDEX mock_items_idx ON mock_items
         USING bm25 (id, description)

--- a/tests/tests/hybrid.rs
+++ b/tests/tests/hybrid.rs
@@ -23,7 +23,7 @@ use tests::fixtures::*;
 #[rstest]
 fn hybrid_deprecated(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -31,7 +31,7 @@ fn fmt_err<T: std::error::Error>(err: T) -> String {
 
 #[rstest]
 fn invalid_create_index(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'public')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'public')"
         .execute(&mut conn);
 
     match r#"CREATE INDEX index_config_index ON index_config
@@ -48,7 +48,7 @@ fn invalid_create_index(mut conn: PgConnection) {
 
 #[rstest]
 fn prevent_duplicate(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -109,7 +109,7 @@ async fn drop_column(mut conn: PgConnection) {
 
 #[rstest]
 fn default_text_field(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -127,7 +127,7 @@ fn default_text_field(mut conn: PgConnection) {
 
 #[rstest]
 fn text_field_with_options(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -147,7 +147,7 @@ fn text_field_with_options(mut conn: PgConnection) {
 
 #[rstest]
 fn multiple_text_fields(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -172,7 +172,7 @@ fn multiple_text_fields(mut conn: PgConnection) {
 
 #[rstest]
 fn default_numeric_field(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -190,7 +190,7 @@ fn default_numeric_field(mut conn: PgConnection) {
 
 #[rstest]
 fn numeric_field_with_options(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -208,7 +208,7 @@ fn numeric_field_with_options(mut conn: PgConnection) {
 
 #[rstest]
 fn default_boolean_field(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -226,7 +226,7 @@ fn default_boolean_field(mut conn: PgConnection) {
 
 #[rstest]
 fn boolean_field_with_options(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -244,7 +244,7 @@ fn boolean_field_with_options(mut conn: PgConnection) {
 
 #[rstest]
 fn default_json_field(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -262,7 +262,7 @@ fn default_json_field(mut conn: PgConnection) {
 
 #[rstest]
 fn json_field_with_options(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -284,7 +284,7 @@ fn json_field_with_options(mut conn: PgConnection) {
 
 #[rstest]
 fn default_datetime_field(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -303,7 +303,7 @@ fn default_datetime_field(mut conn: PgConnection) {
 
 #[rstest]
 fn datetime_field_with_options(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -323,7 +323,7 @@ fn datetime_field_with_options(mut conn: PgConnection) {
 
 #[rstest]
 fn multiple_fields(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
@@ -357,7 +357,7 @@ fn missing_schema_index(mut conn: PgConnection) {
 
 #[rstest]
 fn null_values(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     "INSERT INTO paradedb.index_config (description, category, rating) VALUES ('Null Item 1', NULL, NULL), ('Null Item 2', NULL, 2)"
@@ -1136,7 +1136,7 @@ fn view_no_order_by_limit_pushdown(mut conn: PgConnection) {
 
 #[rstest]
 fn expression_with_options(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config

--- a/tests/tests/one_index.rs
+++ b/tests/tests/one_index.rs
@@ -22,7 +22,7 @@ use tests::fixtures::*;
 #[rstest]
 fn only_one_index_allowed(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     )

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -166,7 +166,7 @@ fn parallel_function_with_agg_subselect(mut conn: PgConnection) {
 #[rstest]
 fn test_issue2061(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     )

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -1135,7 +1135,7 @@ fn parse_with_field_conjunction(mut conn: PgConnection) {
 #[rstest]
 fn range_term(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'deliveries',
         table_type => 'Deliveries'

--- a/tests/tests/query_json.rs
+++ b/tests/tests/query_json.rs
@@ -1160,7 +1160,7 @@ fn match_query(mut conn: PgConnection) {
 #[rstest]
 fn range_term(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(
+    CALL paradedb.create_paradedb_test_table(
         schema_name => 'public',
         table_name => 'deliveries',
         table_type => 'Deliveries'

--- a/tests/tests/reindex.rs
+++ b/tests/tests/reindex.rs
@@ -160,7 +160,7 @@ async fn reindex_schema_validation(mut conn: PgConnection) -> Result<()> {
 #[rstest]
 #[async_std::test]
 async fn reindex_partial_index(mut conn: PgConnection) -> Result<()> {
-    "CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');"
         .execute(&mut conn);
 
     // Create a partial index

--- a/tests/tests/search_config.rs
+++ b/tests/tests/search_config.rs
@@ -236,7 +236,7 @@ fn with_limit_and_offset(mut conn: PgConnection) {
 
 #[rstest]
 fn default_tokenizer_config(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX tokenizer_config_idx ON paradedb.tokenizer_config
@@ -254,7 +254,7 @@ fn default_tokenizer_config(mut conn: PgConnection) {
 
 #[rstest]
 fn ngram_tokenizer_config(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX tokenizer_config_idx ON paradedb.tokenizer_config
@@ -274,7 +274,7 @@ fn ngram_tokenizer_config(mut conn: PgConnection) {
 
 #[rstest]
 fn chinese_compatible_tokenizer_config(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX tokenizer_config_idx ON paradedb.tokenizer_config
@@ -295,7 +295,7 @@ fn chinese_compatible_tokenizer_config(mut conn: PgConnection) {
 #[rstest]
 fn whitespace_tokenizer_config(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description)
@@ -312,7 +312,7 @@ fn whitespace_tokenizer_config(mut conn: PgConnection) {
 #[rstest]
 fn raw_tokenizer_config(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description)
@@ -341,7 +341,7 @@ fn raw_tokenizer_config(mut conn: PgConnection) {
 
 #[rstest]
 fn regex_tokenizer_config(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb')"
+    "CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb')"
         .execute(&mut conn);
 
     r#"CREATE INDEX bm25_search_idx ON paradedb.bm25_search
@@ -427,7 +427,7 @@ fn language_stem_filter(mut conn: PgConnection) {
 #[rstest]
 fn default_config_is_stored_false(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description)
@@ -445,7 +445,7 @@ fn default_config_is_stored_false(mut conn: PgConnection) {
 #[rstest]
 fn stopwords_language_tokenizer_config(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description)
@@ -469,7 +469,7 @@ fn stopwords_language_tokenizer_config(mut conn: PgConnection) {
 #[rstest]
 fn stopwords_tokenizer_config(mut conn: PgConnection) {
     r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description)

--- a/tests/tests/sorting.rs
+++ b/tests/tests/sorting.rs
@@ -25,7 +25,7 @@ fn field_sort_fixture(conn: &mut PgConnection) -> Value {
     // ensure our custom scan wins against our small test table
     r#"
         SET enable_indexscan TO off;
-        CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+        CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
         CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
@@ -164,7 +164,7 @@ fn sort_by_raw(mut conn: PgConnection) {
     // ensure our custom scan wins against our small test table
     r#"
         SET enable_indexscan TO off;
-        CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+        CALL paradedb.create_paradedb_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
         CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)


### PR DESCRIPTION
`paradedb.create_bm25_test_table` predates the access method rename to `paradedb` and is one of the last user-facing identifiers still carrying the old brand. Renames it to `create_paradedb_test_table` and drops the old name in the `0.25.1 → 0.25.2` migration; hard rename with no compatibility shim, and the `'bm25_test_table'` default `table_name` is untouched.