### PR TITLE
test: Add forward-progress liveness and an index-consistency check to the Antithesis stressgres workload

### DIFF
--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -228,10 +228,19 @@ pub(crate) fn tolerate_transient<T>(
     let mut backoff = INITIAL_RECONNECT_BACKOFF;
     let mut down_since: Option<Instant> = None;
     let mut last_grace: Option<Duration> = None;
+    let mut rode_out_fault = false;
     loop {
         let mut progress = TransientProgress::default();
         match op(&mut progress) {
-            Ok(value) => return Ok(Some(value)),
+            Ok(value) => {
+                dst::assert_reachable!("stressgres: completed a database operation");
+                if rode_out_fault {
+                    dst::assert_reachable!(
+                        "stressgres: made forward progress after riding out a transient database fault"
+                    );
+                }
+                return Ok(Some(value));
+            }
             Err(e) if !is_transient_error(&e) => return Err(e),
             Err(e) => {
                 let grace = grace.current();
@@ -274,6 +283,7 @@ pub(crate) fn tolerate_transient<T>(
                     )));
                 }
                 dst::assert_reachable!("stressgres retried a transient database fault");
+                rode_out_fault = true;
                 eprintln!("stressgres: transient database fault, retrying: {e:#}");
                 interruptible_sleep(alive, backoff);
                 backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);

--- a/stressgres/suites/antithesis/eventually_verify_index_consistency.sh
+++ b/stressgres/suites/antithesis/eventually_verify_index_consistency.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Antithesis "eventually" command: with the workload interrupted, every ParadeDB index must pass
+# pg_search's own integrity checks (pdb.verify_index). The retry loop only absorbs pg_search
+# background activity racing the checker (paradedb/paradedb#5913); real corruption fails every
+# attempt.
+
+set -Eeuo pipefail
+
+CONN="postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5"
+
+# EXECUTE keeps the pdb reference out of parse time: the vanilla-postgres timeline has no
+# pg_search extension, so the DO block must no-op there.
+SQL=$(cat <<'EOF'
+DO $$
+DECLARE
+    bad text;
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_extension WHERE extname = 'pg_search') THEN
+        RETURN;
+    END IF;
+    EXECUTE $q$
+        SELECT string_agg(v.check_name || COALESCE(': ' || v.details, ''), E'\n')
+          FROM (SELECT c.oid::regclass AS idx
+                  FROM pg_class c JOIN pg_am am ON am.oid = c.relam
+                 -- The AM is named paradedb; bm25 remains as a legacy alias, and indexes
+                 -- created USING bm25 carry that AM's oid, so match both.
+                 WHERE am.amname IN ('paradedb', 'bm25')) i,
+               LATERAL pdb.verify_index(i.idx) v
+         WHERE NOT v.passed
+    $q$ INTO bad;
+    IF bad IS NOT NULL THEN
+        RAISE EXCEPTION 'ParadeDB index consistency check failed: %', bad;
+    END IF;
+END
+$$;
+EOF
+)
+
+for attempt in $(seq 1 30); do
+  if output=$(psql "${CONN}" -X -qAt -v ON_ERROR_STOP=1 -c "${SQL}" 2>&1); then
+    exit 0
+  fi
+  echo "verify_index attempt ${attempt}/30: ${output}" >&2
+  sleep 2
+done
+
+echo "eventually_verify_index_consistency: ParadeDB indexes are still inconsistent" >&2
+exit 1


### PR DESCRIPTION
Add two oracles to the Antithesis stressgres workload.

The retry loop in `fault_tolerance.rs` now records two reachability properties: the workload completed a database operation, and the workload made forward progress after riding out a transient fault. These catch a workload that never completes an operation or never survives a fault.

A new Antithesis "eventually" command runs `pdb.verify_index` on every BM25 index while the workload is interrupted. A torn index that survives crash recovery is invisible at the connection level but fails this check. The command runs without concurrent writers, which avoids the spurious verify_index failures tracked in #5913; its retry loop only absorbs background activity that races the checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)