### PR TITLE
chore: picked up the df-d fix for the joinscan_concurrent flake.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-10-030937#fe1a153fc0c2d46002c6cc3dd8b51a3588b5b7f9"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-10-165331#aaf1a8129623ad7e1991173fe0fa5cb22a6d1656"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5730,7 +5730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-4uFOckvmexPeat1PaBh7dYNCcn4PBfT9Pq1bWjn+vbU=";
+  cargoHash = "sha256-6YH7gt8fGgZA4cPUE0FyKTvoXsKht2P8TSQxK9lXM1U=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -93,7 +93,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-10-030937", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-10-165331", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"


### PR DESCRIPTION
## Ticket(s) Closed

- None. Reported as flaky `joinscan_concurrent` runs in CI ([community](https://github.com/paradedb/paradedb/actions/runs/31221693830/job/93007528649), [enterprise](https://github.com/paradedb/paradedb-enterprise/actions/runs/31215016161/job/92986410089)).

## What

This PR picks up the `datafusion-distributed` fix for the `joinscan_concurrent` flake.

## Why

`joinscan_concurrent` fails intermittently with `transport receiver detached before this channel's EOF; the producer went away`. A worker inbox latches `detached` when its last data sender drops, and only peer workers count as data senders. Under the pull model a worker blocks on leader-origin frames (`ExecuteTask` requests, dispatched plans), so with two producers and small tables, the faster worker can finish the whole query and exit before the leader has requested work from the slower one. The clean exit failed the survivor's pending waits and the query.

paradedb/datafusion-distributed#73 fixes this at the transport layer: a data-sender detach now fails only the channels still awaiting their `Eof`; the control-plane registries and the receiver slot stay live. Root-cause analysis in paradedb/datafusion-distributed#70.

## How

Pin bump only. #73 is merged, so the branch pins `snapshot-main-2026-08-10-165331`, the first snapshot tag that includes it. Rebased on `main`, which was on `snapshot-main-2026-08-10-030937`.

An embedder-side alternative (parking finished workers until the leader's teardown signal, so their mesh senders outlive every peer's pending waits) also fixed the flake locally. Dropped in favor of the transport fix: one fix at the layer where the detach decision is made, and no extra go-flag state in the launch path.

## Tests

- `joinscan_concurrent` on PG 18: 20 consecutive local runs on the #73 head (`01eedad`), no failures.
- `mpp_cancel`, `aggregate_join`, and `aggregate_custom_scan` pass.
- The existing `joinscan_concurrent` suite in CI is the regression coverage here; the deterministic transport-level tests live in paradedb/datafusion-distributed#73.
