### PR TITLE
fix: unbreak benchmarks after the `paradedb` AM rename, and harden upgrade/docker CI

### DIFF
--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -71,8 +71,9 @@ runs:
       working-directory: pg_search/
       shell: bash
       run: |
-        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c 'CREATE EXTENSION IF NOT EXISTS vector;'
-        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c 'CREATE EXTENSION pg_search;'
+        set -euo pipefail
+        psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} postgres -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+        psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} postgres -c 'CREATE EXTENSION pg_search;'
 
     - name: Create Upgrade Test Databases
       working-directory: pg_search/
@@ -147,12 +148,12 @@ runs:
         set -euo pipefail
         VERSION=$(grep "^version" ../Cargo.toml | head -1 | awk -F '"' '{print $2}')
         psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} postgres -c "CREATE EXTENSION IF NOT EXISTS vector;"
-        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
+        psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} postgres -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
         for case_dir in "$UPGRADE_SQL_DIR"/*; do
           db="$(basename "$case_dir")"
           echo "Creating database $db"
           psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} "$db" -c "CREATE EXTENSION IF NOT EXISTS vector;"
-          psql -h localhost -p 288${{ inputs.pg_version }} "$db" -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
+          psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} "$db" -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
         done
 
     # An `ALTER EXTENSION ... UPDATE` must leave the schema identical to a fresh

--- a/.github/actions/test-pg_search-upgrade/codecs/setup.sql
+++ b/.github/actions/test-pg_search-upgrade/codecs/setup.sql
@@ -1,3 +1,10 @@
+-- NOTE: this file runs against the PRIOR extension version, not the one being built.
+-- The `Preserve SQL Files` step copies these fixtures out of the PR head into a
+-- tmpdir, then checks out an older tag and installs that version, so everything here
+-- must be valid SQL for the oldest tag in the upgrade matrix. That is why the index
+-- below says `using bm25` rather than `using paradedb`: the `paradedb` access method
+-- only exists from 0.25.0 onward. Do not sweep this into current naming.
+
 create table items (
     id bigserial,
     number bigint

--- a/.github/actions/test-pg_search-upgrade/kitchen_sink/setup.sql
+++ b/.github/actions/test-pg_search-upgrade/kitchen_sink/setup.sql
@@ -1,3 +1,11 @@
+-- NOTE: this file runs against the PRIOR extension version, not the one being built.
+-- The `Preserve SQL Files` step copies these fixtures out of the PR head into a
+-- tmpdir, then checks out an older tag and installs that version, so everything here
+-- must be valid SQL for the oldest tag in the upgrade matrix. That is why the index
+-- below says `using bm25` rather than `using paradedb` (the `paradedb` access method
+-- only exists from 0.25.0 onward), and why `paradedb.create_bm25_test_table` keeps its
+-- pre-rename name. Do not sweep these into current naming.
+
 CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');
 
 ALTER TABLE mock_items

--- a/.github/actions/test-pg_search-upgrade/numeric/setup.sql
+++ b/.github/actions/test-pg_search-upgrade/numeric/setup.sql
@@ -1,3 +1,10 @@
+-- NOTE: this file runs against the PRIOR extension version, not the one being built.
+-- The `Preserve SQL Files` step copies these fixtures out of the PR head into a
+-- tmpdir, then checks out an older tag and installs that version, so everything here
+-- must be valid SQL for the oldest tag in the upgrade matrix. That is why the index
+-- below says `using bm25` rather than `using paradedb`: the `paradedb` access method
+-- only exists from 0.25.0 onward. Do not sweep this into current naming.
+
 create table items (
     id bigserial,
     numeric64 numeric(15, 9),

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -186,10 +186,15 @@ jobs:
       - name: Verify PostgreSQL accepts queries and extensions are available
         if: steps.release_gate.outputs.skip != 'true'
         run: |
-          docker exec paradedb psql -U myuser -d mydatabase -c "SELECT 1;"
-          docker exec paradedb psql -U myuser -d mydatabase -c "CREATE EXTENSION IF NOT EXISTS vector;"
-          docker exec paradedb psql -U myuser -d mydatabase -c "CREATE EXTENSION IF NOT EXISTS pg_search;"
-          docker exec paradedb psql -U myuser -d mydatabase -c "SELECT extname, extversion FROM pg_extension ORDER BY extname;"
+          set -euo pipefail
+          # `-v ON_ERROR_STOP=1` is what makes this step an actual gate: psql exits 0
+          # on a SQL error in `-c`, so without it a failed `CREATE EXTENSION` would
+          # print the error and still pass. The log scan above runs before these
+          # commands, so it does not cover them either.
+          docker exec paradedb psql -v ON_ERROR_STOP=1 -U myuser -d mydatabase -c "SELECT 1;"
+          docker exec paradedb psql -v ON_ERROR_STOP=1 -U myuser -d mydatabase -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          docker exec paradedb psql -v ON_ERROR_STOP=1 -U myuser -d mydatabase -c "CREATE EXTENSION IF NOT EXISTS pg_search;"
+          docker exec paradedb psql -v ON_ERROR_STOP=1 -U myuser -d mydatabase -c "SELECT extname, extversion FROM pg_extension ORDER BY extname;"
 
       - name: Verify barman-cloud is functional
         if: steps.release_gate.outputs.skip != 'true' && matrix.flavor == 'paradedb'

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -187,10 +187,6 @@ jobs:
         if: steps.release_gate.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          # `-v ON_ERROR_STOP=1` is what makes this step an actual gate: psql exits 0
-          # on a SQL error in `-c`, so without it a failed `CREATE EXTENSION` would
-          # print the error and still pass. The log scan above runs before these
-          # commands, so it does not cover them either.
           docker exec paradedb psql -v ON_ERROR_STOP=1 -U myuser -d mydatabase -c "SELECT 1;"
           docker exec paradedb psql -v ON_ERROR_STOP=1 -U myuser -d mydatabase -c "CREATE EXTENSION IF NOT EXISTS vector;"
           docker exec paradedb psql -v ON_ERROR_STOP=1 -U myuser -d mydatabase -c "CREATE EXTENSION IF NOT EXISTS pg_search;"

--- a/benchmarks/datasets/cohere/indexes/pg_search.sql
+++ b/benchmarks/datasets/cohere/indexes/pg_search.sql
@@ -1,5 +1,14 @@
+-- Deliberately `USING bm25`, not `USING paradedb`. This SQL is executed against a
+-- cluster restored from a pgBackRest heap snapshot (the `restore-heap` steps in
+-- .github/workflows/benchmark-pg_search-queries.yml), which replaces the entire
+-- data directory. The restored catalog therefore carries whatever pg_search
+-- version the snapshot was captured with, not the version built from the branch,
+-- and the `paradedb` access method only exists from 0.25.0 onward. `bm25` is the
+-- permanent backwards-compatible alias and resolves on every version, so it is
+-- the only name that is safe here until the snapshots are regenerated.
+
 CREATE INDEX cohere_wiki_bm25_idx ON cohere_wiki
-USING paradedb (
+USING bm25 (
     _id,
     (text::pdb.unicode_words('stemmer=english', 'stopwords_language=english')),
     emb vector_cosine_ops

--- a/benchmarks/datasets/stackoverflow/indexes/bm25.sql
+++ b/benchmarks/datasets/stackoverflow/indexes/bm25.sql
@@ -1,5 +1,14 @@
+-- Deliberately `USING bm25`, not `USING paradedb`. This SQL is executed against a
+-- cluster restored from a pgBackRest heap snapshot (the `restore-heap` steps in
+-- .github/workflows/benchmark-pg_search-queries.yml), which replaces the entire
+-- data directory. The restored catalog therefore carries whatever pg_search
+-- version the snapshot was captured with, not the version built from the branch,
+-- and the `paradedb` access method only exists from 0.25.0 onward. `bm25` is the
+-- permanent backwards-compatible alias and resolves on every version, so it is
+-- the only name that is safe here until the snapshots are regenerated.
+
 CREATE INDEX stackoverflow_posts_idx ON stackoverflow_posts
-USING paradedb (
+USING bm25 (
     id,
     (title::pdb.unicode_words('columnar=true')),
     (body::pdb.unicode_words('columnar=true')),
@@ -17,7 +26,7 @@ USING paradedb (
 );
 
 CREATE INDEX badges_idx ON badges
-USING paradedb (
+USING bm25 (
     id,
     (name::pdb.unicode_words('columnar=true')),
     date,
@@ -29,7 +38,7 @@ USING paradedb (
  );
 
 CREATE INDEX comments_idx ON comments
-USING paradedb (
+USING bm25 (
     id,
     post_id,
     score,
@@ -41,7 +50,7 @@ USING paradedb (
 );
 
 CREATE INDEX users_idx ON users
-USING paradedb (
+USING bm25 (
     id,
     (about_me::pdb.unicode_words('columnar=true')),
     (display_name::pdb.unicode_words('columnar=true')),

--- a/pg_search/tests/pg_regress/expected/mpp_range_boundary.out
+++ b/pg_search/tests/pg_regress/expected/mpp_range_boundary.out
@@ -20,11 +20,11 @@ SET paradedb.mpp_queue_size = '64kB';
 CREATE TABLE rb_users    (id bigserial PRIMARY KEY, display_name text, reputation int, about_me text);
 CREATE TABLE rb_posts    (id bigserial PRIMARY KEY, owner_user_id bigint, title text, body text);
 CREATE TABLE rb_comments (id bigserial PRIMARY KEY, post_id bigint, text text, score int);
-CREATE INDEX rb_users_idx ON rb_users USING bm25 (id, display_name, reputation)
+CREATE INDEX rb_users_idx ON rb_users USING paradedb (id, display_name, reputation)
 WITH (key_field='id', partition_by='id', text_fields='{"display_name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"reputation":{"fast":true}}');
-CREATE INDEX rb_posts_idx ON rb_posts USING bm25 (id, owner_user_id, title)
+CREATE INDEX rb_posts_idx ON rb_posts USING paradedb (id, owner_user_id, title)
 WITH (key_field='id', partition_by='id,owner_user_id', text_fields='{"title":{"fast":true}}', numeric_fields='{"owner_user_id":{"fast":true}}');
-CREATE INDEX rb_comments_idx ON rb_comments USING bm25 (id, post_id, text, score)
+CREATE INDEX rb_comments_idx ON rb_comments USING paradedb (id, post_id, text, score)
 WITH (key_field='id', partition_by='post_id', text_fields='{"text":{"fast":true}}', numeric_fields='{"post_id":{"fast":true},"score":{"fast":true}}');
 -- Eight segments per index, kilobyte-scale payloads so batches dwarf the ring.
 SET paradedb.global_mutable_segment_rows = 0;

--- a/pg_search/tests/pg_regress/sql/mpp_range_boundary.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_range_boundary.sql
@@ -24,11 +24,11 @@ CREATE TABLE rb_users    (id bigserial PRIMARY KEY, display_name text, reputatio
 CREATE TABLE rb_posts    (id bigserial PRIMARY KEY, owner_user_id bigint, title text, body text);
 CREATE TABLE rb_comments (id bigserial PRIMARY KEY, post_id bigint, text text, score int);
 
-CREATE INDEX rb_users_idx ON rb_users USING bm25 (id, display_name, reputation)
+CREATE INDEX rb_users_idx ON rb_users USING paradedb (id, display_name, reputation)
 WITH (key_field='id', partition_by='id', text_fields='{"display_name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"reputation":{"fast":true}}');
-CREATE INDEX rb_posts_idx ON rb_posts USING bm25 (id, owner_user_id, title)
+CREATE INDEX rb_posts_idx ON rb_posts USING paradedb (id, owner_user_id, title)
 WITH (key_field='id', partition_by='id,owner_user_id', text_fields='{"title":{"fast":true}}', numeric_fields='{"owner_user_id":{"fast":true}}');
-CREATE INDEX rb_comments_idx ON rb_comments USING bm25 (id, post_id, text, score)
+CREATE INDEX rb_comments_idx ON rb_comments USING paradedb (id, post_id, text, score)
 WITH (key_field='id', partition_by='post_id', text_fields='{"text":{"fast":true}}', numeric_fields='{"post_id":{"fast":true},"score":{"fast":true}}');
 
 -- Eight segments per index, kilobyte-scale payloads so batches dwarf the ring.

--- a/tests/tests/mpp_error_masking.rs
+++ b/tests/tests/mpp_error_masking.rs
@@ -25,9 +25,9 @@ CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 
 CREATE TABLE mem_a (id bigint PRIMARY KEY, state text);
 CREATE TABLE mem_b (id bigint PRIMARY KEY, aid bigint, u text);
-CREATE INDEX mem_a_idx ON mem_a USING bm25 (id, state)
+CREATE INDEX mem_a_idx ON mem_a USING paradedb (id, state)
   WITH (key_field = 'id', target_segment_count = '3', mutable_segment_rows = '0');
-CREATE INDEX mem_b_idx ON mem_b USING bm25 (id, aid, u)
+CREATE INDEX mem_b_idx ON mem_b USING paradedb (id, aid, u)
   WITH (key_field = 'id', target_segment_count = '3');
 
 INSERT INTO mem_a SELECT g, 'active' FROM generate_series(1, 50000) g;

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -721,7 +721,7 @@ fn parallel_with_initplan_param_in_heap_filter(mut conn: PgConnection) {
     SELECT (g % 200) + 1, 'Page text for page ' || g, (g * 17) % 4096
     FROM generate_series(1, 1000) AS g;
 
-    CREATE INDEX bsp_files_idx ON bsp_files USING bm25 (id, title, content)
+    CREATE INDEX bsp_files_idx ON bsp_files USING paradedb (id, title, content)
     WITH (key_field = 'id', text_fields = '{"title": {"fast": true}, "content": {}}');
 
     ANALYZE bsp_files;


### PR DESCRIPTION
Fixes some broken benchmarks following the rename to the `paradedb` AM