### PR TITLE
chore: Add range co-partitioned join benchmarks

### DIFF
--- a/benchmarks/datasets/stackoverflow/indexes/bm25.sql
+++ b/benchmarks/datasets/stackoverflow/indexes/bm25.sql
@@ -22,7 +22,9 @@ USING bm25 (
     (owner_display_name::pdb.unicode_words('columnar=true')),
     owner_user_id
 ) WITH (
-    key_field = 'id'
+    key_field = 'id',
+    -- Join keys: comments.post_id = id, users.id = owner_user_id.
+    partition_by = 'id,owner_user_id'
 );
 
 CREATE INDEX badges_idx ON badges
@@ -46,7 +48,8 @@ USING bm25 (
     creation_date,
     (user_display_name::pdb.literal)
 ) WITH (
-    key_field = 'id'
+    key_field = 'id',
+    partition_by = 'post_id'
 );
 
 CREATE INDEX users_idx ON users
@@ -56,5 +59,6 @@ USING bm25 (
     (display_name::pdb.unicode_words('columnar=true')),
     reputation
 ) WITH (
-    key_field = 'id'
+    key_field = 'id',
+    partition_by = 'id'
 );

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_count.sql
@@ -18,3 +18,10 @@ SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT C
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';
+
+-- DataFusion aggregate scan with range partitioned join
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT COUNT(*)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE p.body ||| 'code';
+

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_date_histogram.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_date_histogram.sql
@@ -32,3 +32,16 @@ GROUP BY
     month
 ORDER BY
     month ASC;
+
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+    date_trunc('month', p.creation_date) AS month,
+    COUNT(*)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'
+GROUP BY
+    month
+ORDER BY
+    month ASC;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
@@ -22,3 +22,12 @@ JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code'
 GROUP BY p.post_type_id
 ORDER BY SUM(c.score) DESC;
+
+-- DataFusion aggregate scan with range partitioned join
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT p.post_type_id, COUNT(*), SUM(c.score)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE p.body ||| 'code'
+GROUP BY p.post_type_id
+ORDER BY SUM(c.score) DESC;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_multi.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_multi.sql
@@ -18,3 +18,10 @@ SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT C
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';
+
+-- DataFusion aggregate scan with range partitioned join
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT COUNT(*), MIN(c.score), MAX(c.score)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE p.body ||| 'code';
+

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_sort.sql
@@ -32,3 +32,18 @@ GROUP BY
 ORDER BY
     last_activity DESC            -- Single Feature Sort (Computed Aggregate)
 LIMIT 10;
+
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+    p.id,
+    p.title,
+    MAX(c.creation_date) as last_activity
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'             -- Search Term
+GROUP BY
+    p.id, p.title
+ORDER BY
+    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
+LIMIT 10;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
@@ -37,3 +37,18 @@ GROUP BY
 ORDER BY
     COUNT(*) DESC
 LIMIT 10;
+
+-- DataFusion TopK aggregate scan with range partitioned join
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+    p.owner_display_name,
+    COUNT(*)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'
+GROUP BY
+    p.owner_display_name
+ORDER BY
+    COUNT(*) DESC
+LIMIT 10;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_window_facet.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_window_facet.sql
@@ -37,3 +37,18 @@ WHERE
 ORDER BY
     c.score DESC
 LIMIT 10;
+
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+    c.id,
+    p.post_type_id,
+    p.owner_user_id,
+    COUNT(*) OVER (PARTITION BY p.post_type_id) as post_type_facet,
+    COUNT(*) OVER (PARTITION BY p.owner_user_id) as user_facet
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'
+ORDER BY
+    c.score DESC
+LIMIT 10;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_distinct_parent_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_distinct_parent_sort.sql
@@ -35,3 +35,19 @@ WHERE
 ORDER BY
     u.display_name ASC              -- Single Feature Sort (Parent Field)
 LIMIT 50;
