### PR TITLE
ci: Run Antithesis once a week on Tuesday nights

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -12,7 +12,7 @@ on:
   # (community) the job-level `if` below short-circuits the schedule trigger. The cron
   # entry stays here so the same workflow file can be synced between the two repos.
   schedule:
-    - cron: "0 2 * * 1,4" # At 02:00 UTC on Monday and Thursday (Sunday night and Wednesday night)
+    - cron: "0 2 * * 3" # At 02:00 UTC on Wednesday (Tuesday night)
   pull_request:
     types: [labeled]
   workflow_dispatch:


### PR DESCRIPTION
# Ticket(s) Closed

N/A

# What

Changes the Antithesis cron from `0 2 * * 1,4` to `0 2 * * 3`, i.e. from twice a week (Sunday and Wednesday nights) to once a week on Tuesday night.

# Why

Twice-weekly runs are more Antithesis compute than we need.

# How

Single cron edit in `.github/workflows/test-pg_search-antithesis.yml`. Scheduled runs only fire on `paradedb-enterprise`, so this needs syncing there to take effect.

https://claude.ai/code/session_017Q6cNtzGBcizGXVxpQ3trC