### PR TITLE
fix: Report dynamic filter pushdown under MPP

### DIFF
--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -26,7 +26,7 @@
 //! in parallel execution, or chained end-to-end when serial.
 
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
@@ -184,20 +184,9 @@ pub struct PgSearchScanPlan {
     pub indexrelid: u32,
     /// The JoinScan source identity when visibility is deferred.
     deferred_ctid_plan_position: Option<usize>,
-    /// When true, a HashJoin InList was successfully pushed down to a TermSet query.
-    dynamic_filter_pushdown: Arc<AtomicBool>,
     /// Sort order preserved across `with_filter_pushdown` rebuilds so the
     /// rebuilt plan keeps its equivalence properties.
     sort_order: Option<SortByField>,
-    /// Captures the per-segment `TermSetStrategy` chosen by the tantivy planner
-    /// for the pushed-down dynamic filter (issue #4895). Last-segment-wins is
-    /// fine because `EXPLAIN ANALYZE` only asks "did any segment use it?".
-    /// Stored as `u8` so it can live behind an `AtomicU8`; round-tripped
-    /// through `tantivy::query::StrategyTag` at render time. A value of
-    /// `StrategyTag::None as u8` (= 0) means no `TermSetWeight` ran on
-    /// this scan to write a tag — the EXPLAIN renderer falls back to
-    /// `=true` in that case.
-    dynamic_filter_strategy: Arc<AtomicU8>,
     range_sample: Option<RangePartitioningSample>,
     /// Global partition selected for a task-specialized variant. When present, this plan
     /// exposes one local partition and maps `execute(0)` back to this global partition.
@@ -221,9 +210,7 @@ impl Clone for PgSearchScanPlan {
             ffhelper: self.ffhelper.clone(),
             indexrelid: self.indexrelid,
             deferred_ctid_plan_position: self.deferred_ctid_plan_position,
-            dynamic_filter_pushdown: Arc::clone(&self.dynamic_filter_pushdown),
             sort_order: self.sort_order.clone(),
-            dynamic_filter_strategy: Arc::clone(&self.dynamic_filter_strategy),
             range_sample: self.range_sample.clone(),
             assigned_partition: self.assigned_partition,
         }
@@ -336,9 +323,7 @@ impl PgSearchScanPlan {
             ffhelper,
             indexrelid,
             deferred_ctid_plan_position,
-            dynamic_filter_pushdown: Arc::new(AtomicBool::new(false)),
             sort_order: sort_order.cloned(),
-            dynamic_filter_strategy: Arc::new(AtomicU8::new(0)),
             range_sample,
             assigned_partition: None,
         }
@@ -430,13 +415,7 @@ impl PgSearchScanPlan {
             ffhelper: self.ffhelper.clone(),
             indexrelid: self.indexrelid,
             deferred_ctid_plan_position: self.deferred_ctid_plan_position,
-            dynamic_filter_pushdown: Arc::new(AtomicBool::new(
-                self.dynamic_filter_pushdown.load(Ordering::Relaxed),
-            )),
             sort_order: self.sort_order.clone(),
-            dynamic_filter_strategy: Arc::new(AtomicU8::new(
-                self.dynamic_filter_strategy.load(Ordering::Relaxed),
-            )),
             range_sample: self.range_sample.clone(),
             assigned_partition: self.assigned_partition,
         })
@@ -841,24 +820,6 @@ impl DisplayAs for PgSearchScanPlan {
         if !self.dynamic_filters.is_empty() {
             write!(f, ", dynamic_filters={}", self.dynamic_filters.len())?;
         }
-        if self.dynamic_filter_pushdown.load(Ordering::Relaxed) {
-            // Render a single token. `TermSetWeight` writes the chosen
-            // `StrategyTag` to the sink on every dispatch, so the value
-            // is the strategy name (`gallop` / `linear` /
-            // `bitset_from_postings` / `automaton` / `empty`). Falls
-            // back to `true` only when pushdown was indicated but no
-            // `TermSetWeight` ran to record a tag — e.g., the dynamic
-            // filter handled a non-TermSet shape, or the scan
-            // short-circuited before any segment was processed.
-            let tag = self.dynamic_filter_strategy.load(Ordering::Relaxed);
-            let strategy = tantivy::query::StrategyTag::try_from(tag)
-                .unwrap_or(tantivy::query::StrategyTag::None);
-            if matches!(strategy, tantivy::query::StrategyTag::None) {
-                write!(f, ", dynamic_filter_pushdown=true")?;
-            } else {
-                write!(f, ", dynamic_filter_pushdown={}", strategy_name(strategy))?;
-            }
-        }
         write!(f, ", query={}", self.resolved_query.explain_format())
     }
 }
