### PR TITLE
chore: put a space between `USING paradedb` and the column list

### DIFF
--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -102,7 +102,7 @@ For example, if `rating` and `created_at` are frequently used in filters, they c
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING paradedb(id, description, rating, created_at)
+USING paradedb (id, description, rating, created_at)
 WITH (key_field = 'id');
 ```
 
@@ -235,7 +235,7 @@ To push down the `category = 'Footwear'` filter, `category` must be indexed usin
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING paradedb(id, description, (category::pdb.literal))
+USING paradedb (id, description, (category::pdb.literal))
 WITH (key_field = 'id');
 ```
 

--- a/docs/legacy/full-text/filtering.mdx
+++ b/docs/legacy/full-text/filtering.mdx
@@ -28,7 +28,7 @@ For example, if `rating` and `created_at` are frequently used in filters, they c
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING paradedb(id, description, rating, created_at)
+USING paradedb (id, description, rating, created_at)
 WITH (key_field = 'id');
 ```
 
@@ -99,7 +99,7 @@ To push down the `category = 'Footwear'` filter, `category` must be indexed usin
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING paradedb(id, description, category)
+USING paradedb (id, description, category)
 WITH (key_field = 'id', text_fields = '{"category": {"tokenizer": {"type": "keyword"}}}');
 ```
 

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -1008,7 +1008,7 @@ mod tests {
         // global override
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
         Spi::run("INSERT INTO t (data) VALUES ('test');").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id', mutable_segment_rows = 500)").unwrap();
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id', mutable_segment_rows = 500)").unwrap();
         let relation_oid: pg_sys::Oid =
             Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
                 .expect("spi should succeed")

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -996,7 +996,7 @@ mod tests {
     unsafe fn test_list_meta_entries() {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
         Spi::run("INSERT INTO t (data) VALUES ('test');").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id')")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id')")
             .unwrap();
         let relation_oid: pg_sys::Oid =
             Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -81,7 +81,7 @@ mod tests {
     #[pg_test]
     unsafe fn test_segment_component_read_bytes() {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id')")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id')")
             .unwrap();
         let relation_oid: pg_sys::Oid =
             Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -664,7 +664,7 @@ mod tests {
             Spi::run("CREATE TABLE t_vec (id SERIAL, data TEXT, embedding vector(3));").unwrap();
             Spi::run("INSERT INTO t_vec (data, embedding) VALUES ('test', '[1,0,0]');").unwrap();
             Spi::run(
-                "CREATE INDEX t_vec_idx ON t_vec USING paradedb(id, data, embedding vector_l2_ops) WITH (key_field = 'id')",
+                "CREATE INDEX t_vec_idx ON t_vec USING paradedb (id, data, embedding vector_l2_ops) WITH (key_field = 'id')",
             )
             .unwrap();
             Spi::get_one::<pg_sys::Oid>(
@@ -676,7 +676,7 @@ mod tests {
             Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
             Spi::run("INSERT INTO t (data) VALUES ('test');").unwrap();
             Spi::run(
-                "CREATE INDEX t_idx ON t USING paradedb(id, (data::pdb.simple)) WITH (key_field = 'id')",
+                "CREATE INDEX t_idx ON t USING paradedb (id, (data::pdb.simple)) WITH (key_field = 'id')",
             )
             .unwrap();
             Spi::get_one::<pg_sys::Oid>(

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -226,7 +226,7 @@ mod tests {
         Spi::run("CREATE TABLE segment_component_drop_guard (id SERIAL PRIMARY KEY, body TEXT);")
             .unwrap();
         Spi::run(
-            "CREATE INDEX segment_component_drop_guard_idx ON segment_component_drop_guard USING paradedb(id, body) WITH (key_field = 'id');",
+            "CREATE INDEX segment_component_drop_guard_idx ON segment_component_drop_guard USING paradedb (id, body) WITH (key_field = 'id');",
         )
         .unwrap();
 
@@ -277,7 +277,7 @@ mod tests {
         Spi::run("DROP TABLE IF EXISTS scw_unwind_guard;").unwrap();
         Spi::run("CREATE TABLE scw_unwind_guard (id SERIAL PRIMARY KEY, body TEXT);").unwrap();
         Spi::run(
-            "CREATE INDEX scw_unwind_guard_idx ON scw_unwind_guard USING paradedb(id, body) WITH (key_field = 'id');",
+            "CREATE INDEX scw_unwind_guard_idx ON scw_unwind_guard USING paradedb (id, body) WITH (key_field = 'id');",
         )
         .unwrap();
 

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -697,7 +697,7 @@ mod tests {
         Spi::run("INSERT INTO t (data) VALUES ('test');").unwrap();
         Spi::run(
             format!(
-                "CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id'{})",
+                "CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id'{})",
                 layer_sizes.config_str()
             )
             .as_str(),

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -489,7 +489,7 @@ mod tests {
     #[pg_test]
     unsafe fn test_linked_bytes_read_write() {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id')")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id')")
             .unwrap();
         let relation_oid: pg_sys::Oid =
             Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
@@ -519,7 +519,7 @@ mod tests {
     #[pg_test]
     unsafe fn test_linked_bytes_is_empty() {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id')")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id')")
             .unwrap();
         let relation_oid: pg_sys::Oid =
             Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
@@ -540,7 +540,7 @@ mod tests {
     #[pg_test]
     unsafe fn test_linked_bytes_mark_deleted() {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id')")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id')")
             .unwrap();
         let relation_oid: pg_sys::Oid =
             Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -1047,7 +1047,7 @@ mod tests {
 
     fn init_bm25_index() -> pg_sys::Oid {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id')")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id')")
             .unwrap();
         Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
             .expect("spi should succeed")

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -373,7 +373,7 @@ mod tests {
         Spi::run("DROP TABLE IF EXISTS merge_list_pid_test CASCADE")?;
         Spi::run("CREATE TABLE merge_list_pid_test (id SERIAL, data TEXT)")?;
         Spi::run(
-            "CREATE INDEX merge_list_pid_test_idx ON merge_list_pid_test USING paradedb(id, data) WITH (key_field = 'id')",
+            "CREATE INDEX merge_list_pid_test_idx ON merge_list_pid_test USING paradedb (id, data) WITH (key_field = 'id')",
         )?;
 
         let index_oid =

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -410,7 +410,7 @@ mod tests {
     fn created_by_version_is_stamped_at_index_build() {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
         Spi::run("INSERT INTO t (data) VALUES ('hello');").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id');")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id');")
             .unwrap();
 
         let index_oid: pg_sys::Oid =
@@ -447,7 +447,7 @@ mod tests {
 
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
         Spi::run("INSERT INTO t (data) VALUES ('hello');").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING paradedb(id, data) WITH (key_field = 'id');")
+        Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id');")
             .unwrap();
 
         let after: TimestampWithTimeZone = Spi::get_one("SELECT clock_timestamp()")

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -38,7 +38,7 @@ mod tests {
         Spi::run("INSERT INTO t (data) SELECT 'test ' || i FROM generate_series(1, 100) i;")
             .unwrap();
         Spi::run(
-            "CREATE INDEX t_idx ON t USING paradedb(id, (data::pdb.simple)) WITH (key_field = 'id')",
+            "CREATE INDEX t_idx ON t USING paradedb (id, (data::pdb.simple)) WITH (key_field = 'id')",
         )
         .unwrap();
 
@@ -188,7 +188,7 @@ mod tests {
 
         Spi::run(
             "CREATE INDEX filter_test_idx ON filter_test
-             USING paradedb(id, price, quantity)
+             USING paradedb (id, price, quantity)
              WITH (
                  key_field = 'id',
                  numeric_fields = '{\"price\": {\"fast\": true}, \"quantity\": {\"fast\": true}}'

--- a/pg_search/tests/pg_regress/common/groupby_filter_setup.sql
+++ b/pg_search/tests/pg_regress/common/groupby_filter_setup.sql
@@ -47,7 +47,7 @@ INSERT INTO filter_agg_test (id, title, description, category, brand, status, pr
 
 -- Create BM25 index with fast fields for all aggregation scenarios
 CREATE INDEX filter_agg_idx ON filter_agg_test
-USING paradedb(id, title, description, category, brand, status, price, rating, in_stock, views)
+USING paradedb (id, title, description, category, brand, status, price, rating, in_stock, views)
 WITH (
     key_field='id',
     text_fields='{

--- a/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
+++ b/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
@@ -31,7 +31,7 @@ INSERT INTO groupby_conflict_test (title, category, rating, price, views) VALUES
 ('Product G2', 'clothing', 1, 299.99, 300);
 -- Create BM25 index with fast fields
 CREATE INDEX groupby_conflict_idx ON groupby_conflict_test 
-USING paradedb(id, title, category, rating, price, views)
+USING paradedb (id, title, category, rating, price, views)
 WITH (
     key_field='id',
     text_fields='{"title": {}, "category": {"fast": true}}',

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -618,8 +618,8 @@ CREATE TABLE comp_a (id SERIAL PRIMARY KEY, description TEXT, x INT, y INT);
 CREATE TABLE comp_b (id SERIAL PRIMARY KEY, name TEXT, x INT, y INT);
 INSERT INTO comp_a VALUES (1,'laptop fast',10,20),(2,'shoes nice',30,40),(3,'laptop pro',10,20);
 INSERT INTO comp_b VALUES (1,'B1',10,20),(2,'B2',30,40);
-CREATE INDEX idx_comp_a ON comp_a USING paradedb(id,description,x,y) WITH (key_field='id',text_fields='{"description":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
-CREATE INDEX idx_comp_b ON comp_b USING paradedb(id,name,x,y) WITH (key_field='id',text_fields='{"name":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
+CREATE INDEX idx_comp_a ON comp_a USING paradedb (id,description,x,y) WITH (key_field='id',text_fields='{"description":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
+CREATE INDEX idx_comp_b ON comp_b USING paradedb (id,name,x,y) WITH (key_field='id',text_fields='{"name":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
 -- Test 8.1: Composite ON with two equi-join keys — should use DataFusion
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*)

--- a/pg_search/tests/pg_regress/expected/columnar_edgecases_05_numeric_handling.out
+++ b/pg_search/tests/pg_regress/expected/columnar_edgecases_05_numeric_handling.out
@@ -34,7 +34,7 @@ FROM generate_series(1, 100) AS i;
 -- Create BM25 index with fast fields
 DROP INDEX IF EXISTS benchmark_data_idx CASCADE;
 CREATE INDEX benchmark_data_idx ON benchmark_data 
-USING paradedb(
+USING paradedb (
     id, 
     string_field1,
     string_field2,

--- a/pg_search/tests/pg_regress/expected/custom_scan_is_numeric_fast_field_capable.out
+++ b/pg_search/tests/pg_regress/expected/custom_scan_is_numeric_fast_field_capable.out
@@ -20,7 +20,7 @@ INSERT INTO test (message, severity) VALUES ('wine cheese a', 5);
 INSERT INTO test (message, severity) VALUES ('wine a', 6);
 INSERT INTO test (message, severity) VALUES ('cheese a', 7);
 -- INSERT INTO test (message) SELECT 'space fillter ' || x FROM generate_series(1, 10000000) x;
-CREATE INDEX idxtest ON test USING paradedb(id, message, severity) WITH (key_field = 'id');
+CREATE INDEX idxtest ON test USING paradedb (id, message, severity) WITH (key_field = 'id');
 CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS $$
 DECLARE
    current_txid bigint;

--- a/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
+++ b/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
@@ -48,7 +48,7 @@ INSERT INTO filter_agg_test (id, title, description, category, brand, status, pr
 (20, 'Golf Clubs', 'golf club set premium', 'sports', 'GolfPro', 'available', 899.99, 5, true, 100);
 -- Create BM25 index with fast fields for all aggregation scenarios
 CREATE INDEX filter_agg_idx ON filter_agg_test
-USING paradedb(id, title, description, category, brand, status, price, rating, in_stock, views)
+USING paradedb (id, title, description, category, brand, status, price, rating, in_stock, views)
 WITH (
     key_field='id',
     text_fields='{

--- a/pg_search/tests/pg_regress/expected/groupby_filter_mixed_buckets.out
+++ b/pg_search/tests/pg_regress/expected/groupby_filter_mixed_buckets.out
@@ -45,7 +45,7 @@ INSERT INTO filter_agg_test (id, title, description, category, brand, status, pr
 (20, 'Golf Clubs', 'golf club set premium', 'sports', 'GolfPro', 'available', 899.99, 5, true, 100);
 -- Create BM25 index with fast fields for all aggregation scenarios
 CREATE INDEX filter_agg_idx ON filter_agg_test
-USING paradedb(id, title, description, category, brand, status, price, rating, in_stock, views)
+USING paradedb (id, title, description, category, brand, status, price, rating, in_stock, views)
 WITH (
     key_field='id',
     text_fields='{

--- a/pg_search/tests/pg_regress/expected/issue_2844-rls.out
+++ b/pg_search/tests/pg_regress/expected/issue_2844-rls.out
@@ -178,7 +178,7 @@ CREATE POLICY contacts_team_isolation ON app.contacts
 -- Create a search index on the contacts table
 CREATE INDEX IF NOT EXISTS
     contacts_search_idx ON app.contacts
-    USING paradedb(id, org_id, search, created_at, assignee, tags)
+    USING paradedb (id, org_id, search, created_at, assignee, tags)
     WITH (
     key_field='id',
     text_fields='{

--- a/pg_search/tests/pg_regress/expected/issue_3998.out
+++ b/pg_search/tests/pg_regress/expected/issue_3998.out
@@ -13,7 +13,7 @@ INSERT INTO fieldnorms_test VALUES
 (2, ('this is a test ' || repeat('word ', 500))::pdb.simple);
 CREATE INDEX fieldnorms_test_idx
 ON fieldnorms_test
-USING paradedb(content)
+USING paradedb (content)
 WITH (key_field = 'id');
 SELECT
     id,

--- a/pg_search/tests/pg_regress/expected/layer_size_config.out
+++ b/pg_search/tests/pg_regress/expected/layer_size_config.out
@@ -7,7 +7,7 @@ SET paradedb.enable_columnar_exec = true;
 DROP TABLE IF EXISTS layer_sizes;
 CREATE TABLE layer_sizes (id serial8 not null primary key);
 -- 1 layer ✅
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '1kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
  layer_sizes 
 -------------
@@ -21,7 +21,7 @@ SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 (1 row)
 
 DROP INDEX idxlayer_sizes;
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '1kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
  layer_sizes 
 -------------
@@ -36,12 +36,12 @@ SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 
 DROP INDEX idxlayer_sizes;
 -- negative layer ❌
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '-1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '-1kb');
 ERROR:  a single layer size must be non-negative
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '-1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '-1kb');
 ERROR:  a single layer size must be non-negative
 -- zero layer ✅
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '0kb, 10kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '0kb, 10kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
  layer_sizes 
 -------------
@@ -55,7 +55,7 @@ SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 (1 row)
 
 DROP INDEX idxlayer_sizes;
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '0kb, 10kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '0kb, 10kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
  layer_sizes 
 -------------
@@ -70,12 +70,12 @@ SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 
 DROP INDEX idxlayer_sizes;
 -- malformed layer ❌
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '1kb, bob''s your uncle');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '1kb, bob''s your uncle');
 ERROR:  invalid size: " bob's your uncle"
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '1kb, bob''s your uncle');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '1kb, bob''s your uncle');
 ERROR:  invalid size: " bob's your uncle"
 -- multiple layers ✅
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '1kb, 10kb, 100MB');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '1kb, 10kb, 100MB');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
       layer_sizes       
 ------------------------
@@ -89,7 +89,7 @@ SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 (1 row)
 
 DROP INDEX idxlayer_sizes;
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '1kb, 10kb, 100MB');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '1kb, 10kb, 100MB');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
  layer_sizes 
 -------------

--- a/pg_search/tests/pg_regress/expected/mixed_fast_fields_bug.out
+++ b/pg_search/tests/pg_regress/expected/mixed_fast_fields_bug.out
@@ -35,7 +35,7 @@ FROM generate_series(1, 100) AS i;
 -- Create BM25 index with fast fields
 DROP INDEX IF EXISTS benchmark_data_idx CASCADE;
 CREATE INDEX benchmark_data_idx ON benchmark_data 
-USING paradedb(
+USING paradedb (
     id, 
     string_field1,
     string_field2,

--- a/pg_search/tests/pg_regress/expected/slop.out
+++ b/pg_search/tests/pg_regress/expected/slop.out
@@ -143,7 +143,7 @@ INSERT INTO content_segment_text (
 -- 文档8: 路径为 /docs/report (parent_id=101)
 ('doc8_001', 'user_1000', 1, 'text', 1000, 1000, 1000, 10008, '季度报告.docx', 5001, 1678003200000, 1678003200000, 2023, 202303, 20230305, 'docx', 18432, 101, '{100, 101}', 'document', 1, 1678003200000, 'office', '第一季度报告...');
 CREATE INDEX content_segment_text_bm25 ON content_segment_text 
-USING paradedb(id, routing_id, group_id, parent_id, ext_group,  filename, content) 
+USING paradedb (id, routing_id, group_id, parent_id, ext_group,  filename, content) 
 WITH (
     key_field = 'id',
     text_fields = '{

--- a/pg_search/tests/pg_regress/expected/string_id_limit.out
+++ b/pg_search/tests/pg_regress/expected/string_id_limit.out
@@ -13,7 +13,7 @@ CREATE TABLE comments (
 	text TEXT DEFAULT ''
 );
 -- add search index
-CREATE INDEX comments_search ON comments USING paradedb(
+CREATE INDEX comments_search ON comments USING paradedb (
 	id, customer_id, text
 )
 WITH (

--- a/pg_search/tests/pg_regress/expected/topk-agg-facet.out
+++ b/pg_search/tests/pg_regress/expected/topk-agg-facet.out
@@ -23,7 +23,7 @@ INSERT INTO products (name, description, category, brand, price, rating, in_stoc
     ('ASUS ROG', 'Gaming laptop with RTX graphics', 'Laptops', 'ASUS', 1899, 4.7, true, 90);
 -- Create BM25 index
 CREATE INDEX products_idx ON products
-USING paradedb(id, name, description, category, brand, price, rating, in_stock, sales)
+USING paradedb (id, name, description, category, brand, price, rating, in_stock, sales)
 WITH (
     key_field='id',
     text_fields='{
@@ -1732,7 +1732,7 @@ CREATE TABLE product_categories (
 INSERT INTO product_categories VALUES 
 ('Laptops', 'Portable computing devices', 1);
 CREATE INDEX product_categories_idx ON product_categories
-USING paradedb(name, description, priority)
+USING paradedb (name, description, priority)
 WITH (key_field='name');
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT 

--- a/pg_search/tests/pg_regress/sql/aggregate-groupby-conflict.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate-groupby-conflict.sql
@@ -35,7 +35,7 @@ INSERT INTO groupby_conflict_test (title, category, rating, price, views) VALUES
 
 -- Create BM25 index with fast fields
 CREATE INDEX groupby_conflict_idx ON groupby_conflict_test 
-USING paradedb(id, title, category, rating, price, views)
+USING paradedb (id, title, category, rating, price, views)
 WITH (
     key_field='id',
     text_fields='{"title": {}, "category": {"fast": true}}',

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -364,8 +364,8 @@ CREATE TABLE comp_a (id SERIAL PRIMARY KEY, description TEXT, x INT, y INT);
 CREATE TABLE comp_b (id SERIAL PRIMARY KEY, name TEXT, x INT, y INT);
 INSERT INTO comp_a VALUES (1,'laptop fast',10,20),(2,'shoes nice',30,40),(3,'laptop pro',10,20);
 INSERT INTO comp_b VALUES (1,'B1',10,20),(2,'B2',30,40);
-CREATE INDEX idx_comp_a ON comp_a USING paradedb(id,description,x,y) WITH (key_field='id',text_fields='{"description":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
-CREATE INDEX idx_comp_b ON comp_b USING paradedb(id,name,x,y) WITH (key_field='id',text_fields='{"name":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
+CREATE INDEX idx_comp_a ON comp_a USING paradedb (id,description,x,y) WITH (key_field='id',text_fields='{"description":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
+CREATE INDEX idx_comp_b ON comp_b USING paradedb (id,name,x,y) WITH (key_field='id',text_fields='{"name":{}}',numeric_fields='{"x":{"fast":true},"y":{"fast":true}}');
 
 -- Test 8.1: Composite ON with two equi-join keys — should use DataFusion
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/sql/columnar_edgecases_05_numeric_handling.sql
+++ b/pg_search/tests/pg_regress/sql/columnar_edgecases_05_numeric_handling.sql
@@ -39,7 +39,7 @@ FROM generate_series(1, 100) AS i;
 -- Create BM25 index with fast fields
 DROP INDEX IF EXISTS benchmark_data_idx CASCADE;
 CREATE INDEX benchmark_data_idx ON benchmark_data 
-USING paradedb(
+USING paradedb (
     id, 
     string_field1,
     string_field2,

--- a/pg_search/tests/pg_regress/sql/custom_scan_is_numeric_fast_field_capable.sql
+++ b/pg_search/tests/pg_regress/sql/custom_scan_is_numeric_fast_field_capable.sql
@@ -24,7 +24,7 @@ INSERT INTO test (message, severity) VALUES ('cheese a', 7);
 
 -- INSERT INTO test (message) SELECT 'space fillter ' || x FROM generate_series(1, 10000000) x;
 
-CREATE INDEX idxtest ON test USING paradedb(id, message, severity) WITH (key_field = 'id');
+CREATE INDEX idxtest ON test USING paradedb (id, message, severity) WITH (key_field = 'id');
 CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS $$
 DECLARE
    current_txid bigint;

--- a/pg_search/tests/pg_regress/sql/issue_2844-rls.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2844-rls.sql
@@ -199,7 +199,7 @@ CREATE POLICY contacts_team_isolation ON app.contacts
 
 CREATE INDEX IF NOT EXISTS
     contacts_search_idx ON app.contacts
-    USING paradedb(id, org_id, search, created_at, assignee, tags)
+    USING paradedb (id, org_id, search, created_at, assignee, tags)
     WITH (
     key_field='id',
     text_fields='{

--- a/pg_search/tests/pg_regress/sql/issue_3998.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3998.sql
@@ -12,7 +12,7 @@ INSERT INTO fieldnorms_test VALUES
 
 CREATE INDEX fieldnorms_test_idx
 ON fieldnorms_test
-USING paradedb(content)
+USING paradedb (content)
 WITH (key_field = 'id');
 
 SELECT

--- a/pg_search/tests/pg_regress/sql/layer_size_config.sql
+++ b/pg_search/tests/pg_regress/sql/layer_size_config.sql
@@ -4,42 +4,42 @@ DROP TABLE IF EXISTS layer_sizes;
 CREATE TABLE layer_sizes (id serial8 not null primary key);
 
 -- 1 layer ✅
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '1kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
 SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 DROP INDEX idxlayer_sizes;
 
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '1kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
 SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 DROP INDEX idxlayer_sizes;
 
 -- negative layer ❌
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '-1kb');
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '-1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '-1kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '-1kb');
 
 -- zero layer ✅
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '0kb, 10kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '0kb, 10kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
 SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 DROP INDEX idxlayer_sizes;
 
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '0kb, 10kb');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '0kb, 10kb');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
 SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 DROP INDEX idxlayer_sizes;
 
 -- malformed layer ❌
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '1kb, bob''s your uncle');
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '1kb, bob''s your uncle');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '1kb, bob''s your uncle');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '1kb, bob''s your uncle');
 
 -- multiple layers ✅
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', layer_sizes = '1kb, 10kb, 100MB');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', layer_sizes = '1kb, 10kb, 100MB');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
 SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 DROP INDEX idxlayer_sizes;
 
-CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb(id) WITH (key_field='id', background_layer_sizes = '1kb, 10kb, 100MB');
+CREATE INDEX idxlayer_sizes ON layer_sizes USING paradedb (id) WITH (key_field='id', background_layer_sizes = '1kb, 10kb, 100MB');
 SELECT * FROM paradedb.layer_sizes('idxlayer_sizes');
 SELECT * FROM paradedb.background_layer_sizes('idxlayer_sizes');
 DROP INDEX idxlayer_sizes;

--- a/pg_search/tests/pg_regress/sql/mixed_fast_fields_bug.sql
+++ b/pg_search/tests/pg_regress/sql/mixed_fast_fields_bug.sql
@@ -39,7 +39,7 @@ FROM generate_series(1, 100) AS i;
 -- Create BM25 index with fast fields
 DROP INDEX IF EXISTS benchmark_data_idx CASCADE;
 CREATE INDEX benchmark_data_idx ON benchmark_data 
-USING paradedb(
+USING paradedb (
     id, 
     string_field1,
     string_field2,

--- a/pg_search/tests/pg_regress/sql/slop.sql
+++ b/pg_search/tests/pg_regress/sql/slop.sql
@@ -90,7 +90,7 @@ INSERT INTO content_segment_text (
 ('doc8_001', 'user_1000', 1, 'text', 1000, 1000, 1000, 10008, '季度报告.docx', 5001, 1678003200000, 1678003200000, 2023, 202303, 20230305, 'docx', 18432, 101, '{100, 101}', 'document', 1, 1678003200000, 'office', '第一季度报告...');
 
 CREATE INDEX content_segment_text_bm25 ON content_segment_text 
-USING paradedb(id, routing_id, group_id, parent_id, ext_group,  filename, content) 
+USING paradedb (id, routing_id, group_id, parent_id, ext_group,  filename, content) 
 WITH (
     key_field = 'id',
     text_fields = '{

--- a/pg_search/tests/pg_regress/sql/string_id_limit.sql
+++ b/pg_search/tests/pg_regress/sql/string_id_limit.sql
@@ -9,7 +9,7 @@ CREATE TABLE comments (
 	text TEXT DEFAULT ''
 );
 -- add search index
-CREATE INDEX comments_search ON comments USING paradedb(
+CREATE INDEX comments_search ON comments USING paradedb (
 	id, customer_id, text
 )
 WITH (

--- a/pg_search/tests/pg_regress/sql/topk-agg-facet.sql
+++ b/pg_search/tests/pg_regress/sql/topk-agg-facet.sql
@@ -28,7 +28,7 @@ INSERT INTO products (name, description, category, brand, price, rating, in_stoc
 
 -- Create BM25 index
 CREATE INDEX products_idx ON products
-USING paradedb(id, name, description, category, brand, price, rating, in_stock, sales)
+USING paradedb (id, name, description, category, brand, price, rating, in_stock, sales)
 WITH (
     key_field='id',
     text_fields='{
@@ -929,7 +929,7 @@ INSERT INTO product_categories VALUES
 ('Laptops', 'Portable computing devices', 1);
 
 CREATE INDEX product_categories_idx ON product_categories
-USING paradedb(name, description, priority)
+USING paradedb (name, description, priority)
 WITH (key_field='name');
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)

--- a/stressgres/src/sqlscanner.rs
+++ b/stressgres/src/sqlscanner.rs
@@ -285,7 +285,7 @@ INSERT INTO test (message) VALUES ('cheese a');
 
 -- INSERT INTO test (message) SELECT 'space fillter ' || x FROM generate_series(1, 10000000) x;
 
-CREATE INDEX idxtest ON test USING paradedb(id, message) WITH (key_field = 'id');
+CREATE INDEX idxtest ON test USING paradedb (id, message) WITH (key_field = 'id');
 CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS $$
 DECLARE
     current_txid bigint;

--- a/stressgres/suites/background-merge.toml
+++ b/stressgres/suites/background-merge.toml
@@ -24,7 +24,7 @@ SELECT
     (random() * 4 + 1)::int
 FROM generate_series(1, 1000000) as id;
 
-CREATE INDEX idxtest ON test USING paradedb(id, message, severity) WITH (key_field = 'id', target_segment_count = 16, layer_sizes = '1kb', background_layer_sizes = '10kb, 100kb, 1mb, 10mb');
+CREATE INDEX idxtest ON test USING paradedb (id, message, severity) WITH (key_field = 'id', target_segment_count = 16, layer_sizes = '1kb', background_layer_sizes = '10kb, 100kb, 1mb, 10mb');
 CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool LANGUAGE plpgsql AS $$
 DECLARE
     current_txid bigint;

--- a/stressgres/suites/bulk-updates.toml
+++ b/stressgres/suites/bulk-updates.toml
@@ -31,7 +31,7 @@ BEGIN
    EXECUTE format('ALTER DATABASE %I SET paradedb.max_mergeable_segment_size = %L', dbname, '5MB');
 END $$;
 
-CREATE INDEX idxtest ON test USING paradedb(id, message, severity) WITH (key_field = 'id');
+CREATE INDEX idxtest ON test USING paradedb (id, message, severity) WITH (key_field = 'id');
 CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool LANGUAGE plpgsql AS $$
 DECLARE
     current_txid bigint;

--- a/stressgres/suites/logical-replication-merge.toml
+++ b/stressgres/suites/logical-replication-merge.toml
@@ -72,7 +72,7 @@ DROP SUBSCRIPTION IF EXISTS stressgres_sub;
 CREATE SUBSCRIPTION stressgres_sub CONNECTION '@Publisher_CONNSTR@' PUBLICATION stressgres_pub;
 SELECT pg_sleep(5);
 
-CREATE INDEX idxtest ON test USING paradedb(id, message) WITH (key_field = 'id', layer_sizes = '10kb, 100kb, 1mb, 100mb');
+CREATE INDEX idxtest ON test USING paradedb (id, message) WITH (key_field = 'id', layer_sizes = '10kb, 100kb, 1mb, 100mb');
 
 ALTER SYSTEM SET autovacuum_naptime TO '1s';
 SELECT pg_reload_conf();

--- a/stressgres/suites/logical-replication.toml
+++ b/stressgres/suites/logical-replication.toml
@@ -74,7 +74,7 @@ DROP SUBSCRIPTION IF EXISTS stressgres_sub;
 CREATE SUBSCRIPTION stressgres_sub CONNECTION '@Publisher_CONNSTR@' PUBLICATION stressgres_pub;
 SELECT pg_sleep(5);
 
-CREATE INDEX idxtest ON test USING paradedb(id, message) WITH (key_field = 'id', layer_sizes = '10kb, 100kb, 1mb, 100mb');
+CREATE INDEX idxtest ON test USING paradedb (id, message) WITH (key_field = 'id', layer_sizes = '10kb, 100kb, 1mb, 100mb');
 CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool LANGUAGE plpgsql AS $$
 DECLARE
     current_txid bigint;

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -28,7 +28,7 @@ INSERT INTO test (message) VALUES ('wine cheese a');
 INSERT INTO test (message) VALUES ('wine a');
 INSERT INTO test (message) VALUES ('cheese a');
 
-CREATE INDEX idxtest ON test USING paradedb(
+CREATE INDEX idxtest ON test USING paradedb (
     id,
     message,
     (category::pdb.literal)

--- a/tests/tests/copy.rs
+++ b/tests/tests/copy.rs
@@ -26,7 +26,7 @@ async fn test_copy_to_table(mut conn: PgConnection) {
     r#"
         DROP TABLE IF EXISTS test_copy_to_table;
         CREATE TABLE test_copy_to_table (id SERIAL PRIMARY KEY, name TEXT);
-        CREATE INDEX idx_test_copy_to_table ON test_copy_to_table USING paradedb(id, name) WITH (key_field = 'id');
+        CREATE INDEX idx_test_copy_to_table ON test_copy_to_table USING paradedb (id, name) WITH (key_field = 'id');
     "#.execute(&mut conn);
 
     let mut copyin = conn

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -616,7 +616,7 @@ fn top_k_matches(mut conn: PgConnection) {
 
         -- INSERT INTO test (message) SELECT 'space fillter ' || x FROM generate_series(1, 10000000) x;
 
-        CREATE INDEX idxtest ON test USING paradedb(id, message, severity) WITH (key_field = 'id');
+        CREATE INDEX idxtest ON test USING paradedb (id, message, severity) WITH (key_field = 'id');
         CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS $$
         DECLARE
             current_txid bigint;
@@ -772,7 +772,7 @@ fn parallel_custom_scan_with_jsonb_issue2432(mut conn: PgConnection) {
             severity INTEGER
         ) WITH (autovacuum_enabled = false);
 
-        CREATE INDEX idxtest ON test USING paradedb(id, message, severity) WITH (key_field = 'id', layer_sizes = '1GB, 1GB', mutable_segment_rows=1);
+        CREATE INDEX idxtest ON test USING paradedb (id, message, severity) WITH (key_field = 'id', layer_sizes = '1GB, 1GB', mutable_segment_rows=1);
 
         INSERT INTO test (message, severity) VALUES ('beer wine cheese a', 1);
         INSERT INTO test (message, severity) VALUES ('beer wine a', 2);
@@ -1150,7 +1150,7 @@ fn uses_max_parallel_workers_per_gather_issue2515(mut conn: PgConnection) {
 
     CREATE TABLE t (id bigint);
     INSERT INTO t (id) SELECT x FROM generate_series(1, 1000000) x;
-    CREATE INDEX t_idx ON t USING paradedb(id) WITH (key_field='id');
+    CREATE INDEX t_idx ON t USING paradedb (id) WITH (key_field='id');
     "#
     .execute(&mut conn);
 

--- a/tests/tests/executor_hooks.rs
+++ b/tests/tests/executor_hooks.rs
@@ -25,9 +25,9 @@ fn multiple_index_changes_in_same_xact(mut conn: PgConnection) {
         CREATE TABLE a (id int, value text);
         CREATE TABLE b (id int, value text);
         CREATE TABLE c (id int, value text);
-        CREATE INDEX idxa ON a USING paradedb(id, value) WITH (key_field='id');
-        CREATE INDEX idxb ON b USING paradedb(id, value) WITH (key_field='id');
-        CREATE INDEX idxc ON c USING paradedb(id, value) WITH (key_field='id');
+        CREATE INDEX idxa ON a USING paradedb (id, value) WITH (key_field='id');
+        CREATE INDEX idxb ON b USING paradedb (id, value) WITH (key_field='id');
+        CREATE INDEX idxc ON c USING paradedb (id, value) WITH (key_field='id');
         INSERT INTO a (id, value) VALUES (1, 'a');
         INSERT INTO b (id, value) VALUES (1, 'b');
         INSERT INTO c (id, value) VALUES (1, 'c');


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Stacked on #5916. That rename left 81 spots where the parenthesis sits flush against the access method name — `USING paradedb(id, ...)`. This adds the space: `USING paradedb (id, ...)`.

47 files:

- `pg_search/tests/pg_regress/` — 11 `sql/`+`expected/` pairs, plus `common/groupby_filter_setup.sql` and the two `expected/` files that echo it
- `pg_search/src/` — `#[pg_test]` SPI setup in `gucs.rs`, `scan/tests.rs`, `index/{directory,reader,writer}/*`, `postgres/{merge,storage/*}.rs`
- `tests/tests/{copy,custom_scan,executor_hooks}.rs`
- `stressgres/suites/*.toml` (5 suites) and `stressgres/src/sqlscanner.rs`
- `docs/documentation/filtering.mdx`, `docs/legacy/full-text/filtering.mdx`

No `USING bm25(` remains in the repo, so nothing was left half-fixed.

## Why

Every other `USING paradedb` in the repo (2284 of them) already has the space, and it's how Postgres renders a normalized index definition back to you. The flush-paren spots were incidental, not deliberate.

## How

Mechanical rewrite of `USING\s+paradedb\(` → `USING paradedb (`, case-insensitive. Only `USING paradedb(` matched — the `ParadeDB(...)` query-builder calls in the Python docs are untouched.

## Tests

Not run locally. `cargo fmt --all -- --check` is clean — no line crossed 100 cols from the extra character. The pg_regress `expected/` files were rewritten by the same pass rather than regenerated, so CI is the check; `sql/` and `expected/` occurrence counts were verified to match per test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqune2xSmNMFkDj3dyvkDn)_