### PR TITLE
test: Ride out post-fault recovery in the Antithesis index-consistency check

### DIFF
--- a/stressgres/suites/antithesis/eventually_verify_index_consistency.sh
+++ b/stressgres/suites/antithesis/eventually_verify_index_consistency.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 #
-# Antithesis "eventually" command: with the workload interrupted, every ParadeDB index must pass
-# pg_search's own integrity checks (pdb.verify_index). The retry loop only absorbs pg_search
-# background activity racing the checker (paradedb/paradedb#5913); real corruption fails every
-# attempt.
+# Antithesis "eventually" command: with the workload killed and faults stopped, every ParadeDB
+# index must pass pg_search's own integrity checks (pdb.verify_index). Faults stop when an
+# eventually command starts, but recovery takes time (a killed postgres pod needs a restart and
+# WAL replay), so the deadline loop rides out connection errors as well as pg_search background
+# activity racing the checker (paradedb/paradedb#5913); real corruption fails every attempt
+# until the deadline.
 
 set -Eeuo pipefail
 
@@ -37,13 +39,18 @@ $$;
 EOF
 )
 
-for attempt in $(seq 1 30); do
+# The deadline is 1.5x the workload's own 200s reconnect-grace: that grace holds under active
+# fault injection, while this command runs with all faults stopped, so a database that is still
+# unreachable at the deadline is itself a recovery-liveness failure worth reporting.
+DEADLINE=$((SECONDS + 300))
+output=""
+while (( SECONDS < DEADLINE )); do
   if output=$(psql "${CONN}" -X -qAt -v ON_ERROR_STOP=1 -c "${SQL}" 2>&1); then
     exit 0
   fi
-  echo "verify_index attempt ${attempt}/30: ${output}" >&2
-  sleep 2
+  echo "verify_index retry (t=${SECONDS}s): ${output}" >&2
+  sleep 5
 done
 
-echo "eventually_verify_index_consistency: ParadeDB indexes are still inconsistent" >&2
+echo "eventually_verify_index_consistency failed: ${output}" >&2
 exit 1


### PR DESCRIPTION
Follow-up to #5915, which merged before this fix landed on the branch.

The 30x2s retry loop in `eventually_verify_index_consistency.sh` fails when the database is still mid-recovery: faults stop when an eventually command starts, but the cluster takes time to become operational again. A 60-minute Antithesis validation run showed 305 timelines failing on connection errors alone, with no index ever inconsistent.

Replace the fixed attempt count with a longer deadline loop and report the last real error on failure, so an unreachable database and an inconsistent index are distinguishable in the report. A follow-up 60-minute run with this version passed the check on all 332 timelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)