@@ -1009,13 +970,12 @@ impl ExecutionPlan for PgSearchScanPlan {
             .then(|| MetricBuilder::new(&self.metrics).counter("rows_pruned", target_partition));
 
         let baseline_metrics = BaselineMetrics::new(&self.metrics, target_partition);
+        let plan_metrics = self.metrics.clone();
         let schema = self.properties.eq_properties.schema().clone();
         let score_column_schema_idx: Option<usize> = schema
             .column_with_name(&WhichFastField::Score.name())
             .map(|(idx, _)| idx);
         let dynamic_filters = self.dynamic_filters.clone();
-        let dynamic_filter_pushdown = self.dynamic_filter_pushdown.clone();
-        let dynamic_filter_strategy = self.dynamic_filter_strategy.clone();
 
         let stream_gen = async_stream::try_stream! {
             // Create a local copy of the reader if the query changed
@@ -1029,15 +989,16 @@ impl ExecutionPlan for PgSearchScanPlan {
             // this block is evaluated lazily during the first `poll_next`, which happens
             // AFTER the build side has completed and dynamic filters are published.
             let mut dynamic_filters = dynamic_filters.clone();
-            if !dynamic_filters.is_empty()
-                && try_dynamic_filter_pushdown(
+            let strategy_sink = Arc::new(AtomicU8::new(0));
+            let pushed = if !dynamic_filters.is_empty() {
+                try_dynamic_filter_pushdown(
                     &mut reader,
                     &mut dynamic_filters,
-                    Some(dynamic_filter_strategy.clone()),
+                    Some(strategy_sink.clone()),
                 )
-            {
-                dynamic_filter_pushdown.store(true, Ordering::Relaxed);
-            }
+            } else {
+                false
+            };
 
             let search_results = if range_boundaries.is_some() {
                 // Range partitioned mode explicitly scans all segments
@@ -1060,6 +1021,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                 scanner.set_batch_size(df_batch_size as usize);
             }
 
+            let mut pushdown_metric_recorded = false;
             loop {
                 let timer = baseline_metrics.elapsed_compute().timer();
                 let (pre_filters, score_threshold) = build_filters(&dynamic_filters, &schema, score_column_schema_idx);
@@ -1080,12 +1042,42 @@ impl ExecutionPlan for PgSearchScanPlan {
                 );
                 timer.done();
 
+                if pushed && !pushdown_metric_recorded {
+                    let tag = strategy_sink.load(Ordering::Relaxed);
+                    if tag > 0 {
+                        let strategy = tantivy::query::StrategyTag::try_from(tag)
+                            .unwrap_or(tantivy::query::StrategyTag::None);
+                        let metric_name = if matches!(strategy, tantivy::query::StrategyTag::None) {
+                            "dynamic_filter_pushdown".to_string()
+                        } else {
+                            format!("dynamic_filter_pushdown_{}", strategy_name(strategy))
+                        };
+                        MetricBuilder::new(&plan_metrics)
+                            .counter(metric_name, target_partition)
+                            .add(1);
+                        pushdown_metric_recorded = true;
+                    }
+                }
+
                 match next_batch {
                     Some(batch) => {
                         let record_batch = batch.to_record_batch(&schema);
                         yield record_batch.record_output(&baseline_metrics);
                     }
                     None => {
+                        if pushed && !pushdown_metric_recorded {
+                            let tag = strategy_sink.load(Ordering::Relaxed);
+                            let strategy = tantivy::query::StrategyTag::try_from(tag)
+                                .unwrap_or(tantivy::query::StrategyTag::None);
+                            let metric_name = if matches!(strategy, tantivy::query::StrategyTag::None) {
+                                "dynamic_filter_pushdown".to_string()
+                            } else {
+                                format!("dynamic_filter_pushdown_{}", strategy_name(strategy))
+                            };
+                            MetricBuilder::new(&plan_metrics)
+                                .counter(metric_name, target_partition)
+                                .add(1);
+                        }
                         // Flush pre-materialization filter stats from Scanner.
                         if let Some(ref counter) = rows_scanned {
                             counter.add(scanner.pre_filter_rows_scanned);

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -189,7 +189,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=gallop, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=2.00 K]
 (16 rows)
 
 SELECT t1.val, t2.val

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -149,7 +149,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=25.8 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=25.8 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=1.10 K]
 (15 rows)
 
 -- Block B: correctness. Run the same query with gallop disabled and
@@ -227,7 +227,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=1.10 K]
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
 (18 rows)
@@ -308,7 +308,7 @@ LIMIT 10;
            :             CooperativeExec
            :               PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :             CooperativeExec
-           :               PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :               PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=1.10 K]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :         CooperativeExec

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -363,7 +363,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, dynamic_filter_pushdown_gallop=1, rows_pruned=11.75 K, rows_scanned=20.00 K]
 (15 rows)
 
 -- Verify results
@@ -459,8 +459,8 @@ JOIN null_val_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val' OR t1.val IS NULL
 ORDER BY t1.val DESC NULLS FIRST, t1.id
 LIMIT 25;
-                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=25.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=25.00 loops=1)
          Relation Tree: t2 INNER t1
@@ -475,7 +475,7 @@ LIMIT 25;
            :         CooperativeExec
            :           PgSearchScan: segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :         CooperativeExec
-           :           PgSearchScan: segments=2, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, rows_pruned=11.57 K, rows_scanned=20.00 K]
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, dynamic_filter_pushdown_gallop=1, rows_pruned=11.57 K, rows_scanned=20.00 K]
 (15 rows)
 
 SELECT t1.id, t1.val

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -163,7 +163,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=50]
 (15 rows)
 
 -- =============================================================================
