### PR TITLE
fix(tests): backport the db_error_message fixture to 0.25.x

### DIFF
--- a/tests/src/fixtures/mod.rs
+++ b/tests/src/fixtures/mod.rs
@@ -37,6 +37,23 @@ pub fn database() -> Db {
     block_on(async { Db::new().await })
 }
 
+/// Render a database error as just the message the server sent.
+///
+/// `sqlx::Error`'s `Display` is not a stable thing to assert on: from 0.9 it appends the
+/// Postgres source line that raised the error, so `err.to_string()` reads
+/// `...does not exist at line 248`. That line number is a position in *our* source and
+/// moves whenever the extension's code moves, which would make every assertion on an
+/// error message a tripwire. Assert on this instead.
+///
+/// On sqlx 0.8 this produces exactly what `Display` already produces; it exists here so
+/// tests written against `main` port back unchanged.
+pub fn db_error_message(err: &sqlx::Error) -> String {
+    match err.as_database_error() {
+        Some(db_err) => format!("error returned from database: {}", db_err.message()),
+        None => err.to_string(),
+    }
+}
+
 pub fn pg_major_version(conn: &mut PgConnection) -> usize {
     r#"select (regexp_match(version(), 'PostgreSQL (\d+)'))[1]::int;"#
         .fetch_one::<(i32,)>(conn)


### PR DESCRIPTION
# Description

`tests/tests/schema_grants.rs` came over in #5905 and calls `db_error_message`, but that helper was added on `main` by #5803, the sqlx 0.8 -> 0.9 upgrade, which was never backported. `0.25.x` is still on sqlx 0.8.6, so the tests crate does not compile:

```
error[E0425]: cannot find function `db_error_message` in this scope
  --> tests/tests/schema_grants.rs:62:13
```

That breaks the `Test pg_search on PostgreSQL *` jobs for every PR targeting `0.25.x`, #5907 included.

Add the helper, identical to main's. On sqlx 0.8 `as_database_error().message()` renders exactly what `Display` already renders, so behaviour on this branch is unchanged -- the point is keeping the branches aligned so test backports port across unmodified.

`cargo check -p tests --tests`, `cargo clippy -p tests --tests` and `cargo fmt --check` are all clean.

https://claude.ai/code/session_01JdMSrer4khcosMWVrpTosH