### PR TITLE
perf: removed the string round-trip from `NUMERIC` sum accumulation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,7 +2564,8 @@ checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 [[package]]
 name = "decimal-bytes"
 version = "0.4.3"
-source = "git+https://github.com/paradedb/decimal-bytes?rev=f8eeb31a61a83d4452632e247633a73b47777010#f8eeb31a61a83d4452632e247633a73b47777010"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ca5c5cd9fae79b456f0a067c6b428ab1edad0c3a32b95c6e72ce8e777466cb"
 dependencies = [
  "serde",
  "thiserror 2.0.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5047,6 +5047,7 @@ dependencies = [
  "arrow-select 59.1.0",
  "async-stream",
  "async-trait",
+ "bigdecimal",
  "bincode 2.0.1",
  "bitpacking",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,9 +2563,8 @@ checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 
 [[package]]
 name = "decimal-bytes"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269277cb6b69f2fa55423ff5f3ff61f783893488b4e019b50fd4b57e077e1d4e"
+version = "0.4.3"
+source = "git+https://github.com/paradedb/decimal-bytes?rev=934d4de0b46d522e46c185ef08011154e8fbf9b6#934d4de0b46d522e46c185ef08011154e8fbf9b6"
 dependencies = [
  "serde",
  "thiserror 2.0.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,7 +2564,7 @@ checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 [[package]]
 name = "decimal-bytes"
 version = "0.4.3"
-source = "git+https://github.com/paradedb/decimal-bytes?rev=934d4de0b46d522e46c185ef08011154e8fbf9b6#934d4de0b46d522e46c185ef08011154e8fbf9b6"
+source = "git+https://github.com/paradedb/decimal-bytes?rev=f8eeb31a61a83d4452632e247633a73b47777010#f8eeb31a61a83d4452632e247633a73b47777010"
 dependencies = [
  "serde",
  "thiserror 2.0.19",

--- a/benchmarks/datasets/stackoverflow/before_create_index.sql
+++ b/benchmarks/datasets/stackoverflow/before_create_index.sql
@@ -1,0 +1,8 @@
+-- Restored heap snapshots can predate the generated NUMERIC columns. These
+-- backfill them on such heaps and no-op once the snapshots are regenerated
+-- from create_tables.sql.
+ALTER TABLE stackoverflow_posts
+    ADD COLUMN IF NOT EXISTS amount15 NUMERIC(15, 2) GENERATED ALWAYS AS (view_count::numeric / 100) STORED;
+
+ALTER TABLE stackoverflow_posts
+    ADD COLUMN IF NOT EXISTS amount78 NUMERIC(78, 0) GENERATED ALWAYS AS ('1e70'::numeric + view_count) STORED;

--- a/benchmarks/datasets/stackoverflow/create_tables.sql
+++ b/benchmarks/datasets/stackoverflow/create_tables.sql
@@ -25,7 +25,12 @@ CREATE TABLE stackoverflow_posts (
     post_type_id SMALLINT,
     score INTEGER,
     tags VARCHAR,
-    view_count INTEGER
+    view_count INTEGER,
+    -- NUMERIC shapes for aggregate pushdown benchmarks, one per storage
+    -- format. Generated so the sampled CSVs stay unchanged: COPY skips
+    -- generated columns. amount78 mimics uint256-style token amounts.
+    amount15 NUMERIC(15, 2) GENERATED ALWAYS AS (view_count::numeric / 100) STORED,
+    amount78 NUMERIC(78, 0) GENERATED ALWAYS AS ('1e70'::numeric + view_count) STORED
 );
 
 CREATE TABLE badges (

--- a/benchmarks/datasets/stackoverflow/indexes/bm25.sql
+++ b/benchmarks/datasets/stackoverflow/indexes/bm25.sql
@@ -19,6 +19,8 @@ USING bm25 (
     view_count,
     answer_count,
     comment_count,
+    amount15,
+    amount78,
     (owner_display_name::pdb.unicode_words('columnar=true')),
     owner_user_id
 ) WITH (

--- a/benchmarks/datasets/stackoverflow/queries/sum-int-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/sum-int-filter.sql
@@ -1,0 +1,5 @@
+-- postgres aggregate over fast fields
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT SUM(view_count) FROM stackoverflow_posts WHERE body ||| 'error';
+
+-- tantivy aggregate custom scan (reference for the NUMERIC variants)
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT SUM(view_count) FROM stackoverflow_posts WHERE body ||| 'error';

--- a/benchmarks/datasets/stackoverflow/queries/sum-numeric15-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/sum-numeric15-filter.sql
@@ -1,0 +1,5 @@
+-- postgres aggregate over fast fields
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT SUM(amount15) FROM stackoverflow_posts WHERE body ||| 'error';
+
+-- datafusion aggregate custom scan, NUMERIC(15,2) scaled-i64 storage
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT SUM(amount15) FROM stackoverflow_posts WHERE body ||| 'error';

--- a/benchmarks/datasets/stackoverflow/queries/sum-numeric78-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/sum-numeric78-filter.sql
@@ -1,0 +1,5 @@
+-- postgres aggregate over fast fields
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT SUM(amount78) FROM stackoverflow_posts WHERE body ||| 'error';
+
+-- datafusion aggregate custom scan, NUMERIC(78,0) decimal-bytes storage
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT SUM(amount78) FROM stackoverflow_posts WHERE body ||| 'error';

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -584,9 +584,10 @@ async fn process_index_creation(args: &BenchmarkArgs) -> anyhow::Result<Vec<Inde
     Ok(results)
 }
 
-async fn process_after_create_index_sql(args: &BenchmarkArgs) -> anyhow::Result<()> {
-    let after_create_index_sql = format!("datasets/{}/after_create_index.sql", args.dataset);
-    if !Path::new(&after_create_index_sql).exists() {
+/// Run an optional per-dataset setup file (`datasets/{dataset}/{stem}.sql`).
+async fn process_setup_sql(args: &BenchmarkArgs, stem: &str) -> anyhow::Result<()> {
+    let setup_sql = format!("datasets/{}/{stem}.sql", args.dataset);
+    if !Path::new(&setup_sql).exists() {
         return Ok(());
     }
 
@@ -595,7 +596,7 @@ async fn process_after_create_index_sql(args: &BenchmarkArgs) -> anyhow::Result<
         .with_context(|| "Failed to connect to database")?;
 
     // Resolve `{{ params }}` (e.g. probes, sized to the dataset) and run each statement.
-    let statements = queries(Path::new(&after_create_index_sql));
+    let statements = queries(Path::new(&setup_sql));
     let params =
         resolve_template_params(&mut conn, &args.dataset, args.size.as_deref(), &statements)
             .await?;
@@ -606,10 +607,22 @@ async fn process_after_create_index_sql(args: &BenchmarkArgs) -> anyhow::Result<
             .await
             .with_context(|| {
                 let preview: String = statement.chars().take(60).collect();
-                format!("Failed to run after_create_index statement: {preview}")
+                format!("Failed to run {stem} statement: {preview}")
             })?;
     }
     Ok(())
+}
+
+/// Schema amendments that must exist before the index builds. Restored heap
+/// snapshots can predate additions in `create_tables.sql`; this hook lets a
+/// dataset backfill them without the statements landing in the per-statement
+/// index-creation metrics.
+async fn process_before_create_index_sql(args: &BenchmarkArgs) -> anyhow::Result<()> {
+    process_setup_sql(args, "before_create_index").await
+}
+
+async fn process_after_create_index_sql(args: &BenchmarkArgs) -> anyhow::Result<()> {
+    process_setup_sql(args, "after_create_index").await
 }
 
 /// Database-level GUC holding the query vector that every query file orders by.
@@ -1223,6 +1236,7 @@ async fn generate_markdown_output(args: &BenchmarkArgs) -> anyhow::Result<()> {
     write_test_info(&mut file, args).await?;
     write_postgres_settings(&mut file, &args.url).await?;
     if !args.skip_index {
+        process_before_create_index_sql(args).await?;
         process_index_creation_md(&mut file, args).await?;
         process_after_create_index_sql(args).await?;
     }
@@ -1234,6 +1248,7 @@ async fn generate_csv_output(args: &BenchmarkArgs) -> anyhow::Result<()> {
     write_test_info_csv(args).await?;
     write_postgres_settings_csv(&args.url).await?;
     if !args.skip_index {
+        process_before_create_index_sql(args).await?;
         process_index_creation_csv(args).await?;
         process_after_create_index_sql(args).await?;
     }
@@ -1245,6 +1260,7 @@ async fn generate_json_output(args: &BenchmarkArgs) -> anyhow::Result<()> {
     // Index and query metrics share one results.json, so the publish step reports them as one set.
     let mut results = Vec::new();
     if !args.skip_index {
+        process_before_create_index_sql(args).await?;
         results.extend(
             process_index_creation(args)
                 .await?

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -136,7 +136,7 @@ CREATE TABLE transfers (
 
 The following shapes fall back to Postgres for aggregation:
 
-- Columns declared as unbounded `NUMERIC` (no precision and scale). Declare a precision and scale to enable pushdown. `COUNT` still pushes down.
+- Columns declared as unbounded `NUMERIC` (no precision and scale). Declare a precision and scale to enable pushdown. `COUNT` on such a column still pushes down, but a `GROUP BY` on it declines the whole query.
 - `HAVING` over a `NUMERIC` aggregate
 - `SUM(DISTINCT ...)` / `AVG(DISTINCT ...)` on `NUMERIC` columns
 - `STDDEV`, `VARIANCE`, and other statistical aggregates on `NUMERIC` columns

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -140,5 +140,4 @@ The following shapes fall back to Postgres for aggregation:
 - `HAVING` over a `NUMERIC` aggregate
 - `SUM(DISTINCT ...)` / `AVG(DISTINCT ...)` on `NUMERIC` columns
 - `STDDEV`, `VARIANCE`, and other statistical aggregates on `NUMERIC` columns
-- Indexes built before v0.22, which store `NUMERIC` as `FLOAT8`. `REINDEX` to enable pushdown.
 - `pdb.agg()` on `NUMERIC` fields (use standard SQL aggregate functions instead)

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -124,25 +124,21 @@ When a fallback happens, the query still runs correctly through Postgres' native
 
 ## NUMERIC Columns
 
-`NUMERIC` columns do not support aggregate pushdown. Queries with aggregates on `NUMERIC` columns will automatically fall back to Postgres for aggregation.
-
-For numeric data that requires aggregate pushdown, use `FLOAT` or `DOUBLE PRECISION` instead:
+`SUM`, `AVG`, `MIN`, `MAX`, and `COUNT` push down for `NUMERIC(p, s)` columns of any precision, including high-precision columns like `NUMERIC(78, 0)`. Results are exact and match Postgres, including `NaN` handling.
 
 ```sql
--- Aggregates can be pushed down
-CREATE TABLE products (
+-- Aggregates push down for any declared precision
+CREATE TABLE transfers (
     id SERIAL PRIMARY KEY,
-    price DOUBLE PRECISION
-);
-
--- Aggregates fall back to PostgreSQL
-CREATE TABLE products (
-    id SERIAL PRIMARY KEY,
-    price NUMERIC(10,2)
+    amount NUMERIC(78,0)
 );
 ```
 
-<Note>
-  Filter pushdown (equality and range queries) is fully supported for all
-  `NUMERIC` columns. Only aggregate pushdown is not supported.
-</Note>
+The following shapes fall back to Postgres for aggregation:
+
+- Columns declared as unbounded `NUMERIC` (no precision and scale). Declare a precision and scale to enable pushdown. `COUNT` still pushes down.
+- `HAVING` over a `NUMERIC` aggregate
+- `SUM(DISTINCT ...)` / `AVG(DISTINCT ...)` on `NUMERIC` columns
+- `STDDEV`, `VARIANCE`, and other statistical aggregates on `NUMERIC` columns
+- Indexes built before v0.22, which store `NUMERIC` as `FLOAT8`. `REINDEX` to enable pushdown.
+- `pdb.agg()` on `NUMERIC` fields (use standard SQL aggregate functions instead)

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-F0wRF0D/U5+5irFykPIdJ7FuszuNO8AhRqJqi99tiYI=";
+  cargoHash = "sha256-gChuALQOnxXt3DHciAX6U6+pZqCra56TmmijRJOyJJ4=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-A5DEra1QySa1Jg9BtL/BHR2Qtd+RGIGYYuuVaSmXKFs=";
+  cargoHash = "sha256-0hqU+dxw2TR0GBzxlkjA74dd4R5pWGhgOZIrNm6njV0=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-0hqU+dxw2TR0GBzxlkjA74dd4R5pWGhgOZIrNm6njV0=";
+  cargoHash = "sha256-F0wRF0D/U5+5irFykPIdJ7FuszuNO8AhRqJqi99tiYI=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-gChuALQOnxXt3DHciAX6U6+pZqCra56TmmijRJOyJJ4=";
+  cargoHash = "sha256-t6IyG26XAwUBNVpMV+KyURap3VzW2+3Rl2F3h2FCMbc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -84,6 +84,7 @@ macros = { path = "../macros" }
 half = "2.7.1"
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
 decimal-bytes = "0.4.2"
+bigdecimal = "0.4.10"
 paste = "1.0.15"
 typetag = "0.2"
 tokio = { version = "1", features = ["rt"] }

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -83,7 +83,7 @@ lazy_static = "1.5.0"
 macros = { path = "../macros" }
 half = "2.7.1"
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
-decimal-bytes = "0.4.2"
+decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes", rev = "934d4de0b46d522e46c185ef08011154e8fbf9b6" }
 bigdecimal = "0.4.10"
 paste = "1.0.15"
 typetag = "0.2"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -83,7 +83,7 @@ lazy_static = "1.5.0"
 macros = { path = "../macros" }
 half = "2.7.1"
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
-decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes", rev = "934d4de0b46d522e46c185ef08011154e8fbf9b6" }
+decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes", rev = "f8eeb31a61a83d4452632e247633a73b47777010" }
 bigdecimal = "0.4.10"
 paste = "1.0.15"
 typetag = "0.2"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -83,7 +83,7 @@ lazy_static = "1.5.0"
 macros = { path = "../macros" }
 half = "2.7.1"
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
-decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes", rev = "f8eeb31a61a83d4452632e247633a73b47777010" }
+decimal-bytes = "0.4.3"
 bigdecimal = "0.4.10"
 paste = "1.0.15"
 typetag = "0.2"

--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -225,8 +225,10 @@ impl AggregateType {
         let first_arg = args.get_ptr(0).ok_or("aggregate missing argument")?;
         let (field, missing) = parse_aggregate_field(first_arg, heaprelid)?;
 
-        // Check if aggregate pushdown is supported for this field type
-        // NUMERIC fields are not supported - they fall back to PostgreSQL
+        // Check if aggregate pushdown is supported for this field type on the
+        // Tantivy backend. NUMERIC fields are not supported here; standard SQL
+        // aggregates over them route to the DataFusion backend at path
+        // creation time and never reach this classifier.
         if !bm25_index.field_supports_aggregate(&field).unwrap_or(false) {
             return Err(format!(
                 "field '{}' does not support aggregate pushdown",

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -494,14 +494,6 @@ impl CustomScanClause<AggregateScan> for AggregateCSClause {
     }
 }
 
-/// Returns true when the query has ORDER BY on any aggregate + LIMIT.
-/// These queries are routed to DataFusion instead of Tantivy because:
-/// - Tantivy's max_buckets (65000) silently drops groups beyond that limit,
-///   which could exclude groups that belong in the top-K.
-/// - DataFusion has no bucket cap and provides native TopK via SortExec(fetch=K).
-///
-/// This is a lightweight parse-tree check used before building the full
-/// AggregateCSClause — it only looks at the sort clause structure.
 /// True when the query aggregates over a NUMERIC column or groups by one,
 /// where the column is a direct `Var` reference. Those queries must route to
 /// the DataFusion backend: the Tantivy aggregation engine computes metrics in
@@ -571,6 +563,14 @@ pub(super) unsafe fn has_numeric_aggregate_or_group(args: &CreateUpperPathsHookA
     false
 }
 
+/// Returns true when the query has ORDER BY on any aggregate + LIMIT.
+/// These queries are routed to DataFusion instead of Tantivy because:
+/// - Tantivy's max_buckets (65000) silently drops groups beyond that limit,
+///   which could exclude groups that belong in the top-K.
+/// - DataFusion has no bucket cap and provides native TopK via SortExec(fetch=K).
+///
+/// This is a lightweight parse-tree check used before building the full
+/// AggregateCSClause — it only looks at the sort clause structure.
 pub(super) unsafe fn has_aggregate_orderby_with_limit(args: &CreateUpperPathsHookArgs) -> bool {
     let parse = args.root().parse;
     if parse.is_null() || (*parse).sortClause.is_null() || (*parse).groupClause.is_null() {

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -502,6 +502,75 @@ impl CustomScanClause<AggregateScan> for AggregateCSClause {
 ///
 /// This is a lightweight parse-tree check used before building the full
 /// AggregateCSClause — it only looks at the sort clause structure.
+/// True when the query aggregates over a NUMERIC column or groups by one,
+/// where the column is a direct `Var` reference. Those queries must route to
+/// the DataFusion backend: the Tantivy aggregation engine computes metrics in
+/// f64 and cannot aggregate the decimal-bytes storage at all.
+///
+/// Wrapped expressions (casts of JSON sub-fields, COALESCE) stay on the
+/// Tantivy backend, which classifies and declines them with its own messages;
+/// the DataFusion backend cannot take them either.
+pub(super) unsafe fn has_numeric_aggregate_or_group(args: &CreateUpperPathsHookArgs) -> bool {
+    use pgrx::pg_guard;
+
+    let parse = args.root().parse;
+    if parse.is_null() || (*parse).targetList.is_null() {
+        return false;
+    }
+
+    unsafe fn is_direct_numeric_var(expr: *mut pg_sys::Node) -> bool {
+        super::join_targetlist::unwrap_to_var(expr)
+            .is_some_and(|var| (*var).vartype == pg_sys::NUMERICOID)
+    }
+
+    struct WalkerContext {
+        found: bool,
+    }
+
+    #[pg_guard]
+    unsafe extern "C-unwind" fn numeric_aggref_walker(
+        node: *mut pg_sys::Node,
+        context: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+        let ctx = &mut *(context as *mut WalkerContext);
+        if (*node).type_ == pg_sys::NodeTag::T_Aggref {
+            let aggref = node as *mut pg_sys::Aggref;
+            let agg_args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
+            for arg in agg_args.iter_ptr() {
+                if is_direct_numeric_var((*arg).expr as *mut pg_sys::Node) {
+                    ctx.found = true;
+                    return true;
+                }
+            }
+        }
+        pg_sys::expression_tree_walker(node, Some(numeric_aggref_walker), context)
+    }
+
+    let mut context = WalkerContext { found: false };
+    numeric_aggref_walker(
+        (*parse).targetList as *mut pg_sys::Node,
+        std::ptr::addr_of_mut!(context).cast(),
+    );
+    if context.found {
+        return true;
+    }
+
+    if !(*parse).groupClause.is_null() {
+        let group_clauses = PgList::<pg_sys::SortGroupClause>::from_pg((*parse).groupClause);
+        for gc in group_clauses.iter_ptr() {
+            let expr = pg_sys::get_sortgroupclause_expr(gc, (*parse).targetList);
+            if !expr.is_null() && is_direct_numeric_var(expr) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
 pub(super) unsafe fn has_aggregate_orderby_with_limit(args: &CreateUpperPathsHookArgs) -> bool {
     let parse = args.root().parse;
     if parse.is_null() || (*parse).sortClause.is_null() || (*parse).groupClause.is_null() {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -27,9 +27,12 @@
 use super::join_targetlist::AggOrderByEntry;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::aggregatescan::join_targetlist::{
-    AggKind, JoinAggregateEntry, JoinAggregateTargetList,
+    AggKind, JoinAggregateEntry, JoinAggregateTargetList, NumericAggStorage,
 };
 use crate::postgres::customscan::aggregatescan::privdat::{CompareOp, DataFusionTopK, FilterExpr};
+use crate::postgres::customscan::datafusion::numeric_agg::{
+    numeric_bytes_avg_udaf, numeric_bytes_sum_udaf, numeric64_avg_udaf, numeric64_sum_udaf,
+};
 use crate::postgres::customscan::datafusion::translator::{
     ColumnMapper, PredicateTranslator, apply_join_level_filter, build_join_df, make_col,
     make_source_col,
@@ -145,8 +148,14 @@ pub async fn build_join_aggregate_plan(
                         None,   // null_treatment
                     )))
                 }
-                AggKind::Sum => agg_field_col(agg, plan).map(sum),
-                AggKind::Avg => agg_field_col(agg, plan).map(avg),
+                AggKind::Sum => agg_field_col(agg, plan).map(|col| match &agg.numeric {
+                    None => sum(col),
+                    Some(storage) => numeric_agg_expr(storage, col, false),
+                }),
+                AggKind::Avg => agg_field_col(agg, plan).map(|col| match &agg.numeric {
+                    None => avg(col),
+                    Some(storage) => numeric_agg_expr(storage, col, true),
+                }),
                 AggKind::Min => agg_field_col(agg, plan).map(min),
                 AggKind::Max => agg_field_col(agg, plan).map(max),
                 AggKind::StddevSamp => agg_field_col(agg, plan).map(stddev),
@@ -671,6 +680,41 @@ fn agg_field_col(agg: &JoinAggregateEntry, plan: &RelNode) -> Result<Expr> {
         DataFusionError::Internal("non-COUNT(*) aggregate must have a field reference".to_string())
     })?;
     Ok(make_plan_position_col(plan, r.plan_position, &r.field_name))
+}
+
+/// SUM/AVG expression for a NUMERIC column. The scaled-Int64 UDAFs take the
+/// scale as a plan literal so it survives plan serialization for parallel and
+/// MPP execution; decimal-bytes values are self-describing.
+fn numeric_agg_expr(storage: &NumericAggStorage, col: Expr, is_avg: bool) -> Expr {
+    let (udaf, args) = match storage {
+        NumericAggStorage::Numeric64 { scale } => {
+            let udaf = if is_avg {
+                numeric64_avg_udaf()
+            } else {
+                numeric64_sum_udaf()
+            };
+            (udaf, vec![col, lit(*scale as i32)])
+        }
+        NumericAggStorage::NumericBytes { .. } => {
+            let udaf = if is_avg {
+                numeric_bytes_avg_udaf()
+            } else {
+                numeric_bytes_sum_udaf()
+            };
+            (udaf, vec![col])
+        }
+        NumericAggStorage::LegacyF64 => {
+            unreachable!("legacy F64 numeric aggregates decline at plan time")
+        }
+    };
+    Expr::AggregateFunction(AggregateFunction::new_udf(
+        udaf,
+        args,
+        false,  // distinct
+        None,   // filter
+        vec![], // order_by
+        None,   // null_treatment
+    ))
 }
 
 /// Convert aggregate ORDER BY entries to DataFusion `Sort` expressions.

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -703,9 +703,6 @@ fn numeric_agg_expr(storage: &NumericAggStorage, col: Expr, is_avg: bool) -> Exp
             };
             (udaf, vec![col])
         }
-        NumericAggStorage::LegacyF64 => {
-            unreachable!("legacy F64 numeric aggregates decline at plan time")
-        }
     };
     Expr::AggregateFunction(AggregateFunction::new_udf(
         udaf,

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -23,9 +23,12 @@
 //! - The aggregate result schema directly maps to the SQL output
 //! - Type conversion is limited to aggregate-relevant types
 
-use super::join_targetlist::{AggKind, JoinAggregateTargetList};
-use arrow_array::{Array, RecordBatch};
-use pgrx::{IntoDatum, pg_sys};
+use super::join_targetlist::{AggKind, JoinAggregateEntry, JoinAggregateTargetList};
+use crate::postgres::customscan::datafusion::numeric_agg::decode_avg_blob;
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, RecordBatch};
+use decimal_bytes::Decimal;
+use pgrx::{AnyNumeric, IntoDatum, pg_sys};
 
 /// Project a single row from an aggregate `RecordBatch` into a Postgres `TupleTableSlot`.
 ///
@@ -79,7 +82,7 @@ pub unsafe fn project_aggregate_row_to_slot(
                 col.as_ref(),
                 row_idx,
                 pgrx::PgOid::from(expected_type),
-                None,
+                gc.numeric_scale,
             ) {
                 Ok(Some(datum)) => {
                     datums[pg_idx] = datum;
@@ -124,12 +127,26 @@ pub unsafe fn project_aggregate_row_to_slot(
                     datums[pg_idx] = pg_sys::Datum::null();
                 }
             }
+        } else if matches!(agg.agg_kind, AggKind::Avg) && agg.numeric.is_some() {
+            match numeric_avg_to_datum(col, row_idx) {
+                Ok(Some(datum)) => {
+                    datums[pg_idx] = datum;
+                    isnull[pg_idx] = false;
+                }
+                Ok(None) => {
+                    isnull[pg_idx] = true;
+                    datums[pg_idx] = pg_sys::Datum::null();
+                }
+                Err(e) => {
+                    panic!("BUG: Aggregate projection failed: {}", e);
+                }
+            }
         } else {
             match crate::postgres::types_arrow::arrow_array_to_datum(
                 col.as_ref(),
                 row_idx,
                 pgrx::PgOid::from(agg.result_type_oid),
-                None,
+                numeric_display_scale(agg),
             ) {
                 Ok(Some(datum)) => {
                     datums[pg_idx] = datum;
@@ -152,4 +169,29 @@ pub unsafe fn project_aggregate_row_to_slot(
     (*slot).tts_nvalid = natts as i16;
 
     slot
+}
+
+/// Display scale for a numeric SUM/MIN/MAX result. AVG never reaches the
+/// generic conversion (it is handled by [`numeric_avg_to_datum`]).
+fn numeric_display_scale(agg: &JoinAggregateEntry) -> Option<i16> {
+    agg.numeric.and_then(|n| n.scale())
+}
+
+/// Convert a numeric AVG blob (`[count u64 BE, decimal-bytes sum]`) into a
+/// NUMERIC datum. The division runs through `AnyNumeric` so the result scale
+/// follows Postgres' numeric division rules, matching a non-pushed-down AVG.
+fn numeric_avg_to_datum(col: &ArrayRef, row_idx: usize) -> Result<Option<pg_sys::Datum>, String> {
+    let blob = col.as_binary::<i32>().value(row_idx);
+    let (count, sum_bytes) = decode_avg_blob(blob).map_err(|e| e.to_string())?;
+    if count == 0 {
+        return Ok(None);
+    }
+    let sum = Decimal::from_bytes(sum_bytes)
+        .map_err(|e| format!("failed to decode numeric AVG sum: {e:?}"))?;
+    let sum: AnyNumeric = sum
+        .to_string()
+        .parse()
+        .map_err(|e| format!("failed to parse numeric AVG sum: {e}"))?;
+    let count = AnyNumeric::from(count as i64);
+    Ok((sum / count).into_datum())
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -27,6 +27,7 @@ use super::privdat::FilterExpr;
 use crate::api::SortDirection;
 use crate::postgres::customscan::CreateUpperPathsHookArgs;
 use crate::postgres::var::{VarContext, find_one_aggref, find_one_var_and_fieldname};
+use crate::schema::SearchFieldType;
 use pgrx::PgList;
 use pgrx::pg_sys;
 use pgrx::pg_sys::{
@@ -112,6 +113,115 @@ pub struct JoinGroupColumn {
     pub field_name: String,
     /// Position in the output tuple (index into `output_rel.reltarget.exprs`).
     pub output_index: usize,
+    /// Declared scale when this is a NUMERIC field. Grouping itself works on
+    /// the stored representation; the scale is needed to render group keys
+    /// with the column's display scale.
+    #[serde(default)]
+    pub numeric_scale: Option<i16>,
+}
+
+/// Storage representation of a NUMERIC field referenced by an aggregate,
+/// captured at plan time. Execution picks the matching UDAF from it, and
+/// projection renders results with the declared scale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum NumericAggStorage {
+    /// NUMERIC(p <= 18): scaled `Int64` fast field.
+    Numeric64 { scale: i16 },
+    /// NUMERIC(p > 18): decimal-bytes `BinaryView` fast field. The scale is
+    /// `None` for columns declared without a typmod.
+    NumericBytes { scale: Option<i16> },
+    /// Pre-v0.22 index that stored NUMERIC as F64. Aggregating the lossy
+    /// f64 column would change results vs Postgres, so SUM/AVG/MIN/MAX
+    /// decline and fall back.
+    LegacyF64,
+}
+
+impl NumericAggStorage {
+    pub fn scale(&self) -> Option<i16> {
+        match self {
+            NumericAggStorage::Numeric64 { scale } => Some(*scale),
+            NumericAggStorage::NumericBytes { scale } => *scale,
+            NumericAggStorage::LegacyF64 => None,
+        }
+    }
+}
+
+/// Display scale for a NUMERIC GROUP BY column. Grouping compares the stored
+/// representation, which is order- and equality-preserving for both NUMERIC
+/// storages, but rendering the keys needs the declared scale. Unbounded
+/// NUMERIC drops per-value display scale at index time, so it declines.
+fn numeric_group_scale(source: &JoinAggSource, field_name: &str) -> Result<Option<i16>, String> {
+    match numeric_storage(source, field_name) {
+        // Legacy F64 group keys keep their existing Float64 handling.
+        None | Some(NumericAggStorage::LegacyF64) => Ok(None),
+        Some(storage) => match storage.scale() {
+            Some(scale) => Ok(Some(scale)),
+            None => Err(format!(
+                "GROUP BY column {field_name} is an unbounded NUMERIC; declare a precision and \
+                 scale to enable aggregate pushdown"
+            )),
+        },
+    }
+}
+
+/// Decide whether an aggregate over a NUMERIC field is supported, and which
+/// storage the execution layer must handle.
+///
+/// COUNT variants work on the stored representation directly (the encodings
+/// are canonical, so byte-distinct means value-distinct) and return `None`.
+/// SUM/AVG/MIN/MAX need the declared scale to render results; unbounded
+/// NUMERIC declines because index storage drops per-value display scale.
+/// Everything else declines so the query falls back to Postgres instead of
+/// failing when DataFusion rejects the storage type.
+fn validate_numeric_aggregate(
+    agg_kind: &AggKind,
+    field_refs: &[JoinAggColRef],
+    has_distinct: bool,
+) -> Result<Option<NumericAggStorage>, String> {
+    let Some(storage) = field_refs.iter().find_map(|r| r.numeric) else {
+        return Ok(None);
+    };
+
+    match agg_kind {
+        AggKind::CountStar | AggKind::Count | AggKind::CountDistinct => Ok(None),
+        AggKind::Sum | AggKind::Avg | AggKind::Min | AggKind::Max => {
+            if has_distinct {
+                return Err(format!(
+                    "{agg_kind} with DISTINCT is not supported on NUMERIC columns"
+                ));
+            }
+            if matches!(storage, NumericAggStorage::LegacyF64) {
+                return Err(format!(
+                    "{agg_kind} on a NUMERIC column stored as F64 (pre-v0.22 index) is not \
+                     supported; REINDEX to enable aggregate pushdown"
+                ));
+            }
+            if storage.scale().is_none() {
+                return Err(format!(
+                    "{agg_kind} on an unbounded NUMERIC column is not supported; declare a \
+                     precision and scale to enable aggregate pushdown"
+                ));
+            }
+            Ok(Some(storage))
+        }
+        _ => Err(format!("{agg_kind} is not supported on NUMERIC columns")),
+    }
+}
+
+/// NUMERIC storage info for a resolved field; `None` for non-NUMERIC fields.
+/// Legacy indexes that stored NUMERIC as F64 also return `None`: their column
+/// data really is `Float64` and the native aggregates apply.
+fn numeric_storage(source: &JoinAggSource, field_name: &str) -> Option<NumericAggStorage> {
+    let index = source.bm25_index.as_ref()?;
+    let schema = index.schema().ok()?;
+    match schema.get_field_type(field_name)? {
+        SearchFieldType::Numeric64(_, scale) => Some(NumericAggStorage::Numeric64 { scale }),
+        SearchFieldType::NumericBytes(_, scale) => Some(NumericAggStorage::NumericBytes { scale }),
+        SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
+            Some(NumericAggStorage::LegacyF64)
+        }
+        _ => None,
+    }
 }
 
 /// Aggregate-argument column reference. Same identity model as
@@ -121,6 +231,9 @@ pub struct JoinAggColRef {
     pub plan_position: usize,
     pub attno: pg_sys::AttrNumber,
     pub field_name: String,
+    /// Set when the referenced field is NUMERIC.
+    #[serde(default)]
+    pub numeric: Option<NumericAggStorage>,
 }
 
 /// Aggregate ORDER BY entry (e.g. `STRING_AGG(col, ',' ORDER BY col2)`).
@@ -164,6 +277,10 @@ pub struct JoinAggregateEntry {
     /// `None` when the aggregate has no FILTER.
     #[serde(default)]
     pub filter: Option<FilterExpr>,
+    /// Set for SUM/AVG/MIN/MAX over a NUMERIC field. COUNT works on the
+    /// stored representation and leaves this `None`.
+    #[serde(default)]
+    pub numeric: Option<NumericAggStorage>,
 }
 
 /// The complete aggregate target list for a join aggregate query. Each
@@ -289,11 +406,14 @@ pub unsafe fn extract_aggregate_targetlist(
                     )
                 })?;
 
+            let numeric_scale = numeric_group_scale(source, &field_name)?;
+
             group_columns.push(JoinGroupColumn {
                 plan_position,
                 attno,
                 field_name,
                 output_index: idx,
+                numeric_scale,
             });
         } else if let Some((var, field_name)) = find_one_var_and_fieldname(
             VarContext::from_planner(args.root),
@@ -318,11 +438,17 @@ pub unsafe fn extract_aggregate_targetlist(
                     )
                 })?;
 
+            let numeric_scale = match find_source_by_rti(sources, rti, "GROUP BY expression") {
+                Ok(source) => numeric_group_scale(source, &field_name)?,
+                Err(_) => None,
+            };
+
             group_columns.push(JoinGroupColumn {
                 plan_position,
                 attno,
                 field_name,
                 output_index: idx,
+                numeric_scale,
             });
         } else if let Some(aggref) = find_one_aggref(expr as *mut pg_sys::Node) {
             // Aggregate function (possibly wrapped in COALESCE, etc.)
@@ -382,6 +508,8 @@ pub unsafe fn extract_aggregate_targetlist(
             // not a guessed type - this avoids segfaults from type mismatches
             let result_type_oid = (*aggref).aggtype;
 
+            let numeric = validate_numeric_aggregate(&agg_kind, &field_refs, has_distinct)?;
+
             aggregates.push(JoinAggregateEntry {
                 func_oid: aggfnoid,
                 agg_kind,
@@ -391,6 +519,7 @@ pub unsafe fn extract_aggregate_targetlist(
                 filter,
                 distinct: has_distinct,
                 order_by,
+                numeric,
             });
         } else {
             return Err(format!(
@@ -498,10 +627,13 @@ unsafe fn extract_aggref_field_refs(
                 )
             })?;
 
+        let numeric = numeric_storage(source, &field_name);
+
         refs.push(JoinAggColRef {
             plan_position,
             attno,
             field_name,
+            numeric,
         });
     }
 
@@ -594,7 +726,7 @@ unsafe fn extract_aggref_order_by(
 /// Unwrap an expression to a bare `Var`, allowing only `RelabelType` wrappers.
 /// Returns `None` for anything more complex (COALESCE, FuncExpr, etc.)
 /// so the caller can reject and fall back to native Postgres.
-unsafe fn unwrap_to_var(mut node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var> {
+pub(super) unsafe fn unwrap_to_var(mut node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var> {
     while !node.is_null() {
         match (*node).type_ {
             pg_sys::NodeTag::T_Var => return Some(node as *mut pg_sys::Var),

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -141,10 +141,6 @@ pub enum NumericAggStorage {
     /// NUMERIC(p > 18): decimal-bytes `BinaryView` fast field. The scale is
     /// `None` for columns declared without a typmod.
     NumericBytes { scale: Option<i16> },
-    /// Pre-v0.22 index that stored NUMERIC as F64. Aggregating the lossy
-    /// f64 column would change results vs Postgres, so SUM/AVG/MIN/MAX
-    /// decline and fall back.
-    LegacyF64,
 }
 
 impl NumericAggStorage {
@@ -152,7 +148,6 @@ impl NumericAggStorage {
         match self {
             NumericAggStorage::Numeric64 { scale } => Some(*scale),
             NumericAggStorage::NumericBytes { scale } => *scale,
-            NumericAggStorage::LegacyF64 => None,
         }
     }
 }
@@ -163,8 +158,7 @@ impl NumericAggStorage {
 /// NUMERIC drops per-value display scale at index time, so it declines.
 fn numeric_group_scale(source: &JoinAggSource, field_name: &str) -> Result<Option<i16>, String> {
     match numeric_storage(source, field_name) {
-        // Legacy F64 group keys keep their existing Float64 handling.
-        None | Some(NumericAggStorage::LegacyF64) => Ok(None),
+        None => Ok(None),
         Some(storage) => match storage.scale() {
             Some(scale) => Ok(Some(scale)),
             None => Err(format!(
@@ -201,12 +195,6 @@ fn validate_numeric_aggregate(
                     "{agg_kind} with DISTINCT is not supported on NUMERIC columns"
                 ));
             }
-            if matches!(storage, NumericAggStorage::LegacyF64) {
-                return Err(format!(
-                    "{agg_kind} on a NUMERIC column stored as F64 (pre-v0.22 index) is not \
-                     supported; REINDEX to enable aggregate pushdown"
-                ));
-            }
             if storage.scale().is_none() {
                 return Err(format!(
                     "{agg_kind} on an unbounded NUMERIC column is not supported; declare a \
@@ -220,17 +208,14 @@ fn validate_numeric_aggregate(
 }
 
 /// NUMERIC storage info for a resolved field; `None` for non-NUMERIC fields.
-/// Legacy indexes that stored NUMERIC as F64 return [`NumericAggStorage::LegacyF64`]
-/// so [`validate_numeric_aggregate`] can decline with a REINDEX hint.
+/// Legacy indexes that stored NUMERIC as F64 also return `None`: their column
+/// data really is `Float64` and the native aggregates apply.
 fn numeric_storage(source: &JoinAggSource, field_name: &str) -> Option<NumericAggStorage> {
     let index = source.bm25_index.as_ref()?;
     let schema = index.schema().ok()?;
     match schema.get_field_type(field_name)? {
         SearchFieldType::Numeric64(_, scale) => Some(NumericAggStorage::Numeric64 { scale }),
         SearchFieldType::NumericBytes(_, scale) => Some(NumericAggStorage::NumericBytes { scale }),
-        SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
-            Some(NumericAggStorage::LegacyF64)
-        }
         _ => None,
     }
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -55,6 +55,17 @@ fn find_source_by_rti<'a>(
     })
 }
 
+/// Heap attribute name for decline messages, so the planner warning names the
+/// column instead of an (RTI, attno) pair the user can't act on.
+unsafe fn attname_or_attno(relid: pg_sys::Oid, attno: pg_sys::AttrNumber) -> String {
+    let ptr = pg_sys::get_attname(relid, attno, true);
+    if ptr.is_null() {
+        format!("attno {attno}")
+    } else {
+        std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned()
+    }
+}
+
 /// Simplified aggregate classification for the DataFusion backend.
 /// Unlike `AggregateType` (Tantivy-oriented), this enum is lightweight and maps
 /// directly to DataFusion aggregate expressions.
@@ -209,8 +220,8 @@ fn validate_numeric_aggregate(
 }
 
 /// NUMERIC storage info for a resolved field; `None` for non-NUMERIC fields.
-/// Legacy indexes that stored NUMERIC as F64 also return `None`: their column
-/// data really is `Float64` and the native aggregates apply.
+/// Legacy indexes that stored NUMERIC as F64 return [`NumericAggStorage::LegacyF64`]
+/// so [`validate_numeric_aggregate`] can decline with a REINDEX hint.
 fn numeric_storage(source: &JoinAggSource, field_name: &str) -> Option<NumericAggStorage> {
     let index = source.bm25_index.as_ref()?;
     let schema = index.schema().ok()?;
@@ -392,8 +403,8 @@ pub unsafe fn extract_aggregate_targetlist(
 
             let field_name = source.column_name(attno).ok_or_else(|| {
                 format!(
-                    "could not resolve field name for GROUP BY column (RTI={}, attno={})",
-                    rti, attno
+                    "GROUP BY column {} is not indexed as a fast field",
+                    attname_or_attno(source.relid, attno)
                 )
             })?;
 
@@ -438,6 +449,10 @@ pub unsafe fn extract_aggregate_targetlist(
                     )
                 })?;
 
+            // A missing source happens for rti-aliased JSON group keys from
+            // sub-PlannerInfos; their fields are JSON paths, never NUMERIC.
+            // Bare NUMERIC columns are plain Vars and take the branch above,
+            // which propagates the lookup failure.
             let numeric_scale = match find_source_by_rti(sources, rti, "GROUP BY expression") {
                 Ok(source) => numeric_group_scale(source, &field_name)?,
                 Err(_) => None,
@@ -613,8 +628,8 @@ unsafe fn extract_aggref_field_refs(
 
         let field_name = source.column_name(attno).ok_or_else(|| {
             format!(
-                "could not resolve field name for aggregate argument (RTI={}, attno={})",
-                rti, attno
+                "aggregate argument {} is not indexed as a fast field",
+                attname_or_attno(source.relid, attno)
             )
         })?;
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -246,6 +246,12 @@ impl CustomScan for AggregateScan {
                         // ORDER BY aggregate + LIMIT: route to DataFusion which has
                         // no bucket cap and provides native TopK via SortExec(fetch=K).
                         || build::has_aggregate_orderby_with_limit(builder.args())
+                        // NUMERIC aggregates and NUMERIC group keys only work on
+                        // the DataFusion backend: Tantivy aggregations compute in
+                        // f64 and cannot read the decimal-bytes storage. pdb.agg()
+                        // stays on the Tantivy path, which rejects NUMERIC fields.
+                        || (!has_paradedb_agg
+                            && build::has_numeric_aggregate_or_group(builder.args()))
                 };
                 if use_datafusion {
                     if !gucs::enable_aggregate_custom_scan() && !has_paradedb_agg {
@@ -1273,21 +1279,32 @@ impl AggregateScan {
         let having_filter = unsafe {
             let parse = builder.args().root().parse;
             if !parse.is_null() && !(*parse).havingQual.is_null() {
-                Some(
-                    privdat::FilterExpr::from_pg_node(
-                        (*parse).havingQual,
-                        &datafusion_build::FilterExprBuildContext::Having {
-                            targetlist: &targetlist,
-                            plan: &plan,
-                            outer_root_id,
-                        },
-                    )
-                    .ok_or_else(|| {
-                        warn(AggregateDeclineReason::Other(
-                            "HAVING clause cannot be translated for aggregate-on-join".into(),
-                        ))
-                    })?,
+                let having = privdat::FilterExpr::from_pg_node(
+                    (*parse).havingQual,
+                    &datafusion_build::FilterExprBuildContext::Having {
+                        targetlist: &targetlist,
+                        plan: &plan,
+                        outer_root_id,
+                    },
                 )
+                .ok_or_else(|| {
+                    warn(AggregateDeclineReason::Other(
+                        "HAVING clause cannot be translated for aggregate-on-join".into(),
+                    ))
+                })?;
+                // HAVING literals compare as f64, but numeric SUM/AVG results
+                // are decimal-bytes blobs; the comparison would be garbage.
+                if having.any_agg_ref(&|idx| {
+                    targetlist
+                        .aggregates
+                        .get(idx)
+                        .is_some_and(|a| a.numeric.is_some())
+                }) {
+                    return Err(warn(AggregateDeclineReason::Other(
+                        "HAVING on a NUMERIC aggregate is not supported".into(),
+                    )));
+                }
+                Some(having)
             } else {
                 None
             }
@@ -2018,6 +2035,15 @@ unsafe fn detect_join_aggregate_topk(
         if targetlist::find_single_aggref_in_expr(sort_expr)
             .is_none_or(|a| a as *mut pg_sys::Node != sort_expr)
         {
+            return None;
+        }
+        // A numeric AVG evaluates to a [count, sum] blob whose byte order
+        // does not follow the quotient, so DataFusion cannot TopK on it.
+        // Skipping TopK is correct: all groups are returned and Postgres
+        // applies its own Sort + Limit above the scan. Numeric SUM/MIN/MAX
+        // sort fine: decimal-bytes ordering matches numeric ordering.
+        let agg = &targetlist.aggregates[agg_idx];
+        if matches!(agg.agg_kind, join_targetlist::AggKind::Avg) && agg.numeric.is_some() {
             return None;
         }
         return Some(privdat::DataFusionTopK {

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -63,6 +63,30 @@ pub enum FilterExpr {
     IsNotNull(Box<FilterExpr>),
 }
 
+impl FilterExpr {
+    /// True if any [`FilterExpr::AggRef`] in this tree satisfies `pred`.
+    pub fn any_agg_ref(&self, pred: &impl Fn(usize) -> bool) -> bool {
+        match self {
+            FilterExpr::AggRef(idx) => pred(*idx),
+            FilterExpr::GroupRef(_)
+            | FilterExpr::ColumnRef { .. }
+            | FilterExpr::LitInt(_)
+            | FilterExpr::LitFloat(_)
+            | FilterExpr::LitBool(_)
+            | FilterExpr::LitString(_) => false,
+            FilterExpr::BinOp { left, right, .. } => {
+                left.any_agg_ref(pred) || right.any_agg_ref(pred)
+            }
+            FilterExpr::And(children) | FilterExpr::Or(children) => {
+                children.iter().any(|c| c.any_agg_ref(pred))
+            }
+            FilterExpr::Not(inner) | FilterExpr::IsNull(inner) | FilterExpr::IsNotNull(inner) => {
+                inner.any_agg_ref(pred)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum CompareOp {
     Eq,

--- a/pg_search/src/postgres/customscan/datafusion/mod.rs
+++ b/pg_search/src/postgres/customscan/datafusion/mod.rs
@@ -29,4 +29,5 @@
 pub mod explain;
 mod expr_translators;
 pub mod memory;
+pub mod numeric_agg;
 pub mod translator;

--- a/pg_search/src/postgres/customscan/datafusion/numeric_agg.rs
+++ b/pg_search/src/postgres/customscan/datafusion/numeric_agg.rs
@@ -42,7 +42,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef};
 use arrow_schema::{DataType, Field, FieldRef};
 use bigdecimal::BigDecimal;
-use bigdecimal::num_bigint::BigInt;
+use bigdecimal::num_bigint::{BigInt, BigUint, Sign};
 use datafusion::common::ScalarValue;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
@@ -50,7 +50,9 @@ use datafusion::logical_expr::{
     Accumulator, AggregateUDF, AggregateUDFImpl, Signature, Volatility,
 };
 use datafusion::physical_plan::expressions::Literal;
-use decimal_bytes::{Decimal, Decimal64NoScale};
+use decimal_bytes::{
+    Decimal, Decimal64NoScale, SpecialValue, decode_parts_into, decode_special_value,
+};
 
 pub const NUMERIC64_SUM_NAME: &str = "numeric64_sum";
 pub const NUMERIC64_AVG_NAME: &str = "numeric64_avg";
@@ -142,6 +144,8 @@ struct NumericSumState {
     special: Special,
     scaled: i128,
     decimal: BigDecimal,
+    /// Reused per-row digit buffer for decimal-bytes decoding.
+    digit_buf: Vec<u8>,
 }
 
 impl NumericSumState {
@@ -151,6 +155,7 @@ impl NumericSumState {
             special: Special::Finite,
             scaled: 0,
             decimal: BigDecimal::from(0),
+            digit_buf: Vec::new(),
         }
     }
 
@@ -168,23 +173,37 @@ impl NumericSumState {
         }
     }
 
+    /// Decodes straight to digits and builds the `BigDecimal` from them:
+    /// a string round-trip here would dominate the whole aggregation.
     fn add_decimal_bytes(&mut self, bytes: &[u8]) -> Result<()> {
-        let d = Decimal::from_bytes(bytes).map_err(|e| {
+        self.seen = true;
+        if let Some(special) = decode_special_value(bytes) {
+            self.special.absorb(match special {
+                SpecialValue::NaN => Special::Nan,
+                SpecialValue::Infinity => Special::PosInf,
+                SpecialValue::NegInfinity => Special::NegInf,
+            });
+            return Ok(());
+        }
+        if self.special != Special::Finite {
+            return Ok(());
+        }
+        let parts = decode_parts_into(bytes, &mut self.digit_buf).map_err(|e| {
             DataFusionError::Internal(format!("failed to decode decimal bytes: {e:?}"))
         })?;
-        self.seen = true;
-        if d.is_nan() {
-            self.special.absorb(Special::Nan);
-        } else if d.is_pos_infinity() {
-            self.special.absorb(Special::PosInf);
-        } else if d.is_neg_infinity() {
-            self.special.absorb(Special::NegInf);
-        } else if self.special == Special::Finite {
-            let parsed = BigDecimal::from_str(&d.to_string()).map_err(|e| {
-                DataFusionError::Internal(format!("failed to parse decimal '{d}': {e}"))
-            })?;
-            self.decimal += parsed;
+        let Some((negative, exponent)) = parts else {
+            return Err(DataFusionError::Internal(
+                "decimal parts missing for a finite value".to_string(),
+            ));
+        };
+        if self.digit_buf.is_empty() {
+            return Ok(());
         }
+        let scale = self.digit_buf.len() as i64 - exponent as i64;
+        let magnitude = BigUint::from_radix_be(&self.digit_buf, 10)
+            .ok_or_else(|| DataFusionError::Internal("decimal digit out of range".to_string()))?;
+        let sign = if negative { Sign::Minus } else { Sign::Plus };
+        self.decimal += BigDecimal::new(BigInt::from_biguint(sign, magnitude), scale);
         Ok(())
     }
 
@@ -712,6 +731,15 @@ mod tests {
         state.add_scaled_i64(Decimal64NoScale::nan().raw());
         state.add_scaled_i64(100);
         assert_eq!(decode(&state.encode(2).unwrap().unwrap()), "NaN");
+    }
+
+    #[test]
+    fn sum_bytes_negative_and_zero() {
+        let mut state = NumericSumState::new();
+        state.add_decimal_bytes(&bytes_of("-2.50")).unwrap();
+        state.add_decimal_bytes(&bytes_of("1.25")).unwrap();
+        state.add_decimal_bytes(&bytes_of("0")).unwrap();
+        assert_eq!(decode(&state.encode(2).unwrap().unwrap()), "-1.25");
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/datafusion/numeric_agg.rs
+++ b/pg_search/src/postgres/customscan/datafusion/numeric_agg.rs
@@ -188,6 +188,14 @@ impl NumericSumState {
         Ok(())
     }
 
+    /// Approximate heap bytes of the running sum, for DataFusion memory
+    /// accounting: a high-cardinality GROUP BY keeps one accumulator per
+    /// group, so the `BigInt` digits must count toward the pool.
+    fn heap_size(&self) -> usize {
+        // ~3.3 bits per decimal digit, rounded up to limb granularity.
+        (self.decimal.digits() as usize) / 2 + 8
+    }
+
     /// Encode the running sum as decimal-bytes. `None` when no rows were seen,
     /// which surfaces as SQL NULL (Postgres `SUM` over zero rows).
     fn encode(&self, scale: i32) -> Result<Option<Vec<u8>>> {
@@ -326,7 +334,7 @@ impl Accumulator for NumericSumAccumulator {
     }
 
     fn size(&self) -> usize {
-        size_of_val(self)
+        size_of_val(self) + self.state.heap_size()
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {
@@ -516,7 +524,7 @@ impl Accumulator for NumericAvgAccumulator {
     }
 
     fn size(&self) -> usize {
-        size_of_val(self)
+        size_of_val(self) + self.state.heap_size()
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {

--- a/pg_search/src/postgres/customscan/datafusion/numeric_agg.rs
+++ b/pg_search/src/postgres/customscan/datafusion/numeric_agg.rs
@@ -1,0 +1,724 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Aggregate UDAFs for NUMERIC columns.
+//!
+//! DataFusion's native `sum`/`avg` cannot be used for NUMERIC fast fields:
+//!
+//! - `Numeric64` columns are scaled `Int64` values with sentinel encodings for
+//!   NaN and +/-Infinity, so a native `sum(Int64)` would add sentinels into the
+//!   total and can overflow i64.
+//! - `NumericBytes` columns are `decimal-bytes` encoded `BinaryView` values,
+//!   which native aggregates do not accept at all.
+//!
+//! The UDAFs here accumulate exactly (i128 for `Numeric64`, `BigDecimal` for
+//! `NumericBytes`) and emit a `decimal-bytes` encoded `Binary`. That encoding
+//! represents NaN and +/-Infinity natively and is what the Arrow-to-Datum
+//! conversion already decodes, so partial states, MPP merges, and final
+//! results all use one representation.
+//!
+//! AVG returns `[count: u64 BE, sum: decimal-bytes]` in one `Binary` value.
+//! The final `sum / count` division happens on the Postgres side with
+//! `AnyNumeric` so the result scale matches Postgres' division rules.
+
+use std::str::FromStr;
+use std::sync::{Arc, LazyLock};
+
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef};
+use arrow_schema::{DataType, Field, FieldRef};
+use bigdecimal::BigDecimal;
+use bigdecimal::num_bigint::BigInt;
+use datafusion::common::ScalarValue;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
+use datafusion::logical_expr::{
+    Accumulator, AggregateUDF, AggregateUDFImpl, Signature, Volatility,
+};
+use datafusion::physical_plan::expressions::Literal;
+use decimal_bytes::{Decimal, Decimal64NoScale};
+
+pub const NUMERIC64_SUM_NAME: &str = "numeric64_sum";
+pub const NUMERIC64_AVG_NAME: &str = "numeric64_avg";
+pub const NUMERIC_BYTES_SUM_NAME: &str = "numeric_bytes_sum";
+pub const NUMERIC_BYTES_AVG_NAME: &str = "numeric_bytes_avg";
+
+static NUMERIC64_SUM: LazyLock<Arc<AggregateUDF>> =
+    LazyLock::new(|| Arc::new(AggregateUDF::from(Numeric64Sum::new())));
+static NUMERIC64_AVG: LazyLock<Arc<AggregateUDF>> =
+    LazyLock::new(|| Arc::new(AggregateUDF::from(Numeric64Avg::new())));
+static NUMERIC_BYTES_SUM: LazyLock<Arc<AggregateUDF>> =
+    LazyLock::new(|| Arc::new(AggregateUDF::from(NumericBytesSum::new())));
+static NUMERIC_BYTES_AVG: LazyLock<Arc<AggregateUDF>> =
+    LazyLock::new(|| Arc::new(AggregateUDF::from(NumericBytesAvg::new())));
+
+pub fn numeric64_sum_udaf() -> Arc<AggregateUDF> {
+    Arc::clone(&NUMERIC64_SUM)
+}
+
+pub fn numeric64_avg_udaf() -> Arc<AggregateUDF> {
+    Arc::clone(&NUMERIC64_AVG)
+}
+
+pub fn numeric_bytes_sum_udaf() -> Arc<AggregateUDF> {
+    Arc::clone(&NUMERIC_BYTES_SUM)
+}
+
+pub fn numeric_bytes_avg_udaf() -> Arc<AggregateUDF> {
+    Arc::clone(&NUMERIC_BYTES_AVG)
+}
+
+/// Resolve a numeric aggregate UDAF by name, for the plan codecs. These
+/// functions are not in any session registry, so serialized plans (parallel
+/// and MPP dispatch) decode them through here.
+pub fn udaf_by_name(name: &str) -> Option<Arc<AggregateUDF>> {
+    match name {
+        NUMERIC64_SUM_NAME => Some(numeric64_sum_udaf()),
+        NUMERIC64_AVG_NAME => Some(numeric64_avg_udaf()),
+        NUMERIC_BYTES_SUM_NAME => Some(numeric_bytes_sum_udaf()),
+        NUMERIC_BYTES_AVG_NAME => Some(numeric_bytes_avg_udaf()),
+        _ => None,
+    }
+}
+
+/// Split an AVG result blob into `(count, decimal-bytes sum)`.
+pub fn decode_avg_blob(blob: &[u8]) -> Result<(u64, &[u8])> {
+    if blob.len() < 8 {
+        return Err(DataFusionError::Internal(format!(
+            "numeric AVG blob too short: {} bytes",
+            blob.len()
+        )));
+    }
+    let count = u64::from_be_bytes(blob[..8].try_into().unwrap());
+    Ok((count, &blob[8..]))
+}
+
+/// Postgres SUM semantics for NUMERIC special values: NaN absorbs everything,
+/// and +Infinity combined with -Infinity yields NaN. These rules are
+/// associative and commutative, so partial-aggregate merges preserve them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Special {
+    Finite,
+    PosInf,
+    NegInf,
+    Nan,
+}
+
+impl Special {
+    fn absorb(&mut self, other: Special) {
+        use Special::*;
+        *self = match (*self, other) {
+            (Nan, _) | (_, Nan) => Nan,
+            (PosInf, NegInf) | (NegInf, PosInf) => Nan,
+            (PosInf, _) | (_, PosInf) => PosInf,
+            (NegInf, _) | (_, NegInf) => NegInf,
+            (Finite, Finite) => Finite,
+        };
+    }
+}
+
+/// Exact running sum shared by all four accumulators.
+///
+/// `Numeric64` updates accumulate into `scaled`, an i128 of scaled values,
+/// which cannot overflow (2^63 rows of i64 would be needed). Merged partial
+/// states and `NumericBytes` updates accumulate into `decimal`.
+#[derive(Debug)]
+struct NumericSumState {
+    seen: bool,
+    special: Special,
+    scaled: i128,
+    decimal: BigDecimal,
+}
+
+impl NumericSumState {
+    fn new() -> Self {
+        Self {
+            seen: false,
+            special: Special::Finite,
+            scaled: 0,
+            decimal: BigDecimal::from(0),
+        }
+    }
+
+    fn add_scaled_i64(&mut self, value: i64) {
+        self.seen = true;
+        let v = Decimal64NoScale::from_raw(value);
+        if v.is_nan() {
+            self.special.absorb(Special::Nan);
+        } else if v.is_pos_infinity() {
+            self.special.absorb(Special::PosInf);
+        } else if v.is_neg_infinity() {
+            self.special.absorb(Special::NegInf);
+        } else if self.special == Special::Finite {
+            self.scaled += value as i128;
+        }
+    }
+
+    fn add_decimal_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        let d = Decimal::from_bytes(bytes).map_err(|e| {
+            DataFusionError::Internal(format!("failed to decode decimal bytes: {e:?}"))
+        })?;
+        self.seen = true;
+        if d.is_nan() {
+            self.special.absorb(Special::Nan);
+        } else if d.is_pos_infinity() {
+            self.special.absorb(Special::PosInf);
+        } else if d.is_neg_infinity() {
+            self.special.absorb(Special::NegInf);
+        } else if self.special == Special::Finite {
+            let parsed = BigDecimal::from_str(&d.to_string()).map_err(|e| {
+                DataFusionError::Internal(format!("failed to parse decimal '{d}': {e}"))
+            })?;
+            self.decimal += parsed;
+        }
+        Ok(())
+    }
+
+    /// Encode the running sum as decimal-bytes. `None` when no rows were seen,
+    /// which surfaces as SQL NULL (Postgres `SUM` over zero rows).
+    fn encode(&self, scale: i32) -> Result<Option<Vec<u8>>> {
+        if !self.seen {
+            return Ok(None);
+        }
+        let d = match self.special {
+            Special::Nan => Decimal::nan(),
+            Special::PosInf => Decimal::infinity(),
+            Special::NegInf => Decimal::neg_infinity(),
+            Special::Finite => {
+                let mut total = self.decimal.clone();
+                if self.scaled != 0 {
+                    total += BigDecimal::new(BigInt::from(self.scaled), scale as i64);
+                }
+                Decimal::from_str(&total.to_string()).map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "failed to encode numeric sum '{total}': {e:?}"
+                    ))
+                })?
+            }
+        };
+        Ok(Some(d.into_bytes()))
+    }
+}
+
+/// Add every non-null decimal-bytes value of `array` into `state`.
+/// Accepts both the scan's `BinaryView` columns and the `Binary` state arrays.
+fn accumulate_binary_array(state: &mut NumericSumState, array: &ArrayRef) -> Result<u64> {
+    let mut non_null = 0u64;
+    match array.data_type() {
+        DataType::BinaryView => {
+            let arr = array.as_binary_view();
+            for v in arr.iter().flatten() {
+                state.add_decimal_bytes(v)?;
+                non_null += 1;
+            }
+        }
+        DataType::Binary => {
+            let arr = array.as_binary::<i32>();
+            for v in arr.iter().flatten() {
+                state.add_decimal_bytes(v)?;
+                non_null += 1;
+            }
+        }
+        other => {
+            return Err(DataFusionError::Internal(format!(
+                "numeric aggregate expected a binary array, got {other}"
+            )));
+        }
+    }
+    Ok(non_null)
+}
+
+/// Extract the constant scale argument (second UDAF argument) at accumulator
+/// creation time. The scale travels as a plan literal so it survives
+/// serialization for parallel and MPP execution.
+fn scale_from_args(args: &AccumulatorArgs, name: &str) -> Result<i32> {
+    let expr = args
+        .exprs
+        .get(1)
+        .ok_or_else(|| DataFusionError::Internal(format!("{name} requires a scale argument")))?;
+    let literal = expr
+        .as_ref()
+        .downcast_ref::<Literal>()
+        .ok_or_else(|| DataFusionError::Internal(format!("{name} scale must be a literal")))?;
+    match literal.value() {
+        ScalarValue::Int32(Some(scale)) => Ok(*scale),
+        other => Err(DataFusionError::Internal(format!(
+            "{name} scale must be a non-null Int32 literal, got {other}"
+        ))),
+    }
+}
+
+fn reject_distinct(args: &AccumulatorArgs, name: &str) -> Result<()> {
+    if args.is_distinct {
+        return Err(DataFusionError::NotImplemented(format!(
+            "{name} does not support DISTINCT"
+        )));
+    }
+    Ok(())
+}
+
+fn sum_state_fields(args: StateFieldsArgs) -> Vec<FieldRef> {
+    vec![Field::new(format!("{}[sum]", args.name), DataType::Binary, true).into()]
+}
+
+fn avg_state_fields(args: StateFieldsArgs) -> Vec<FieldRef> {
+    vec![
+        Field::new(format!("{}[sum]", args.name), DataType::Binary, true).into(),
+        Field::new(format!("{}[count]", args.name), DataType::UInt64, true).into(),
+    ]
+}
+
+// ============================================================================
+// SUM
+// ============================================================================
+
+#[derive(Debug)]
+struct NumericSumAccumulator {
+    /// Scale of the scaled `Int64` input column; 0 for decimal-bytes input,
+    /// whose values are self-describing.
+    scale: i32,
+    state: NumericSumState,
+}
+
+impl NumericSumAccumulator {
+    fn new(scale: i32) -> Self {
+        Self {
+            scale,
+            state: NumericSumState::new(),
+        }
+    }
+
+    fn update_binary(&mut self, values: &[ArrayRef]) -> Result<()> {
+        accumulate_binary_array(&mut self.state, &values[0])?;
+        Ok(())
+    }
+
+    fn update_scaled_i64(&mut self, values: &[ArrayRef]) -> Result<()> {
+        let arr = values[0].as_primitive::<arrow_array::types::Int64Type>();
+        for v in arr.iter().flatten() {
+            self.state.add_scaled_i64(v);
+        }
+        Ok(())
+    }
+}
+
+impl Accumulator for NumericSumAccumulator {
+    fn update_batch(&mut self, _values: &[ArrayRef]) -> Result<()> {
+        unreachable!("update_batch is provided by the concrete wrapper")
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        Ok(ScalarValue::Binary(self.state.encode(self.scale)?))
+    }
+
+    fn size(&self) -> usize {
+        size_of_val(self)
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        Ok(vec![self.evaluate()?])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        accumulate_binary_array(&mut self.state, &states[0])?;
+        Ok(())
+    }
+}
+
+/// The concrete accumulators differ only in how a batch of input values is
+/// folded into the shared inner state.
+macro_rules! delegate_accumulator {
+    ($name:ident, $inner:ident, $update:ident) => {
+        #[derive(Debug)]
+        struct $name($inner);
+
+        impl Accumulator for $name {
+            fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+                self.0.$update(values)
+            }
+
+            fn evaluate(&mut self) -> Result<ScalarValue> {
+                self.0.evaluate()
+            }
+
+            fn size(&self) -> usize {
+                self.0.size()
+            }
+
+            fn state(&mut self) -> Result<Vec<ScalarValue>> {
+                self.0.state()
+            }
+
+            fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+                self.0.merge_batch(states)
+            }
+        }
+    };
+}
+
+delegate_accumulator!(
+    Numeric64SumAccumulator,
+    NumericSumAccumulator,
+    update_scaled_i64
+);
+delegate_accumulator!(
+    NumericBytesSumAccumulator,
+    NumericSumAccumulator,
+    update_binary
+);
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Numeric64Sum {
+    signature: Signature,
+}
+
+impl Numeric64Sum {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![DataType::Int64, DataType::Int32],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl AggregateUDFImpl for Numeric64Sum {
+    fn name(&self) -> &str {
+        NUMERIC64_SUM_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Binary)
+    }
+
+    fn accumulator(&self, args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+        reject_distinct(&args, self.name())?;
+        let scale = scale_from_args(&args, self.name())?;
+        Ok(Box::new(Numeric64SumAccumulator(
+            NumericSumAccumulator::new(scale),
+        )))
+    }
+
+    fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
+        Ok(sum_state_fields(args))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct NumericBytesSum {
+    signature: Signature,
+}
+
+impl NumericBytesSum {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::BinaryView], Volatility::Immutable),
+        }
+    }
+}
+
+impl AggregateUDFImpl for NumericBytesSum {
+    fn name(&self) -> &str {
+        NUMERIC_BYTES_SUM_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Binary)
+    }
+
+    fn accumulator(&self, args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+        reject_distinct(&args, self.name())?;
+        Ok(Box::new(NumericBytesSumAccumulator(
+            NumericSumAccumulator::new(0),
+        )))
+    }
+
+    fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
+        Ok(sum_state_fields(args))
+    }
+}
+
+// ============================================================================
+// AVG
+// ============================================================================
+
+#[derive(Debug)]
+struct NumericAvgAccumulator {
+    scale: i32,
+    state: NumericSumState,
+    count: u64,
+}
+
+impl NumericAvgAccumulator {
+    fn new(scale: i32) -> Self {
+        Self {
+            scale,
+            state: NumericSumState::new(),
+            count: 0,
+        }
+    }
+
+    fn update_binary(&mut self, values: &[ArrayRef]) -> Result<()> {
+        self.count += accumulate_binary_array(&mut self.state, &values[0])?;
+        Ok(())
+    }
+
+    fn update_scaled_i64(&mut self, values: &[ArrayRef]) -> Result<()> {
+        let arr = values[0].as_primitive::<arrow_array::types::Int64Type>();
+        for v in arr.iter().flatten() {
+            self.state.add_scaled_i64(v);
+            self.count += 1;
+        }
+        Ok(())
+    }
+
+    fn sum_bytes(&self) -> Result<Option<Vec<u8>>> {
+        self.state.encode(self.scale)
+    }
+}
+
+impl Accumulator for NumericAvgAccumulator {
+    fn update_batch(&mut self, _values: &[ArrayRef]) -> Result<()> {
+        unreachable!("update_batch is provided by the concrete wrapper")
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        let blob = self.sum_bytes()?.map(|sum| {
+            let mut blob = Vec::with_capacity(8 + sum.len());
+            blob.extend_from_slice(&self.count.to_be_bytes());
+            blob.extend_from_slice(&sum);
+            blob
+        });
+        Ok(ScalarValue::Binary(blob))
+    }
+
+    fn size(&self) -> usize {
+        size_of_val(self)
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        Ok(vec![
+            ScalarValue::Binary(self.sum_bytes()?),
+            ScalarValue::UInt64(Some(self.count)),
+        ])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        accumulate_binary_array(&mut self.state, &states[0])?;
+        let counts = states[1].as_primitive::<arrow_array::types::UInt64Type>();
+        for c in counts.iter().flatten() {
+            self.count += c;
+        }
+        Ok(())
+    }
+}
+
+delegate_accumulator!(
+    Numeric64AvgAccumulator,
+    NumericAvgAccumulator,
+    update_scaled_i64
+);
+delegate_accumulator!(
+    NumericBytesAvgAccumulator,
+    NumericAvgAccumulator,
+    update_binary
+);
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Numeric64Avg {
+    signature: Signature,
+}
+
+impl Numeric64Avg {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![DataType::Int64, DataType::Int32],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl AggregateUDFImpl for Numeric64Avg {
+    fn name(&self) -> &str {
+        NUMERIC64_AVG_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Binary)
+    }
+
+    fn accumulator(&self, args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+        reject_distinct(&args, self.name())?;
+        let scale = scale_from_args(&args, self.name())?;
+        Ok(Box::new(Numeric64AvgAccumulator(
+            NumericAvgAccumulator::new(scale),
+        )))
+    }
+
+    fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
+        Ok(avg_state_fields(args))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct NumericBytesAvg {
+    signature: Signature,
+}
+
+impl NumericBytesAvg {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::BinaryView], Volatility::Immutable),
+        }
+    }
+}
+
+impl AggregateUDFImpl for NumericBytesAvg {
+    fn name(&self) -> &str {
+        NUMERIC_BYTES_AVG_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Binary)
+    }
+
+    fn accumulator(&self, args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+        reject_distinct(&args, self.name())?;
+        Ok(Box::new(NumericBytesAvgAccumulator(
+            NumericAvgAccumulator::new(0),
+        )))
+    }
+
+    fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
+        Ok(avg_state_fields(args))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes_of(s: &str) -> Vec<u8> {
+        Decimal::from_str(s).unwrap().into_bytes()
+    }
+
+    fn decode(bytes: &[u8]) -> String {
+        Decimal::from_bytes(bytes).unwrap().to_string()
+    }
+
+    #[test]
+    fn sum_bytes_exact_at_78_digits() {
+        let mut state = NumericSumState::new();
+        let nines = "9".repeat(78);
+        state.add_decimal_bytes(&bytes_of(&nines)).unwrap();
+        state.add_decimal_bytes(&bytes_of("1")).unwrap();
+        let out = state.encode(0).unwrap().unwrap();
+        let mut expected = String::from("1");
+        expected.push_str(&"0".repeat(78));
+        assert_eq!(decode(&out), expected);
+    }
+
+    #[test]
+    fn sum_scaled_i64_uses_scale() {
+        let mut state = NumericSumState::new();
+        state.add_scaled_i64(110);
+        state.add_scaled_i64(220);
+        let out = state.encode(2).unwrap().unwrap();
+        assert_eq!(decode(&out), "3.3");
+    }
+
+    #[test]
+    fn sum_mixes_scaled_and_merged_decimal() {
+        let mut state = NumericSumState::new();
+        state.add_scaled_i64(150); // 1.50 at scale 2
+        state.add_decimal_bytes(&bytes_of("2.25")).unwrap();
+        let out = state.encode(2).unwrap().unwrap();
+        assert_eq!(decode(&out), "3.75");
+    }
+
+    #[test]
+    fn sum_special_values_follow_postgres() {
+        // NaN absorbs everything
+        let mut state = NumericSumState::new();
+        state.add_decimal_bytes(&bytes_of("1")).unwrap();
+        state
+            .add_decimal_bytes(&Decimal::nan().into_bytes())
+            .unwrap();
+        assert_eq!(decode(&state.encode(0).unwrap().unwrap()), "NaN");
+
+        // +Infinity + -Infinity = NaN
+        let mut state = NumericSumState::new();
+        state
+            .add_decimal_bytes(&Decimal::infinity().into_bytes())
+            .unwrap();
+        state
+            .add_decimal_bytes(&Decimal::neg_infinity().into_bytes())
+            .unwrap();
+        assert_eq!(decode(&state.encode(0).unwrap().unwrap()), "NaN");
+
+        // +Infinity + finite = +Infinity
+        let mut state = NumericSumState::new();
+        state
+            .add_decimal_bytes(&Decimal::infinity().into_bytes())
+            .unwrap();
+        state.add_decimal_bytes(&bytes_of("42")).unwrap();
+        assert_eq!(decode(&state.encode(0).unwrap().unwrap()), "Infinity");
+    }
+
+    #[test]
+    fn sum_i64_sentinels() {
+        let mut state = NumericSumState::new();
+        state.add_scaled_i64(Decimal64NoScale::nan().raw());
+        state.add_scaled_i64(100);
+        assert_eq!(decode(&state.encode(2).unwrap().unwrap()), "NaN");
+    }
+
+    #[test]
+    fn empty_state_encodes_null() {
+        let state = NumericSumState::new();
+        assert!(state.encode(0).unwrap().is_none());
+    }
+
+    #[test]
+    fn avg_blob_roundtrip() {
+        let sum = bytes_of("10.5");
+        let mut blob = 3u64.to_be_bytes().to_vec();
+        blob.extend_from_slice(&sum);
+        let (count, sum_bytes) = decode_avg_blob(&blob).unwrap();
+        assert_eq!(count, 3);
+        assert_eq!(decode(sum_bytes), "10.5");
+    }
+}

--- a/pg_search/src/postgres/customscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pushdown.rs
@@ -302,7 +302,7 @@ pub unsafe fn try_build_pushdown_qual(
 
     match lookup_operator(opexpr.opno()) {
         Some(pgsearch_operator) => {
-            // can't push down tokenized text (but NumericBytes fields are stored as text with raw tokenizer)
+            // can't push down tokenized text (but NumericBytes fields are untokenized decimal-bytes)
             if (search_field.is_text() || opexpr.is_text_binary())
                 && !search_field.is_keyword()
                 && !search_field.is_numeric_bytes()

--- a/pg_search/src/postgres/types_arrow.rs
+++ b/pg_search/src/postgres/types_arrow.rs
@@ -180,6 +180,23 @@ pub fn arrow_array_to_datum(
                         pgrx::Uuid::from_bytes(val.try_into().map_err(|_| "Invalid UUID bytes")?);
                     uuid.into_datum()
                 }
+                // Numeric aggregate results (e.g. SUM over a NUMERIC field)
+                // are decimal-bytes encoded, same as BinaryView fast fields.
+                PgOid::BuiltIn(PgBuiltInOids::NUMERICOID) => {
+                    let decimal = Decimal::from_bytes(val)
+                        .map_err(|e| format!("Failed to decode bytes as Decimal: {e:?}"))?;
+
+                    let decimal_str = if let Some(scale) = numeric_scale {
+                        decimal.to_string_with_scale(scale as i32)
+                    } else {
+                        decimal.to_string()
+                    };
+
+                    decimal_str
+                        .parse::<pgrx::AnyNumeric>()
+                        .map_err(|e| format!("Failed to parse Decimal string as AnyNumeric: {e}"))?
+                        .into_datum()
+                }
                 _ => return Err(format!("Unsupported OID for Binary Arrow type: {oid:?}")),
             }
         }

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -246,15 +246,19 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
     }
 
     fn try_decode_udaf(&self, name: &str, _buf: &[u8]) -> Result<Arc<AggregateUDF>> {
+        use crate::postgres::customscan::datafusion::numeric_agg;
+
         match name {
             "min" => Ok(dfa::min_max::min_udaf()),
             "max" => Ok(dfa::min_max::max_udaf()),
             "count" => Ok(dfa::count::count_udaf()),
             "sum" => Ok(dfa::sum::sum_udaf()),
             "avg" => Ok(dfa::average::avg_udaf()),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "LogicalExtensionCodec is not provided for aggregate function {name}"
-            ))),
+            _ => numeric_agg::udaf_by_name(name).ok_or_else(|| {
+                DataFusionError::NotImplemented(format!(
+                    "LogicalExtensionCodec is not provided for aggregate function {name}"
+                ))
+            }),
         }
     }
 

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -200,21 +200,13 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
     ) -> Result<Arc<datafusion::logical_expr::AggregateUDF>> {
         // The numeric aggregate UDAFs are stateless singletons resolved by
         // name; they are not in any session registry, so a dispatched plan
-        // that references them must decode through here.
+        // that references them must decode through here. The encode side is
+        // the trait default (accept, write nothing): name-only travel.
         numeric_agg::udaf_by_name(name).ok_or_else(|| {
             DataFusionError::NotImplemented(format!(
                 "UDAF '{name}' deserialization not implemented"
             ))
         })
-    }
-
-    fn try_encode_udaf(
-        &self,
-        _node: &datafusion::logical_expr::AggregateUDF,
-        _buf: &mut Vec<u8>,
-    ) -> Result<()> {
-        // Name-only encoding; decode resolves by name.
-        Ok(())
     }
 }
 

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -200,13 +200,21 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
     ) -> Result<Arc<datafusion::logical_expr::AggregateUDF>> {
         // The numeric aggregate UDAFs are stateless singletons resolved by
         // name; they are not in any session registry, so a dispatched plan
-        // that references them must decode through here. The encode side is
-        // the trait default (accept, write nothing): name-only travel.
+        // that references them must decode through here.
         numeric_agg::udaf_by_name(name).ok_or_else(|| {
             DataFusionError::NotImplemented(format!(
                 "UDAF '{name}' deserialization not implemented"
             ))
         })
+    }
+
+    fn try_encode_udaf(
+        &self,
+        _node: &datafusion::logical_expr::AggregateUDF,
+        _buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        // Name-only encoding; decode resolves by name.
+        Ok(())
     }
 }
 

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -42,6 +42,7 @@ use tantivy::index::SegmentId;
 use crate::api::{HashMap, HashSet};
 use crate::index::fast_fields_helper::FFHelper;
 use crate::postgres::ParallelScanState;
+use crate::postgres::customscan::datafusion::numeric_agg;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
 use crate::scan::execution_plan::PgSearchScanPlan;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
@@ -191,6 +192,30 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         try_encode_pg_search_udf(node, buf)?;
         Ok(())
     }
+
+    fn try_decode_udaf(
+        &self,
+        name: &str,
+        _buf: &[u8],
+    ) -> Result<Arc<datafusion::logical_expr::AggregateUDF>> {
+        // The numeric aggregate UDAFs are stateless singletons resolved by
+        // name; they are not in any session registry, so a dispatched plan
+        // that references them must decode through here.
+        numeric_agg::udaf_by_name(name).ok_or_else(|| {
+            DataFusionError::NotImplemented(format!(
+                "UDAF '{name}' deserialization not implemented"
+            ))
+        })
+    }
+
+    fn try_encode_udaf(
+        &self,
+        _node: &datafusion::logical_expr::AggregateUDF,
+        _buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        // Name-only encoding; decode resolves by name.
+        Ok(())
+    }
 }
 
 /// Per-scan runtime handles pulled from a decoded subtree, used to re-wire the deferred execs.
@@ -293,6 +318,24 @@ impl PhysicalExtensionCodec for DistributedCodecHostingPgSearchUdfs {
         if is_pg_search_udf(node.name()) {
             return Err(DataFusionError::NotImplemented(format!(
                 "UDF '{}' is encoded by the pg_search codec",
+                node.name()
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_encode_udaf(
+        &self,
+        node: &datafusion::logical_expr::AggregateUDF,
+        _buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        // Same shadowing hazard as `try_encode_udf`: accepting the encode here
+        // would record this codec's index, and its decode has no resolver for
+        // the numeric aggregate UDAFs. Decline ours so composition falls
+        // through to `PgSearchPhysicalExtensionCodec`.
+        if numeric_agg::udaf_by_name(node.name()).is_some() {
+            return Err(DataFusionError::NotImplemented(format!(
+                "UDAF '{}' is encoded by the pg_search codec",
                 node.name()
             )));
         }

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -356,7 +356,7 @@ impl From<SearchFieldConfig> for TextOptions {
                     text_options = text_options.set_indexing_options(text_field_indexing);
                 }
             }
-            // NumericBytes fields are stored as hex-encoded text strings.
+            // NumericBytes fields are stored as decimal-bytes columns.
             // They don't need tokenization since they're exact values.
             SearchFieldConfig::Numeric { indexed, fast, .. } => {
                 if fast {

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -500,11 +500,13 @@ impl SearchIndexSchema {
         }
     }
 
-    /// Check if a field supports aggregate pushdown.
+    /// Check if a field supports aggregate pushdown on the Tantivy backend.
     ///
-    /// Returns `false` for NUMERIC fields (which don't support aggregate pushdown
-    /// due to NaN/Infinity handling), `true` for all other field types.
-    /// Returns `false` if the field doesn't exist.
+    /// Returns `false` for NUMERIC fields: Tantivy aggregations compute in f64
+    /// (losing precision and mishandling NaN/Infinity sentinels) and cannot read
+    /// the decimal-bytes storage at all. Standard SQL aggregates over NUMERIC
+    /// route to the DataFusion backend instead; `pdb.agg()` has no such backend
+    /// and declines. Returns `false` if the field doesn't exist.
     pub fn field_supports_aggregate(&self, name: impl AsRef<str>) -> bool {
         self.search_field(name)
             .is_some_and(|f| !f.field_type().is_numeric())
@@ -740,8 +742,9 @@ impl SearchField {
         self.field_entry.field_type().is_str()
     }
 
-    /// Returns true if this field uses NumericBytes storage (hex-encoded string).
-    /// NumericBytes fields are stored as text but should support direct equality/range pushdown.
+    /// Returns true if this field uses NumericBytes storage (decimal-bytes column).
+    /// NumericBytes fields support direct equality/range pushdown because the
+    /// encoding is lexicographically order-preserving.
     pub fn is_numeric_bytes(&self) -> bool {
         matches!(self.field_type, SearchFieldType::NumericBytes(..))
     }

--- a/pg_search/tests/pg_regress/expected/numeric_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/numeric_aggregate.out
@@ -1,0 +1,671 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+-- ============================================================================
+-- NUMERIC AGGREGATE PUSHDOWN TESTS
+-- ============================================================================
+-- SUM/AVG/MIN/MAX/COUNT over NUMERIC columns route to the DataFusion backend
+-- of the aggregate custom scan:
+-- 1. Numeric64 (scaled I64): NUMERIC(p,s) where p <= 18
+-- 2. NumericBytes (decimal-bytes): NUMERIC(p,s) where p > 18
+-- Unbounded NUMERIC (no typmod) falls back to Postgres.
+-- ============================================================================
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET max_parallel_workers_per_gather = 2;
+DROP TABLE IF EXISTS numagg CASCADE;
+CREATE TABLE numagg (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price NUMERIC(15, 2),
+    weight NUMERIC(38, 9),
+    amount NUMERIC(78, 0),
+    free NUMERIC
+);
+INSERT INTO numagg (description, category, price, weight, amount, free) VALUES
+    ('apple laptop', 'electronics', 1000.10, 1.500000001, 100000000000000000000000000000000000000000000000000000000000000000000000000001, 1.10),
+    ('apple phone', 'electronics', 2000.25, 2.250000002, 200000000000000000000000000000000000000000000000000000000000000000000000000002, 2.20),
+    ('banana basket', 'grocery', 10.05, 0.100000003, 33, 0.30),
+    ('cherry basket', 'grocery', 20.90, 0.200000004, 44, NULL),
+    ('empty crate', 'grocery', NULL, NULL, NULL, NULL);
+CREATE INDEX numagg_idx ON numagg USING bm25 (
+    id, description, category, price, weight, amount, free
+) WITH (key_field = 'id', text_fields = '{"description": {}, "category": {"fast": true}}');
+-- Deterministic worker selection in fallback EXPLAINs
+ANALYZE numagg;
+-- ============================================================================
+-- PART 1: Scalar aggregates, Numeric64 storage: NUMERIC(15,2)
+-- ============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (numagg)
+   Aggregates: SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Final, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric64_avg(numagg_0.price, 2) as agg_1, min(numagg_0.price) as agg_2, max(numagg_0.price) as agg_3, count(numagg_0.price) as agg_4]
+     :   CoalescePartitionsExec
+     :     AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric64_avg(numagg_0.price, 2) as agg_1, min(numagg_0.price) as agg_2, max(numagg_0.price) as agg_3, count(numagg_0.price) as agg_4]
+     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+     :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket OR crate","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+   sum   |         avg          |  min  |   max   | count 
+---------+----------------------+-------+---------+-------
+ 3031.30 | 757.8250000000000000 | 10.05 | 2000.25 |     4
+(1 row)
+
+-- Cross-check against Postgres without pushdown
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+   sum   |         avg          |  min  |   max   | count 
+---------+----------------------+-------+---------+-------
+ 3031.30 | 757.8250000000000000 | 10.05 | 2000.25 |     4
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- ============================================================================
+-- PART 2: Scalar aggregates, NumericBytes storage: NUMERIC(38,9)
+-- ============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (numagg)
+   Aggregates: SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Final, gby=[], aggr=[numeric_bytes_sum(numagg_0.weight) as agg_0, numeric_bytes_avg(numagg_0.weight) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.weight) as agg_3, count(numagg_0.weight) as agg_4]
+     :   CoalescePartitionsExec
+     :     AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.weight) as agg_0, numeric_bytes_avg(numagg_0.weight) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.weight) as agg_3, count(numagg_0.weight) as agg_4]
+     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+     :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket OR crate","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+     sum     |          avg           |     min     |     max     | count 
+-------------+------------------------+-------------+-------------+-------
+ 4.050000010 | 1.01250000250000000000 | 0.100000003 | 2.250000002 |     4
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+     sum     |          avg           |     min     |     max     | count 
+-------------+------------------------+-------------+-------------+-------
+ 4.050000010 | 1.01250000250000000000 | 0.100000003 | 2.250000002 |     4
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- ============================================================================
+-- PART 3: Scalar aggregates, NumericBytes storage: NUMERIC(78,0)
+-- ============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (numagg)
+   Aggregates: SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Final, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.amount) as agg_2, max(numagg_0.amount) as agg_3, count(numagg_0.amount) as agg_4]
+     :   CoalescePartitionsExec
+     :     AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.amount) as agg_2, max(numagg_0.amount) as agg_3, count(numagg_0.amount) as agg_4]
+     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+     :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket OR crate","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+                                      sum                                       |                                      avg                                      | min |                                      max                                       | count 
+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------+-----+--------------------------------------------------------------------------------+-------
+ 300000000000000000000000000000000000000000000000000000000000000000000000000080 | 75000000000000000000000000000000000000000000000000000000000000000000000000020 |  33 | 200000000000000000000000000000000000000000000000000000000000000000000000000002 |     4
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+                                      sum                                       |                                      avg                                      | min |                                      max                                       | count 
+--------------------------------------------------------------------------------+-------------------------------------------------------------------------------+-----+--------------------------------------------------------------------------------+-------
+ 300000000000000000000000000000000000000000000000000000000000000000000000000080 | 75000000000000000000000000000000000000000000000000000000000000000000000000020 |  33 | 200000000000000000000000000000000000000000000000000000000000000000000000000002 |     4
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- ============================================================================
+-- PART 4: Unbounded NUMERIC falls back to Postgres
+-- ============================================================================
+-- Serial for the fallback EXPLAIN so no worker-count lines appear
+SET max_parallel_workers_per_gather = 0;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+WARNING:  Aggregate Scan (DataFusion) not used: SUM on an unbounded NUMERIC column is not supported; declare a precision and scale to enable aggregate pushdown (table: join)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: sum(free)
+   ->  Custom Scan (ParadeDB Base Scan) on public.numagg
+         Output: free
+         Table: numagg
+         Index: numagg_idx
+         Worker Selection: Cost model
+         Exec Method: ColumnarExecState
+         Fast Fields: free
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket OR crate","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+SELECT SUM(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+WARNING:  Aggregate Scan (DataFusion) not used: SUM on an unbounded NUMERIC column is not supported; declare a precision and scale to enable aggregate pushdown (table: join)
+ sum 
+-----
+ 3.6
+(1 row)
+
+SET max_parallel_workers_per_gather = 2;
+-- COUNT on an unbounded NUMERIC column still pushes down
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (numagg)
+   Aggregates: COUNT(free)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Final, gby=[], aggr=[count(numagg_0.free) as agg_0]
+     :   CoalescePartitionsExec
+     :     AggregateExec: mode=Partial, gby=[], aggr=[count(numagg_0.free) as agg_0]
+     :       RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+     :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket OR crate","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+SELECT COUNT(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+ count 
+-------
+     3
+(1 row)
+
+-- ============================================================================
+-- PART 5: GROUP BY a text column, numeric aggregates
+-- ============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate' GROUP BY category ORDER BY category;
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: category, (sum(price)), (avg(amount)), (min(weight)), (max(price))
+   Sort Key: numagg.category
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Output: category, (sum(price)), (avg(amount)), (min(weight)), (max(price))
+         Backend: DataFusion
+         Indexes: numagg_idx (numagg)
+         Group By: category
+         Aggregates: SUM(price), AVG(amount), MIN(weight), MAX(price)
+         DataFusion Physical Plan: 
+           : CoalescePartitionsExec
+           :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.price) as agg_3]
+           :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
+           :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.price) as agg_3]
+           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket OR crate","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
+
+SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate' GROUP BY category ORDER BY category;
+  category   |   sum   |                                      avg                                       |     min     |   max   
+-------------+---------+--------------------------------------------------------------------------------+-------------+---------
+ electronics | 3000.35 | 150000000000000000000000000000000000000000000000000000000000000000000000000002 | 1.500000001 | 2000.25
+ grocery     |   30.95 |                                                            38.5000000000000000 | 0.100000003 |   20.90
+(2 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate' GROUP BY category ORDER BY category;
+  category   |   sum   |                                      avg                                       |     min     |   max   
+-------------+---------+--------------------------------------------------------------------------------+-------------+---------
+ electronics | 3000.35 | 150000000000000000000000000000000000000000000000000000000000000000000000000002 | 1.500000001 | 2000.25
+ grocery     |   30.95 |                                                            38.5000000000000000 | 0.100000003 |   20.90
+(2 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- ============================================================================
+-- PART 6: GROUP BY a NUMERIC column
+-- ============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT price, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY price ORDER BY price;
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: price, (count(*))
+   Sort Key: numagg.price
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Output: price, (count(*))
+         Backend: DataFusion
+         Indexes: numagg_idx (numagg)
+         Group By: price
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : CoalescePartitionsExec
+           :   AggregateExec: mode=FinalPartitioned, gby=[price@0 as price], aggr=[count(1) as agg_0]
+           :     RepartitionExec: partitioning=Hash([price@0], 2), input_partitions=2
+           :       AggregateExec: mode=Partial, gby=[price@0 as price], aggr=[count(1) as agg_0]
+           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
+
+SELECT price, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY price ORDER BY price;
+  price  | count 
+---------+-------
+   10.05 |     1
+   20.90 |     1
+ 1000.10 |     1
+ 2000.25 |     1
+(4 rows)
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amount, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY amount ORDER BY amount;
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: amount, (count(*))
+   Sort Key: numagg.amount
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Output: amount, (count(*))
+         Backend: DataFusion
+         Indexes: numagg_idx (numagg)
+         Group By: amount
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : CoalescePartitionsExec
+           :   AggregateExec: mode=FinalPartitioned, gby=[amount@0 as amount], aggr=[count(1) as agg_0]
+           :     RepartitionExec: partitioning=Hash([amount@0], 2), input_partitions=2
+           :       AggregateExec: mode=Partial, gby=[amount@0 as amount], aggr=[count(1) as agg_0]
+           :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
+
+SELECT amount, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY amount ORDER BY amount;
+                                     amount                                     | count 
+--------------------------------------------------------------------------------+-------
+                                                                             33 |     1
+                                                                             44 |     1
+ 100000000000000000000000000000000000000000000000000000000000000000000000000001 |     1
+ 200000000000000000000000000000000000000000000000000000000000000000000000000002 |     1
+(4 rows)
+
+-- ============================================================================
+-- PART 6b: ORDER BY a numeric aggregate with LIMIT (TopK)
+-- ============================================================================
+-- SUM sorts natively: decimal-bytes ordering matches numeric ordering
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: category, (sum(amount))
+   ->  Sort
+         Output: category, (sum(amount))
+         Sort Key: (sum(numagg.amount)) DESC
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Output: category, (sum(amount))
+               Backend: DataFusion
+               Indexes: numagg_idx (numagg)
+               Group By: category
+               Aggregates: SUM(amount)
+               DataFusion Physical Plan: 
+                 : SortPreservingMergeExec: [agg_0@1 DESC], fetch=1
+                 :   SortExec: TopK(fetch=1), expr=[agg_0@1 DESC], preserve_partitioning=[true]
+                 :     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0]
+                 :       RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
+                 :         AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0]
+                 :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+                 :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
+  category   |                                       s                                        
+-------------+--------------------------------------------------------------------------------
+ electronics | 300000000000000000000000000000000000000000000000000000000000000000000000000003
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
+  category   |                                       s                                        
+-------------+--------------------------------------------------------------------------------
+ electronics | 300000000000000000000000000000000000000000000000000000000000000000000000000003
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- AVG blobs do not sort; TopK is skipped and Postgres sorts above the scan
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: category, (avg(price))
+   ->  Sort
+         Output: category, (avg(price))
+         Sort Key: (avg(numagg.price))
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Output: category, (avg(price))
+               Backend: DataFusion
+               Indexes: numagg_idx (numagg)
+               Group By: category
+               Aggregates: AVG(price)
+               DataFusion Physical Plan: 
+                 : CoalescePartitionsExec
+                 :   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric64_avg(numagg_0.price, 2) as agg_0]
+                 :     RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
+                 :       AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_avg(numagg_0.price, 2) as agg_0]
+                 :         RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+                 :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
+ category |          a          
+----------+---------------------
+ grocery  | 15.4750000000000000
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
+ category |          a          
+----------+---------------------
+ grocery  | 15.4750000000000000
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- ============================================================================
+-- PART 7: NaN handling
+-- ============================================================================
+INSERT INTO numagg (description, category, price, weight, amount) VALUES
+    ('durian crate', 'grocery', 'NaN', 'NaN', 'NaN');
+ANALYZE numagg;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description @@@ 'durian OR basket';
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (numagg)
+   Aggregates: SUM(price), MIN(price), MAX(price)
+   DataFusion Physical Plan: 
+     : ┌───── DistributedExec
+     : │ AggregateExec: mode=Final, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, min(numagg_0.price) as agg_1, max(numagg_0.price) as agg_2]
+     : │   CoalescePartitionsExec
+     : │     [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+     : └──────────────────────────────────────────────────
+     :   ┌───── Stage 1 ── tasks=2, partitions=4
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, min(numagg_0.price) as agg_1, max(numagg_0.price) as agg_2]
+     :   │   DistributedLeafExec:
+     :   │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"durian OR basket","lenient":null,"conjunction_mode":null}}}}
+     :   │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"durian OR basket","lenient":null,"conjunction_mode":null}}}}
+     :   └──────────────────────────────────────────────────
+(17 rows)
+
+SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description @@@ 'durian OR basket';
+ sum |  min  | max 
+-----+-------+-----
+ NaN | 10.05 | NaN
+(1 row)
+
+SELECT SUM(weight), MIN(weight), MAX(weight) FROM numagg WHERE description @@@ 'durian OR basket';
+ sum |     min     | max 
+-----+-------------+-----
+ NaN | 0.100000003 | NaN
+(1 row)
+
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount) FROM numagg WHERE description @@@ 'durian OR basket';
+ sum | avg | min | max 
+-----+-----+-----+-----
+ NaN | NaN |  33 | NaN
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description @@@ 'durian OR basket';
+ sum |  min  | max 
+-----+-------+-----
+ NaN | 10.05 | NaN
+(1 row)
+
+SELECT SUM(weight), MIN(weight), MAX(weight) FROM numagg WHERE description @@@ 'durian OR basket';
+ sum |     min     | max 
+-----+-------------+-----
+ NaN | 0.100000003 | NaN
+(1 row)
+
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount) FROM numagg WHERE description @@@ 'durian OR basket';
+ sum | avg | min | max 
+-----+-----+-----+-----
+ NaN | NaN |  33 | NaN
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- ============================================================================
+-- PART 8: Empty result set and FILTER clause
+-- ============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('COUNT(*)'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (numagg)
+   Aggregates: SUM(amount), COUNT(*)
+   DataFusion Physical Plan: 
+     : ┌───── DistributedExec
+     : │ AggregateExec: mode=Final, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, count(1) as agg_1]
+     : │   CoalescePartitionsExec
+     : │     [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+     : └──────────────────────────────────────────────────
+     :   ┌───── Stage 1 ── tasks=2, partitions=4
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, count(1) as agg_1]
+     :   │   DistributedLeafExec:
+     :   │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"nonexistent","lenient":null,"conjunction_mode":null}}}}
+     :   │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"nonexistent","lenient":null,"conjunction_mode":null}}}}
+     :   └──────────────────────────────────────────────────
+(17 rows)
+
+SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+ sum | count 
+-----+-------
+     |     0
+(1 row)
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE description @@@ 'apple OR basket';
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (numagg)
+   Aggregates: SUM(price)
+   DataFusion Physical Plan: 
+     : ┌───── DistributedExec
+     : │ AggregateExec: mode=Final, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) FILTER (WHERE numagg_0.category = Utf8View("grocery")) as agg_0]
+     : │   CoalescePartitionsExec
+     : │     [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+     : └──────────────────────────────────────────────────
+     :   ┌───── Stage 1 ── tasks=2, partitions=4
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) FILTER (WHERE numagg_0.category = Utf8View("grocery")) as agg_0]
+     :   │   DistributedLeafExec:
+     :   │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+     :   │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+     :   └──────────────────────────────────────────────────
+(17 rows)
+
+SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE description @@@ 'apple OR basket';
+  sum  
+-------
+ 30.95
+(1 row)
+
+-- ============================================================================
+-- PART 9: Declined shapes fall back to Postgres
+-- ============================================================================
+-- Serial for the fallback EXPLAINs so no worker-count lines appear
+SET max_parallel_workers_per_gather = 0;
+-- HAVING over a numeric aggregate
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category HAVING SUM(price) > 100 ORDER BY category;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING on a NUMERIC aggregate is not supported (table: join)
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: category, sum(price)
+   Group Key: numagg.category
+   Filter: (sum(numagg.price) > '100'::numeric)
+   ->  Sort
+         Output: category, price
+         Sort Key: numagg.category
+         ->  Custom Scan (ParadeDB Base Scan) on public.numagg
+               Output: category, price
+               Table: numagg
+               Index: numagg_idx
+               Worker Selection: Cost model
+               Exec Method: ColumnarExecState
+               Fast Fields: category, price
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
+
+SELECT category, SUM(price) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category HAVING SUM(price) > 100 ORDER BY category;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING on a NUMERIC aggregate is not supported (table: join)
+  category   |   sum   
+-------------+---------
+ electronics | 3000.35
+(1 row)
+
+-- SUM(DISTINCT numeric)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(DISTINCT price) FROM numagg WHERE description @@@ 'apple OR basket';
+WARNING:  Aggregate Scan (DataFusion) not used: SUM with DISTINCT is not supported on NUMERIC columns (table: join)
+                                                                                 QUERY PLAN                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: sum(DISTINCT price)
+   ->  Sort
+         Output: price
+         Sort Key: numagg.price
+         ->  Custom Scan (ParadeDB Base Scan) on public.numagg
+               Output: price
+               Table: numagg
+               Index: numagg_idx
+               Worker Selection: Cost model
+               Exec Method: ColumnarExecState
+               Fast Fields: price
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(14 rows)
+
+SELECT SUM(DISTINCT price) FROM numagg WHERE description @@@ 'apple OR basket';
+WARNING:  Aggregate Scan (DataFusion) not used: SUM with DISTINCT is not supported on NUMERIC columns (table: join)
+   sum   
+---------
+ 3031.30
+(1 row)
+
+-- stddev is not supported on NUMERIC columns
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT STDDEV(price) FROM numagg WHERE description @@@ 'apple OR basket';
+WARNING:  Aggregate Scan (DataFusion) not used: STDDEV_SAMP is not supported on NUMERIC columns (table: join)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: stddev(price)
+   ->  Custom Scan (ParadeDB Base Scan) on public.numagg
+         Output: price
+         Table: numagg
+         Index: numagg_idx
+         Worker Selection: Cost model
+         Exec Method: ColumnarExecState
+         Fast Fields: price
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+SELECT STDDEV(price) FROM numagg WHERE description @@@ 'apple OR basket';
+WARNING:  Aggregate Scan (DataFusion) not used: STDDEV_SAMP is not supported on NUMERIC columns (table: join)
+      stddev      
+------------------
+ 949.481079765855
+(1 row)
+
+-- ============================================================================
+-- PART 10: Aggregate over a join
+-- ============================================================================
+SET max_parallel_workers_per_gather = 2;
+SET paradedb.enable_join_custom_scan TO on;
+DROP TABLE IF EXISTS numagg_lines CASCADE;
+CREATE TABLE numagg_lines (
+    id SERIAL PRIMARY KEY,
+    numagg_id INTEGER,
+    note TEXT
+);
+INSERT INTO numagg_lines (numagg_id, note) VALUES
+    (1, 'first line'),
+    (1, 'second line'),
+    (2, 'third line'),
+    (3, 'fourth line');
+CREATE INDEX numagg_lines_idx ON numagg_lines USING bm25 (
+    id, numagg_id, note
+) WITH (key_field = 'id');
+ANALYZE numagg_lines;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description @@@ 'apple OR basket';
+                                                                                                      QUERY PLAN                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('SUM'::text), pdb.agg_fn('MIN'::text)
+   Backend: DataFusion
+   Indexes: numagg_idx (n), numagg_lines_idx (l)
+   Aggregates: SUM(price), SUM(amount), MIN(weight)
+   DataFusion Physical Plan: 
+     : ┌───── DistributedExec
+     : │ AggregateExec: mode=Final, gby=[], aggr=[numeric64_sum(n_0.price, 2) as agg_0, numeric_bytes_sum(n_0.amount) as agg_1, min(n_0.weight) as agg_2]
+     : │   CoalescePartitionsExec
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+     : └──────────────────────────────────────────────────
+     :   ┌───── Stage 2 ── tasks=2, partitions=4
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(n_0.price, 2) as agg_0, numeric_bytes_sum(n_0.amount) as agg_1, min(n_0.weight) as agg_2]
+     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(numagg_id@0, id@0)], projection=[price@2, weight@3, amount@4]
+     :   │     CoalescePartitionsExec
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=1
+     :   │     DistributedLeafExec:
+     :   │       t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+     :   │       t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+     :   └──────────────────────────────────────────────────
+     :     ┌───── Stage 1 ── tasks=1, partitions=2
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
+     :     │   DistributedLeafExec:
+     :     │     t0: PgSearchScan: segments=1, query="all"
+     :     └──────────────────────────────────────────────────
+(25 rows)
+
+SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description @@@ 'apple OR basket';
+   sum   |                                      sum                                       |     min     
+---------+--------------------------------------------------------------------------------+-------------
+ 4010.50 | 400000000000000000000000000000000000000000000000000000000000000000000000000037 | 0.100000003
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description @@@ 'apple OR basket';
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: l, n)
+   sum   |                                      sum                                       |     min     
+---------+--------------------------------------------------------------------------------+-------------
+ 4010.50 | 400000000000000000000000000000000000000000000000000000000000000000000000000037 | 0.100000003
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+DROP TABLE numagg_lines CASCADE;
+DROP TABLE numagg CASCADE;

