### PR TITLE
feat: Add `paradedb.vector_clusters` for cluster size/radius distributions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -2711,7 +2711,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -4418,7 +4418,7 @@ checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "macros"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -6897,7 +6897,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -7295,7 +7295,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -7459,7 +7459,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.25.2"
+version = "0.25.3"
 edition = "2024"
 license = "AGPL-3.0"
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-ztGef4Tx2Kq/r4ZzgfHide82V+R+tQYlJtc+v0O7kH0=";
+  cargoHash = "sha256-mhGrRacE6clk43w8aTg8MchMHavaBYZpLV3XqWD6/Cc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-absHvfXDfZ4URR8iuw3fvinQiFAcpdxBB1DYTu2Nm1o=";
+  cargoHash = "sha256-YilptQU9A3DE3n949pY0nxL/qEFaDPu/zumr6LFVuaw=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-dRgVvO8V29MEZxoBp1DcYj+J617etQmfNTqXPE2vnQs=";
+  cargoHash = "sha256-Tm2Hnwp+G76TLk+GuU458MvIhoMDS+ay04TliJizYIE=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -75,3 +75,13 @@ CREATE  FUNCTION "term_search_query_input"(
 IMMUTABLE STRICT PARALLEL SAFE
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';
+
+-- Rename paradedb.create_bm25_test_table to paradedb.create_paradedb_test_table.
+-- The bm25 name predates the access method rename to `paradedb`, and this
+-- procedure was one of the last user-facing identifiers still carrying it. The
+-- signature and behaviour are unchanged, including the 'bm25_test_table'
+-- default table name, so an existing call that passes no table_name still
+-- creates exactly the same table.
+DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(table_name pg_catalog."varchar", schema_name pg_catalog."varchar", table_type paradedb.testtable);
+CREATE OR REPLACE PROCEDURE paradedb.create_paradedb_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
+LANGUAGE c AS 'MODULE_PATHNAME', 'create_paradedb_test_table_wrapper';

