### PR TITLE
perf: Fast path for unfiltered / single term filter counts

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -427,6 +427,31 @@ pub fn execute_aggregate(
             NonNull::new(planstate),
             query.needs_tokenizer(),
         )?;
+
+        // Fast path: a bare doc count without MVCC filtering is answerable by
+        // `Weight::count` — a stored-doc_freq metadata read for term queries
+        // on delete-free segments, a scoreless docset drain otherwise —
+        // skipping the aggregation framework's per-doc column iteration.
+        if !solve_mvcc
+            && matches!(&agg_req, AggregateRequest::Sql(clause) if clause.is_bare_doc_count())
+        {
+            let count = reader.count_matched_docs()?;
+            let mut results = AggregationResults::default();
+            // Key "0" matches `CollectAggregations::collect`'s enumeration of
+            // the single aggregate.
+            results.0.insert(
+                "0".to_string(),
+                tantivy::aggregation::agg_result::AggregationResult::MetricResult(
+                    tantivy::aggregation::agg_result::MetricResult::Count(
+                        tantivy::aggregation::metric::SingleMetricResult {
+                            value: Some(count as f64),
+                        },
+                    ),
+                ),
+            );
+            return Ok(results);
+        }
+
         let ambulkdelete_epoch = MetaPage::open(index).ambulkdelete_epoch();
         let segment_ids = reader
             .segment_readers()

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -561,6 +561,22 @@ impl SearchIndexReader {
         self.and_query(tantivy_query)
     }
 
