### PR TITLE
test: Port ltree regress test to V2 query syntax

### DIFF
--- a/pg_search/tests/pg_regress/expected/ltree.out
+++ b/pg_search/tests/pg_regress/expected/ltree.out
@@ -105,9 +105,9 @@ RESET paradedb.enable_columnar_exec;
 -- Test &&& operator with ltree (ltree is intentionally incompatible with &&&)
 SELECT id, category FROM tbl_ltree WHERE category &&& 'Top.Science.Biology' ORDER BY id;
 ERROR:  type `ltree` is not compatible with the `&&&` operator
--- Test paradedb.term() query with ltree (exercises value_to_term facet branch)
+-- Test pdb.term() query with ltree (exercises value_to_term facet branch)
 SELECT id, category FROM tbl_ltree
-WHERE tbl_ltree @@@ paradedb.term(field => 'category', value => 'Top.Hobbies.Photography')
+WHERE category @@@ pdb.term('Top.Hobbies.Photography')
 ORDER BY id;
  id |        category         
 ----+-------------------------

--- a/pg_search/tests/pg_regress/sql/ltree.sql
+++ b/pg_search/tests/pg_regress/sql/ltree.sql
@@ -65,9 +65,9 @@ RESET paradedb.enable_columnar_exec;
 -- Test &&& operator with ltree (ltree is intentionally incompatible with &&&)
 SELECT id, category FROM tbl_ltree WHERE category &&& 'Top.Science.Biology' ORDER BY id;
 
--- Test paradedb.term() query with ltree (exercises value_to_term facet branch)
+-- Test pdb.term() query with ltree (exercises value_to_term facet branch)
 SELECT id, category FROM tbl_ltree
-WHERE tbl_ltree @@@ paradedb.term(field => 'category', value => 'Top.Hobbies.Photography')
+WHERE category @@@ pdb.term('Top.Hobbies.Photography')
 ORDER BY id;
 
 RESET paradedb.enable_aggregate_custom_scan;


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #4391 (does not close it)

## What

Ports the last remaining V1 API usage in `pg_search/tests/pg_regress/sql/ltree.sql` to the V2 syntax:

```sql
-- before
WHERE tbl_ltree @@@ paradedb.term(field => 'category', value => 'Top.Hobbies.Photography')

-- after
WHERE category @@@ pdb.term('Top.Hobbies.Photography')
```

The accompanying comment is updated to say `pdb.term()`, and `expected/ltree.out` is updated to match the new echoed SQL.

## Why

Per @philippemnoel and @stuhood in #4391, in-repo usage of the V1 API is being migrated to V2 iteratively via small, scoped PRs as prework for removing V1 altogether. This is one such slice, [scoped in this comment](https://github.com/paradedb/paradedb/issues/4391#issuecomment-5276569862).

The rest of this file already used V2 (`pdb.all()`), so this brings it fully over.

## How

Field moves from a function argument to the left-hand side of `@@@`, which is the V2 shape.

**The expected result rows are deliberately left unchanged.** The test still asserts the same single row:

```
 id |        category
----+-------------------------
  6 | Top.Hobbies.Photography
```

so the diff asserts that the port is behavior-preserving, rather than promoting whatever output the new syntax happens to produce.

The test comment notes this query "exercises `value_to_term` facet branch". That coverage is preserved: the V2 path (`pdb_query::term`) calls the same `value_to_term()` helper as the V1 path, and the `FieldType::Facet(_)` branch that converts the value via `Term::from_facet(field, &dot_path_to_facet(text))` is selected on field type, not on which API invoked it.

## Tests

Existing regress test, ported in place. Verified locally against PostgreSQL 18:

```
$ cargo pgrx regress -p pg_search -- pg18 ltree

--- beginning regression test run ---
PASS setup 1663ms
PASS issue_4906_ltree_desc_op_pushdown 187ms
PASS issue_4906_ltree_op_absent 123ms
PASS ltree 178ms
passed=4 failed=0
```

Run without `--auto`, so the pass is a genuine comparison against the committed expected output rather than a regenerated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