--- a/pg_search/tests/pg_regress/expected/numeric_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/numeric_aggregate.out
@@ -343,6 +343,46 @@ SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR baske
 (1 row)
 
 SET paradedb.enable_aggregate_custom_scan TO on;
+-- Numeric64 SUM sorts the same way
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: category, (sum(price))
+   ->  Sort
+         Output: category, (sum(price))
+         Sort Key: (sum(numagg.price))
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Output: category, (sum(price))
+               Backend: DataFusion
+               Indexes: numagg_idx (numagg)
+               Group By: category
+               Aggregates: SUM(price)
+               DataFusion Physical Plan: 
+                 : SortPreservingMergeExec: [agg_0@1 ASC NULLS LAST], fetch=1
+                 :   SortExec: TopK(fetch=1), expr=[agg_0@1 ASC NULLS LAST], preserve_partitioning=[true]
+                 :     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
+                 :       RepartitionExec: partitioning=Hash([category@0], 2), input_partitions=2
+                 :         AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
+                 :           RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+                 :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"apple OR basket","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
+ category |   s   
+----------+-------
+ grocery  | 30.95
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
+ category |   s   
+----------+-------
+ grocery  | 30.95
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
 -- AVG blobs do not sort; TopK is skipped and Postgres sorts above the scan
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
@@ -449,36 +489,85 @@ SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount) FROM numagg WHERE desc
 (1 row)
 
 SET paradedb.enable_aggregate_custom_scan TO on;