+    /// Count matched docs by summing `Weight::count` across segments.
+    ///
+    /// For term-like queries (term, or term wrapped in boost/const-score) on
+    /// segments without deletes this reads the stored doc_freq from the term
+    /// dictionary without touching postings; other queries drain their
+    /// docsets without scoring or collection overhead. Counts raw index
+    /// entries: no MVCC filtering.
+    pub fn count_matched_docs(&self) -> tantivy::Result<u64> {
+        let weight = self.weight();
+        let mut total = 0u64;
+        for segment_reader in self.searcher.segment_readers() {
+            total += u64::from(weight.count(segment_reader)?);
+        }
+        Ok(total)
+    }
+
     pub fn weight(&self) -> Box<dyn Weight> {
         self.query
             .weight(if self.need_scores {

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -334,6 +334,59 @@ impl AggregateCSClause {
         AggregateType::resolve_mvcc_enabled(self.aggregates())
     }
 
+    /// True when this clause is a single doc-count aggregate with no GROUP BY,
+    /// FILTER, or ORDER BY: the shape answerable by `Weight::count` alone.
+    /// Matches `COUNT(*)` and pdb.agg value_count over a field guaranteed
+    /// present exactly once per doc.
+    pub fn is_bare_doc_count(&self) -> bool {
+        if self.has_groupby() || self.has_filter() || self.orderby.has_orderby() {
+            return false;
+        }
+        let mut aggregates = self.aggregates();
+        let (Some(aggregate), None) = (aggregates.next(), aggregates.next()) else {
+            return false;
+        };
+        match aggregate {
+            AggregateType::CountAny { filter: None, .. } => true,
+            AggregateType::Custom {
+                agg_json,
+                filter: None,
+                ..
+            } => self.is_doc_count_json(agg_json),
+            _ => false,
+        }
+    }
+
+    /// True for `{"value_count": {"field": f}}` where `f` is single-valued and
+    /// present on every doc — the key field or ctid — making the value count
+    /// equal to the doc count.
+    fn is_doc_count_json(&self, agg_json: &serde_json::Value) -> bool {
+        let Some(aggs) = agg_json.as_object() else {
+            return false;
+        };
+        if aggs.len() != 1 {
+            return false;
+        }
+        let Some(value_count) = aggs.get("value_count").and_then(|v| v.as_object()) else {
+            return false;
+        };
+        let Some(field) = value_count.get("field").and_then(|f| f.as_str()) else {
+            return false;
+        };
+        if value_count
+            .iter()
+            .any(|(k, v)| k != "field" && !v.is_null())
+        {
+            return false;
+        }
+        if field == "ctid" {
+            return true;
+        }
+        let indexrel = PgSearchRelation::with_lock(self.indexrelid, pg_sys::AccessShareLock as _);
+        SearchIndexSchema::open(&indexrel)
+            .is_ok_and(|schema| schema.key_field_name().to_string() == field)
+    }
+
     pub fn planner_should_replace_aggrefs(&self) -> bool {
         self.targetlist.grouping_columns().is_empty()
             && self.orderby.orderby_info().is_empty()

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -1982,7 +1982,7 @@ fn match_query(
         Occur::Should
     };
 
-    let clauses: Vec<_> = terms
+    let mut clauses: Vec<_> = terms
         .into_iter()
         .map(|term| {
             let query: Box<dyn TantivyQuery> = match (distance, prefix) {
@@ -1994,6 +1994,12 @@ fn match_query(
         })
         .collect();
 
+    // A boolean of one positive clause is that clause: unwrapping skips the
+    // union scorer and preserves `Weight::count` fast paths (e.g. doc_freq
+    // for a single term).
+    if clauses.len() == 1 {
+        return Ok(clauses.pop().unwrap().1);
+    }
     Ok(Box::new(BooleanQuery::new(clauses)))
 }
 #[allow(clippy::too_many_arguments)]
@@ -2050,6 +2056,10 @@ fn match_array_query(
         terms.push((occur, term_query));
     }
 
+    // See `match_query`: a boolean of one positive clause is that clause.
+    if terms.len() == 1 {
+        return Ok(terms.pop().unwrap().1);
+    }
     Ok(Box::new(BooleanQuery::new(terms)))
 }
 

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -1927,6 +1927,29 @@ fn parse_with_field<QueryParserCtor: Fn() -> QueryParser>(
     )
 }
 
+/// Clauses destined for a [`BooleanQuery`].
+///
+/// Collapses on build: a boolean of one positive clause is that clause, so
+/// unwrapping skips the union scorer and preserves `Weight::count` fast
+/// paths (e.g. doc_freq for a single term). A lone `MustNot` is not
+/// equivalent to its inner query and stays wrapped.
+struct BooleanClauses(Vec<(Occur, Box<dyn TantivyQuery>)>);
+
+impl FromIterator<(Occur, Box<dyn TantivyQuery>)> for BooleanClauses {
+    fn from_iter<I: IntoIterator<Item = (Occur, Box<dyn TantivyQuery>)>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl BooleanClauses {
+    fn into_query(mut self) -> Box<dyn TantivyQuery> {
+        if self.0.len() == 1 && !matches!(self.0[0].0, Occur::MustNot) {
+            return self.0.pop().unwrap().1;
+        }
+        Box::new(BooleanQuery::new(self.0))
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn match_query(
     field: &FieldName,
@@ -1982,7 +2005,7 @@ fn match_query(
         Occur::Should
     };
 
-    let mut clauses: Vec<_> = terms
+    let clauses: BooleanClauses = terms
         .into_iter()
         .map(|term| {
             let query: Box<dyn TantivyQuery> = match (distance, prefix) {
@@ -1994,13 +2017,7 @@ fn match_query(
         })
         .collect();
 
-    // A boolean of one positive clause is that clause: unwrapping skips the
-    // union scorer and preserves `Weight::count` fast paths (e.g. doc_freq
-    // for a single term).
-    if clauses.len() == 1 {
-        return Ok(clauses.pop().unwrap().1);
-    }
-    Ok(Box::new(BooleanQuery::new(clauses)))
+    Ok(clauses.into_query())
 }
 #[allow(clippy::too_many_arguments)]
 fn match_array_query(
@@ -2056,11 +2073,7 @@ fn match_array_query(
         terms.push((occur, term_query));
     }
 
-    // See `match_query`: a boolean of one positive clause is that clause.
-    if terms.len() == 1 {
-        return Ok(terms.pop().unwrap().1);
-    }
-    Ok(Box::new(BooleanQuery::new(terms)))
+    Ok(BooleanClauses(terms).into_query())
 }
 
 fn fuzzy_term(


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

With MVCC disabled, Tantivy has a count fast path we're not using. If:

1. The query is unfiltered OR
2. There is a single term filter AND the segment has no deleted docs

Tantivy can simply consult the segment doc count (for 1) or the term doc frequency (for 2). On a local test table this was a 50-100x speedup (15ms -> 0.2ms).

The query shape to try:

```sql
SELECT pdb.agg('{"value_count": {"field": "id"}}', false) 
FROM uuid_card_test 
WHERE uuid_card_test @@@ pdb.all();
```

## Why

## How

## Tests
