### PR TITLE
fix(mpp): build aggregate plans once

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -563,12 +563,9 @@ async fn build_source_df(
     let needs_runtime_context =
         source_query.has_postgres_expressions() || source_query.has_parameters();
     // `.or(expr_context)` can hand every source the same context, but only the
-    // EXPLAIN-only rebuild both reaches it and goes on to physical planning.
-    // There it is safe: `PgSearchTableProvider::scan()` returns "postgres
-    // expressions have not been solved: missing planstate" before it would call
+    // EXPLAIN-only rebuild reaches it. There it is safe: `PgSearchTableProvider::scan()` returns
+    // "postgres expressions have not been solved: missing planstate" before it would call
     // `solve_postgres_expressions`, so the shared context is never reset.
-    // `stash_mpp_plan_bytes` also passes `planstate: None`, but stops at the
-    // logical plan, so `scan()` never runs there.
     let source_expr_context = if needs_runtime_context {
         unsafe {
             planstate

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -105,7 +105,6 @@ use crate::postgres::types::{TantivyValue, is_datetime_type};
 use crate::postgres::utils::{
     ExprContextGuard, add_vars_to_tlist, is_unnest_func, make_text_const,
 };
-use crate::scan::codec::serialize_logical_plan;
 use pgrx::{PgList, PgMemoryContexts, PgTupleDesc, pg_sys};
 use std::ffi::CStr;
 
@@ -601,12 +600,14 @@ impl CustomScan for AggregateScan {
                 );
                 state.custom_state_mut().scan_slot = Some(scan_slot);
             }
-            // MPP: serialize the logical plan now, while the source manifests are alive; the
-            // first exec call's launch sizes the DSM dispatch-payload region from its length.
-            // Only the leader runs this branch (`ParallelWorkerNumber == -1` in the leader
-            // backend).
-            if mpp_is_active() && unsafe { pg_sys::ParallelWorkerNumber } == -1 {
-                Self::stash_mpp_plan_bytes(state);
+            // MPP: pin the source manifests and mark one launch attempt. The real logical and
+            // physical plan is built once, on first execution; its finished stages provide the
+            // exact dispatch-payload size. Plain EXPLAIN never executes and must not prepare MPP.
+            if eflags & (pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) == 0
+                && mpp_is_active()
+                && unsafe { pg_sys::ParallelWorkerNumber } == -1
+            {
+                Self::prepare_mpp(state);
             }
             return;
         }
@@ -830,67 +831,16 @@ impl AggregateScan {
         state.custom_state_mut().source_manifests = manifests;
     }
 
-    /// Serialize the leader's logical plan (already on `df_state`) and move the MPP lifecycle
-    /// to `PlanBytes`. `launch_mpp` uses the byte length to size the DSM payload region; the
-    /// dispatched stage plans themselves are derived later, from the leader's physical plan.
-    fn stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
-        // Capture source manifests BEFORE building the logical plan.
-        // We pass `is_mpp: false` below because this plan is only serialized to compute `.len()`
-        // to size the DSM payload. The actual dispatched payload is derived later from the
-        // leader's physical plan. The resulting byte length is a close approximation, and
-        // `DISPATCH_BLOAT_FACTOR` absorbs any difference from omitted `source_idx` fields.
+    /// Pin the MPP source manifests and mark one launch attempt for the first execution call.
+    /// Planning remains lazy: the finished physical stages provide the exact dispatch payload
+    /// before DSM allocation, so begin never needs a throwaway logical plan.
+    fn prepare_mpp(state: &mut CustomScanStateWrapper<Self>) {
         Self::ensure_source_manifests(state);
 
         let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() else {
             return;
         };
-        // Build a logical plan eagerly. The DataFusion exec path normally
-        // builds it lazily on first `exec_custom_scan` call; MPP serializes
-        // it at begin time so the launch can size the dispatch payload.
-        let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                pgrx::warning!("mpp: tokio runtime build failed: {e}; skipping MPP");
-                return;
-            }
-        };
-        let ctx = create_aggregate_session_context();
-        let custom_exprs = df_state.custom_exprs;
-        let custom_scan_tlist = df_state.custom_scan_tlist;
-        let logical = runtime.block_on(async {
-            build_join_aggregate_plan(
-                &df_state.plan,
-                &df_state.targetlist,
-                df_state.topk.as_ref(),
-                &df_state.join_level_predicates,
-                custom_exprs,
-                custom_scan_tlist,
-                df_state.having_filter.as_ref(),
-                &ctx,
-                None,
-                None,
-                false,
-            )
-            .await
-        });
-        let logical = match logical {
-            Ok((lp, _group_df_indices)) => lp,
-            Err(e) => {
-                pgrx::warning!("mpp: build_join_aggregate_plan failed: {e}; skipping MPP");
-                return;
-            }
-        };
-        let bytes = match serialize_logical_plan(&logical) {
-            Ok(b) => b,
-            Err(e) => {
-                pgrx::warning!("mpp: serialize_logical_plan failed: {e}; skipping MPP");
-                return;
-            }
-        };
-        df_state.mpp = MppLifecycle::PlanBytes(bytes.to_vec());
+        df_state.mpp = MppLifecycle::Pending;
     }
 
     /// Plan-first MPP launch (#5667). Called with the leader's already-built physical plan:
@@ -900,10 +850,8 @@ impl AggregateScan {
     fn launch_mpp(
         state: &mut CustomScanStateWrapper<Self>,
         physical: &Arc<dyn ExecutionPlan>,
-        plan_bytes_len: usize,
     ) -> Option<crate::postgres::customscan::mpp::glue::MppLeaderState> {
-        // Manifests were captured in `stash_mpp_plan_bytes` (begin); `ensure`
-        // is idempotent.
+        // Manifests were captured in `prepare_mpp` (begin); `ensure` is idempotent.
         Self::ensure_source_manifests(state);
 
         let all_sources: Vec<&[tantivy::SegmentReader]> = state
@@ -918,11 +866,7 @@ impl AggregateScan {
             with_aggregates: false,
         };
 
-        crate::postgres::customscan::mpp::launch::launch_mpp_aggregate(
-            physical,
-            plan_bytes_len,
-            args,
-        )
+        crate::postgres::customscan::mpp::launch::launch_mpp_aggregate(physical, args)
     }
 
     /// Build the aggregate's DataFusion physical plan under `ctx`. `is_mpp` marks that parallel
@@ -1549,13 +1493,13 @@ impl AggregateScan {
             .as_ref()
             .is_some_and(|d| d.runtime.is_none());
 
-        // Taken up front (not inside the df_state borrow below) because the launch needs
-        // `state` for the source manifests.
-        let mpp_plan_bytes = state
+        // Taken up front (not inside the df_state borrow below) because the launch needs `state`
+        // for the source manifests.
+        let mpp_pending = state
             .custom_state_mut()
             .datafusion_state
             .as_mut()
-            .and_then(|d| d.mpp.take_plan_bytes());
+            .is_some_and(|d| d.mpp.take_pending());
 
         // First call: build and execute the DataFusion plan
         if first_call {
@@ -1569,7 +1513,7 @@ impl AggregateScan {
             // `producer_worker_cap()` acting as the planner's ceiling. The mesh and the
             // dispatch source are execute-time concerns; the exec session below carries them
             // once the workers are committed.
-            let is_mpp = mpp_plan_bytes.is_some();
+            let is_mpp = mpp_pending;
             let plan_ctx = if is_mpp {
                 Self::build_mpp_session_context(None)
             } else {
@@ -1597,9 +1541,10 @@ impl AggregateScan {
             // On a launch fallback (nothing to distribute, or too few attached workers) no workers
             // remain and the `DistributedExec` shape has no mesh to read from, so replan serially
             // below.
-            let leader = match &mpp_plan_bytes {
-                Some(bytes) => Self::launch_mpp(state, &physical_plan, bytes.len()),
-                None => None,
+            let leader = if mpp_pending {
+                Self::launch_mpp(state, &physical_plan)
+            } else {
+                None
             };
 
             let df_state = state

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -81,9 +81,9 @@ pub struct DataFusionAggState {
     /// output RecordBatch. Needed because DataFusion deduplicates grouping
     /// expressions (e.g. metadata.brand).
     pub group_df_indices: Vec<usize>,
-    /// Where MPP sits in its launch lifecycle for this scan: plan bytes stashed at begin,
-    /// launched on first exec once the built plan's stages are committed (#5667: the plan
-    /// comes first; workers spawn only after it exists). Stays `Inactive` on the serial path.
+    /// Where MPP sits in its launch lifecycle for this scan: marked pending at begin, launched
+    /// on first exec once the built plan's stages are committed (#5667: the plan comes first;
+    /// workers spawn only after it exists). Stays `Inactive` on the serial path.
     /// Applies only when parallel execution is enabled and the query qualifies (binary join +
     /// supported aggregate).
     pub mpp: MppLifecycle,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -890,7 +890,6 @@ impl JoinScan {
     fn launch_mpp(
         state: &mut CustomScanStateWrapper<Self>,
         physical: &Arc<dyn ExecutionPlan>,
-        plan_bytes_len: usize,
     ) -> Option<crate::postgres::customscan::mpp::glue::MppLeaderState> {
         Self::ensure_source_manifests(state);
         let all_sources: Vec<&[tantivy::SegmentReader]> = state
@@ -904,7 +903,7 @@ impl JoinScan {
             query: vec![],
             with_aggregates: false,
         };
-        crate::postgres::customscan::mpp::launch::launch_mpp_join(physical, plan_bytes_len, args)
+        crate::postgres::customscan::mpp::launch::launch_mpp_join(physical, args)
     }
 
     /// Re-bake the DataFusion logical plan from the current (post-solve) `join_clause`, so the
@@ -1359,15 +1358,15 @@ impl CustomScan for JoinScan {
                 state.custom_state_mut().result_slot = Some(state.csstate.ss.ps.ps_ResultTupleSlot);
                 state.runtime_context = state.csstate.ss.ps.ps_ExprContext;
             }
-            // Stash a pending-launch marker for the leader. The stored planning-time bytes are
-            // not used for JoinScan DSM sizing: exec_custom_scan first resolves and rebakes
-            // runtime expressions, then sizes DSM from that current plan. Workers receive
-            // per-stage physical fragments over the mesh, never these logical bytes.
+            // MPP: mark one launch attempt for the first exec call. The existing logical plan is
+            // resolved and rebaked at execution time before it is deserialized to build the
+            // physical plan. The finished stages then provide the exact dispatch payload before
+            // DSM allocation. Only the leader runs this branch (`ParallelWorkerNumber == -1`).
             if mpp_is_active()
                 && unsafe { pg_sys::ParallelWorkerNumber } == -1
-                && let Some(bytes) = state.custom_state().logical_plan.clone()
+                && state.custom_state().logical_plan.is_some()
             {
-                state.custom_state_mut().mpp = MppLifecycle::PlanBytes(bytes.to_vec());
+                state.custom_state_mut().mpp = MppLifecycle::Pending;
             }
         }
     }
@@ -1375,18 +1374,17 @@ impl CustomScan for JoinScan {
     fn rescan_custom_scan(state: &mut CustomScanStateWrapper<Self>) {
         let relaunch_mpp = matches!(
             &state.custom_state().mpp,
-            MppLifecycle::PlanBytes(_) | MppLifecycle::Launched(_)
+            MppLifecycle::Pending | MppLifecycle::Launched(_)
         );
         Self::finish_mpp_execution(state);
         state.custom_state_mut().relations.clear();
         state.custom_state_mut().reset();
         if relaunch_mpp {
-            let bytes = state
-                .custom_state()
-                .logical_plan
-                .clone()
-                .expect("MPP rescan requires logical plan bytes");
-            state.custom_state_mut().mpp = MppLifecycle::PlanBytes(bytes.to_vec());
+            assert!(
+                state.custom_state().logical_plan.is_some(),
+                "MPP rescan requires logical plan bytes"
+            );
+            state.custom_state_mut().mpp = MppLifecycle::Pending;
         }
     }
 
@@ -1491,13 +1489,13 @@ impl CustomScan for JoinScan {
                             .expect("Failed to create execution plan")
                     };
 
-                let mpp_plan_bytes = state.custom_state_mut().mpp.take_plan_bytes();
+                let mpp_pending = state.custom_state_mut().mpp.take_pending();
                 // Leader session context: on an MPP attempt, layer the DF-D fork's
                 // distributed-planner knobs over the Join profile so the resulting physical
                 // plan is a `DistributedExec`, with `producer_worker_cap()` acting as the
                 // planner's ceiling. The mesh and the dispatch source are execute-time
                 // concerns; the exec session below carries them once the workers are committed.
-                let plan_ctx = if mpp_plan_bytes.is_some() {
+                let plan_ctx = if mpp_pending {
                     Self::build_mpp_session_context(None)
                 } else {
                     create_datafusion_session_context(SessionContextProfile::Join)
@@ -1509,8 +1507,8 @@ impl CustomScan for JoinScan {
                 // On a launch fallback (nothing to distribute, or too few attached workers) no
                 // workers remain and the `DistributedExec` shape has no mesh to read from, so
                 // replan serially.
-                let (ctx, plan) = match mpp_plan_bytes {
-                    Some(_) => match Self::launch_mpp(state, &plan, plan_bytes.len()) {
+                let (ctx, plan) = if mpp_pending {
+                    match Self::launch_mpp(state, &plan) {
                         Some(leader) => {
                             let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
                             let exec_ctx = Self::build_mpp_session_context(Some(Arc::clone(
@@ -1563,8 +1561,9 @@ impl CustomScan for JoinScan {
                                 Some(bytes::Bytes::from(fallback_bytes));
                             (serial_ctx, plan)
                         }
-                    },
-                    None => (plan_ctx, plan),
+                    }
+                } else {
+                    (plan_ctx, plan)
                 };
 
                 let task_ctx = build_task_context(

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -231,9 +231,10 @@ pub struct JoinScanState {
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
 
-    /// Where MPP sits in its launch lifecycle for this scan. Planning-time bytes represent a
-    /// pending launch only; execution rebakes parameterized plans and sizes DSM from the current
-    /// bytes instead. Stays `Inactive` on the serial path.
+    /// Where MPP sits in its launch lifecycle for this scan: marked pending at begin, launched
+    /// on first exec after runtime expressions are resolved and the built plan's stages are
+    /// committed (#5667: the plan comes first; workers spawn only after it exists). Stays
+    /// `Inactive` on the serial path.
     pub mpp: crate::postgres::customscan::mpp::launch::MppLifecycle,
 }
 

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -61,43 +61,18 @@ fn blob_config() -> impl bincode::config::Config {
     bincode::config::standard()
 }
 
-/// Physical-plan blobs grow with the logical plan but with a different constant: the physical
-/// encoding repeats schemas per node and carries the dispatch descriptors. The factor is
-/// deliberately generous because the region lives only for the query and an overflowing blob
-/// falls back to serial, while an undersized region costs the MPP path.
-const DISPATCH_BLOAT_FACTOR: usize = 64;
-/// Floor for tiny logical plans, whose physical expansion is dominated by fixed overhead.
-const DISPATCH_MIN_CAPACITY: usize = 1 << 20;
-
-/// DSM plan-region capacity for the dispatch payload (`[tag][u64 len][blob][pad]`).
+/// Frame the blob into the exact DSM dispatch payload:
+/// `[TAG_BLOB][u64 len LE][blob]`.
 ///
-/// The region is sized at `estimate_dsm` time, before the physical plan (and so the real blob
-/// size) can be known, because `ParallelScanState` doesn't exist yet. Size generously from the
-/// logical-plan length; an overflowing blob falls back to serial. `estimate_dsm` and
-/// `initialize_dsm` MUST call this with the same `logical_len` so the DSM layout matches.
-pub fn dispatch_plan_capacity(logical_len: usize) -> usize {
-    1 + 8
-        + logical_len
-            .saturating_mul(DISPATCH_BLOAT_FACTOR)
-            .max(DISPATCH_MIN_CAPACITY)
-}
-
-/// Frame the blob into a fixed-capacity dispatch payload:
-/// `[TAG_BLOB][u64 len LE][blob][zero pad to capacity]`. Errors if it doesn't fit `capacity` so
-/// the caller can fall back to serial.
-pub fn frame_dispatch_payload(blob: &[u8], capacity: usize) -> Result<Vec<u8>> {
-    let needed = 1 + 8 + blob.len();
-    if needed > capacity {
-        return Err(DataFusionError::Internal(format!(
-            "mpp dispatch: blob {needed} bytes exceeds DSM plan capacity {capacity}"
-        )));
-    }
-    let mut payload = Vec::with_capacity(capacity);
+/// MPP launch is plan-first, so the physical stages and their routing metadata exist before DSM
+/// allocation. Building this frame first lets the caller size DSM from `payload.len()` instead
+/// of estimating from an unrelated serialized logical-plan length.
+pub fn frame_dispatch_payload(blob: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(1 + 8 + blob.len());
     payload.push(TAG_BLOB);
     payload.extend_from_slice(&(blob.len() as u64).to_le_bytes());
     payload.extend_from_slice(blob);
-    payload.resize(capacity, 0);
-    Ok(payload)
+    payload
 }
 
 /// Extract the blob from a framed dispatch payload body (the bytes after the mode tag).
@@ -114,13 +89,10 @@ fn unframe_dispatch_payload(body: &[u8]) -> Result<&[u8]> {
     })
 }
 
-/// Build the dispatch payload (the routing blob, framed to `capacity`) from the stages the launch
-/// enumerated. The stage subplans travel separately: the coordinator serializes each through the
-/// leader's [`crate::postgres::customscan::mpp::glue::StagePlanDispatchSource`] as it dispatches.
-pub fn dispatch_payload_from_stages(
-    stages: &[DiscoveredStage],
-    capacity: usize,
-) -> Result<Vec<u8>> {
+/// Build the exact-size dispatch payload from the stages the launch enumerated. The stage
+/// subplans travel separately: the coordinator serializes each through the leader's
+/// [`crate::postgres::customscan::mpp::glue::StagePlanDispatchSource`] as it dispatches.
+pub fn dispatch_payload_from_stages(stages: &[DiscoveredStage]) -> Result<Vec<u8>> {
     let entries = classify_stages(stages)?;
     let dispatched: Vec<DispatchedStage> = entries
         .into_iter()
@@ -132,7 +104,7 @@ pub fn dispatch_payload_from_stages(
         .collect();
     let blob = bincode::serde::encode_to_vec(&dispatched, blob_config())
         .map_err(|e| DataFusionError::Internal(format!("mpp dispatch: blob encode: {e}")))?;
-    frame_dispatch_payload(&blob, capacity)
+    Ok(frame_dispatch_payload(&blob))
 }
 
 /// Decode the dispatch blob from the framed DSM payload a worker copied out of DSM.
@@ -224,6 +196,16 @@ pub fn fragments_for_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn frames_dispatch_payload_to_exact_length() {
+        let blob = [1, 2, 3, 4];
+        let payload = frame_dispatch_payload(&blob);
+
+        assert_eq!(payload.len(), 1 + 8 + blob.len());
+        assert_eq!(payload[0], TAG_BLOB);
+        assert_eq!(unframe_dispatch_payload(&payload[1..]).unwrap(), blob);
+    }
 
     #[test]
     fn assigns_every_logical_task_once_after_short_launch() {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -69,13 +69,13 @@ pub(super) fn mpp_queue_size() -> usize {
     gucs_mpp_queue_size()
 }
 
-/// Total DSM bytes the leader will need for the mesh header, the worker plan, and one MPSC
+/// Total DSM bytes the leader will need for the mesh header, the dispatch payload, and one MPSC
 /// inbox per process. `n_procs` is the total proc count (leader + launched producers) the
 /// plan-first launch computed from the physical plan — the mesh grows as `n_procs²`, so this
 /// is sized from the plan's needs, not the GUC ceiling (#5667). A short launch may initialize a
 /// narrower logical mesh in this allocation, but never a wider one.
-pub fn estimate_dsm_size(n_procs: u32, plan_bytes_len: usize) -> Result<usize, String> {
-    shm::dsm_region_bytes(n_procs, mpp_queue_size(), plan_bytes_len).map_err(|e| e.to_string())
+pub fn estimate_dsm_size(n_procs: u32, payload_len: usize) -> Result<usize, String> {
+    shm::dsm_region_bytes(n_procs, mpp_queue_size(), payload_len).map_err(|e| e.to_string())
 }
 
 /// Maximum number of producer workers a launch may spawn:
@@ -97,7 +97,7 @@ pub fn producer_worker_cap() -> u32 {
 /// decode and first scan.
 #[derive(Default, Clone, Copy, Debug)]
 pub struct MppLaunchTiming {
-    /// DSM alloc and scan-state populate, before the dispatch payload is built.
+    /// DSM alloc and scan-state populate, after the exact dispatch payload is sized.
     pub prepare_us: u64,
     /// Leader physical planning.
     pub plan_us: u64,
@@ -171,12 +171,12 @@ unsafe fn self_receiver_token() -> u64 {
 ///   plus the launched producer workers. It must not exceed the count passed to
 ///   [`estimate_dsm_size`] for this region. A short launch may use fewer processes than the
 ///   preallocated region was sized for.
-/// - `plan_bytes` must have the same length passed to [`estimate_dsm_size`]
+/// - `dispatch_payload` must have the same length passed to [`estimate_dsm_size`]
 ///   so the leader doesn't overrun the region.
 pub unsafe fn leader_setup(
     coordinate: *mut c_void,
     n_procs: u32,
-    plan_bytes: Vec<u8>,
+    dispatch_payload: Vec<u8>,
 ) -> Result<MppLeaderState, String> {
     let wakeup: Arc<dyn Wakeup> = Arc::new(PgWakeup);
     let interrupt: Arc<dyn Interrupt> = Arc::new(PgInterrupt);
@@ -191,7 +191,7 @@ pub unsafe fn leader_setup(
             coordinate,
             n_procs,
             mpp_queue_size(),
-            &plan_bytes,
+            &dispatch_payload,
             wakeup,
             token,
             interrupt,

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -462,14 +462,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pending_launch_is_consumed_once() {
-        let mut lifecycle = MppLifecycle::Pending;
-
-        assert!(lifecycle.take_pending());
-        assert!(!lifecycle.take_pending());
-    }
-
-    #[test]
     fn short_launch_uses_the_attached_width_when_the_mesh_is_viable() {
         assert_eq!(
             mpp_attach_outcome(5, 0),

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -457,11 +457,21 @@ pub fn launch_mpp_join(
     launch_mpp(physical, args, "mpp_launched_worker_join")
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
+    use pgrx::pg_test;
 
-    #[test]
+    #[pg_test]
+    fn pending_launch_is_consumed_once() {
+        let mut lifecycle = MppLifecycle::Pending;
+
+        assert!(lifecycle.take_pending());
+        assert!(!lifecycle.take_pending());
+    }
+
+    #[pg_test]
     fn short_launch_uses_the_attached_width_when_the_mesh_is_viable() {
         assert_eq!(
             mpp_attach_outcome(5, 0),

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -58,9 +58,7 @@ use crate::postgres::customscan::aggregatescan::datafusion_exec::create_aggregat
 use crate::postgres::customscan::joinscan::scan_state::{
     SessionContextProfile, create_datafusion_session_context,
 };
-use crate::postgres::customscan::mpp::dispatch::{
-    dispatch_payload_from_stages, dispatch_plan_capacity,
-};
+use crate::postgres::customscan::mpp::dispatch::dispatch_payload_from_stages;
 use crate::postgres::customscan::mpp::exec_worker::{MppWorkerInputs, run_mpp_worker};
 use crate::postgres::customscan::mpp::glue::{
     MIN_TOTAL_WORKER_COUNT, MppLeaderState, estimate_dsm_size, leader_setup, producer_worker_cap,
@@ -238,24 +236,23 @@ pub enum MppLifecycle {
     /// teardown already reclaimed the leader state.
     #[default]
     Inactive,
-    /// Serialized logical-plan bytes retained while an MPP launch is pending. AggregateScan uses
-    /// their length for DSM sizing; JoinScan treats only the variant as the pending marker and
-    /// sizes DSM from its freshly rebound execute-time plan.
-    PlanBytes(Vec<u8>),
+    /// The scan qualified for one MPP planning and launch attempt. No plan is stored here: the
+    /// finished physical stages produce the exact dispatch payload before DSM allocation.
+    Pending,
     /// The workers are running dispatched fragments; carries the leader's mesh and finish
     /// handles until teardown.
     Launched(MppLeaderState),
 }
 
 impl MppLifecycle {
-    /// Consume the stashed plan bytes. Leaves `Inactive`, so a launch fallback reads as the
+    /// Consume the pending launch marker. Leaves `Inactive`, so a launch fallback reads as the
     /// serial path from then on.
-    pub fn take_plan_bytes(&mut self) -> Option<Vec<u8>> {
+    pub fn take_pending(&mut self) -> bool {
         match std::mem::take(self) {
-            MppLifecycle::PlanBytes(bytes) => Some(bytes),
+            MppLifecycle::Pending => true,
             other => {
                 *self = other;
-                None
+                false
             }
         }
     }
@@ -299,7 +296,6 @@ impl MppLifecycle {
 /// where a silent serial fallback would hide a real bug.
 fn launch_mpp(
     physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    plan_bytes_len: usize,
     args: ParallelScanArgs,
     worker_entrypoint: &'static str,
 ) -> Option<MppLeaderState> {
@@ -321,9 +317,17 @@ fn launch_mpp(
     let cap = producer_worker_cap();
     let producer_count = (max_tasks as u32).clamp(MIN_TOTAL_WORKER_COUNT - 1, cap);
 
+    // The finished physical stages contain all routing metadata, so build the real payload before
+    // sizing DSM. A failure is a codec bug, and no workers have been started at this point.
+    let t_payload = std::time::Instant::now();
+    let payload = match dispatch_payload_from_stages(&stages) {
+        Ok(p) => p,
+        Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
+    };
+    timing.payload_us = t_payload.elapsed().as_micros() as u64;
+
     let t_prepare = std::time::Instant::now();
-    let payload_capacity = dispatch_plan_capacity(plan_bytes_len);
-    let region_bytes = match estimate_dsm_size(producer_count + 1, payload_capacity) {
+    let region_bytes = match estimate_dsm_size(producer_count + 1, payload.len()) {
         Ok(sz) => sz,
         Err(e) => {
             pgrx::warning!("mpp: estimate_dsm failed: {e}; running serially");
@@ -366,17 +370,6 @@ fn launch_mpp(
     // launch was attempted at all (mpp_worker_sizing).
     crate::mpp_log!("launch: spawning {producer_count} producers");
     let attach = launcher.launch()?;
-
-    // Derive the per-stage subplans from the plan the leader itself will execute. Built before
-    // `wait_for_attach` so serialization overlaps worker attachment (#5756). A failure here is
-    // a hard error: a serialization gap is a codec bug, and the parked workers die with the
-    // transaction.
-    let t_payload = std::time::Instant::now();
-    let payload = match dispatch_payload_from_stages(&stages, payload_capacity) {
-        Ok(p) => p,
-        Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
-    };
-    timing.payload_us = t_payload.elapsed().as_micros() as u64;
 
     let t_attach = std::time::Instant::now();
     let finish = attach.wait_for_attach()?;
@@ -451,24 +444,30 @@ fn launch_mpp(
 /// AggregateScan launch entry: aggregate worker symbol.
 pub fn launch_mpp_aggregate(
     physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    plan_bytes_len: usize,
     args: ParallelScanArgs,
 ) -> Option<MppLeaderState> {
-    launch_mpp(physical, plan_bytes_len, args, "mpp_launched_worker_agg")
+    launch_mpp(physical, args, "mpp_launched_worker_agg")
 }
 
 /// JoinScan launch entry: join worker symbol.
 pub fn launch_mpp_join(
     physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    plan_bytes_len: usize,
     args: ParallelScanArgs,
 ) -> Option<MppLeaderState> {
-    launch_mpp(physical, plan_bytes_len, args, "mpp_launched_worker_join")
+    launch_mpp(physical, args, "mpp_launched_worker_join")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pending_launch_is_consumed_once() {
+        let mut lifecycle = MppLifecycle::Pending;
+
+        assert!(lifecycle.take_pending());
+        assert!(!lifecycle.take_pending());
+    }
 
     #[test]
     fn short_launch_uses_the_attached_width_when_the_mesh_is_viable() {

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn nested_coalesce_destination_is_width_independent() {
-        // This invariant is why the dispatch payload can be built while workers attach and reused
+        // This invariant is why the dispatch payload can be built before worker launch and reused
         // unchanged after a viable short launch.
         for worker_count in 1..=8 {
             assert_eq!(proc_for_task(worker_count, 0), FIRST_WORKER_PROC);

--- a/pg_search/tests/pg_regress/expected/issue_2533.out
+++ b/pg_search/tests/pg_regress/expected/issue_2533.out
@@ -129,9 +129,8 @@ VALUES (10, 'cloe', 'red', '53');
 INSERT INTO orders
 VALUES (11, 'brandy', 'green', '92');
 ANALYZE;
--- This regression covers a known aggregate-planning failure, not MPP behavior.
--- Keep MPP disabled so it does not emit the duplicate diagnostic tracked by #5783.
-SET max_parallel_workers_per_gather = 0;
+-- Keep MPP active: the known aggregate-planning failure must be built and reported only once.
+SET max_parallel_workers_per_gather = 2;
 -- TODO: See https://github.com/paradedb/paradedb/issues/5266.
 SET paradedb.enable_aggregate_custom_scan TO on;
 SELECT (SELECT COUNT(*)

--- a/pg_search/tests/pg_regress/sql/issue_2533.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2533.sql
@@ -144,9 +144,8 @@ VALUES (11, 'brandy', 'green', '92');
 
 ANALYZE;
 
--- This regression covers a known aggregate-planning failure, not MPP behavior.
--- Keep MPP disabled so it does not emit the duplicate diagnostic tracked by #5783.
-SET max_parallel_workers_per_gather = 0;
+-- Keep MPP active: the known aggregate-planning failure must be built and reported only once.
+SET max_parallel_workers_per_gather = 2;
 -- TODO: See https://github.com/paradedb/paradedb/issues/5266.
 SET paradedb.enable_aggregate_custom_scan TO on;
 SELECT (SELECT COUNT(*)


### PR DESCRIPTION
## What

- replace the eager AggregateScan planning pass with a one-shot pending MPP marker
- build the dispatch routing payload from the finished physical stages before DSM allocation and size the region from the exact payload length
- apply the same lifecycle and exact-size launch path to JoinScan, which shares the MPP launcher
- keep the issue #2533 regression under active MPP coverage

## Why

AggregateScan built and serialized a logical plan in `BeginCustomScan` only to estimate dispatch capacity, then built the real plan again on first execution. Planning failures were therefore reported twice, and plain `EXPLAIN` also did work that could never be executed.

The MPP launch is already plan-first: physical stages and their routing metadata exist before DSM allocation. Framing that routing payload first removes the throwaway planning pass as well as the unrelated 64x/1 MiB capacity heuristic.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p pg_search --lib --no-default-features --features pg18,deferred_wal -- -D warnings`
- `cargo pgrx regress -p pg_search pg18 issue_2533`

Closes #5783