+-- TopK over a group whose SUM is NaN: NaN sorts highest, matching Postgres
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: category, (sum(price))
+   ->  Sort
+         Output: category, (sum(price))
+         Sort Key: (sum(numagg.price)) DESC
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Output: category, (sum(price))
+               Backend: DataFusion
+               Indexes: numagg_idx (numagg)
+               Group By: category
+               Aggregates: SUM(price)
+               DataFusion Physical Plan: 
+                 : ┌───── DistributedExec
+                 : │ SortPreservingMergeExec: [agg_0@1 DESC], fetch=1
+                 : │   [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+                 : └──────────────────────────────────────────────────
+                 :   ┌───── Stage 2 ── tasks=2, partitions=2
+                 :   │ SortExec: TopK(fetch=1), expr=[agg_0@1 DESC], preserve_partitioning=[true]
+                 :   │   AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
+                 :   │     [Stage 1] => NetworkShuffleExec: output_partitions=2, input_tasks=2
+                 :   └──────────────────────────────────────────────────
+                 :     ┌───── Stage 1 ── tasks=2, partitions=4
+                 :     │ RepartitionExec: partitioning=Hash([category@0], 4), input_partitions=2
+                 :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
+                 :     │     DistributedLeafExec:
+                 :     │       t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"durian OR basket OR apple","lenient":null,"conjunction_mode":null}}}}
+                 :     │       t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"durian OR basket OR apple","lenient":null,"conjunction_mode":null}}}}
+                 :     └──────────────────────────────────────────────────
+(28 rows)
+
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
+ category |  s  
+----------+-----
+ grocery  | NaN
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
+ category |  s  
+----------+-----
+ grocery  | NaN
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 -- PART 8: Empty result set and FILTER clause
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
-SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
-   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('COUNT(*)'::text)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
    Indexes: numagg_idx (numagg)
