### PR TITLE
chore: Bump df-d rev to use version with correctness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-10-030937#fe1a153fc0c2d46002c6cc3dd8b51a3588b5b7f9"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-10-165331#aaf1a8129623ad7e1991173fe0fa5cb22a6d1656"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-4uFOckvmexPeat1PaBh7dYNCcn4PBfT9Pq1bWjn+vbU=";
+  cargoHash = "sha256-cngqrxJDNdlQ0+01t9ZfsqtsrwYo4zjLjSoBuh6IO5Q=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -93,7 +93,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-10-030937", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-10-165331", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"


### PR DESCRIPTION
## What
Bump the DatafusionDistributed rev. This rev includes plan-shape correctness fixes that we don't currently have.