+
+SET work_mem TO '8GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT DISTINCT
+    u.id,
+    u.display_name,
+    u.about_me
+FROM users u
+JOIN stackoverflow_posts p ON u.id = p.owner_user_id
+JOIN comments c ON p.id = c.post_id
+WHERE
+    c.score > 0                     -- Filter on the "Many" side
+    AND u.id @@@ pdb.all()
+    AND u.reputation > 100
+ORDER BY
+    u.display_name ASC              -- Single Feature Sort (Parent Field)
+LIMIT 50;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_foreign_filter_local_sort.sql
@@ -37,3 +37,20 @@ WHERE
 ORDER BY
     p.creation_date DESC              -- Single Feature Sort (Local Fast Field)
 LIMIT 20;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+    p.id,
+    p.title,
+    p.creation_date,
+    u.display_name as user_display_name,
+    u.about_me as user_about_me
+FROM stackoverflow_posts p
+JOIN users u ON p.owner_user_id = u.id
+WHERE
+    u.id @@@ pdb.all()
+    AND u.reputation > 100
+    AND p.title ||| 'error'
+ORDER BY
+    p.creation_date DESC              -- Single Feature Sort (Local Fast Field)
+LIMIT 20;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-large.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-large.sql
@@ -20,3 +20,12 @@ FROM
 WHERE
   users.id @@@ pdb.all() AND users.reputation > 100 AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
 LIMIT 5;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+  *
+FROM
+  users JOIN stackoverflow_posts ON users.id = stackoverflow_posts.owner_user_id JOIN comments ON comments.post_id = stackoverflow_posts.id
+WHERE
+  users.id @@@ pdb.all() AND users.reputation > 100 AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
+LIMIT 5;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-small.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-small.sql
@@ -24,3 +24,14 @@ FROM
 WHERE
   users.id @@@ pdb.all() AND users.reputation > 100 AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
 LIMIT 5;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+  users.id,
+  stackoverflow_posts.id,
+  comments.id
+FROM
+  users JOIN stackoverflow_posts ON users.id = stackoverflow_posts.owner_user_id JOIN comments ON comments.post_id = stackoverflow_posts.id
+WHERE
+  users.id @@@ pdb.all() AND users.reputation > 100 AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
+LIMIT 5;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-large.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-large.sql
@@ -60,3 +60,15 @@ WHERE
   users.about_me ||| 'java' AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
 ORDER BY pdb_score DESC
 LIMIT 1000;
+
+-- Directly, without a CTE.
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+  *,
+  pdb.score(users.id) + pdb.score(stackoverflow_posts.id) + pdb.score(comments.id) AS pdb_score
+FROM
+  users JOIN stackoverflow_posts ON users.id = stackoverflow_posts.owner_user_id JOIN comments ON comments.post_id = stackoverflow_posts.id
+WHERE
+  users.about_me ||| 'java' AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
+ORDER BY pdb_score DESC
+LIMIT 1000;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-small.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-small.sql
@@ -28,3 +28,16 @@ WHERE
   users.id @@@ pdb.all() AND users.reputation > 100 AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
 ORDER BY pdb_score DESC
 LIMIT 1000;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+  users.id,
+  stackoverflow_posts.id,
+  comments.id,
+  pdb.score(users.id) + pdb.score(stackoverflow_posts.id) + pdb.score(comments.id) AS pdb_score
+FROM
+  users JOIN stackoverflow_posts ON users.id = stackoverflow_posts.owner_user_id JOIN comments ON comments.post_id = stackoverflow_posts.id
+WHERE
+  users.id @@@ pdb.all() AND users.reputation > 100 AND stackoverflow_posts.title ||| 'error' AND comments.text ||| 'question'
+ORDER BY pdb_score DESC
+LIMIT 1000;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_permissioned_search.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_permissioned_search.sql
@@ -33,3 +33,18 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
+    p.id,
+    p.title,
+    pdb.score(p.id) as relevance
+FROM stackoverflow_posts p
+JOIN users u ON p.owner_user_id = u.id
+WHERE
+    p.title ||| 'how using get create'  -- Driving the Sort (Single Feature)
+    AND u.id @@@ pdb.all()
+    AND u.reputation > 100
+ORDER BY
+    relevance DESC
+LIMIT 10;
+