-   Aggregates: SUM(amount), COUNT(*)
+   Aggregates: SUM(amount), AVG(amount), COUNT(*)
    DataFusion Physical Plan: 
      : ┌───── DistributedExec
-     : │ AggregateExec: mode=Final, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, count(1) as agg_1]
+     : │ AggregateExec: mode=Final, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, count(1) as agg_2]
      : │   CoalescePartitionsExec
      : │     [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
      : └──────────────────────────────────────────────────
      :   ┌───── Stage 1 ── tasks=2, partitions=4
-     :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, count(1) as agg_1]
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, count(1) as agg_2]
      :   │   DistributedLeafExec:
      :   │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"nonexistent","lenient":null,"conjunction_mode":null}}}}
      :   │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"nonexistent","lenient":null,"conjunction_mode":null}}}}
      :   └──────────────────────────────────────────────────
 (17 rows)
 
-SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
- sum | count 
------+-------
-     |     0
+SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+ sum | avg | count 
+-----+-----+-------
+     |     |     0
 (1 row)
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)

--- a/pg_search/tests/pg_regress/expected/numeric_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/numeric_pushdown.out
@@ -1692,7 +1692,7 @@ FROM numeric_unbounded_agg_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_unbounded_agg_test)
+WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=2) (table: join)
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  GroupAggregate
@@ -1717,7 +1717,7 @@ FROM numeric_unbounded_agg_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_unbounded_agg_test)
+WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=2) (table: join)
  category |               total                
 ----------+------------------------------------
  A        | 301.111111110111111111011111111100
