### PR TITLE
fix: don't hold the planner-warning borrow across ereport

### DIFF
--- a/pg_search/src/postgres/planner_warnings.rs
+++ b/pg_search/src/postgres/planner_warnings.rs
@@ -192,12 +192,26 @@ pub fn clear_planner_warnings() {
     });
 }
 
-pub fn emit_planner_warnings() {
+/// Render the collected warnings into the lines [`emit_planner_warnings`] will emit.
+///
+/// Kept separate from the emission so that no borrow of [`PLANNER_STATE`] is alive while Postgres
+/// is reporting: `pgrx::warning!` reaches `errfinish()`, which ends in `CHECK_FOR_INTERRUPTS()`.
+/// An interrupt there — statement timeout, cancel, recovery conflict — raises an `ERROR` and
+/// `siglongjmp`s past these Rust frames without running a single destructor, so a `Ref` guard held
+/// across the call would leave the thread-local borrowed for the life of the backend and every
+/// later planning cycle would fail in [`clear_planner_warnings`] with "RefCell already borrowed".
+///
+/// This reads the warnings rather than draining them: [`superseded_by_scan_warning`] still needs
+/// them while the plan executes, and they are cleared at the start of the next planning cycle.
+fn render_planner_warnings() -> Vec<String> {
     PLANNER_STATE.with(|state| {
         let state = state.borrow();
         // Flatten the map to iterate over all messages regardless of category
-        for category_warnings in state.warnings.values() {
-            for (message, warning_data) in category_warnings.iter() {
+        state
+            .warnings
+            .values()
+            .flat_map(|category_warnings| category_warnings.iter())
+            .map(|(message, warning_data)| {
                 let mut output = message.clone();
 
                 if !warning_data.details.is_empty() {
@@ -216,7 +230,7 @@ pub fn emit_planner_warnings() {
                 }
 
                 if warning_data.contexts.is_empty() {
-                    pgrx::warning!("{}", output);
+                    output
                 } else {
                     let label = if warning_data.contexts.len() > 1 {
                         "tables"
@@ -230,11 +244,17 @@ pub fn emit_planner_warnings() {
                         .cloned()
                         .collect::<Vec<_>>()
                         .join(", ");
-                    pgrx::warning!("{output} ({label}: {context_str})");
+                    format!("{output} ({label}: {context_str})")
                 }
-            }
-        }
-    });
+            })
+            .collect()
+    })
+}
+
+pub fn emit_planner_warnings() {
+    for message in render_planner_warnings() {
+        pgrx::warning!("{message}");
+    }
 }
 
 //
@@ -310,4 +330,52 @@ pub fn warn_filter_spilled() {
         &WARNED_SPILLED_AT,
         "the query's filter match set exceeded work_mem and spilled to a temporary file; query performance may be degraded",
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendering_warnings_holds_no_borrow_and_leaves_the_state_readable() {
+        clear_planner_warnings();
+
+        add_detailed_planner_warning(
+            "Join",
+            "JoinScan not used",
+            "orders",
+            vec!["text".to_string()],
+        );
+        add_planner_warning(
+            "Top K",
+            "Top K not used",
+            vec!["a".to_string(), "b".to_string()],
+        );
+
+        let mut messages = render_planner_warnings();
+        messages.sort();
+
+        assert_eq!(
+            messages,
+            vec![
+                "JoinScan not used (type: text) (table: orders)".to_string(),
+                "Top K not used (tables: a, b)".to_string(),
+            ]
+        );
+
+        // Nothing may still be borrowing the state once rendering returns. `pgrx::warning!` can
+        // longjmp out of `emit_planner_warnings`, and a guard alive at that moment would poison
+        // `PLANNER_STATE` for the rest of the backend.
+        assert!(
+            PLANNER_STATE.with(|state| state.try_borrow_mut().is_ok()),
+            "render_planner_warnings left PLANNER_STATE borrowed"
+        );
+
+        // Rendering reads the warnings, it does not consume them: `superseded_by_scan_warning`
+        // reads the same state while the plan executes.
+        assert_eq!(render_planner_warnings().len(), 2);
+
+        clear_planner_warnings();
+        assert!(render_planner_warnings().is_empty());
+    }
 }


### PR DESCRIPTION
Closes #5810.

## The problem

`emit_planner_warnings()` held the `PLANNER_STATE` `Ref` guard while calling `pgrx::warning!`:

```rust
PLANNER_STATE.with(|state| {
    let state = state.borrow();          // guard alive for the whole loop
    for category_warnings in state.warnings.values() {
        …
        pgrx::warning!("{output} ({label}: {context_str})");
    }
});
```

`pgrx::warning!` goes through pgrx's deliberately unguarded ereport FFI into Postgres' `errfinish()`, which ends in `CHECK_FOR_INTERRUPTS()`. If an interrupt fires in that window — statement timeout, cancel, recovery conflict — `ProcessInterrupts` raises an `ERROR` and `siglongjmp`s back to `PostgresMain`'s `sigsetjmp` **without unwinding the Rust frames**. The `Ref` destructor never runs, and `catch_unwind` does not engage because there is no Rust panic, only a C longjmp.

The thread-local is then shared-borrowed for the life of the backend, and the next statement's `clear_planner_warnings()` → `borrow_mut()` hits `BorrowMutError`. Every subsequent query through the planner hook on that backend fails with `ERROR: RefCell already borrowed`. The issue has the three consecutive log records from an Antithesis run showing exactly this sequence.

## The constraint that shapes the fix

The tempting fix is to `mem::take` the warnings out of the cell and emit from the local copy. That is wrong here: `superseded_by_scan_warning()` reads `PLANNER_STATE.warnings` **during execution**, and its doc comment says so —

> The planner state is populated during planning and only cleared at the start of the next planning cycle, so it is still readable while the plan executes.

Draining in `emit_planner_warnings()` would empty the map before the executor reads it, so `warn_sequential_scan()` and `warn_filter_spilled()` would stop being suppressed by an already-emitted JoinScan/AggregateScan warning. The fix has to leave the state intact and only stop holding a guard.

## The change

Split rendering from emission. `render_planner_warnings()` formats the lines into owned `String`s while the borrow is held — no ereport happens in that window — and the guard is dropped when it returns. `emit_planner_warnings()` then emits from the `Vec`, with nothing borrowed:

```rust
pub fn emit_planner_warnings() {
    for message in render_planner_warnings() {
        pgrx::warning!("{message}");
    }
}
```

The emitted text is byte-for-byte what it was: the same `(type…)` / `(types…)` and `(table…)` / `(tables…)` composition, just returned instead of passed straight to `warning!`.

I also checked whether this pattern occurs elsewhere in `pg_search`. The only other thread-local `RefCell`s are `CURRENT` and `PER_SEGMENT` in `index/reader/io_stats.rs`, and both use `with_borrow_mut(|…| …)` with no reporting inside the closure — so this is the single site, and the change stays scoped to the issue.

## Test

`rendering_warnings_holds_no_borrow_and_leaves_the_state_readable` pins both halves of the fix: that no guard survives rendering (`try_borrow_mut().is_ok()` afterwards), and that rendering does not consume the warnings (a second render still returns them, so `superseded_by_scan_warning` keeps working). It also asserts the rendered text.

## Verification — and its limits, stated plainly

**This is a Windows machine, so I could not run `cargo pgrx` or the crate's test suite.** Rather than submit an assertion I had never executed, I lifted `PlannerWarningState`, the mutators, `clear_planner_warnings` and `render_planner_warnings` verbatim into a standalone crate and ran the same test there:

- It passes on the fixed shape.
- It **fails** when I reintroduce the pre-fix shape by `mem::forget`ing the guard inside the render closure — which is precisely what the longjmp does to that destructor:

  ```
  test tests::rendering_warnings_holds_no_borrow_and_leaves_the_state_readable ... FAILED
  panicked at src\lib.rs:264:9:      // the try_borrow_mut assertion
  ```
- It passes again once the guard is restored.

So the assertion is tied to the real invariant rather than passing vacuously. `rustfmt --edition 2024 --check` is clean on the file. In-tree compilation and the full suite are on CI — if anything there disagrees, it is mine to fix.

I understand this change and stand behind it.
