### PR TITLE
feat: Attribute buffer hits/reads to routing vs probing for vector search

### DIFF
--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -23,6 +23,7 @@ deferred_wal = []
 dst = ["dst/enabled", "dep:antithesis-instrumentation"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 block_tracker = [] # for debugging when blocks are acquired and released
+io_stats = [] # per-component buffer hit/read counts in EXPLAIN Segment Info
 debug-logging = [
   "dep:env_logger",
 ] # enables env_logger for dependency debug output

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -49,7 +49,7 @@ use tantivy::directory::{
     DirectoryLock, DirectoryPanicHandler, FileHandle, InnerWritePtr, Lock, RamDirectory,
     WatchCallback, WatchHandle,
 };
-use tantivy::index::{SegmentId, SegmentMetaInventory};
+use tantivy::index::{SegmentComponent, SegmentId, SegmentMetaInventory};
 use tantivy::{Directory, IndexMeta, SegmentMeta, TantivyError};
 
 /// By default Tantivy writes 8192 bytes at a time (the `BufWriter` default).
@@ -197,7 +197,13 @@ impl MVCCDirectory {
                     ));
                 };
                 Ok(Arc::new(unsafe {
-                    SegmentComponentReader::new(&self.indexrel, file_entry)
+                    SegmentComponentReader::new(
+                        &self.indexrel,
+                        file_entry,
+                        path.extension()
+                            .and_then(|ext| ext.to_str())
+                            .and_then(|ext| SegmentComponent::try_from(ext).ok()),
+                    )
                 }))
             }
             LoadedSegmentMetaEntry::Memory {
@@ -347,7 +353,13 @@ impl Directory for MVCCDirectory {
                         };
                     Ok(vacant
                         .insert(Arc::new(unsafe {
-                            SegmentComponentReader::new(&self.indexrel, file_entry)
+                            SegmentComponentReader::new(
+                                &self.indexrel,
+                                file_entry,
+                                path.extension()
+                                    .and_then(|ext| ext.to_str())
+                                    .and_then(|ext| SegmentComponent::try_from(ext).ok()),
+                            )
                         }))
                         .clone())
                 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -28,6 +28,7 @@ use crate::api::version::Version;
 use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::FFHelper;
 use crate::index::mvcc::MvccSatisfies;
+use crate::index::reader::io_stats;
 use crate::index::reader::scorer::{DeferredScorer, LazyWeight, ScorerIter};
 use crate::index::setup_tokenizers;
 use crate::postgres::heap::VisibilityChecker;
@@ -1093,7 +1094,8 @@ impl SearchIndexReader {
                     ),
                 };
                 let segment_ids = collected_ids.into_inner();