--- a/benchmarks/datasets/stackoverflow/queries/join_semi_filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_semi_filter.sql
@@ -7,10 +7,6 @@
 -- - 'David John Alex' selectivity on users.display_name: ~2%
 -- - combined selectivity on users (about_me ||| 'java' AND display_name ||| 'David John Alex'): <1%
 
--- TODO: the two "Sortedness enabled" blocks now run the same SQL as their "Sortedness disabled"
--- twins, since the sort toggle that separated them is gone. Drop them on the next pass that can
--- reset the benchmark baseline (removing alternatives renumbers the stored history).
-
 SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
     p.id,
     p.title,
@@ -44,8 +40,8 @@ ORDER BY
     p.title ASC
 LIMIT 25;
 
--- Sortedness enabled, no join scan.
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
+-- Range-partitioned join scan.
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT
     p.id,
     p.title,
     p.creation_date
@@ -71,23 +67,6 @@ WHERE
     p.owner_user_id @@@ pdb.term_set((
         SELECT array_agg(id) FROM users WHERE about_me ||| 'java' AND display_name ||| 'David John Alex'
     ))
-ORDER BY
-    p.title ASC
-LIMIT 25;
-
--- Sortedness enabled, with join scan.
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT
-    p.id,
-    p.title,
-    p.creation_date
-FROM stackoverflow_posts p
-WHERE
-    p.owner_user_id IN (
-        SELECT id
-        FROM users
-        WHERE about_me ||| 'java'
-        AND display_name ||| 'David John Alex'
-    )
 ORDER BY
     p.title ASC
 LIMIT 25;

--- a/benchmarks/datasets/stackoverflow/queries/join_top_k-score-desc-high-selectivity.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_top_k-score-desc-high-selectivity.sql
@@ -30,3 +30,15 @@ JOIN users u ON p.owner_user_id = u.id
 WHERE p.body ||| 'the' AND u.about_me ||| 'the' -- restricted on user.about_me contents
 ORDER BY score DESC -- sort is driven by a single table
 LIMIT 5;
+
+-- version with range partitioned join scan on
+SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_range_partitioned_join TO on; SELECT 
+  p.id, 
+  pdb.score(p.id) AS score, 
+  p.title 
+FROM stackoverflow_posts p 
+JOIN users u ON p.owner_user_id = u.id 
+WHERE p.body ||| 'the' AND u.about_me ||| 'the' -- restricted on user.about_me contents
+ORDER BY score DESC -- sort is driven by a single table
+LIMIT 5;
+

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -38,6 +38,9 @@ static CHECK_AGGREGATE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 /// Allows the user to toggle the use of our "ParadeDB Join Scan".
 static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
+/// Allows the user to toggle range co-partitioning for joins.
+static ENABLE_RANGE_PARTITIONED_JOIN: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
 /// default is `false`.
 static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(false);
