### PR TITLE
docs: Correct cargo-pgrx version in pg_search README

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -31,7 +31,7 @@ sudo pacman -S extra/clang extra/lld
 Then install `cargo-pgrx` and let it bootstrap a managed PostgreSQL installation under `~/.pgrx/`:
 
 ```bash
-cargo install --locked cargo-pgrx --version 0.18.1
+cargo install --locked cargo-pgrx --version 0.19.2
 # On macOS, if `cargo pgrx init` fails with ICU-related errors, run
 # `brew install icu4c`
 # and then run


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Updates the `cargo-pgrx` install command in `pg_search/README.md` from `0.18.1` to `0.19.2`.

## Why

The README instructs:

```bash
cargo install --locked cargo-pgrx --version 0.18.1
```

but the workspace pins `pgrx = "=0.19.2"` in `Cargo.toml`. The README itself states two lines above that command:

> The `cargo-pgrx` version must match the `pgrx` dependency declared in [`pg_search/Cargo.toml`](Cargo.toml).

So following the setup instructions as written installs a mismatched `cargo-pgrx`. I hit this while setting up a fresh development environment.

## How

One-line version bump in the documented install command.

## Tests

No tests — documentation only. Verified by following the corrected instructions on a clean macOS environment: `cargo install --locked cargo-pgrx --version 0.19.2` followed by `cargo pgrx init --pg18 download` completes successfully, and `cargo pgrx --version` then reports `cargo-pgrx 0.19.2`, matching the pin.

---

Note: no issue is linked, as `CONTRIBUTING.md` welcomes small documentation contributions that "correct wrong information". Happy to open one if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)