### PR TITLE
fix: reject unsortable top_hits.sort fields at plan time

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -481,7 +481,7 @@ pub(crate) fn validate_agg_json_fields(
 }
 
 /// Recursively walk `agg_json` and validate that every `top_hits.sort` field is a type
-/// Tantivy's sort accessor supports (see [`SearchFieldType::supports_top_hits_sort`]).
+/// Tantivy's sort accessor supports (see [`crate::schema::SearchFieldType::supports_top_hits_sort`]).
 ///
 /// A text / uuid / inet / ltree / json / range / vector sort key would fall back to an empty
 /// accessor and every hit would silently get `"sort": [null]` with no ordering applied

--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -439,12 +439,19 @@ impl AggregateType {
 /// Returns an error if:
 /// - Any referenced field doesn't exist in the index
 /// - Any referenced field is a NUMERIC type (not supported for aggregation)
+/// - Any `top_hits.sort` key has a type Tantivy's sort accessor does not support
+///   (only `I64` / `U64` / `F64` / `Date` / `Numeric64` are accepted)
 pub(crate) fn validate_agg_json_fields(
     agg_json: &serde_json::Value,
     schema: &SearchIndexSchema,
 ) -> Result<(), String> {
     let mut fields = HashSet::default();
     extract_fields_from_agg_json(agg_json, &mut fields);
+    // top_hits.sort keys are object keys inside the sort array rather than values under a
+    // "field" key, so extract_fields_from_agg_json will not see them. Collect them here so
+    // the existence check below covers them and validate_top_hits_sort_fields can rely on
+    // schema.get_field_type() returning Some.
+    collect_top_hits_sort_field_names(agg_json, &mut fields);
     let indexed_fields: HashSet<String> = schema
         .fields()
         .map(|(_, entry)| entry.name().to_string())
@@ -511,11 +518,14 @@ fn validate_top_hits_sort_fields(
                             continue;
                         }
                         let root = FieldName::from(field_name.as_str()).root();
-                        let Some(field_type) = schema.get_field_type(&root) else {
-                            // Missing-field errors are surfaced by the fields loop above; skip
-                            // here so this validator only reports the sort-type problem.
-                            continue;
-                        };
+                        // Existence is guaranteed by the fields loop in
+                        // validate_agg_json_fields (which now includes top_hits.sort keys via
+                        // collect_top_hits_sort_field_names). Panic loudly if that invariant
+                        // is ever broken so the failure is not silent.
+                        let field_type = schema.get_field_type(&root).expect(
+                            "top_hits.sort field existence should have been validated by the \
+                             indexed_fields loop in validate_agg_json_fields",
+                        );
                         if !field_type.supports_top_hits_sort() {
                             return Err(format!(
                                 "top_hits.sort field '{}' has an unsupported type for sorting. \
@@ -539,6 +549,45 @@ fn validate_top_hits_sort_fields(
         _ => {}
     }
     Ok(())
+}
+
+/// Recursively walk `json` and add every `top_hits.sort` field key to `fields`. Sort keys
+/// appear as object keys inside the sort array (`{"field_name": "asc"}`), so
+/// [`extract_fields_from_agg_json`] does not see them. Elasticsearch-style pseudo fields
+/// (`_score`, `_doc`) are skipped since they do not resolve to schema fields.
+fn collect_top_hits_sort_field_names(json: &serde_json::Value, fields: &mut HashSet<String>) {
+    match json {
+        serde_json::Value::Object(map) => {
+            if let Some(sort) = map
+                .get("top_hits")
+                .and_then(|v| v.as_object())
+                .and_then(|top_hits| top_hits.get("sort"))
+                .and_then(|v| v.as_array())
+            {
+                for entry in sort {
+                    let Some(sort_obj) = entry.as_object() else {
+                        continue;
+                    };
+                    for field_name in sort_obj.keys() {
+                        if field_name.starts_with('_') {
+                            continue;
+                        }
+                        let field_name = FieldName::from(field_name.as_str());
+                        fields.insert(field_name.root());
+                    }
+                }
+            }
+            for value in map.values() {
+                collect_top_hits_sort_field_names(value, fields);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr {
+                collect_top_hits_sort_field_names(item, fields);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn extract_fields_from_agg_json(json: &serde_json::Value, fields: &mut HashSet<String>) {

--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -474,6 +474,70 @@ pub(crate) fn validate_agg_json_fields(
             ));
         }
     }
+
+    validate_top_hits_sort_fields(agg_json, schema)?;
+
+    Ok(())
+}
+
+/// Recursively walk `agg_json` and validate that every `top_hits.sort` field is a type
+/// Tantivy's sort accessor supports (see [`SearchFieldType::supports_top_hits_sort`]).
+///
+/// A text / uuid / inet / ltree / json / range / vector sort key would fall back to an empty
+/// accessor and every hit would silently get `"sort": [null]` with no ordering applied
+/// (issue #5710). Raising a clear planning-time error is friendlier than silent wrong
+/// results.
+///
+/// Elasticsearch-style pseudo fields prefixed with `_` (`_score`, `_doc`) are skipped:
+/// they do not resolve to schema fields and have their own accessor path in Tantivy.
+fn validate_top_hits_sort_fields(
+    agg_json: &serde_json::Value,
+    schema: &SearchIndexSchema,
+) -> Result<(), String> {
+    match agg_json {
+        serde_json::Value::Object(map) => {
+            if let Some(sort) = map
+                .get("top_hits")
+                .and_then(|v| v.as_object())
+                .and_then(|top_hits| top_hits.get("sort"))
+                .and_then(|v| v.as_array())
+            {
+                for entry in sort {
+                    let Some(sort_obj) = entry.as_object() else {
+                        continue;
+                    };
+                    for field_name in sort_obj.keys() {
+                        if field_name.starts_with('_') {
+                            continue;
+                        }
+                        let root = FieldName::from(field_name.as_str()).root();
+                        let Some(field_type) = schema.get_field_type(&root) else {
+                            // Missing-field errors are surfaced by the fields loop above; skip
+                            // here so this validator only reports the sort-type problem.
+                            continue;
+                        };
+                        if !field_type.supports_top_hits_sort() {
+                            return Err(format!(
+                                "top_hits.sort field '{}' has an unsupported type for sorting. \
+                                 Only numeric and date fields can be used as top_hits.sort keys.",
+                                field_name
+                            ));
+                        }
+                    }
+                }
+            }
+
+            for value in map.values() {
+                validate_top_hits_sort_fields(value, schema)?;
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr {
+                validate_top_hits_sort_fields(item, schema)?;
+            }
+        }
+        _ => {}
+    }
     Ok(())
 }
 

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -160,6 +160,25 @@ impl SearchFieldType {
         )
     }
 
+    /// Returns true if this field type is supported as a `top_hits.sort` key.
+    ///
+    /// Tantivy's `top_hits` sort accessor is built with numeric-or-date column types only
+    /// (`F64` / `U64` / `I64` / `DateTime`); a text-like or binary field falls back to an
+    /// empty accessor and every hit gets `"sort": [null]` with no ordering applied (see
+    /// issue #5710). Sortable types must therefore lower to one of those Arrow storage
+    /// types: `I64`, `U64`, `F64`, `Date`, and `Numeric64` (stored as scaled `Int64`) all
+    /// qualify. `NumericBytes` is excluded because it stores as `BinaryView`.
+    pub fn supports_top_hits_sort(&self) -> bool {
+        matches!(
+            self,
+            SearchFieldType::I64(_)
+                | SearchFieldType::U64(_)
+                | SearchFieldType::F64(_)
+                | SearchFieldType::Date(_)
+                | SearchFieldType::Numeric64(..)
+        )
+    }
+
     /// Returns the Arrow DataType used to store this field type in fast fields.
     ///
     /// Multiple SearchFieldType variants may map to the same Arrow storage type.

--- a/pg_search/tests/pg_regress/expected/issue_5710.out
+++ b/pg_search/tests/pg_regress/expected/issue_5710.out
@@ -1,0 +1,108 @@
+-- Regression test for issue #5710.
+-- top_hits.sort on a text field silently returned null sort values with no
+-- ordering, because Tantivy's top_hits sort accessor is numeric/date-only and
+-- text fields fell back to an empty accessor. The plan-time validator now
+-- rejects unsortable sort keys with a clear error.
+CREATE TABLE issue_5710_repro (
+    id uuid PRIMARY KEY,
+    group_id integer NOT NULL,
+    label text NOT NULL,
+    created_at timestamp NOT NULL
+);
+INSERT INTO issue_5710_repro (id, group_id, label, created_at) VALUES
+    ('00000000-0000-0000-0000-000000000001', 1, 'zebra',  '2026-01-01 00:00:00'),
+    ('00000000-0000-0000-0000-000000000002', 1, 'alpha',  '2026-01-02 00:00:00'),
+    ('00000000-0000-0000-0000-000000000003', 1, 'mango',  '2026-01-03 00:00:00');
+-- `(label::pdb.literal)` makes label a fast field so docvalue_fields can
+-- return it. Without this, top_hits errors on docvalue_fields resolution
+-- rather than on the sort validator we are testing.
+CREATE INDEX issue_5710_idx ON issue_5710_repro
+    USING paradedb (id, group_id, (label::pdb.literal), created_at)
+    WITH (key_field = 'id');
+-- Case 1: sort on a text field must raise a clear error.
+-- Before the fix, this returned three hits each with "sort": [null] and no
+-- ordering. After the fix, planning rejects the query.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"label": "asc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+ERROR:  top_hits.sort field 'label' has an unsupported type for sorting. Only numeric and date fields can be used as top_hits.sort keys.
+-- Case 2: sort on a date field still works. Baseline for the positive path.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"created_at": "asc"}],
+    "docvalue_fields": ["label", "created_at"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+                                                                                                                                                                               agg                                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"hits": [{"sort": [9224192577654775808], "docvalue_fields": {"label": ["zebra"], "created_at": ["2026-01-01T00:00:00Z"]}}, {"sort": [9224192664054775808], "docvalue_fields": {"label": ["alpha"], "created_at": ["2026-01-02T00:00:00Z"]}}, {"sort": [9224192750454775808], "docvalue_fields": {"label": ["mango"], "created_at": ["2026-01-03T00:00:00Z"]}}]}
+(1 row)
+
+-- Case 3: sort on an integer field still works.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"group_id": "desc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+                                                                                                                   agg                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"hits": [{"sort": [9223372036854775809], "docvalue_fields": {"label": ["zebra"]}}, {"sort": [9223372036854775809], "docvalue_fields": {"label": ["alpha"]}}, {"sort": [9223372036854775809], "docvalue_fields": {"label": ["mango"]}}]}
+(1 row)
+
+-- Case 4: sort on the Elasticsearch-style pseudo field `_score` is not a
+-- schema field and must not trip the new validator.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"_score": "desc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+                                                                                             agg                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"hits": [{"sort": [null], "docvalue_fields": {"label": ["zebra"]}}, {"sort": [null], "docvalue_fields": {"label": ["alpha"]}}, {"sort": [null], "docvalue_fields": {"label": ["mango"]}}]}
+(1 row)
+
+-- Case 5: mixed sort with one bad field must still error, since Tantivy
+-- would produce null sort values for the text key while sorting on the date.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"created_at": "asc"}, {"label": "asc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+ERROR:  top_hits.sort field 'label' has an unsupported type for sorting. Only numeric and date fields can be used as top_hits.sort keys.
+DROP TABLE issue_5710_repro CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_5710.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5710.sql
@@ -1,0 +1,100 @@
+-- Regression test for issue #5710.
+-- top_hits.sort on a text field silently returned null sort values with no
+-- ordering, because Tantivy's top_hits sort accessor is numeric/date-only and
+-- text fields fell back to an empty accessor. The plan-time validator now
+-- rejects unsortable sort keys with a clear error.
+
+CREATE TABLE issue_5710_repro (
+    id uuid PRIMARY KEY,
+    group_id integer NOT NULL,
+    label text NOT NULL,
+    created_at timestamp NOT NULL
+);
+
+INSERT INTO issue_5710_repro (id, group_id, label, created_at) VALUES
+    ('00000000-0000-0000-0000-000000000001', 1, 'zebra',  '2026-01-01 00:00:00'),
+    ('00000000-0000-0000-0000-000000000002', 1, 'alpha',  '2026-01-02 00:00:00'),
+    ('00000000-0000-0000-0000-000000000003', 1, 'mango',  '2026-01-03 00:00:00');
+
+-- `(label::pdb.literal)` makes label a fast field so docvalue_fields can
+-- return it. Without this, top_hits errors on docvalue_fields resolution
+-- rather than on the sort validator we are testing.
+CREATE INDEX issue_5710_idx ON issue_5710_repro
+    USING paradedb (id, group_id, (label::pdb.literal), created_at)
+    WITH (key_field = 'id');
+
+-- Case 1: sort on a text field must raise a clear error.
+-- Before the fix, this returned three hits each with "sort": [null] and no
+-- ordering. After the fix, planning rejects the query.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"label": "asc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+
+-- Case 2: sort on a date field still works. Baseline for the positive path.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"created_at": "asc"}],
+    "docvalue_fields": ["label", "created_at"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+
+-- Case 3: sort on an integer field still works.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"group_id": "desc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+
+-- Case 4: sort on the Elasticsearch-style pseudo field `_score` is not a
+-- schema field and must not trip the new validator.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"_score": "desc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+
+-- Case 5: mixed sort with one bad field must still error, since Tantivy
+-- would produce null sort values for the text key while sorting on the date.
+SELECT pdb.agg($$
+{
+  "top_hits": {
+    "size": 3,
+    "sort": [{"created_at": "asc"}, {"label": "asc"}],
+    "docvalue_fields": ["label"]
+  }
+}
+$$::jsonb)
+FROM issue_5710_repro
+WHERE id @@@ pdb.all()
+GROUP BY group_id;
+
+DROP TABLE issue_5710_repro CASCADE;


### PR DESCRIPTION
Fixes #5710. `top_hits.sort` on a text / uuid / inet / ltree / json / range / vector / numeric_bytes / bool key silently returned `"sort": [null]` on every hit with no ordering, because Tantivy's sort accessor is numeric-or-date only.

Add `SearchFieldType::supports_top_hits_sort` (allows I64 / U64 / F64 / Date / Numeric64) and a walker `validate_top_hits_sort_fields` that visits every `top_hits.sort` array in the aggregation JSON and errors out at plan time. Wired into `validate_agg_json_fields` so it fires from all three entry points (direct `paradedb.agg`, AggregateScan pushdown, BaseScan aggregation). Elasticsearch pseudo fields (`_score`, `_doc`) are skipped.

`cargo pgrx regress pg18`: 322/322 green, includes new `issue_5710` covering text-error, date-sort-works, integer-sort-works, `_score`-bypasses, and mixed-sort-catches-bad-key.