### PR TITLE
fix: Declare only the assigned partition when scaling a PgSearchScan node

### DIFF
--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -273,7 +273,7 @@ impl PgSearchScanPlan {
         // If state is None, execute() will return an EmptyStream for this single partition.
         let range_boundaries = range_sample.as_ref().map(|s| s.build(partition_count));
         let partitioning =
-            declared_partitioning(&schema, partition_count, range_boundaries.as_ref());
+            declared_partitioning(&schema, partition_count, range_boundaries.as_ref(), None);
         let eq_properties = build_equivalence_properties(schema, sort_order);
 
         let properties = Arc::new(PlanProperties::new(
@@ -391,6 +391,7 @@ impl PgSearchScanPlan {
             self.properties.eq_properties.schema(),
             target_partitions,
             range_boundaries,
+            self.assigned_partition,
         );
         let new_properties = Arc::new(PlanProperties::new(
             self.properties.eq_properties.clone(),
@@ -408,6 +409,18 @@ impl PgSearchScanPlan {
         properties: Arc<PlanProperties>,
         dynamic_filters: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Arc<Self> {
+        let properties = if self.assigned_partition.is_some()
+            && properties.output_partitioning().partition_count() != 1
+        {
+            Arc::new(PlanProperties::new(
+                properties.eq_properties.clone(),
+                Partitioning::UnknownPartitioning(1),
+                properties.emission_type,
+                properties.boundedness,
+            ))
+        } else {
+            properties
+        };
         Arc::new(Self {
             state: Mutex::new(state),
             planner_estimated_rows: self.planner_estimated_rows,
@@ -430,6 +443,24 @@ impl PgSearchScanPlan {
             range_sample: self.range_sample.clone(),
             assigned_partition: self.assigned_partition,
         })
+    }
+
+    /// Returns a variant of this plan configured to execute assigned partition `assigned`.
+    ///
+    /// The variant declares `Partitioning::UnknownPartitioning(1)` so DataFusion treats
+    /// it as a single-partition plan, while `assigned_partition` records which partition's
+    /// workload (range bounds or parallel state assignment) this variant executes.
+    pub fn with_assigned_partition(self: &Arc<Self>, assigned: usize) -> Arc<Self> {
+        let mut variant = self.as_ref().clone();
+        variant.assigned_partition = Some(assigned);
+        let new_properties = Arc::new(PlanProperties::new(
+            variant.properties.eq_properties.clone(),
+            Partitioning::UnknownPartitioning(1),
+            variant.properties.emission_type,
+            variant.properties.boundedness,
+        ));
+        variant.properties = new_properties;
+        Arc::new(variant)
     }
 
     /// Late-bind the shared `ParallelScanState` into this scan's execution state (#5667).
@@ -658,9 +689,14 @@ impl PgSearchScanPlan {
             parallel_state,
             descriptor.range_sample,
         );
-        plan.assigned_partition = descriptor.assigned_partition;
         plan.dynamic_filters = dynamic_filters;
-        Ok(Arc::new(plan))
+        let plan_arc = Arc::new(plan);
+        let final_plan = if let Some(assigned) = descriptor.assigned_partition {
+            plan_arc.with_assigned_partition(assigned)
+        } else {
+            plan_arc
+        };
+        Ok(final_plan)
     }
 }
 
@@ -704,7 +740,11 @@ fn declared_partitioning(
     schema: &SchemaRef,
     partition_count: usize,
     range_boundaries: Option<&RangePartitioning>,
+    assigned_partition: Option<usize>,
 ) -> Partitioning {
+    if assigned_partition.is_some() {
+        return Partitioning::UnknownPartitioning(1);
+    }
     if partition_count > 1
         && let Some(boundaries) = range_boundaries
         && boundaries.split_points.len() + 1 == partition_count
@@ -770,10 +810,15 @@ impl DisplayAs for PgSearchScanPlan {
         write!(f, "PgSearchScan: segments={}", self.segment_count)?;
         if let Some(range_sample) = &self.range_sample {
             if let Some(assigned) = self.assigned_partition {
-                let partitioning =
-                    range_sample.build(self.properties.output_partitioning().partition_count());
+                let state_guard = self.state.lock().ok();
+                let partitioning = match state_guard.as_deref() {
+                    Some(ExecutionState::RangePartitioned {
+                        range_boundaries, ..
+                    }) => range_boundaries.clone(),
+                    _ => range_sample.build(assigned + 1),
+                };
 
-                let lower = if assigned > 0 {
+                let lower = if assigned > 0 && assigned - 1 < partitioning.split_points.len() {
                     let val = &partitioning.split_points[assigned - 1];
                     serde_json::to_string(val).unwrap_or_else(|_| format!("{:?}", val))
                 } else {
@@ -886,19 +931,6 @@ impl ExecutionPlan for PgSearchScanPlan {
             pgrx::error!("artificial panic to test worker error propagation");
         }
 
-        // Under DataFusion Distributed execution, upstream stage operators (such as `RepartitionExec`)
-        // call `execute(p)` for all partition indices `p` in the stage's requested partition range.
-        // For partitions where `p != assigned`, we return an empty stream so multi-partition
-        // stage pipelines can pull and repartition data without failing.
-        if let Some(assigned) = self.assigned_partition
-            && partition != assigned
-        {
-            let schema = self.properties.eq_properties.schema().clone();
-            return Ok(Box::pin(unsafe {
-                UnsafeSendStream::new(futures::stream::empty(), schema)
-            }));
-        }
-
         let mut state_guard = self.state.lock().map_err(|e| {
             DataFusionError::Internal(format!("Failed to lock PgSearchScanPlan state: {e}"))
         })?;
@@ -911,6 +943,7 @@ impl ExecutionPlan for PgSearchScanPlan {
             )));
         }
 
+        let target_partition = self.assigned_partition.unwrap_or(partition);
         let state = std::mem::replace(&mut *state_guard, ExecutionState::Consumed);
 
         // Handle state transitions for execution.
@@ -925,7 +958,7 @@ impl ExecutionPlan for PgSearchScanPlan {
             } => {
                 // If target_partitions scaled past the available sample boundaries, we
                 // just return empty streams for the extra partitions.
-                if partition > range_boundaries.split_points.len() {
+                if target_partition > range_boundaries.split_points.len() {
                     let schema = self.properties.eq_properties.schema().clone();
                     return Ok(Box::pin(unsafe {
                         UnsafeSendStream::new(futures::stream::empty(), schema)
@@ -936,7 +969,7 @@ impl ExecutionPlan for PgSearchScanPlan {
             }
             ExecutionState::Consumed => {
                 return Err(DataFusionError::Internal(format!(
-                    "PgSearchScanPlan partition {partition} executed more than once"
+                    "PgSearchScanPlan partition {target_partition} executed more than once"
                 )));
             }
             ExecutionState::Uninitialized => {
@@ -958,11 +991,11 @@ impl ExecutionPlan for PgSearchScanPlan {
 
         let has_dynamic_filters = !self.dynamic_filters.is_empty();
         let rows_scanned = has_dynamic_filters
-            .then(|| MetricBuilder::new(&self.metrics).counter("rows_scanned", partition));
+            .then(|| MetricBuilder::new(&self.metrics).counter("rows_scanned", target_partition));
         let rows_pruned = has_dynamic_filters
-            .then(|| MetricBuilder::new(&self.metrics).counter("rows_pruned", partition));
+            .then(|| MetricBuilder::new(&self.metrics).counter("rows_pruned", target_partition));
 
-        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+        let baseline_metrics = BaselineMetrics::new(&self.metrics, target_partition);
         let schema = self.properties.eq_properties.schema().clone();
         let score_column_schema_idx: Option<usize> = schema
             .column_with_name(&WhichFastField::Score.name())
@@ -974,7 +1007,7 @@ impl ExecutionPlan for PgSearchScanPlan {
         let stream_gen = async_stream::try_stream! {
             // Create a local copy of the reader if the query changed
             let mut reader = match &range_boundaries {
-                Some(rb) => reader.and_query_input(&rb.partition_bounds(partition)),
+                Some(rb) => reader.and_query_input(&rb.partition_bounds(target_partition)),
                 None => reader,
             };
 
@@ -1260,12 +1293,9 @@ pub(crate) fn pg_search_scan_scale_up_leaf_node(
 
         // Assign each task its explicit execution partition to ensure it is the only one
         // executing it.
+        let final_scan_plan_arc = Arc::new(final_scan_plan.clone());
         let variants = (0..ev.task_count)
-            .map(|i| {
-                let mut variant = final_scan_plan.clone();
-                variant.assigned_partition = Some(i);
-                Arc::new(variant) as Arc<dyn ExecutionPlan>
-            })
+            .map(|i| final_scan_plan_arc.with_assigned_partition(i) as Arc<dyn ExecutionPlan>)
             .collect::<Vec<_>>();
 
         Ok(ScaleUpLeafNodeEventResponse::new(Arc::new(

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -161,9 +161,9 @@ pub struct PgSearchScanPlan {
     /// from ParallelScanState or the reader, and kept around for EXPLAIN after
     /// the state is consumed.
     segment_count: usize,
-    /// Number of partitions in the scan before task specialization. Assigned variants expose
-    /// one local partition to DataFusion, but dispatch still needs this global count to rebuild
-    /// the same range boundaries on the receiving worker.
+    /// Number of partitions in the scan before task specialization. A specialized variant's
+    /// `output_partitioning` is always one, so this count is serialized separately and used to
+    /// rebuild the original range boundaries when the variant is decoded on its worker.
     global_partition_count: usize,
     properties: Arc<PlanProperties>,
     resolved_query: SearchQueryInput,
@@ -272,7 +272,7 @@ impl PgSearchScanPlan {
         // If state is None, execute() will return an EmptyStream for this single partition.
         let range_boundaries = range_sample.as_ref().map(|s| s.build(partition_count));
         let partitioning =
-            declared_partitioning(&schema, partition_count, range_boundaries.as_ref(), None);
+            declared_partitioning(&schema, partition_count, range_boundaries.as_ref());
         let eq_properties = build_equivalence_properties(schema, sort_order);
 
         let properties = Arc::new(PlanProperties::new(
@@ -397,7 +397,6 @@ impl PgSearchScanPlan {
             self.properties.eq_properties.schema(),
             target_partitions,
             range_boundaries,
-            self.assigned_partition,
         );
         let new_properties = Arc::new(
             PlanProperties::clone(self.properties.as_ref()).with_partitioning(partitioning),
@@ -418,16 +417,6 @@ impl PgSearchScanPlan {
         dynamic_filters: Vec<Arc<dyn PhysicalExpr>>,
         global_partition_count: usize,
     ) -> Arc<Self> {
-        let properties = if self.assigned_partition.is_some()
-            && properties.output_partitioning().partition_count() != 1
-        {
-            Arc::new(
-                PlanProperties::clone(properties.as_ref())
-                    .with_partitioning(Partitioning::UnknownPartitioning(1)),
-            )
-        } else {
-            properties
-        };
         Arc::new(Self {
             state: Mutex::new(state),
             planner_estimated_rows: self.planner_estimated_rows,
@@ -458,17 +447,17 @@ impl PgSearchScanPlan {
     /// The variant declares `Partitioning::UnknownPartitioning(1)` so DataFusion treats
     /// it as a single-partition plan, while `assigned_partition` records which partition's
     /// workload (range bounds or parallel state assignment) this variant executes.
-    pub(crate) fn with_assigned_partition(self: &Arc<Self>, assigned: usize) -> Arc<Self> {
-        debug_assert!(
+    pub(crate) fn with_assigned_partition(&self, assigned: usize) -> Arc<Self> {
+        assert!(
             self.assigned_partition.is_none(),
             "PgSearchScanPlan is already task-specialized"
         );
-        debug_assert!(
+        assert!(
             assigned < self.global_partition_count,
             "assigned partition {assigned} is outside global partition count {}",
             self.global_partition_count
         );
-        let mut variant = self.as_ref().clone();
+        let mut variant = self.clone();
         variant.assigned_partition = Some(assigned);
         let new_properties = Arc::new(
             PlanProperties::clone(variant.properties.as_ref())
@@ -705,11 +694,10 @@ impl PgSearchScanPlan {
             descriptor.range_sample,
         );
         plan.dynamic_filters = dynamic_filters;
-        let plan_arc = Arc::new(plan);
         let final_plan = if let Some(assigned) = descriptor.assigned_partition {
-            plan_arc.with_assigned_partition(assigned)
+            plan.with_assigned_partition(assigned)
         } else {
-            plan_arc
+            Arc::new(plan)
         };
         Ok(final_plan)
     }
@@ -757,11 +745,7 @@ fn declared_partitioning(
     schema: &SchemaRef,
     partition_count: usize,
     range_boundaries: Option<&RangePartitioning>,
-    assigned_partition: Option<usize>,
 ) -> Partitioning {
-    if assigned_partition.is_some() {
-        return Partitioning::UnknownPartitioning(1);
-    }
     if partition_count > 1
         && let Some(boundaries) = range_boundaries
         && boundaries.split_points.len() + 1 == partition_count
@@ -827,13 +811,7 @@ impl DisplayAs for PgSearchScanPlan {
         write!(f, "PgSearchScan: segments={}", self.segment_count)?;
         if let Some(range_sample) = &self.range_sample {
             if let Some(assigned) = self.assigned_partition {
-                let state_guard = self.state.lock().ok();
-                let partitioning = match state_guard.as_deref() {
-                    Some(ExecutionState::RangePartitioned {
-                        range_boundaries, ..
-                    }) => range_boundaries.clone(),
-                    _ => range_sample.build(self.global_partition_count),
-                };
+                let partitioning = range_sample.build(self.global_partition_count);
 
                 let lower = if assigned > 0 && assigned - 1 < partitioning.split_points.len() {
                     let val = &partitioning.split_points[assigned - 1];
@@ -895,19 +873,37 @@ impl ExecutionPlan for PgSearchScanPlan {
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
-        let partition_count = self.properties.output_partitioning().partition_count();
-        let num_rows = match partition {
+        let local_partition_count = self.properties.output_partitioning().partition_count();
+        if let Some(partition) = partition
+            && partition >= local_partition_count
+        {
+            return Err(DataFusionError::Internal(format!(
+                "Partition {} out of range (have {} partitions)",
+                partition, local_partition_count
+            )));
+        }
+
+        // `None` means the whole visible plan. For a specialized variant, that whole plan is its
+        // one assigned global partition; for the original plan it is all global partitions.
+        let global_partition = self.assigned_partition.or(partition);
+        let num_rows = match global_partition {
             None => Precision::Inexact(self.planner_estimated_rows as usize),
-            Some(p) if p < partition_count => {
-                let rows_per_partition =
-                    self.planner_estimated_rows as usize / partition_count.max(1);
-                Precision::Inexact(rows_per_partition)
-            }
-            Some(p) => {
-                return Err(DataFusionError::Internal(format!(
-                    "Partition {} out of range (have {} partitions)",
-                    p, partition_count
-                )));
+            Some(global_partition) => {
+                // A short range sample leaves surplus global partitions intentionally empty.
+                let populated_partition_count = self
+                    .range_sample
+                    .as_ref()
+                    .map(|sample| {
+                        self.global_partition_count
+                            .min(sample.sample_points.len().saturating_add(1))
+                    })
+                    .unwrap_or(self.global_partition_count);
+                let rows = if global_partition < populated_partition_count {
+                    self.planner_estimated_rows as usize / populated_partition_count.max(1)
+                } else {
+                    0
+                };
+                Precision::Inexact(rows)
             }
         };
 
@@ -1315,9 +1311,8 @@ pub(crate) fn pg_search_scan_scale_up_leaf_node(
 
         // Assign each task its explicit execution partition to ensure it is the only one
         // executing it.
-        let final_scan_plan_arc = Arc::new(final_scan_plan.clone());
         let variants = (0..ev.task_count)
-            .map(|i| final_scan_plan_arc.with_assigned_partition(i) as Arc<dyn ExecutionPlan>)
+            .map(|i| final_scan_plan.with_assigned_partition(i) as Arc<dyn ExecutionPlan>)
             .collect::<Vec<_>>();
 
         Ok(ScaleUpLeafNodeEventResponse::new(Arc::new(

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -114,23 +114,19 @@ pub struct ScanState {
 
 /// Execution state for a single `PgSearchScanPlan`.
 ///
-/// Under multi-partition distributed or parallel execution, a plan variant's `assigned_partition` indicates
-/// which partition should consume the state and yield data. Calling `execute()` on that assigned partition
-/// consumes the state exactly once and transitions it to `Consumed`.
-///
-/// Any calls to `execute()` for a partition that does not match `assigned_partition` will yield an
-/// empty stream and leave the state untouched. This ensures each plan variant only yields data for its
-/// explicitly assigned slice of the workload.
+/// Under distributed execution, a task-specialized variant exposes one local partition.
+/// Its `assigned_partition` maps that local partition back to the global partition whose
+/// state and range bounds it must consume exactly once.
 #[derive(Default, Clone)]
 pub enum ExecutionState {
     /// In Shared mode, we optionally load-balance via ParallelScanState.
-    /// The state is consumed by the assigned partition.
+    /// The state is consumed at most once by this plan or one of its task variants.
     Shared {
         parallel_state: Option<UnsafeSendSync<*mut crate::postgres::ParallelScanState>>,
         scan_state: Box<UnsafeSendSync<ScanState>>,
     },
     /// In RangePartitioned mode, we static-partition using RangePartitioning.
-    /// The state is consumed by the assigned partition.
+    /// A task variant maps its sole local partition to one range before consuming the state.
     RangePartitioned {
         range_boundaries: RangePartitioning,
         scan_state: Box<UnsafeSendSync<ScanState>>,
@@ -144,13 +140,12 @@ pub enum ExecutionState {
 
 /// A DataFusion `ExecutionPlan` for scanning `pg_search` index segments.
 ///
-/// Under multi-partition parallel or distributed execution, this plan's `output_partitioning` declares
-/// a *capacity* (`min(segments, target_partitions)`). The plan is then cloned into multiple variants,
-/// where each variant has its `assigned_partition` explicitly set. When `execute()` is called, only
-/// the assigned partition actually consumes the scan state to produce a stream, guaranteeing exactly-once
-/// processing of the underlying data.
+/// Before task specialization, this plan's `output_partitioning` declares the planner-selected
+/// global partition count. Each specialized variant then exposes one local partition while
+/// retaining the global partition count and its `assigned_partition`, so local `execute(0)`
+/// consumes exactly the assigned slice of the workload.
 pub struct PgSearchScanPlan {
-    /// State for this single-partition scan.
+    /// State consumed exactly once by this plan or one of its task-specialized clones.
     ///
     /// We use a Mutex to allow taking ownership of the scanner during `execute()`.
     /// We wrap the state in `UnsafeSendSync` to satisfy `ExecutionPlan`'s `Send` + `Sync`
@@ -166,6 +161,10 @@ pub struct PgSearchScanPlan {
     /// from ParallelScanState or the reader, and kept around for EXPLAIN after
     /// the state is consumed.
     segment_count: usize,
+    /// Number of partitions in the scan before task specialization. Assigned variants expose
+    /// one local partition to DataFusion, but dispatch still needs this global count to rebuild
+    /// the same range boundaries on the receiving worker.
+    global_partition_count: usize,
     properties: Arc<PlanProperties>,
     resolved_query: SearchQueryInput,
     /// Dynamic filters pushed down from parent operators (e.g. Top K threshold
@@ -200,9 +199,8 @@ pub struct PgSearchScanPlan {
     /// `=true` in that case.
     dynamic_filter_strategy: Arc<AtomicU8>,
     range_sample: Option<RangePartitioningSample>,
-    /// When executing in a multi-task distributed or parallel environment, this
-    /// indicates the specific execution partition this plan variant is responsible for.
-    /// It guarantees that the `ExecutionState` is consumed exactly once by the designated worker.
+    /// Global partition selected for a task-specialized variant. When present, this plan
+    /// exposes one local partition and maps `execute(0)` back to this global partition.
     pub(crate) assigned_partition: Option<usize>,
 }
 
@@ -214,6 +212,7 @@ impl Clone for PgSearchScanPlan {
             state: Mutex::new(new_state),
             planner_estimated_rows: self.planner_estimated_rows,
             segment_count: self.segment_count,
+            global_partition_count: self.global_partition_count,
             properties: Arc::clone(&self.properties),
             resolved_query: self.resolved_query.clone(),
             dynamic_filters: self.dynamic_filters.clone(),
@@ -249,8 +248,8 @@ impl PgSearchScanPlan {
     /// * `resolved_query` - The filter-combined, param-solved query the readers were opened
     ///   with. Used for EXPLAIN and shipped on dispatch.
     /// * `sort_order` - Optional sort order declaration for equivalence properties
-    /// * `partition_count` - Number of distributed tasks/partitions this scan natively supports
-    ///   (usually `min(segments, target_partitions)`).
+    /// * `partition_count` - Planner-selected number of global partitions. Non-range scans cap
+    ///   this at their segment count; sampled range scans may expose more partitions than segments.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         state: Option<ScanState>,
@@ -328,6 +327,7 @@ impl PgSearchScanPlan {
             state: Mutex::new(exec_state),
             planner_estimated_rows,
             segment_count,
+            global_partition_count: partition_count,
             properties,
             resolved_query,
             dynamic_filters: Vec::new(),
@@ -354,7 +354,13 @@ impl PgSearchScanPlan {
     /// - For `RangePartitioned` mode, it asks the internal `range_sample` to safely
     ///   down-sample (or up-sample) the partitioning bounds so the new partition count
     ///   has roughly uniformly distributed boundaries.
-    pub fn repartition(&self, target_partitions: usize) -> Result<Arc<dyn ExecutionPlan>> {
+    pub(crate) fn repartition(&self, target_partitions: usize) -> Result<Arc<dyn ExecutionPlan>> {
+        if self.assigned_partition.is_some() {
+            return Err(DataFusionError::Internal(
+                "Cannot repartition a task-specialized PgSearchScanPlan".into(),
+            ));
+        }
+
         let state_guard = self
             .state
             .lock()
@@ -393,14 +399,16 @@ impl PgSearchScanPlan {
             range_boundaries,
             self.assigned_partition,
         );
-        let new_properties = Arc::new(PlanProperties::new(
-            self.properties.eq_properties.clone(),
-            partitioning,
-            self.properties.emission_type,
-            self.properties.boundedness,
-        ));
+        let new_properties = Arc::new(
+            PlanProperties::clone(self.properties.as_ref()).with_partitioning(partitioning),
+        );
 
-        Ok(self.with_overrides(new_state, new_properties, self.dynamic_filters.clone()))
+        Ok(self.with_overrides(
+            new_state,
+            new_properties,
+            self.dynamic_filters.clone(),
+            target_partitions,
+        ))
     }
 
     fn with_overrides(
@@ -408,16 +416,15 @@ impl PgSearchScanPlan {
         state: ExecutionState,
         properties: Arc<PlanProperties>,
         dynamic_filters: Vec<Arc<dyn PhysicalExpr>>,
+        global_partition_count: usize,
     ) -> Arc<Self> {
         let properties = if self.assigned_partition.is_some()
             && properties.output_partitioning().partition_count() != 1
         {
-            Arc::new(PlanProperties::new(
-                properties.eq_properties.clone(),
-                Partitioning::UnknownPartitioning(1),
-                properties.emission_type,
-                properties.boundedness,
-            ))
+            Arc::new(
+                PlanProperties::clone(properties.as_ref())
+                    .with_partitioning(Partitioning::UnknownPartitioning(1)),
+            )
         } else {
             properties
         };
@@ -425,6 +432,7 @@ impl PgSearchScanPlan {
             state: Mutex::new(state),
             planner_estimated_rows: self.planner_estimated_rows,
             segment_count: self.segment_count,
+            global_partition_count,
             properties,
             resolved_query: self.resolved_query.clone(),
             dynamic_filters,
@@ -450,15 +458,22 @@ impl PgSearchScanPlan {
     /// The variant declares `Partitioning::UnknownPartitioning(1)` so DataFusion treats
     /// it as a single-partition plan, while `assigned_partition` records which partition's
     /// workload (range bounds or parallel state assignment) this variant executes.
-    pub fn with_assigned_partition(self: &Arc<Self>, assigned: usize) -> Arc<Self> {
+    pub(crate) fn with_assigned_partition(self: &Arc<Self>, assigned: usize) -> Arc<Self> {
+        debug_assert!(
+            self.assigned_partition.is_none(),
+            "PgSearchScanPlan is already task-specialized"
+        );
+        debug_assert!(
+            assigned < self.global_partition_count,
+            "assigned partition {assigned} is outside global partition count {}",
+            self.global_partition_count
+        );
         let mut variant = self.as_ref().clone();
         variant.assigned_partition = Some(assigned);
-        let new_properties = Arc::new(PlanProperties::new(
-            variant.properties.eq_properties.clone(),
-            Partitioning::UnknownPartitioning(1),
-            variant.properties.emission_type,
-            variant.properties.boundedness,
-        ));
+        let new_properties = Arc::new(
+            PlanProperties::clone(variant.properties.as_ref())
+                .with_partitioning(Partitioning::UnknownPartitioning(1)),
+        );
         variant.properties = new_properties;
         Arc::new(variant)
     }
@@ -558,7 +573,7 @@ impl PgSearchScanPlan {
             batch_size_hint: scanner_config.batch_size_hint,
             source_idx,
             planner_estimated_rows,
-            partition_count: self.properties.output_partitioning().partition_count(),
+            global_partition_count: self.global_partition_count,
             range_sample: self.range_sample.clone(),
             assigned_partition: self.assigned_partition,
         };
@@ -685,7 +700,7 @@ impl PgSearchScanPlan {
             ffhelper_arg,
             descriptor.indexrelid,
             descriptor.deferred_ctid_plan_position,
-            descriptor.partition_count,
+            descriptor.global_partition_count,
             parallel_state,
             descriptor.range_sample,
         );
@@ -724,7 +739,9 @@ struct ScanDispatchDescriptor {
     /// single-counter checkout (basescan and non-MPP parallel joins). All-sources position.
     source_idx: Option<usize>,
     planner_estimated_rows: u64,
-    partition_count: usize,
+    /// Number of partitions before task specialization. This remains global even when an
+    /// assigned variant advertises one local output partition to DataFusion.
+    global_partition_count: usize,
     range_sample: Option<RangePartitioningSample>,
     assigned_partition: Option<usize>,
 }
@@ -815,7 +832,7 @@ impl DisplayAs for PgSearchScanPlan {
                     Some(ExecutionState::RangePartitioned {
                         range_boundaries, ..
                     }) => range_boundaries.clone(),
-                    _ => range_sample.build(assigned + 1),
+                    _ => range_sample.build(self.global_partition_count),
                 };
 
                 let lower = if assigned > 0 && assigned - 1 < partitioning.split_points.len() {
@@ -1159,7 +1176,12 @@ impl ExecutionPlan for PgSearchScanPlan {
                 ))
             })?);
 
-            let new_plan = self.with_overrides(state, self.properties.clone(), dynamic_filters);
+            let new_plan = self.with_overrides(
+                state,
+                self.properties.clone(),
+                dynamic_filters,
+                self.global_partition_count,
+            );
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)
                     .with_updated_node(new_plan as Arc<dyn ExecutionPlan>),

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -869,7 +869,7 @@ mod tests {
             ],
         };
 
-        let mut plan = PgSearchScanPlan::new(
+        let plan = PgSearchScanPlan::new(
             Some(scan_state),
             build_arrow_schema(&fields),
             SearchQueryInput::All,
@@ -883,12 +883,12 @@ mod tests {
             Some(sample),
         );
         // As one of four task variants: this one owns partition 1 alone.
-        plan.assigned_partition = Some(1);
+        let plan = Arc::new(plan).with_assigned_partition(1);
 
-        assert_eq!(plan.properties().output_partitioning().partition_count(), 4);
+        assert_eq!(plan.properties().output_partitioning().partition_count(), 1);
         assert!(matches!(
             plan.properties().output_partitioning(),
-            Partitioning::Range(_)
+            Partitioning::UnknownPartitioning(1)
         ));
 
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -907,14 +907,10 @@ mod tests {
             rows
         };
 
-        // Non-assigned partitions yield empty streams without touching the state, so
-        // the assigned partition still consumes it afterwards.
-        assert_eq!(count_rows(0), 0);
-        assert_eq!(count_rows(2), 0);
-        assert_eq!(count_rows(3), 0);
-        assert_eq!(count_rows(1), 25); // ids 25..=49
+        // Executing partition 0 on this single-partition variant scans assigned partition 1 (ids 25..=49).
+        assert_eq!(count_rows(0), 25);
 
         // The state is consumed exactly once.
-        assert!(plan.execute(1, Arc::new(TaskContext::default())).is_err());
+        assert!(plan.execute(0, Arc::new(TaskContext::default())).is_err());
     }
 }

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -26,6 +26,7 @@ mod tests {
     use crate::query::SearchQueryInput;
     use crate::scan::execution_plan::PgSearchScanPlan;
     use crate::schema::SearchFieldType;
+    use datafusion::common::stats::Precision;
     use datafusion::execution::TaskContext;
     use datafusion::physical_plan::ExecutionPlan;
     use futures::StreamExt;
@@ -639,6 +640,7 @@ mod tests {
     }
 
     #[pg_test]
+    #[allow(deprecated)] // Exercises PgSearchScanPlan's DataFusion partition-statistics contract.
     fn test_range_partitioning_repartition() {
         let (heap_oid, index_oid) = get_relation_oids();
         let heap_rel = PgSearchRelation::open(heap_oid);
@@ -668,7 +670,7 @@ mod tests {
 
         let partition = crate::scan::execution_plan::ScanState {
             source_idx: None,
-            planner_estimated_rows: 0,
+            planner_estimated_rows: 100,
             scanner_config: crate::scan::execution_plan::ScannerConfig {
                 which_fast_fields: fields.clone(),
                 heap_relid: heap_oid.into(),
@@ -736,6 +738,30 @@ mod tests {
             plan_10.properties().output_partitioning(),
             Partitioning::UnknownPartitioning(_)
         ));
+        assert_eq!(
+            plan_10.partition_statistics(Some(0)).unwrap().num_rows,
+            Precision::Inexact(20)
+        );
+        assert_eq!(
+            plan_10.partition_statistics(Some(9)).unwrap().num_rows,
+            Precision::Inexact(0)
+        );
+
+        let empty_variant = plan_10
+            .downcast_ref::<PgSearchScanPlan>()
+            .unwrap()
+            .with_assigned_partition(9);
+        assert_eq!(
+            empty_variant.partition_statistics(None).unwrap().num_rows,
+            Precision::Inexact(0)
+        );
+        assert_eq!(
+            empty_variant
+                .partition_statistics(Some(0))
+                .unwrap()
+                .num_rows,
+            Precision::Inexact(0)
+        );
     }
 
     #[pg_test]
@@ -815,6 +841,7 @@ mod tests {
     }
 
     #[pg_test]
+    #[allow(deprecated)] // Exercises PgSearchScanPlan's DataFusion partition-statistics contract.
     fn test_range_partitioned_assigned_execution() {
         use arrow_array::Int64Array;
         use datafusion::physical_plan::Partitioning;
@@ -848,7 +875,7 @@ mod tests {
 
         let scan_state = crate::scan::execution_plan::ScanState {
             source_idx: None,
-            planner_estimated_rows: 0,
+            planner_estimated_rows: 100,
             scanner_config: crate::scan::execution_plan::ScannerConfig {
                 which_fast_fields: fields.clone(),
                 heap_relid: heap_oid.into(),
@@ -884,8 +911,25 @@ mod tests {
             None,
             Some(sample),
         );
+
+        // The planner-facing original retains all four global ranges. Only the variant sent to
+        // one distributed task advertises a single local partition.
+        assert_eq!(plan.properties().output_partitioning().partition_count(), 4);
+        assert!(matches!(
+            plan.properties().output_partitioning(),
+            Partitioning::Range(_)
+        ));
+        assert_eq!(
+            plan.partition_statistics(None).unwrap().num_rows,
+            Precision::Inexact(100)
+        );
+        assert_eq!(
+            plan.partition_statistics(Some(1)).unwrap().num_rows,
+            Precision::Inexact(25)
+        );
+
         // As one of four task variants: this one owns partition 1 alone.
-        let plan = Arc::new(plan).with_assigned_partition(1);
+        let plan = plan.with_assigned_partition(1);
 
         assert!(plan.repartition(2).is_err());
         assert_eq!(plan.properties().output_partitioning().partition_count(), 1);
@@ -893,6 +937,15 @@ mod tests {
             plan.properties().output_partitioning(),
             Partitioning::UnknownPartitioning(1)
         ));
+        assert_eq!(
+            plan.partition_statistics(None).unwrap().num_rows,
+            Precision::Inexact(25)
+        );
+        assert_eq!(
+            plan.partition_statistics(Some(0)).unwrap().num_rows,
+            Precision::Inexact(25)
+        );
+        assert!(plan.partition_statistics(Some(1)).is_err());
 
         // Dispatch must preserve the four global ranges even though this task-specialized
         // variant advertises one local partition to DataFusion.
@@ -913,6 +966,10 @@ mod tests {
             plan.properties().output_partitioning(),
             Partitioning::UnknownPartitioning(1)
         ));
+
+        // The specialized plan exposes only local partition 0. Rejecting another local
+        // partition must not consume the assigned global partition's execution state.
+        assert!(plan.execute(1, Arc::new(TaskContext::default())).is_err());
 
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -816,7 +816,9 @@ mod tests {
 
     #[pg_test]
     fn test_range_partitioned_assigned_execution() {
+        use arrow_array::Int64Array;
         use datafusion::physical_plan::Partitioning;
+        use datafusion_proto::physical_plan::DefaultPhysicalProtoConverter;
 
         let (heap_oid, index_oid) = get_relation_oids();
         let heap_rel = PgSearchRelation::open(heap_oid);
@@ -885,6 +887,27 @@ mod tests {
         // As one of four task variants: this one owns partition 1 alone.
         let plan = Arc::new(plan).with_assigned_partition(1);
 
+        assert!(plan.repartition(2).is_err());
+        assert_eq!(plan.properties().output_partitioning().partition_count(), 1);
+        assert!(matches!(
+            plan.properties().output_partitioning(),
+            Partitioning::UnknownPartitioning(1)
+        ));
+
+        // Dispatch must preserve the four global ranges even though this task-specialized
+        // variant advertises one local partition to DataFusion.
+        let proto_converter = DefaultPhysicalProtoConverter {};
+        let encoded = plan.encode_for_dispatch(&proto_converter).unwrap();
+        let task_context = TaskContext::default();
+        let plan = PgSearchScanPlan::decode_for_dispatch(
+            &encoded,
+            None,
+            None,
+            &task_context,
+            &proto_converter,
+        )
+        .unwrap();
+
         assert_eq!(plan.properties().output_partitioning().partition_count(), 1);
         assert!(matches!(
             plan.properties().output_partitioning(),
@@ -894,21 +917,28 @@ mod tests {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap();
-        let count_rows = |partition: usize| {
+        let collect_ids = |partition: usize| {
             let mut stream = plan
                 .execute(partition, Arc::new(TaskContext::default()))
                 .unwrap();
-            let mut rows = 0;
+            let mut ids = Vec::new();
             runtime.block_on(async {
                 while let Some(batch) = stream.next().await {
-                    rows += batch.unwrap().num_rows();
+                    let batch = batch.unwrap();
+                    let id_array = batch
+                        .column(1)
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .expect("id should be an Int64Array");
+                    ids.extend(id_array.values().iter().copied());
                 }
             });
-            rows
+            ids.sort_unstable();
+            ids
         };
 
-        // Executing partition 0 on this single-partition variant scans assigned partition 1 (ids 25..=49).
-        assert_eq!(count_rows(0), 25);
+        // Local partition 0 must map to global partition 1, not merely any 25-row range.
+        assert_eq!(collect_ids(0), (25_i64..50).collect::<Vec<_>>());
 
         // The state is consumed exactly once.
         assert!(plan.execute(0, Arc::new(TaskContext::default())).is_err());

--- a/pg_search/tests/pg_regress/expected/issue_5747.out
+++ b/pg_search/tests/pg_regress/expected/issue_5747.out
@@ -47,13 +47,13 @@ LIMIT 5;
            : │       VisibilityFilterExec: tables=[sv, le]
            : │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, series_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
            : │           CoalescePartitionsExec
-           : │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=2, input_tasks=2
+           : │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=1, input_tasks=2
            : │           RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
            : │             DistributedLeafExec:
            : │               t0: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"term":{"field":"user_id","value":"u1"}}}}
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 1 ── tasks=2, partitions=4
-           :   │ BroadcastExec: input_partitions=2, consumer_tasks=1, output_partitions=2
+           :   ┌───── Stage 1 ── tasks=2, partitions=2
+           :   │ BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
            :   │   DistributedLeafExec:
            :   │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}
            :   │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"term":{"field":"state","value":"merged"}}}}

--- a/pg_search/tests/pg_regress/expected/join_outer.out
+++ b/pg_search/tests/pg_regress/expected/join_outer.out
@@ -448,7 +448,7 @@ LIMIT 10;
            :   │       [Stage 2] => NetworkShuffleExec: output_partitions=4, input_tasks=2
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=2, partitions=8
-           :     │ RepartitionExec: partitioning=Hash([file_id@1], 8), input_partitions=2
+           :     │ RepartitionExec: partitioning=Hash([file_id@1], 8), input_partitions=1
            :     │   DistributedLeafExec:
            :     │     t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
            :     │     t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
@@ -456,7 +456,7 @@ LIMIT 10;
            :     ┌───── Stage 2 ── tasks=2, partitions=8
            :     │ RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=4
            :     │   VisibilityFilterExec: tables=[f]
-           :     │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2
+           :     │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
            :     │       DistributedLeafExec:
            :     │         t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     │         t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
@@ -624,14 +624,14 @@ WHERE p.page_text @@@ 'Page';
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(f_1.id) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@0, file_id@0)], projection=[id@0]
      :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
      :   │       DistributedLeafExec:
      :   │         t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
      :   │         t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── tasks=2, partitions=8
-     :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+     :     ┌───── Stage 1 ── tasks=2, partitions=4
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
      :     │     t0: PgSearchScan: segments=2, query="all"
      :     │     t1: PgSearchScan: segments=2, query="all"

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
@@ -124,22 +124,22 @@ LIMIT 5000;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            : │   SortPreservingMergeExec: [id@1 DESC], fetch=5000
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=16, input_tasks=4
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=4
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=4, partitions=16
+           :   ┌───── Stage 2 ── tasks=4, partitions=4
            :   │ SortExec: TopK(fetch=5000), expr=[id@1 DESC], preserve_partitioning=[true]
            :   │   VisibilityFilterExec: tables=[i]
            :   │     NestedLoopJoinExec: join_type=RightAnti, filter=pattern@2 = name@0 OR pattern@2 = alt_name@1, projection=[ctid_0@0, id@3]
            :   │       CoalescePartitionsExec
-           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=8, input_tasks=2
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=4, input_tasks=2
            :   │       DistributedLeafExec:
            :   │         t0: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   │         t1: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   │         t2: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   │         t3: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=2, partitions=16
-           :     │ BroadcastExec: input_partitions=2, consumer_tasks=4, output_partitions=8
+           :     ┌───── Stage 1 ── tasks=2, partitions=8
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=4, output_partitions=4
            :     │   DistributedLeafExec:
            :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
            :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
@@ -249,22 +249,22 @@ LIMIT 5000;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            : │   SortPreservingMergeExec: [id@1 ASC NULLS LAST], fetch=5000
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=16, input_tasks=4
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=4
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=4, partitions=16
+           :   ┌───── Stage 2 ── tasks=4, partitions=4
            :   │ SortExec: TopK(fetch=5000), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[true]
            :   │   VisibilityFilterExec: tables=[i]
            :   │     NestedLoopJoinExec: join_type=RightSemi, filter=pattern@3 = name@0 OR pattern@3 = alt_name@1 OR pattern@3 = category@2, projection=[ctid_0@0, id@4]
            :   │       CoalescePartitionsExec
-           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=8, input_tasks=2
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=4, input_tasks=2
            :   │       DistributedLeafExec:
            :   │         t0: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   │         t1: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   │         t2: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   │         t3: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=2, partitions=16
-           :     │ BroadcastExec: input_partitions=2, consumer_tasks=4, output_partitions=8
+           :     ┌───── Stage 1 ── tasks=2, partitions=8
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=4, output_partitions=4
            :     │   DistributedLeafExec:
            :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
            :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}

--- a/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
+++ b/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
@@ -131,7 +131,7 @@ LIMIT 10;
            :     │         t0: PgSearchScan: segments=2, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
            :     └──────────────────────────────────────────────────
            :     ┌───── Stage 2 ── tasks=4, partitions=16
-           :     │ RepartitionExec: partitioning=Hash([company_id@0], 16), input_partitions=4
+           :     │ RepartitionExec: partitioning=Hash([company_id@0], 16), input_partitions=1
            :     │   DistributedLeafExec:
            :     │     t0: PgSearchScan: segments=30, dynamic_filters=1, query="all"
            :     │     t1: PgSearchScan: segments=30, dynamic_filters=1, query="all"

--- a/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
@@ -154,27 +154,27 @@ LIMIT 48;
                  :   │     [Stage 3] => NetworkShuffleExec: output_partitions=2, input_tasks=2
                  :   └──────────────────────────────────────────────────
                  :     ┌───── Stage 3 ── tasks=2, partitions=4
-                 :     │ RepartitionExec: partitioning=Hash([col_1@0, col_2@1, col_3@2, col_4@3], 4), input_partitions=2
+                 :     │ RepartitionExec: partitioning=Hash([col_1@0, col_2@1, col_3@2, col_4@3], 4), input_partitions=1
                  :     │   AggregateExec: mode=Partial, gby=[id@1 as col_1, name@2 as col_2, id@4 as col_3, id@6 as col_4], aggr=[min(u_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(o_2.ctid_2) as ctid_2]
                  :     │     VisibilityFilterExec: tables=[u, p, o]
                  :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@5, age@1)], projection=[ctid_0@0, id@1, name@2, ctid_1@3, id@4, ctid_2@6, id@8]
                  :     │         CoalescePartitionsExec
-                 :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+                 :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
                  :     │         DistributedLeafExec:
                  :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 2 ── tasks=2, partitions=8
-                 :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :       ┌───── Stage 2 ── tasks=2, partitions=4
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
                  :       │     CoalescePartitionsExec
-                 :       │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+                 :       │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
                  :       │     DistributedLeafExec:
                  :       │       t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
                  :       │       t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
-                 :         ┌───── Stage 1 ── tasks=2, partitions=8
-                 :         │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :         ┌───── Stage 1 ── tasks=2, partitions=4
+                 :         │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :         │   DistributedLeafExec:
                  :         │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
                  :         │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -175,14 +175,14 @@ WHERE f.content @@@ 'Section';
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       DistributedLeafExec:
      :   │         t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   │         t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── tasks=2, partitions=8
-     :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+     :     ┌───── Stage 1 ── tasks=2, partitions=4
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
      :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
@@ -232,14 +232,14 @@ LIMIT 5;
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │         DistributedLeafExec:
                  :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── tasks=2, partitions=8
-                 :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :       ┌───── Stage 1 ── tasks=2, partitions=4
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
                  :       │     t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       │     t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
@@ -136,7 +136,7 @@ LIMIT 5;
                  :   │     [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
                  :   └──────────────────────────────────────────────────
                  :     ┌───── Stage 1 ── tasks=3, partitions=9
-                 :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=3
+                 :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=1
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :     │       DistributedLeafExec:

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -128,14 +128,14 @@ ORDER BY f.category;
            :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1, min(p_1.size_bytes) as agg_2, max(p_1.size_bytes) as agg_3]
            :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
            :     │       CoalescePartitionsExec
-           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-           :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+           :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :     │         DistributedLeafExec:
            :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-           :       ┌───── Stage 1 ── tasks=2, partitions=8
-           :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :       ┌───── Stage 1 ── tasks=2, partitions=4
+           :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
            :       │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
@@ -219,14 +219,14 @@ LIMIT 10;
                  :     │   AggregateExec: mode=Partial, gby=[category@1 as category, title@0 as title], aggr=[count(1) as agg_0]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, category@2]
                  :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │         DistributedLeafExec:
                  :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── tasks=2, partitions=8
-                 :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :       ┌───── Stage 1 ── tasks=2, partitions=4
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
                  :       │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
@@ -309,14 +309,14 @@ LIMIT 3;
                  :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
                  :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │         DistributedLeafExec:
                  :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── tasks=2, partitions=8
-                 :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :       ┌───── Stage 1 ── tasks=2, partitions=4
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
                  :       │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
@@ -374,14 +374,14 @@ WHERE f.content @@@ 'Section';
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       DistributedLeafExec:
      :   │         t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   │         t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── tasks=2, partitions=8
-     :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+     :     ┌───── Stage 1 ── tasks=2, partitions=4
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
      :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
@@ -476,23 +476,23 @@ ORDER BY c.name;
            :     │   AggregateExec: mode=Partial, gby=[name@1 as name], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
            :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(name@0, category@0)], projection=[size_bytes@2, name@0]
            :     │       CoalescePartitionsExec
-           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
            :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
            :     │         CoalescePartitionsExec
-           :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-           :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+           :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :     │           DistributedLeafExec:
            :     │             t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     │             t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-           :       ┌───── Stage 1 ── tasks=2, partitions=8
-           :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :       ┌───── Stage 1 ── tasks=2, partitions=4
+           :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
            :       │     t0: PgSearchScan: segments=2, query="all"
            :       │     t1: PgSearchScan: segments=2, query="all"
            :       └──────────────────────────────────────────────────
-           :       ┌───── Stage 2 ── tasks=2, partitions=8
-           :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :       ┌───── Stage 2 ── tasks=2, partitions=4
+           :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
            :       │     t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       │     t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -472,7 +472,7 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                   QUERY PLAN                                                                                                                    
+                                                                                                                   QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
@@ -485,7 +485,7 @@ LIMIT 5;
                Indexes: mpp_join_files_idx (f), mpp_join_pages_idx (p)
                Group By: title
                Aggregates: COUNT(*), SUM(size_bytes)
-               DataFusion Physical Plan: 
+               DataFusion Physical Plan:
                  : ┌───── DistributedExec
                  : │ SortPreservingMergeExec: [title@0 ASC NULLS LAST], fetch=5
                  : │   [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
@@ -516,7 +516,7 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-  title   | count |  sum  
+  title   | count |  sum
 ----------+-------+-------
  file-1   |     5 | 10040
  file-10  |     5 | 10189

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -184,10 +184,11 @@ LIMIT 10;
 (10 rows)
 
 -- =====================================================================
--- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
--- Asserts presence, not content: how many workers launch and how they
--- split the rows isn't pinned, so per-fragment metrics vary run to run.
--- A fragment's row counts appear only once its TaskMetrics crossed the mesh.
+-- Pass 3: worker metrics and dynamic-filter pruning reach the leader's
+-- EXPLAIN ANALYZE display. Asserts presence, not exact counts: how many
+-- workers launch and how they split the rows isn't pinned, so per-fragment
+-- metrics vary run to run. A fragment's row counts appear only once its
+-- TaskMetrics crossed the mesh.
 -- =====================================================================
 CREATE OR REPLACE FUNCTION mpp_explain_analyze_lines(q text) RETURNS SETOF text AS $$
 DECLARE r record;
@@ -196,20 +197,50 @@ BEGIN
     RETURN NEXT r."QUERY PLAN";
   END LOOP;
 END $$ LANGUAGE plpgsql;
-SELECT count(*) > 0 AS worker_metrics_shown
+CREATE TEMP TABLE mpp_explain_analyze_output AS
+SELECT line
 FROM mpp_explain_analyze_lines(
   'SELECT f.title, p.size_bytes
    FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
    WHERE f.content @@@ ''Section''
+     AND f.id <= 20
    ORDER BY f.title, p.size_bytes
    LIMIT 10'
-) AS line
+) AS line;
+SELECT count(*) > 0 AS worker_metrics_shown
+FROM mpp_explain_analyze_output
 WHERE line LIKE '%output_rows%';
  worker_metrics_shown 
 ----------------------
  t
 (1 row)
 
+-- Assigned range variants expose one local partition, satisfying DataFusion's
+-- dynamic-filter routing condition. Positive pruning is worker-runtime proof
+-- that a populated join filter reached the Tantivy scan after dispatch.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM mpp_explain_analyze_output
+    WHERE line LIKE '%DistributedExec%'
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM mpp_explain_analyze_output
+    WHERE line LIKE '%partition=%'
+  ) THEN
+    RAISE EXCEPTION 'expected an MPP range-partitioned join';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM mpp_explain_analyze_output
+    WHERE line ~ 'rows_pruned=\{[^}]*:[1-9][0-9]*'
+  ) THEN
+    RAISE EXCEPTION 'expected an MPP range-join worker to prune rows with a dynamic filter';
+  END IF;
+END $$;
+DROP TABLE mpp_explain_analyze_output;
 DROP FUNCTION mpp_explain_analyze_lines(text);
 -- =====================================================================
 -- Pass 4: MPP with heap filter

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -216,8 +216,8 @@ WHERE line LIKE '%output_rows%';
 (1 row)
 
 -- Assigned range variants expose one local partition, satisfying DataFusion's
--- dynamic-filter routing condition. Positive pruning is worker-runtime proof
--- that a populated join filter reached the Tantivy scan after dispatch.
+-- dynamic-filter routing condition. A worker may apply the resulting filter
+-- either in the batch pre-filter or by pushing it directly into Tantivy.
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -236,8 +236,9 @@ BEGIN
     SELECT 1
     FROM mpp_explain_analyze_output
     WHERE line ~ 'rows_pruned=\{[^}]*:[1-9][0-9]*'
+       OR line LIKE '%dynamic_filter_pushdown=%'
   ) THEN
-    RAISE EXCEPTION 'expected an MPP range-join worker to prune rows with a dynamic filter';
+    RAISE EXCEPTION 'expected an MPP range-join worker to apply a dynamic filter';
   END IF;
 END $$;
 DROP TABLE mpp_explain_analyze_output;

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -472,7 +472,7 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                   QUERY PLAN
+                                                                                                                   QUERY PLAN                                                                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
@@ -485,7 +485,7 @@ LIMIT 5;
                Indexes: mpp_join_files_idx (f), mpp_join_pages_idx (p)
                Group By: title
                Aggregates: COUNT(*), SUM(size_bytes)
-               DataFusion Physical Plan:
+               DataFusion Physical Plan: 
                  : ┌───── DistributedExec
                  : │ SortPreservingMergeExec: [title@0 ASC NULLS LAST], fetch=5
                  : │   [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
@@ -516,7 +516,7 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-  title   | count |  sum
+  title   | count |  sum  
 ----------+-------+-------
  file-1   |     5 | 10040
  file-10  |     5 | 10189

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -146,9 +146,9 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │     [Stage 1] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 1 ── tasks=3, partitions=9
+           :   ┌───── Stage 1 ── tasks=3, partitions=3
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
@@ -240,9 +240,9 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │     [Stage 1] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 1 ── tasks=3, partitions=9
+           :   ┌───── Stage 1 ── tasks=3, partitions=3
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
@@ -370,7 +370,7 @@ LIMIT 10;
            :   │         [Stage 2] => NetworkShuffleExec: output_partitions=4, input_tasks=4
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=4, partitions=16
-           :     │ RepartitionExec: partitioning=Hash([id@1], 16), input_partitions=4
+           :     │ RepartitionExec: partitioning=Hash([id@1], 16), input_partitions=1
            :     │   DistributedLeafExec:
            :     │     t0: PgSearchScan: segments=2, partition=id[-∞..38), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     │     t1: PgSearchScan: segments=2, partition=id[38..76), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
@@ -378,7 +378,7 @@ LIMIT 10;
            :     │     t3: PgSearchScan: segments=2, partition=id[126..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
            :     ┌───── Stage 2 ── tasks=4, partitions=16
-           :     │ RepartitionExec: partitioning=Hash([file_id@1], 16), input_partitions=4
+           :     │ RepartitionExec: partitioning=Hash([file_id@1], 16), input_partitions=1
            :     │   VisibilityFilterExec: tables=[p]
            :     │     DistributedLeafExec:
            :     │       t0: PgSearchScan: segments=2, partition=file_id[-∞..38), dynamic_filters=1, query="all"
@@ -464,7 +464,7 @@ LIMIT 5;
                  :   │     [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
                  :   └──────────────────────────────────────────────────
                  :     ┌───── Stage 1 ── tasks=3, partitions=9
-                 :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=3
+                 :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=1
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :     │       DistributedLeafExec:

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -126,10 +126,11 @@ ORDER BY f.title, p.size_bytes
 LIMIT 10;
 
 -- =====================================================================
--- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
--- Asserts presence, not content: how many workers launch and how they
--- split the rows isn't pinned, so per-fragment metrics vary run to run.
--- A fragment's row counts appear only once its TaskMetrics crossed the mesh.
+-- Pass 3: worker metrics and dynamic-filter pruning reach the leader's
+-- EXPLAIN ANALYZE display. Asserts presence, not exact counts: how many
+-- workers launch and how they split the rows isn't pinned, so per-fragment
+-- metrics vary run to run. A fragment's row counts appear only once its
+-- TaskMetrics crossed the mesh.
 -- =====================================================================
 
 CREATE OR REPLACE FUNCTION mpp_explain_analyze_lines(q text) RETURNS SETOF text AS $$
@@ -140,16 +141,48 @@ BEGIN
   END LOOP;
 END $$ LANGUAGE plpgsql;
 
-SELECT count(*) > 0 AS worker_metrics_shown
+CREATE TEMP TABLE mpp_explain_analyze_output AS
+SELECT line
 FROM mpp_explain_analyze_lines(
   'SELECT f.title, p.size_bytes
    FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
    WHERE f.content @@@ ''Section''
+     AND f.id <= 20
    ORDER BY f.title, p.size_bytes
    LIMIT 10'
-) AS line
+) AS line;
+
+SELECT count(*) > 0 AS worker_metrics_shown
+FROM mpp_explain_analyze_output
 WHERE line LIKE '%output_rows%';
 
+-- Assigned range variants expose one local partition, satisfying DataFusion's
+-- dynamic-filter routing condition. Positive pruning is worker-runtime proof
+-- that a populated join filter reached the Tantivy scan after dispatch.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM mpp_explain_analyze_output
+    WHERE line LIKE '%DistributedExec%'
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM mpp_explain_analyze_output
+    WHERE line LIKE '%partition=%'
+  ) THEN
+    RAISE EXCEPTION 'expected an MPP range-partitioned join';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM mpp_explain_analyze_output
+    WHERE line ~ 'rows_pruned=\{[^}]*:[1-9][0-9]*'
+  ) THEN
+    RAISE EXCEPTION 'expected an MPP range-join worker to prune rows with a dynamic filter';
+  END IF;
+END $$;
+
+DROP TABLE mpp_explain_analyze_output;
 DROP FUNCTION mpp_explain_analyze_lines(text);
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -157,8 +157,8 @@ FROM mpp_explain_analyze_output
 WHERE line LIKE '%output_rows%';
 
 -- Assigned range variants expose one local partition, satisfying DataFusion's
--- dynamic-filter routing condition. Positive pruning is worker-runtime proof
--- that a populated join filter reached the Tantivy scan after dispatch.
+-- dynamic-filter routing condition. A worker may apply the resulting filter
+-- either in the batch pre-filter or by pushing it directly into Tantivy.
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -177,8 +177,9 @@ BEGIN
     SELECT 1
     FROM mpp_explain_analyze_output
     WHERE line ~ 'rows_pruned=\{[^}]*:[1-9][0-9]*'
+       OR line LIKE '%dynamic_filter_pushdown=%'
   ) THEN
-    RAISE EXCEPTION 'expected an MPP range-join worker to prune rows with a dynamic filter';
+    RAISE EXCEPTION 'expected an MPP range-join worker to apply a dynamic filter';
   END IF;
 END $$;
 


### PR DESCRIPTION
Related to #5734.

## What

Make each task-specialized `PgSearchScanPlan` expose one local partition while
preserving its assigned global range and the global partition count.

## Why

Each distributed task executes one matching build/probe range, but previously
advertised all global ranges. DataFusion considers a non-hash partitioned join
eligible for dynamic-filter routing only when both inputs expose one partition:

```rust
(left_partitioning, right_partitioning) => {
    left_partitioning.partition_count() == 1
        && right_partitioning.partition_count() == 1
}
```

[DataFusion source](https://github.com/apache/datafusion/blob/8d680db14a9134837bbd3d53497dd58c985c51a7/datafusion/physical-plan/src/joins/hash_join/exec.rs#L898-L912)

Because each task advertised `Range(N)`, this check failed and dynamic filtering
was disabled despite the task executing only one range.

## How

Assigned variants advertise `UnknownPartitioning(1)` and map local `execute(0)`
to their assigned global range. The global partition count is retained
separately to reconstruct the correct range boundaries during dispatch.

## Tests

- Verify dispatch preserves the assigned global range while exposing one local
  partition.
- Verify an MPP range join applies a worker-side dynamic filter through either positive
  `rows_pruned` metrics or direct `dynamic_filter_pushdown`.
- Update affected EXPLAIN snapshots.
