### PR TITLE
test: regression coverage for solve_mvcc in unordered window aggregates (#5944)

### DIFF
--- a/pg_search/tests/pg_regress/expected/issue_5944.out
+++ b/pg_search/tests/pg_regress/expected/issue_5944.out
@@ -1,0 +1,85 @@
+-- Regression test for issue #5944.
+-- pdb.agg(..., solve_mvcc => true) OVER () must exclude deleted-but-unvacuumed
+-- rows on the unordered top-k path (no pushed-down ORDER BY), matching the
+-- ordered path. #5945 established this behavior through aggregations.plan(),
+-- which routes two ways: a value counter wrapped in an MVCCFilterCollector, and
+-- a cardinality fast path that filters per value inside the collector. Neither
+-- arm was covered on the unordered path, so both are exercised here.
+CREATE TABLE issue_5944_mvcc_facet (
+    id serial8 PRIMARY KEY,
+    grp text NOT NULL
+) WITH (autovacuum_enabled = off);
+-- grp lands in 20 buckets. id % 10 = 0 selects exactly the rows in buckets b00
+-- and b10, so those two buckets are fully deleted while the other 18 stay whole.
+INSERT INTO issue_5944_mvcc_facet (grp)
+SELECT 'b' || lpad((x % 20)::text, 2, '0')
+FROM generate_series(1, 10000) x;
+CREATE INDEX issue_5944_idx ON issue_5944_mvcc_facet
+USING bm25 (id, grp)
+WITH (key_field = 'id', text_fields = '{"grp": {"fast": true}}');
+-- Delete 10% of the rows without vacuuming, leaving dead-but-still-in-index
+-- entries the aggregation should not count when solve_mvcc is enabled.
+DELETE FROM issue_5944_mvcc_facet WHERE id % 10 = 0;
+-- Visible after the delete: 9000 rows across 18 distinct buckets.
+SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SELECT count(*) AS rows, count(DISTINCT grp) AS buckets FROM issue_5944_mvcc_facet;
+ rows | buckets 
+------+---------
+ 9000 |      18
+(1 row)
+
+RESET paradedb.check_aggregate_scan;
+-- Case 1: ordered top-k with solve_mvcc=true. Baseline, already correct.
+-- pdb.agg OVER () must be a bare targetlist entry or the custom scan does
+-- not intercept it.
+SELECT pdb.agg('{"value_count":{"field":"id"}}', true) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+ORDER BY id DESC LIMIT 1;
+        agg        
+-------------------
+ {"value": 9000.0}
+(1 row)
+
+-- Case 2: unordered top-k (no ORDER BY) with solve_mvcc=true, MVCCFilterCollector
+-- arm. Must exclude the deleted rows, so the count matches the ordered case
+-- ({"value": 9000.0}) rather than the raw index count.
+SELECT pdb.agg('{"value_count":{"field":"id"}}', true) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+        agg        
+-------------------
+ {"value": 9000.0}
+(1 row)
+
+-- Case 3: unordered top-k with solve_mvcc=false must still return the raw
+-- index count ({"value": 10000.0}), confirming MVCC filtering is not
+-- force-enabled when the user has disabled it.
+SELECT pdb.agg('{"value_count":{"field":"id"}}', false) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+        agg         
+--------------------
+ {"value": 10000.0}
+(1 row)
+
+-- Case 4: unordered top-k with solve_mvcc=true, cardinality fast-path arm.
+-- The two fully deleted buckets must drop out, so distinct buckets is 18.
+SELECT pdb.agg('{"cardinality":{"field":"grp"}}', true) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+       agg       
+-----------------
+ {"value": 18.0}
+(1 row)
+
+-- Case 5: unordered top-k with solve_mvcc=false, cardinality arm. Counts the
+-- deleted buckets still in the index, so distinct buckets is 20.
+SELECT pdb.agg('{"cardinality":{"field":"grp"}}', false) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+       agg       
+-----------------
+ {"value": 20.0}
+(1 row)
+
+DROP TABLE issue_5944_mvcc_facet CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_5944.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5944.sql
@@ -1,0 +1,66 @@
+-- Regression test for issue #5944.
+-- pdb.agg(..., solve_mvcc => true) OVER () must exclude deleted-but-unvacuumed
+-- rows on the unordered top-k path (no pushed-down ORDER BY), matching the
+-- ordered path. #5945 established this behavior through aggregations.plan(),
+-- which routes two ways: a value counter wrapped in an MVCCFilterCollector, and
+-- a cardinality fast path that filters per value inside the collector. Neither
+-- arm was covered on the unordered path, so both are exercised here.
+
+CREATE TABLE issue_5944_mvcc_facet (
+    id serial8 PRIMARY KEY,
+    grp text NOT NULL
+) WITH (autovacuum_enabled = off);
+
+-- grp lands in 20 buckets. id % 10 = 0 selects exactly the rows in buckets b00
+-- and b10, so those two buckets are fully deleted while the other 18 stay whole.
+INSERT INTO issue_5944_mvcc_facet (grp)
+SELECT 'b' || lpad((x % 20)::text, 2, '0')
+FROM generate_series(1, 10000) x;
+
+CREATE INDEX issue_5944_idx ON issue_5944_mvcc_facet
+USING bm25 (id, grp)
+WITH (key_field = 'id', text_fields = '{"grp": {"fast": true}}');
+
+-- Delete 10% of the rows without vacuuming, leaving dead-but-still-in-index
+-- entries the aggregation should not count when solve_mvcc is enabled.
+DELETE FROM issue_5944_mvcc_facet WHERE id % 10 = 0;
+
+-- Visible after the delete: 9000 rows across 18 distinct buckets.
+SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SELECT count(*) AS rows, count(DISTINCT grp) AS buckets FROM issue_5944_mvcc_facet;
+RESET paradedb.check_aggregate_scan;
+
+-- Case 1: ordered top-k with solve_mvcc=true. Baseline, already correct.
+-- pdb.agg OVER () must be a bare targetlist entry or the custom scan does
+-- not intercept it.
+SELECT pdb.agg('{"value_count":{"field":"id"}}', true) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+ORDER BY id DESC LIMIT 1;
+
+-- Case 2: unordered top-k (no ORDER BY) with solve_mvcc=true, MVCCFilterCollector
+-- arm. Must exclude the deleted rows, so the count matches the ordered case
+-- ({"value": 9000.0}) rather than the raw index count.
+SELECT pdb.agg('{"value_count":{"field":"id"}}', true) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+
+-- Case 3: unordered top-k with solve_mvcc=false must still return the raw
+-- index count ({"value": 10000.0}), confirming MVCC filtering is not
+-- force-enabled when the user has disabled it.
+SELECT pdb.agg('{"value_count":{"field":"id"}}', false) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+
+-- Case 4: unordered top-k with solve_mvcc=true, cardinality fast-path arm.
+-- The two fully deleted buckets must drop out, so distinct buckets is 18.
+SELECT pdb.agg('{"cardinality":{"field":"grp"}}', true) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+
+-- Case 5: unordered top-k with solve_mvcc=false, cardinality arm. Counts the
+-- deleted buckets still in the index, so distinct buckets is 20.
+SELECT pdb.agg('{"cardinality":{"field":"grp"}}', false) OVER () AS agg
+FROM issue_5944_mvcc_facet WHERE issue_5944_mvcc_facet @@@ pdb.all()
+LIMIT 1;
+
+DROP TABLE issue_5944_mvcc_facet CASCADE;


### PR DESCRIPTION
## What
Adds pg_regress coverage for pdb.agg(..., solve_mvcc => true) OVER () on the
unordered top-k path (no pushed-down ORDER BY).

#5945 fixed this path as a side effect of the aggregations.plan() vischeck
refactor, but its tests cover cardinality over string on the ordered path. This
locks both plan() arms on the unordered path: value_count through the
MVCCFilterCollector, and cardinality through the per-value fast path.

## Testing
cargo pgrx regress pg18 issue_5944 green. One table, 10k rows in 20 buckets, 10%
unvacuumed deletes that fully remove 2 buckets. value_count 9000 (mvcc) vs 10000
(raw); cardinality 18 (mvcc) vs 20 (raw); ordered baseline 9000.
