### PR TITLE
fix: dont panic on a transiently inconsistent mutable segment after crash recovery

### DIFF
--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -212,9 +212,16 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
                 let entry = directory
                     .segment_meta_entry(&segment_id)
                     .expect("is_mutable() guarantees a loaded entry for this segment");
-                let ctids = entry
-                    .mutable_snapshot(&index_relation)
-                    .expect("is_mutable() guarantees this is a mutable segment");
+                let ctids = match entry.mutable_snapshot(&index_relation) {
+                    Ok(ctids) => ctids,
+                    // Torn after crash recovery (#5937): can't trust the ctid set,
+                    // so skip this segment. A later merge/GC heals it and the next
+                    // VACUUM reclaims its dead tuples.
+                    Err(e) => {
+                        pgrx::debug1!("ambulkdelete: skipping mutable segment {segment_id:?}: {e}");
+                        continue;
+                    }
+                };
                 Box::new(ctids.into_iter().map(|ctid| DeleteTarget::Ctid { ctid }))
             } else {
                 let ctid_ff = FFType::new_ctid(segment_reader.fast_fields());

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -517,7 +517,16 @@ impl SegmentMetaEntry {
                 MutableSegmentEntry::Remove(ctid) => ctid_set.remove(&ctid),
             };
         }
-        assert_eq!(ctid_set.len(), expected_ctids as usize);
+        // The header and the on-disk list are separate WAL records, so crash
+        // recovery can leave them briefly out of sync (#5937). Not corruption: a
+        // later merge/GC rewrites the segment and the next read succeeds. Fail this
+        // read cleanly rather than panic. (No dst::assert_always!: this mismatch is
+        // expected here, and in debug builds the assert would fire on this path.)
+        if ctid_set.len() != expected_ctids as usize {
+            return Err(
+                "mutable segment snapshot inconsistent with header (transient after crash recovery)",
+            );
+        }
 
         let mut ctids: Vec<_> = ctid_set.into_iter().collect();
         ctids.sort_unstable();

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -1045,6 +1045,69 @@ mod tests {
         }
     }
 
+    // #5937: a torn header/list after crash recovery must return Err, not panic.
+    #[pg_test]
+    unsafe fn test_mutable_snapshot_torn_header_returns_err() {
+        use crate::postgres::storage::block::{MutableSegmentEntry, SegmentMetaEntryMutable};
+
+        let relation_oid = init_bm25_index();
+        let indexrel = PgSearchRelation::open(relation_oid);
+
+        // List holds only the 20 Adds; the 18 Removes are the records replay lost,
+        // but num_deleted_docs already counts them (header claims 2 live).
+        let (mut content, mut items) = SegmentMetaEntryMutable::create(&indexrel);
+        let adds = (1u64..=20)
+            .map(MutableSegmentEntry::Add)
+            .collect::<Vec<_>>();
+        items.add_items(&adds, None);
+        content.num_deleted_docs = 18;
+
+        let entry = SegmentMetaEntry::new_mutable(
+            random_segment_id(),
+            20, // max_doc
+            pg_sys::InvalidTransactionId,
+            content,
+        );
+
+        let result = entry.mutable_snapshot(&indexrel);
+        assert!(
+            result.is_err(),
+            "torn mutable segment must return Err, got {result:?}"
+        );
+    }
+
+    // A consistent header still snapshots to Ok: the #5937 fix fires only on a mismatch.
+    #[pg_test]
+    unsafe fn test_mutable_snapshot_consistent_header_returns_live_ctids() {
+        use crate::postgres::storage::block::{MutableSegmentEntry, SegmentMetaEntryMutable};
+
+        let relation_oid = init_bm25_index();
+        let indexrel = PgSearchRelation::open(relation_oid);
+
+        // 20 Adds then Remove ctids 1 and 2: header max_doc=20, num_deleted=2,
+        // so 18 live ctids (3..=20), matching the list.
+        let (mut content, mut items) = SegmentMetaEntryMutable::create(&indexrel);
+        let mut entries = (1u64..=20)
+            .map(MutableSegmentEntry::Add)
+            .collect::<Vec<_>>();
+        entries.push(MutableSegmentEntry::Remove(1));
+        entries.push(MutableSegmentEntry::Remove(2));
+        items.add_items(&entries, None);
+        content.num_deleted_docs = 2;
+
+        let entry = SegmentMetaEntry::new_mutable(
+            random_segment_id(),
+            20, // max_doc
+            pg_sys::InvalidTransactionId,
+            content,
+        );
+
+        let ctids = entry
+            .mutable_snapshot(&indexrel)
+            .expect("consistent mutable segment must snapshot to Ok");
+        assert_eq!(ctids, (3u64..=20).collect::<Vec<_>>());
+    }
+
     fn init_bm25_index() -> pg_sys::Oid {
         Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
         Spi::run("CREATE INDEX t_idx ON t USING paradedb (id, data) WITH (key_field = 'id')")


### PR DESCRIPTION
# Ticket(s) Closed

- closes #5937

## What

after crash recovery, reading a mutable segment could panic the backend in `mutable_snapshot`: `assertion left == right failed, left: 20, right: 2`. no concurrent writers and a later read passes on its own

## Why

a mutable segment's `Add`/`Remove` list and its header (`max_doc` / `num_deleted_docs`) are separate WAL records with no atomicity across them. on single-node recovery, replay can stop between two paired writes, leaving the header ahead of the list. `mutable_snapshot` derives both the replay length and the expected count from the header, so they disagree and the `assert_eq!` panics. not durable corruption: a later merge/GC rewrites the segment and the next read succeeds.

## How

[`mutable_snapshot`](https://github.com/bit2swaz/paradedb/blob/2d8d9704b1c1888905aecaffce89ebfa189c7d06/pg_search/src/postgres/storage/block.rs#L520-L533) returns `Err` on the mismatch instead of asserting, so the read fails cleanly and self-heals on retry. the scan path already propagates it; the [vacuum caller](https://github.com/bit2swaz/paradedb/blob/2d8d9704b1c1888905aecaffce89ebfa189c7d06/pg_search/src/postgres/delete.rs#L215-L224) now skips the torn segment instead of `.expect()`ing (which would just move the panic).

no `dst::assert_always!` alongside: in debug builds it lowers to a live `debug_assert!` that would fire on this exact path, and the mismatch is expected here.

follow-up (ill create a separate PR for this): stamp a per-list length/generation in the header so a torn suffix is detectable instead of guessed

## Tests

new `#[pg_test]`s: a torn header returns `Err`, a consistent one still returns `Ok` with the right ctids