-                let segment_info = probe_stats_to_segment_info(&segment_ids, &fruit.stats);
+                let mut segment_info = probe_stats_to_segment_info(&segment_ids, &fruit.stats);
+                io_stats::attach(&mut segment_info);
                 TopKSearch::with_segment_info(
                     TopKSearchResults::new_for_score(fruit.results, aggregation_results),
                     segment_info,
@@ -1650,11 +1652,14 @@ impl SearchIndexReader {
         collector: &C,
         weight: &dyn Weight,
     ) -> Vec<<<C as Collector>::Child as SegmentCollector>::Fruit> {
+        io_stats::reset();
         self.segment_readers_in_segments(segment_ids)
             .map(|(segment_ord, segment_reader)| {
-                collector
+                let fruit = collector
                     .collect_segment(weight, segment_ord, segment_reader)
-                    .expect("should be able to collect in segment")
+                    .expect("should be able to collect in segment");
+                io_stats::end_segment(segment_reader.segment_id());
+                fruit
             })
             .collect()
     }

--- a/pg_search/src/index/reader/io_stats.rs
+++ b/pg_search/src/index/reader/io_stats.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Attributes Postgres buffer hits/reads to tantivy segment components, keyed
+//! by [`SegmentComponent`]. For vector search, `centroids` reads are routing
+//! and `vec` reads are probing; the text components (`term`, `idx`, `fast`,
+//! ...) are counted the same way.
+//!
+//! Like `block_tracker`, this is compiled out unless the `io_stats` feature is
+//! enabled, in which case the per-segment counters are merged into the
+//! `Segment Info` JSON shown by `EXPLAIN (ANALYZE, VERBOSE)`.
+
+#[cfg(feature = "io_stats")]
+mod imp {
+    use pgrx::pg_sys;
+    use serde_json::json;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+    use tantivy::index::{SegmentComponent, SegmentId};
+
+    #[derive(Debug, Default, Clone, Copy, serde::Serialize)]
+    struct IoCounters {
+        blks_hit: u64,
+        blks_read: u64,
+    }
+
+    type SegmentIo = BTreeMap<String, IoCounters>;
+
+    thread_local! {
+        static CURRENT: RefCell<SegmentIo> = RefCell::default();
+        static PER_SEGMENT: RefCell<Vec<(SegmentId, SegmentIo)>> = RefCell::default();
+    }
+
+    pub fn record<R>(component: &SegmentComponent, read: impl FnOnce() -> R) -> R {
+        let (hit0, read0) = snapshot();
+        let result = read();
+        let (hit1, read1) = snapshot();
+        CURRENT.with_borrow_mut(|current| {
+            let slot = current.entry(component.to_string()).or_default();
+            slot.blks_hit += hit1.saturating_sub(hit0) as u64;
+            slot.blks_read += read1.saturating_sub(read0) as u64;
+        });
+        result
+    }
+
+    fn snapshot() -> (i64, i64) {
+        unsafe {
+            let usage = std::ptr::addr_of!(pg_sys::pgBufferUsage).read();
+            (usage.shared_blks_hit, usage.shared_blks_read)
+        }
+    }
+
+    /// Forget any counts from outside a segment-collection window.
+    pub fn reset() {
+        CURRENT.take();
+        PER_SEGMENT.take();
+    }
+
+    /// Close the current segment's collection window, banking its counters.
+    pub fn end_segment(segment_id: SegmentId) {
+        let current = CURRENT.take();
+        PER_SEGMENT.with_borrow_mut(|per_segment| per_segment.push((segment_id, current)));
+    }
+
+    /// Merge the banked per-segment counters into the per-segment JSON built
+    /// from tantivy's `ProbeStats`.
+    pub fn attach(segment_info: &mut BTreeMap<SegmentId, serde_json::Value>) {
+        for (segment_id, io) in PER_SEGMENT.take() {
+            if io.is_empty() {
+                continue;
+            }
+            if let Some(serde_json::Value::Object(map)) = segment_info.get_mut(&segment_id) {
+                map.insert("io".to_string(), json!(io));
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "io_stats"))]
+mod imp {
+    use std::collections::BTreeMap;
+    use tantivy::index::{SegmentComponent, SegmentId};
+
+    #[inline(always)]
+    pub fn record<R>(_component: &SegmentComponent, read: impl FnOnce() -> R) -> R {
+        read()
+    }
+
+    #[inline(always)]
+    pub fn reset() {}
+
+    #[inline(always)]
+    pub fn end_segment(_segment_id: SegmentId) {}
+
+    #[inline(always)]
+    pub fn attach(_segment_info: &mut BTreeMap<SegmentId, serde_json::Value>) {}
+}
+
+pub use imp::{attach, end_segment, record, reset};

--- a/pg_search/src/index/reader/io_stats.rs
+++ b/pg_search/src/index/reader/io_stats.rs
@@ -16,9 +16,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! Attributes Postgres buffer hits/reads to tantivy segment components, keyed
-//! by [`SegmentComponent`]. For vector search, `centroids` reads are routing
-//! and `vec` reads are probing; the text components (`term`, `idx`, `fast`,
-//! ...) are counted the same way.
+//! by [`tantivy::index::SegmentComponent`]. For vector search, `centroids`
+//! reads are routing and `vec` reads are probing; the text components
+//! (`term`, `idx`, `fast`, ...) are counted the same way.
 //!
 //! Like `block_tracker`, this is compiled out unless the `io_stats` feature is
 //! enabled, in which case the per-segment counters are merged into the

--- a/pg_search/src/index/reader/mod.rs
+++ b/pg_search/src/index/reader/mod.rs
@@ -16,5 +16,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod index;
+pub mod io_stats;
 pub mod scorer;
 pub mod segment_component;

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::index::reader::io_stats;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::FileEntry;
 
@@ -30,13 +31,22 @@ use tantivy::directory::OwnedBytes;
 pub struct SegmentComponentReader {
     block_list: LinkedBytesList,
     entry: FileEntry,
+    component: Option<tantivy::index::SegmentComponent>,
 }
 
 impl SegmentComponentReader {
-    pub unsafe fn new(indexrel: &PgSearchRelation, entry: FileEntry) -> Self {
+    pub unsafe fn new(
+        indexrel: &PgSearchRelation,
+        entry: FileEntry,
+        component: Option<tantivy::index::SegmentComponent>,
+    ) -> Self {
         let block_list = LinkedBytesList::open(indexrel, entry.starting_block);
 
-        Self { block_list, entry }
+        Self {
+            block_list,
+            entry,
+            component,
+        }
     }
 
     fn read_bytes_raw(&self, range: Range<usize>) -> Result<OwnedBytes, Error> {
@@ -52,11 +62,18 @@ impl SegmentComponentReader {
 
 impl FileHandle for SegmentComponentReader {
     fn read_bytes(&self, range: Range<usize>) -> Result<OwnedBytes, Error> {
-        self.read_bytes_raw(range)
+        match &self.component {
+            Some(component) => io_stats::record(component, || self.read_bytes_raw(range)),
+            None => self.read_bytes_raw(range),
+        }
     }
 
     fn read_byte(&self, offset: usize) -> Result<u8, Error> {
-        Ok(unsafe { self.block_list.get_byte(offset) })
+        let read = || Ok(unsafe { self.block_list.get_byte(offset) });
+        match &self.component {
+            Some(component) => io_stats::record(component, read),
+            None => read(),
+        }
     }
 }
 
@@ -98,7 +115,7 @@ mod tests {
         let file_entry = writer.file_entry();
         writer.terminate().unwrap();
 
-        let reader = SegmentComponentReader::new(&indexrel, file_entry);
+        let reader = SegmentComponentReader::new(&indexrel, file_entry, None);
 
         assert_eq!(reader.len(), 100_000);
         assert_eq!(


### PR DESCRIPTION
Adds a compile-time `io_stats` feature (like `block_tracker`) that attributes Postgres buffer hits/reads to tantivy segment components, so vector search I/O can be split into routing (`centroids`) vs probing (`vec`) — or any other component a query touches.

Each `SegmentComponentReader` is tagged with its `SegmentComponent` (from the file extension); reads account `pgBufferUsage` `shared_blks_hit/read` deltas into a thread-local, banked per segment during collection. The vector path merges them into each segment's ProbeStats JSON in `EXPLAIN (ANALYZE, VERBOSE)`'s `Segment Info`:

```json
"io": {"centroids": {"blks_hit": 6, "blks_read": 0}, "vec": {"blks_hit": 11, "blks_read": 0}}
```

Verified warm (all hits) and cold (identical counts as reads) on an IVF index, plus the parallel-worker DSM publish path. Without the feature everything compiles to no-ops.

Build with `cargo pgrx run pg18 --features io_stats` to enable.