@@ -1729,7 +1729,7 @@ SELECT category, SUM(amount) as total
 FROM numeric_unbounded_agg_test
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_unbounded_agg_test)
+WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=2) (table: join)
  category |               total                
 ----------+------------------------------------
  A        | 301.111111110111111111011111111100
@@ -2190,27 +2190,22 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM max_scale_test
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: max_scale_test)
-                           QUERY PLAN                            
------------------------------------------------------------------
- Aggregate
-   Output: sum(val), avg(val), min(val), max(val)
-   ->  Custom Scan (ParadeDB Base Scan) on public.max_scale_test
-         Output: val
-         Table: max_scale_test
-         Index: max_scale_idx
-         Worker Selection: Cost model
-         Exec Method: ColumnarExecState
-         Fast Fields: val
-         Scores: false
-         Full Index Scan: true
-         Tantivy Query: {"with_index":{"query":"all"}}
-(12 rows)
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
+   Backend: DataFusion
+   Indexes: max_scale_idx (max_scale_test)
+   Aggregates: SUM(val), AVG(val), MIN(val), MAX(val)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Single, gby=[], aggr=[numeric64_sum(max_scale_test_0.val, 18) as agg_0, numeric64_avg(max_scale_test_0.val, 18) as agg_1, min(max_scale_test_0.val) as agg_2, max(max_scale_test_0.val) as agg_3]
+     :   CooperativeExec
+     :     PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(9 rows)
 
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM max_scale_test
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: max_scale_test)
          sum          |          avg           |          min          |         max          
 ----------------------+------------------------+-----------------------+----------------------
  0.623456789012345678 | 0.12469135780246913560 | -0.500000000000000000 | 0.999999999999999999