--- a/pg_search/sql/pg_search--0.25.1--0.25.2.sql
+++ b/pg_search/sql/pg_search--0.25.1--0.25.2.sql
@@ -75,13 +75,3 @@ CREATE  FUNCTION "term_search_query_input"(
 IMMUTABLE STRICT PARALLEL SAFE
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'term_search_query_input_wrapper';
-
--- Rename paradedb.create_bm25_test_table to paradedb.create_paradedb_test_table.
--- The bm25 name predates the access method rename to `paradedb`, and this
--- procedure was one of the last user-facing identifiers still carrying it. The
--- signature and behaviour are unchanged, including the 'bm25_test_table'
--- default table name, so an existing call that passes no table_name still
--- creates exactly the same table.
-DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(table_name pg_catalog."varchar", schema_name pg_catalog."varchar", table_type paradedb.testtable);
-CREATE OR REPLACE PROCEDURE paradedb.create_paradedb_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
-LANGUAGE c AS 'MODULE_PATHNAME', 'create_paradedb_test_table_wrapper';

--- a/pg_search/sql/pg_search--0.25.2--0.25.3.sql
+++ b/pg_search/sql/pg_search--0.25.2--0.25.3.sql
@@ -1,0 +1,21 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.3'" to load this file. \quit
+
+-- 0.25.2 -> 0.25.3: add vector_cluster_sizes(index regclass, field text), the
+-- per-segment raw cluster-size arrays behind vector_info's min/avg/max
+-- aggregates, for callers that want percentiles or histograms of the cluster
+-- size distribution. cluster_sizes is NULL for flat segments; sizes count
+-- posting rows, so under replication their sum exceeds the segment's
+-- distinct-doc count.
+-- The CREATE below is the SchemaBot/pgrx canonical text verbatim (the schema
+-- checker compares statements textually); the DROP keeps the script re-runnable.
+DROP FUNCTION IF EXISTS vector_cluster_sizes(regclass, text);
+CREATE  FUNCTION "vector_cluster_sizes"(
+	"index" regclass, /* PgRelation */
+	"field" TEXT /* String */
+) RETURNS TABLE (
+	"segno" TEXT,  /* String */
+	"cluster_sizes" bigint[]  /* :: std :: option :: Option < Vec < i64 > > */
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'vector_cluster_sizes_wrapper';

--- a/pg_search/sql/pg_search--0.25.2--0.25.3.sql
+++ b/pg_search/sql/pg_search--0.25.2--0.25.3.sql
@@ -15,3 +15,13 @@ CREATE  FUNCTION "vector_cluster_sizes"(
 STRICT
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'vector_cluster_sizes_wrapper';
+
+-- Rename paradedb.create_bm25_test_table to paradedb.create_paradedb_test_table
+-- (#5903). The rename originally landed in the 0.25.1 -> 0.25.2 script, but
+-- 0.25.2 had already been released without it, so upgrades from released
+-- 0.25.2 never ran it; moved here so the ALTER EXTENSION UPDATE path applies
+-- it. Signature and behaviour are unchanged, including the 'bm25_test_table'
+-- default table name.
+DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(table_name pg_catalog."varchar", schema_name pg_catalog."varchar", table_type paradedb.testtable);
+CREATE OR REPLACE PROCEDURE paradedb.create_paradedb_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
+LANGUAGE c AS 'MODULE_PATHNAME', 'create_paradedb_test_table_wrapper';

--- a/pg_search/sql/pg_search--0.25.2--0.25.3.sql
+++ b/pg_search/sql/pg_search--0.25.2--0.25.3.sql
@@ -17,11 +17,8 @@ LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'vector_cluster_sizes_wrapper';
 
 -- Rename paradedb.create_bm25_test_table to paradedb.create_paradedb_test_table
--- (#5903). The rename originally landed in the 0.25.1 -> 0.25.2 script, but
--- 0.25.2 had already been released without it, so upgrades from released
--- 0.25.2 never ran it; moved here so the ALTER EXTENSION UPDATE path applies
--- it. Signature and behaviour are unchanged, including the 'bm25_test_table'
--- default table name.
+-- (#5903). The released 0.25.2 shipped without the rename, so it is repeated
+-- here (idempotently) to cover upgrades from released 0.25.2.
 DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(table_name pg_catalog."varchar", schema_name pg_catalog."varchar", table_type paradedb.testtable);
 CREATE OR REPLACE PROCEDURE paradedb.create_paradedb_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb', table_type paradedb.TestTable DEFAULT 'Items')
 LANGUAGE c AS 'MODULE_PATHNAME', 'create_paradedb_test_table_wrapper';

--- a/pg_search/sql/pg_search--0.25.2--0.25.3.sql
+++ b/pg_search/sql/pg_search--0.25.2--0.25.3.sql
@@ -1,20 +1,22 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.3'" to load this file. \quit
 
--- 0.25.2 -> 0.25.3: add vector_cluster_sizes(index regclass, field text), the
--- per-segment per-cluster posting-list sizes, in cluster order.
+-- 0.25.2 -> 0.25.3: add vector_clusters(index regclass, field text), the
+-- per-segment per-cluster posting-list sizes and ball-bound radii, in cluster
+-- order.
 -- The CREATE below is the SchemaBot/pgrx canonical text verbatim (the schema
 -- checker compares statements textually); the DROP keeps the script re-runnable.
-DROP FUNCTION IF EXISTS vector_cluster_sizes(regclass, text);
-CREATE  FUNCTION "vector_cluster_sizes"(
+DROP FUNCTION IF EXISTS vector_clusters(regclass, text);
+CREATE  FUNCTION "vector_clusters"(
 	"index" regclass, /* PgRelation */
 	"field" TEXT /* String */
 ) RETURNS TABLE (
 	"segno" TEXT,  /* String */
-	"cluster_sizes" bigint[]  /* :: std :: option :: Option < Vec < i64 > > */
+	"cluster_sizes" bigint[],  /* :: std :: option :: Option < Vec < i64 > > */
+	"cluster_radii" real[]  /* :: std :: option :: Option < Vec < f32 > > */
 )
 STRICT
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'vector_cluster_sizes_wrapper';
+AS 'MODULE_PATHNAME', 'vector_clusters_wrapper';
 
 -- Rename paradedb.create_bm25_test_table to paradedb.create_paradedb_test_table
 -- (#5903). The released 0.25.2 shipped without the rename, so it is repeated

--- a/pg_search/sql/pg_search--0.25.2--0.25.3.sql
+++ b/pg_search/sql/pg_search--0.25.2--0.25.3.sql
@@ -1,11 +1,7 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.3'" to load this file. \quit
 
 -- 0.25.2 -> 0.25.3: add vector_cluster_sizes(index regclass, field text), the
--- per-segment raw cluster-size arrays behind vector_info's min/avg/max
--- aggregates, for callers that want percentiles or histograms of the cluster
--- size distribution. cluster_sizes is NULL for flat segments; sizes count
--- posting rows, so under replication their sum exceeds the segment's
--- distinct-doc count.
+-- per-segment per-cluster posting-list sizes, in cluster order.
 -- The CREATE below is the SchemaBot/pgrx canonical text verbatim (the schema
 -- checker compares statements textually); the DROP keeps the script re-runnable.
 DROP FUNCTION IF EXISTS vector_cluster_sizes(regclass, text);

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -478,14 +478,23 @@ fn vector_info(
     Ok(TableIterator::new(rows))
 }
 
-/// Per-cluster posting-list sizes for a single vector `field` of `index`, one
-/// row per segment that stores that field, in cluster order.
+/// Per-cluster posting-list sizes and ball-bound radii for a single vector
+/// `field` of `index`, one row per segment that stores that field, in cluster
+/// order.
 #[pg_extern]
-fn vector_cluster_sizes(
+#[allow(clippy::type_complexity)]
+fn vector_clusters(
     index: PgRelation,
     field: String,
 ) -> anyhow::Result<
-    TableIterator<'static, (name!(segno, String), name!(cluster_sizes, Option<Vec<i64>>))>,
+    TableIterator<
+        'static,
+        (
+            name!(segno, String),
+            name!(cluster_sizes, Option<Vec<i64>>),
+            name!(cluster_radii, Option<Vec<f32>>),
+        ),
+    >,
 > {
     // # Safety
     //
@@ -526,7 +535,15 @@ fn vector_cluster_sizes(
             let sizes = vector_index
                 .cluster_sizes()
                 .map(|sizes| sizes.into_iter().map(i64::from).collect());
-            rows.push((segment_reader.segment_id().short_uuid_string(), sizes));
+            let radii = vector_index.index().map(|ivf| {
+                let bounds = ivf.bounds();
+                (0..ivf.num_clusters()).map(|c| bounds.ball_r(c)).collect()
+            });
+            rows.push((
+                segment_reader.segment_id().short_uuid_string(),
+                sizes,
+                radii,
+            ));
         }
     }
 

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -479,11 +479,7 @@ fn vector_info(
 }
 
 /// Per-cluster posting-list sizes for a single vector `field` of `index`, one
-/// row per segment that stores that field, in cluster order. The full
-/// distribution behind [`vector_info`]'s min/avg/max aggregates, for callers
-/// that want percentiles or histograms. `cluster_sizes` is NULL for flat
-/// segments; sizes count posting rows, so under replication their sum exceeds
-/// the segment's distinct-doc count.
+/// row per segment that stores that field, in cluster order.
 #[pg_extern]
 fn vector_cluster_sizes(
     index: PgRelation,

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -478,6 +478,65 @@ fn vector_info(
     Ok(TableIterator::new(rows))
 }
 
+/// Per-cluster posting-list sizes for a single vector `field` of `index`, one
+/// row per segment that stores that field, in cluster order. The full
+/// distribution behind [`vector_info`]'s min/avg/max aggregates, for callers
+/// that want percentiles or histograms. `cluster_sizes` is NULL for flat
+/// segments; sizes count posting rows, so under replication their sum exceeds
+/// the segment's distinct-doc count.
+#[pg_extern]
+fn vector_cluster_sizes(
+    index: PgRelation,
+    field: String,
+) -> anyhow::Result<
+    TableIterator<'static, (name!(segno, String), name!(cluster_sizes, Option<Vec<i64>>))>,
+> {
+    // # Safety
+    //
+    // Lock the index relation until the end of this function (read-only,
+    // AccessShareLock) so it is not dropped or altered while we read it —
+    // identical to `index_info`.
+    let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
+    let index_kind = IndexKind::for_index(index.clone())?;
+    if !index.is_usable() {
+        return Ok(TableIterator::new(Vec::new()));
+    }
+
+    let mut rows = Vec::new();
+    for index in index_kind.partitions() {
+        if !index.is_usable() {
+            continue;
+        }
+        let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)?;
+        let resolved = search_reader
+            .schema()
+            .fields()
+            .find_map(|(f, field_entry)| {
+                (field_entry.name() == field
+                    && matches!(
+                        search_reader.schema().get_field_type(field_entry.name()),
+                        Some(SearchFieldType::Vector(..))
+                    ))
+                .then_some(f)
+            });
+        let Some(vector_field) = resolved else {
+            anyhow::bail!("`{field}` is not a vector field of the index");
+        };
+        for segment_reader in search_reader.segment_readers() {
+            let vector_index = segment_reader.vector_index(vector_field)?;
+            if vector_index.info().is_none() {
+                continue;
+            }
+            let sizes = vector_index
+                .cluster_sizes()
+                .map(|sizes| sizes.into_iter().map(i64::from).collect());
+            rows.push((segment_reader.segment_id().short_uuid_string(), sizes));
+        }
+    }
+
+    Ok(TableIterator::new(rows))
+}
+
 /// Returns the list of segments that contain the specified [`pg_sys::ItemPointerData]` heap tuple
 /// identifier.
 ///


### PR DESCRIPTION
## What

We are interested in measuring per index cluster distributions, which requires segments emitting their per-cluster posting-list sizes and ball-bound radii to be aggregated by our benchmarking tool.