@@ -667,7 +667,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=4, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, rows_pruned=4.19 K, rows_scanned=30.00 K]
+           :           PgSearchScan: segments=4, dynamic_filters=2, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=4.19 K, rows_scanned=30.00 K]
 (15 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/expected/term_set_dispatch.out
+++ b/pg_search/tests/pg_regress/expected/term_set_dispatch.out
@@ -102,7 +102,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=4]
 (15 rows)
 
 SELECT ts_outer.id, ts_unique.id
@@ -145,7 +145,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":5}}}]}}, metrics=[output_rows=5, output_bytes=80.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5, output_bytes=120.0 B, output_batches=1, rows_pruned=0, rows_scanned=5]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=5, output_bytes=120.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=5]
 (15 rows)
 
 SELECT ts_outer.id, ts_unique.id
@@ -188,7 +188,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":6}}}]}}, metrics=[output_rows=6, output_bytes=96.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, dynamic_filter_pushdown_linear=1, rows_pruned=0, rows_scanned=6]
 (15 rows)
 
 SELECT ts_outer.id, ts_unique.id
@@ -234,7 +234,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":50}}}]}}, metrics=[output_rows=50, output_bytes=800.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5.00 K, output_bytes=117.2 KB, output_batches=1, rows_pruned=0, rows_scanned=5.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=5.00 K, output_bytes=117.2 KB, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=5.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_multi.id
@@ -331,7 +331,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100}}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query="all", metrics=[output_rows=100, output_bytes=2.3 KB, output_batches=1, rows_pruned=0, rows_scanned=100]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=100, output_bytes=2.3 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=100]
 (15 rows)
 
 SELECT ts_outer.id, ts_sorted.id
@@ -380,7 +380,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, dynamic_filter_pushdown_linear=1, rows_pruned=0, rows_scanned=4]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_unique;
@@ -411,7 +411,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":20}}}]}}, metrics=[output_rows=20, output_bytes=320.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=20, output_bytes=480.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=20, output_bytes=480.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=20]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_unique;
@@ -475,7 +475,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100}}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=8.19 K, output_bytes=192.0 KB, output_batches=2, rows_pruned=1.81 K, rows_scanned=10.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=8.19 K, output_bytes=192.0 KB, output_batches=2, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=1.81 K, rows_scanned=10.00 K]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_multi;
@@ -508,7 +508,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=4]
 (15 rows)
 
 RESET paradedb.term_set_gallop_enabled;

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -487,7 +487,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=70]
 (15 rows)
 
 SELECT f.id, f.title
@@ -533,7 +533,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=10]
 (15 rows)
 
 SELECT f.id, f.title


### PR DESCRIPTION
## What

Record dynamic filter pushdown via a metric.

## Why

To allow for accurate reporting under MPP. `dynamic_filter_pushdown` is triggered only after execution has started, and only metrics are transferred back over the wire after MPP execution.

## Tests

See changed regress tests.