@@ -2318,27 +2313,22 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM negative_scale_test
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: negative_scale_test)
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Aggregate
-   Output: sum(val), avg(val), min(val), max(val)
-   ->  Custom Scan (ParadeDB Base Scan) on public.negative_scale_test
-         Output: val
-         Table: negative_scale_test
-         Index: negative_scale_idx
-         Worker Selection: Cost model
-         Exec Method: ColumnarExecState
-         Fast Fields: val
-         Scores: false
-         Full Index Scan: true
-         Tantivy Query: {"with_index":{"query":"all"}}
-(12 rows)
+                                                                                                                   QUERY PLAN                                                                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
+   Backend: DataFusion
+   Indexes: negative_scale_idx (negative_scale_test)
+   Aggregates: SUM(val), AVG(val), MIN(val), MAX(val)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Single, gby=[], aggr=[numeric64_sum(negative_scale_test_0.val, -3) as agg_0, numeric64_avg(negative_scale_test_0.val, -3) as agg_1, min(negative_scale_test_0.val) as agg_2, max(negative_scale_test_0.val) as agg_3]
+     :   CooperativeExec
+     :     PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(9 rows)
 
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM negative_scale_test
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: negative_scale_test)
   sum   |        avg         |  min   |  max  
 --------+--------------------+--------+-------
  132000 | 22000.000000000000 | -12000 | 99000