@@ -291,6 +294,15 @@ pub fn init() {
         c"Enable ParadeDB's join custom scan",
         c"Enable ParadeDB's join custom scan, which pushes eligible joins down into the ParadeDB executor. Default is true.",
         &ENABLE_JOIN_CUSTOM_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_range_partitioned_join",
+        c"Allows the user to enable or disable range co-partitioned joins",
+        c"When enabled, DataFusion optimizer rules sample and co-partition inner joins across tables. Note that participating tables must also have a partition_by index option defined. Default is false.",
+        &ENABLE_RANGE_PARTITIONED_JOIN,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -698,6 +710,10 @@ pub fn check_aggregate_scan() -> bool {
 
 pub fn enable_join_custom_scan() -> bool {
     ENABLE_JOIN_CUSTOM_SCAN.get()
+}
+
+pub fn enable_range_partitioned_join() -> bool {
+    ENABLE_RANGE_PARTITIONED_JOIN.get()
 }
 
 pub fn enable_custom_scan_without_operator() -> bool {

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -102,7 +102,7 @@ Execution-layer files under [`pg_search/src/scan/`](../../scan/):
 | GUC                                      | Default | Effect                        |
 | ---------------------------------------- | ------- | ----------------------------- |
 | `paradedb.enable_join_custom_scan`       | `on`    | Master switch                 |
-| `paradedb.enable_range_partitioned_join` | `true`  | Range co-partitioned joins    |
+| `paradedb.enable_range_partitioned_join` | `false` | Range co-partitioned joins    |
 | `paradedb.enable_segmented_topk`         | `true`  | `SegmentedTopKExec` injection |
 
 [activation]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/mod.rs#L317

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -99,10 +99,11 @@ Execution-layer files under [`pg_search/src/scan/`](../../scan/):
 
 ## GUCs
 
-| GUC                                | Default | Effect                        |
-| ---------------------------------- | ------- | ----------------------------- |
-| `paradedb.enable_join_custom_scan` | `on`    | Master switch                 |
-| `paradedb.enable_segmented_topk`   | `true`  | `SegmentedTopKExec` injection |
+| GUC                                      | Default | Effect                        |
+| ---------------------------------------- | ------- | ----------------------------- |
+| `paradedb.enable_join_custom_scan`       | `on`    | Master switch                 |
+| `paradedb.enable_range_partitioned_join` | `true`  | Range co-partitioned joins    |
+| `paradedb.enable_segmented_topk`         | `true`  | `SegmentedTopKExec` injection |
 
 [activation]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/mod.rs#L317
 [relnode]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/build.rs#L575

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -284,7 +284,9 @@ impl OptimizerRule for RangePartitioningRule {
         plan: LogicalPlan,
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
-        if !crate::postgres::customscan::mpp::glue::mpp_is_active() {
+        if !crate::gucs::enable_range_partitioned_join()
+            || !crate::postgres::customscan::mpp::glue::mpp_is_active()
+        {
             return Ok(Transformed::no(plan));
         }
 
@@ -498,6 +500,10 @@ impl PhysicalOptimizerRule for RangeCoPartitionedJoinRule {
         plan: Arc<dyn ExecutionPlan>,
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !crate::gucs::enable_range_partitioned_join() {
+            return Ok(plan);
+        }
+
         plan.transform_up(|node| {
             let Some(join) = node.downcast_ref::<HashJoinExec>() else {
                 return Ok(Transformed::no(node));

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
@@ -14,6 +14,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_range_partitioned_join TO on;
 SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 -- Force parallel even on this tiny dataset; otherwise the cost-based

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -10,6 +10,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_range_partitioned_join TO on;
 SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;
 -- Force parallel even on this tiny dataset; otherwise the cost-based

--- a/pg_search/tests/pg_regress/expected/mpp_range_boundary.out
+++ b/pg_search/tests/pg_regress/expected/mpp_range_boundary.out
@@ -11,6 +11,7 @@
 -- =====================================================================
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_range_partitioned_join TO on;
 SET max_parallel_workers_per_gather TO 8;
 SET max_parallel_workers TO 7;
 SET min_parallel_table_scan_size TO 0;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate_partition_by.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate_partition_by.sql
@@ -16,6 +16,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_range_partitioned_join TO on;
 
 SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -12,6 +12,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_range_partitioned_join TO on;
 
 SET max_parallel_workers_per_gather TO 3;
 SET max_parallel_workers TO 8;

--- a/pg_search/tests/pg_regress/sql/mpp_range_boundary.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_range_boundary.sql
@@ -13,6 +13,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_range_partitioned_join TO on;
 SET max_parallel_workers_per_gather TO 8;
 SET max_parallel_workers TO 7;
 SET min_parallel_table_scan_size TO 0;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5734

## What

Adds range co-partitioned join benchmarks.

## Why

https://github.com/paradedb/paradedb/issues/5734#issuecomment-5277553981 showed that we will not be sure how widely we can enable range co-partitioning of joins until M2.

Adding benchmarks variants for range co-partitioning will help make it clearer when and where we are ready to enable it.

## How

Add the `paradedb.enable_range_partitioned_join` GUC to control whether range co-partitioning is used.