@@ -3246,27 +3236,22 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(val_small), AVG(val_small), MIN(val_small), MAX(val_small)
 FROM numeric_precision_only_test
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'val_small' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_precision_only_test)
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Aggregate
-   Output: sum(val_small), avg(val_small), min(val_small), max(val_small)
-   ->  Custom Scan (ParadeDB Base Scan) on public.numeric_precision_only_test
-         Output: val_small
-         Table: numeric_precision_only_test
-         Index: numeric_prec_only_idx
-         Worker Selection: Cost model
-         Exec Method: ColumnarExecState
-         Fast Fields: val_small
-         Scores: false
-         Full Index Scan: true
-         Tantivy Query: {"with_index":{"query":"all"}}
-(12 rows)
+                                                                                                                                              QUERY PLAN                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
+   Backend: DataFusion
+   Indexes: numeric_prec_only_idx (numeric_precision_only_test)
+   Aggregates: SUM(val_small), AVG(val_small), MIN(val_small), MAX(val_small)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Single, gby=[], aggr=[numeric64_sum(numeric_precision_only_test_0.val_small, 0) as agg_0, numeric64_avg(numeric_precision_only_test_0.val_small, 0) as agg_1, min(numeric_precision_only_test_0.val_small) as agg_2, max(numeric_precision_only_test_0.val_small) as agg_3]
+     :   CooperativeExec
+     :     PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(9 rows)
 
 SELECT SUM(val_small), AVG(val_small), MIN(val_small), MAX(val_small)
 FROM numeric_precision_only_test
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'val_small' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_precision_only_test)
   sum  |          avg          | min  |  max  
 -------+-----------------------+------+-------
  12368 | 1766.8571428571428571 | -500 | 12345
@@ -3275,7 +3260,6 @@ WARNING:  Aggregate Scan not used: field 'val_small' does not support aggregate 
 SELECT SUM(val_large), AVG(val_large), MIN(val_large), MAX(val_large)
 FROM numeric_precision_only_test
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'val_large' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_precision_only_test)
        sum       |         avg         |      min      |       max       
 -----------------+---------------------+---------------+-----------------
  126956789024690 | 18136684146384.2857 | -500000000000 | 123456789012345
@@ -3337,7 +3321,6 @@ ORDER BY id;
 SELECT SUM(implicit_scale), SUM(explicit_scale)
 FROM numeric_explicit_scale_zero
 WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: field 'implicit_scale' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_explicit_scale_zero)
   sum  |  sum  
 -------+-------
  69124 | 69124

--- a/pg_search/tests/pg_regress/expected/numeric_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/numeric_pushdown.out
@@ -1692,7 +1692,7 @@ FROM numeric_unbounded_agg_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=2) (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: GROUP BY column category is not indexed as a fast field (table: join)
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  GroupAggregate
@@ -1717,7 +1717,7 @@ FROM numeric_unbounded_agg_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=2) (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: GROUP BY column category is not indexed as a fast field (table: join)
  category |               total                
 ----------+------------------------------------
  A        | 301.111111110111111111011111111100
@@ -1729,7 +1729,7 @@ SELECT category, SUM(amount) as total
 FROM numeric_unbounded_agg_test
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=2) (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: GROUP BY column category is not indexed as a fast field (table: join)
  category |               total                
 ----------+------------------------------------
  A        | 301.111111110111111111011111111100

--- a/pg_search/tests/pg_regress/expected/topk-agg-facet.out
+++ b/pg_search/tests/pg_regress/expected/topk-agg-facet.out
@@ -1678,7 +1678,7 @@ GROUP BY category
 HAVING AVG(price) > 1000
 ORDER BY avg_price DESC
 LIMIT 3;
-WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: GROUP BY column category is not indexed as a fast field (table: join)
                                                                                      QUERY PLAN                                                                                      
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -1716,7 +1716,7 @@ GROUP BY category
 HAVING AVG(price) > 1000
 ORDER BY avg_price DESC
 LIMIT 3;
-WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: GROUP BY column category is not indexed as a fast field (table: join)
  category | avg_price | total_count 
 ----------+-----------+-------------
  Laptops  |      1849 |           1
@@ -1943,7 +1943,7 @@ GROUP BY p.category, pc.description
 HAVING AVG(p.price) > 1000
 ORDER BY avg_price DESC
 LIMIT 2;
-WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: GROUP BY column category is not indexed as a fast field (table: join)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -1988,7 +1988,7 @@ GROUP BY p.category, pc.description
 HAVING AVG(p.price) > 1000
 ORDER BY avg_price DESC
 LIMIT 2;
-WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: GROUP BY column category is not indexed as a fast field (table: join)
  category |        description         | avg_price | total_count 
 ----------+----------------------------+-----------+-------------
  Laptops  | Portable computing devices |      1849 |           1

--- a/pg_search/tests/pg_regress/sql/numeric_aggregate.sql
+++ b/pg_search/tests/pg_regress/sql/numeric_aggregate.sql
@@ -1,0 +1,229 @@
+\i common/common_setup.sql
+
+-- ============================================================================
+-- NUMERIC AGGREGATE PUSHDOWN TESTS
+-- ============================================================================
+-- SUM/AVG/MIN/MAX/COUNT over NUMERIC columns route to the DataFusion backend
+-- of the aggregate custom scan:
+-- 1. Numeric64 (scaled I64): NUMERIC(p,s) where p <= 18
+-- 2. NumericBytes (decimal-bytes): NUMERIC(p,s) where p > 18
+-- Unbounded NUMERIC (no typmod) falls back to Postgres.
+-- ============================================================================
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET max_parallel_workers_per_gather = 2;
+
+DROP TABLE IF EXISTS numagg CASCADE;
+CREATE TABLE numagg (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price NUMERIC(15, 2),
+    weight NUMERIC(38, 9),
+    amount NUMERIC(78, 0),
+    free NUMERIC
+);
+
+INSERT INTO numagg (description, category, price, weight, amount, free) VALUES
+    ('apple laptop', 'electronics', 1000.10, 1.500000001, 100000000000000000000000000000000000000000000000000000000000000000000000000001, 1.10),
+    ('apple phone', 'electronics', 2000.25, 2.250000002, 200000000000000000000000000000000000000000000000000000000000000000000000000002, 2.20),
+    ('banana basket', 'grocery', 10.05, 0.100000003, 33, 0.30),
+    ('cherry basket', 'grocery', 20.90, 0.200000004, 44, NULL),
+    ('empty crate', 'grocery', NULL, NULL, NULL, NULL);
+
+CREATE INDEX numagg_idx ON numagg USING bm25 (
+    id, description, category, price, weight, amount, free
+) WITH (key_field = 'id', text_fields = '{"description": {}, "category": {"fast": true}}');
+
+-- Deterministic worker selection in fallback EXPLAINs
+ANALYZE numagg;
+
+-- ============================================================================
+-- PART 1: Scalar aggregates, Numeric64 storage: NUMERIC(15,2)
+-- ============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+
+-- Cross-check against Postgres without pushdown
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- ============================================================================
+-- PART 2: Scalar aggregates, NumericBytes storage: NUMERIC(38,9)
+-- ============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- ============================================================================
+-- PART 3: Scalar aggregates, NumericBytes storage: NUMERIC(78,0)
+-- ============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- ============================================================================
+-- PART 4: Unbounded NUMERIC falls back to Postgres
+-- ============================================================================
+
+-- Serial for the fallback EXPLAIN so no worker-count lines appear
+SET max_parallel_workers_per_gather = 0;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SELECT SUM(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SET max_parallel_workers_per_gather = 2;
+
+-- COUNT on an unbounded NUMERIC column still pushes down
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+SELECT COUNT(free) FROM numagg WHERE description @@@ 'apple OR basket OR crate';
+
+-- ============================================================================
+-- PART 5: GROUP BY a text column, numeric aggregates
+-- ============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate' GROUP BY category ORDER BY category;
+SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate' GROUP BY category ORDER BY category;
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description @@@ 'apple OR basket OR crate' GROUP BY category ORDER BY category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- ============================================================================
+-- PART 6: GROUP BY a NUMERIC column
+-- ============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT price, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY price ORDER BY price;
+SELECT price, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY price ORDER BY price;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amount, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY amount ORDER BY amount;
+SELECT amount, COUNT(*) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY amount ORDER BY amount;
+
+-- ============================================================================
+-- PART 6b: ORDER BY a numeric aggregate with LIMIT (TopK)
+-- ============================================================================
+
+-- SUM sorts natively: decimal-bytes ordering matches numeric ordering
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
+SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- AVG blobs do not sort; TopK is skipped and Postgres sorts above the scan
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
+SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- ============================================================================
+-- PART 7: NaN handling
+-- ============================================================================
+
+INSERT INTO numagg (description, category, price, weight, amount) VALUES
+    ('durian crate', 'grocery', 'NaN', 'NaN', 'NaN');
+ANALYZE numagg;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description @@@ 'durian OR basket';
+SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description @@@ 'durian OR basket';
+
+SELECT SUM(weight), MIN(weight), MAX(weight) FROM numagg WHERE description @@@ 'durian OR basket';
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount) FROM numagg WHERE description @@@ 'durian OR basket';
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description @@@ 'durian OR basket';
+SELECT SUM(weight), MIN(weight), MAX(weight) FROM numagg WHERE description @@@ 'durian OR basket';
+SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount) FROM numagg WHERE description @@@ 'durian OR basket';
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- ============================================================================
+-- PART 8: Empty result set and FILTER clause
+-- ============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE description @@@ 'apple OR basket';
+SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE description @@@ 'apple OR basket';
+
+-- ============================================================================
+-- PART 9: Declined shapes fall back to Postgres
+-- ============================================================================
+
+-- Serial for the fallback EXPLAINs so no worker-count lines appear
+SET max_parallel_workers_per_gather = 0;
+
+-- HAVING over a numeric aggregate
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category HAVING SUM(price) > 100 ORDER BY category;
+SELECT category, SUM(price) FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category HAVING SUM(price) > 100 ORDER BY category;
+
+-- SUM(DISTINCT numeric)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(DISTINCT price) FROM numagg WHERE description @@@ 'apple OR basket';
+SELECT SUM(DISTINCT price) FROM numagg WHERE description @@@ 'apple OR basket';
+
+-- stddev is not supported on NUMERIC columns
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT STDDEV(price) FROM numagg WHERE description @@@ 'apple OR basket';
+SELECT STDDEV(price) FROM numagg WHERE description @@@ 'apple OR basket';
+
+-- ============================================================================
+-- PART 10: Aggregate over a join
+-- ============================================================================
+
+SET max_parallel_workers_per_gather = 2;
+SET paradedb.enable_join_custom_scan TO on;
+
+DROP TABLE IF EXISTS numagg_lines CASCADE;
+CREATE TABLE numagg_lines (
+    id SERIAL PRIMARY KEY,
+    numagg_id INTEGER,
+    note TEXT
+);
+
+INSERT INTO numagg_lines (numagg_id, note) VALUES
+    (1, 'first line'),
+    (1, 'second line'),
+    (2, 'third line'),
+    (3, 'fourth line');
+
+CREATE INDEX numagg_lines_idx ON numagg_lines USING bm25 (
+    id, numagg_id, note
+) WITH (key_field = 'id');
+ANALYZE numagg_lines;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description @@@ 'apple OR basket';
+SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description @@@ 'apple OR basket';
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description @@@ 'apple OR basket';
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+DROP TABLE numagg_lines CASCADE;
+DROP TABLE numagg CASCADE;

--- a/pg_search/tests/pg_regress/sql/numeric_aggregate.sql
+++ b/pg_search/tests/pg_regress/sql/numeric_aggregate.sql
@@ -128,6 +128,15 @@ SET paradedb.enable_aggregate_custom_scan TO off;
 SELECT category, SUM(amount) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
 SET paradedb.enable_aggregate_custom_scan TO on;
 
+-- Numeric64 SUM sorts the same way
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
 -- AVG blobs do not sort; TopK is skipped and Postgres sorts above the scan
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, AVG(price) a FROM numagg WHERE description @@@ 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
@@ -158,13 +167,22 @@ SELECT SUM(weight), MIN(weight), MAX(weight) FROM numagg WHERE description @@@ '
 SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount) FROM numagg WHERE description @@@ 'durian OR basket';
 SET paradedb.enable_aggregate_custom_scan TO on;
 
+-- TopK over a group whose SUM is NaN: NaN sorts highest, matching Postgres
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, SUM(price) s FROM numagg WHERE description @@@ 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
 -- ============================================================================
 -- PART 8: Empty result set and FILTER clause
 -- ============================================================================
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
-SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
-SELECT SUM(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
+SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description @@@ 'nonexistent';
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE description @@@ 'apple OR basket';


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #5934

## What

This PR removes the per-row string round-trip from `numeric_bytes_sum` and `numeric_bytes_avg`.

Stacked on #5932. Uses `decimal-bytes` 0.4.3 (paradedb/decimal-bytes#18).

## Why

The accumulator built every row through `Decimal::from_bytes` -> `to_string` -> `BigDecimal::from_str`. Three allocations plus a decimal parse, per row. On `SUM` over a `NUMERIC(78,0)` column that decode dominated the query.

## How

`decode_parts_into` gives back sign, exponent, and BCD digits in a buffer the accumulator owns and reuses across rows. The increment comes from `BigUint::from_radix_be`, so no string and no parser. `NaN` and `+/-Infinity` short-circuit on the raw encoding.

## Tests

`numeric_aggregate` regress output is unchanged, and every result there is cross-checked against the Postgres fallback. Unit tests cover 78-digit sums, `NaN` / `Infinity`, the i64 sentinels, and negatives through the parts decoder.

A/B on 1M rows, parent commit against this one, same machine, median of 5 runs. `SUM(NUMERIC(78,0))` drops from 171 ms to 65 ms filtered, and from 630 ms to 203 ms over the full table. Both return the same 76-digit sum.

CI suite at 20M rows, Postgres fallback against pushdown:

| query | fallback | pushdown |
| --- | --- | --- |
| `SUM(int)` | 38.5 ms | 16.4 ms |
| `SUM(numeric15)` | 125.8 ms | 56.7 ms |
| `SUM(numeric78)` | 265.9 ms | 114.3 ms |

All three speed up by the same 2.2-2.3x, so the decode is no longer what separates `NUMERIC` from `INT`.

At 100K and 1M the pushdown still loses on this query. The DataFusion path costs about 35 ms before the first row against about 7 ms for Tantivy, and the crossover sits near 400K matching rows. That comes from #5932 routing `NUMERIC` to DataFusion, not from this commit.
