### PR TITLE
feat: declare the BM25 key field's uniqueness to DataFusion

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -54,7 +54,7 @@ use datafusion::functions_aggregate::expr_fn::{
 };
 use datafusion::functions_aggregate::string_agg::string_agg_udaf;
 use datafusion::logical_expr::expr::{AggregateFunction, Sort};
-use datafusion::logical_expr::{Expr, lit};
+use datafusion::logical_expr::{Expr, LogicalPlanBuilder, LogicalPlanBuilderOptions, lit};
 use datafusion::prelude::{DataFrame, SessionContext};
 use futures::future::{FutureExt, LocalBoxFuture};
 use pgrx::pg_sys;
@@ -239,7 +239,27 @@ pub async fn build_join_aggregate_plan(
         .collect::<Result<Vec<Expr>>>()?;
 
     // Step 4: Apply aggregate
-    let mut df = df.aggregate(group_exprs, agg_exprs)?;
+    //
+    // Deliberately *not* `DataFrame::aggregate`: that hardcodes
+    // `add_implicit_group_by_exprs(true)`, which appends every column
+    // functionally determined by the group key to the group expression list
+    // (MySQL-style `SELECT col ... GROUP BY pk`). Now that
+    // `PgSearchTableProvider` declares the key field unique, that expansion
+    // would widen the group key behind our back and invalidate
+    // `group_df_indices` — the aggregate columns no longer start where
+    // `project_aggregate_row_to_slot` expects them, and the projection silently
+    // reads a grouping column as an aggregate result.
+    //
+    // Postgres has already validated and fully enumerated the GROUP BY clause
+    // by the time we get here, so the implicit expansion has nothing to add.
+    // Functional dependencies still reach the optimizer via the scan's schema;
+    // only the group-key rewrite is suppressed.
+    let options = LogicalPlanBuilderOptions::new().with_add_implicit_group_by_exprs(false);
+    let aggregated = LogicalPlanBuilder::from(df.into_unoptimized_plan())
+        .with_options(options)
+        .aggregate(group_exprs, agg_exprs)?
+        .build()?;
+    let mut df = DataFrame::new(ctx.state(), aggregated);
 
     // Step 4.5: Apply HAVING filter (post-aggregate)
     if let Some(having) = having_filter {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -32,7 +32,7 @@
 use std::sync::Arc;
 
 use datafusion::common::{DataFusionError, Result};
-use datafusion::logical_expr::{Expr, col};
+use datafusion::logical_expr::{Expr, LogicalPlanBuilder, LogicalPlanBuilderOptions, col};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion::prelude::{DataFrame, SessionConfig, SessionContext};
@@ -766,7 +766,19 @@ fn apply_distinct_group_by(
             .map(|ctid_name| min(col(&ctid_name)).alias(&ctid_name))
             .collect();
 
-    let df = df.aggregate(group_exprs, agg_exprs)?;
+    // As in the aggregate scan: bypass `DataFrame::aggregate` so DataFusion does
+    // not append functionally-dependent columns to the group key. With the key
+    // field now declared unique, an expansion here would pull each source's ctid
+    // into the group key, every input row would land in its own group, and the
+    // DISTINCT would stop collapsing anything — while `min(ctid)` quietly became
+    // an identity.
+    let options = LogicalPlanBuilderOptions::new().with_add_implicit_group_by_exprs(false);
+    let (state, plan) = df.into_parts();
+    let aggregated = LogicalPlanBuilder::from(plan)
+        .with_options(options)
+        .aggregate(group_exprs, agg_exprs)?
+        .build()?;
+    let df = DataFrame::new(state, aggregated);
     Ok((df, distinct_col_map))
 }
 

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -23,7 +23,7 @@ use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::stats::{ColumnStatistics, Precision};
-use datafusion::common::{DataFusionError, Result, Statistics};
+use datafusion::common::{Constraint, Constraints, DataFusionError, Result, Statistics};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use pgrx::pg_sys;
@@ -76,6 +76,12 @@ pub struct PgSearchTableProvider {
     schema: OnceLock<SchemaRef>,
     #[serde(skip)]
     late_materialization_schema: OnceLock<SchemaRef>,
+    /// Cached table-level constraints. `TableProvider::constraints` hands back a
+    /// reference, so the value has to outlive the call. Invalidated by
+    /// `configure_deferred_outputs`, which is the only thing that can change the
+    /// answer after construction.
+    #[serde(skip)]
+    constraints: OnceLock<Option<Constraints>>,
     /// Parallel state is skipped during serialization because it's a raw pointer
     /// to shared memory that is only valid in the current process. It is
     /// re-injected by the execution codec during deserialization if
@@ -152,6 +158,7 @@ impl Clone for PgSearchTableProvider {
             fields: self.fields.clone(),
             schema: self.schema.clone(),
             late_materialization_schema: self.late_materialization_schema.clone(),
+            constraints: self.constraints.clone(),
             parallel_state: self.parallel_state,
             expr_context: self.expr_context,
             planstate: self.planstate,
@@ -180,6 +187,7 @@ impl PgSearchTableProvider {
             fields,
             schema: OnceLock::new(),
             late_materialization_schema: OnceLock::new(),
+            constraints: OnceLock::new(),
             parallel_state: None,
             expr_context: None,
             planstate: None,
@@ -279,6 +287,9 @@ impl PgSearchTableProvider {
         if let VisibilityMode::Deferred { plan_position } = visibility_mode {
             self.enable_deferred_visibility(plan_position);
         }
+        // Deferring visibility changes whether the key field is unique in this
+        // scan's own output, so drop anything `constraints()` may have cached.
+        self.constraints = OnceLock::new();
     }
 
     pub(crate) fn visibility_mode(&self) -> VisibilityMode {
@@ -534,6 +545,58 @@ impl PgSearchTableProvider {
 impl TableProvider for PgSearchTableProvider {
     fn schema(&self) -> SchemaRef {
         self.get_schema()
+    }
+
+    /// Declares the BM25 `key_field` as unique so DataFusion carries a non-empty
+    /// `FunctionalDependencies` through plans built over this scan.
+    ///
+    /// Two conditions gate the declaration:
+    ///
+    /// * **Eager visibility only.** Under [`VisibilityMode::Deferred`] the scan skips
+    ///   per-row visibility checks and `VisibilityFilterExec` prunes above us, so this
+    ///   node can legitimately emit several index documents (old and new versions of
+    ///   the same row) sharing one key value. An UPDATE leaves the superseded doc in
+    ///   a snapshot-visible segment; `batch_scanner::next` is what drops it, via
+    ///   `VisibilityChecker`, and the deferred path skips exactly that step.
+    ///   Uniqueness only holds once `VisibilityFilterExec` has run, and DataFusion is
+    ///   entitled to act on whatever we declare here.
+    ///
+    ///   Note this currently excludes JoinScan entirely: `scan_state.rs` configures
+    ///   every source with `VisibilityMode::Deferred` unconditionally. Covering that
+    ///   path means declaring the constraint on `VisibilityFilterNode`'s output
+    ///   rather than on the scan; see the PR discussion.
+    ///
+    /// * **The key must be a materialized column.** We locate it by index into
+    ///   `self.fields`, which `build_arrow_schema` maps 1:1 onto the Arrow schema. The
+    ///   position is therefore valid for both the logical and late-materialization
+    ///   schemas and does not depend on which one `get_schema` happens to return at
+    ///   call time. Matching the `WhichFastField` variant rather than a schema field
+    ///   name also keeps a `Junk`/`Score`/`Ctid` column from matching by accident.
+    ///
+    /// Indices are against the unprojected schema: `TableScan` applies the projection
+    /// itself via `project_functional_dependencies`.
+    fn constraints(&self) -> Option<&Constraints> {
+        self.constraints
+            .get_or_init(|| {
+                if !matches!(self.visibility_mode, VisibilityMode::Eager) {
+                    return None;
+                }
+
+                let index_rel = PgSearchRelation::open(self.scan_info.indexrelid);
+                let key_name = index_rel.schema().ok()?.key_field_name().root();
+
+                let position = self.fields.iter().position(|wff| match wff {
+                    WhichFastField::Named(name, _) | WhichFastField::Deferred(name, _) => {
+                        name == &key_name
+                    }
+                    _ => false,
+                })?;
+
+                Some(Constraints::new_unverified(vec![Constraint::Unique(vec![
+                    position,
+                ])]))
+            })
+            .as_ref()
     }
 
     fn table_type(&self) -> TableType {

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -64,7 +64,7 @@ WHERE p.description @@@ 'laptop';
    Aggregates: COUNT(*)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[]
+     :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, product_id@0)], projection=[]
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
@@ -1910,15 +1910,15 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                                                                                                    QUERY PLAN                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                      QUERY PLAN                                                                                                                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) (actual rows=1.00 loops=1)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
    Aggregates: COUNT(*)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0], metrics=[output_rows=1, output_bytes=8.0 B, output_batches=1]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[], metrics=[output_rows=6, output_bytes=0.0 B, output_batches=1, build_mem_used=44.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=3, input_batches=2, input_rows=9, avg_fanout=100% (6/6), probe_hit_rate=66.67% (6/9)]
+     :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, product_id@0)], projection=[], metrics=[output_rows=6, output_bytes=0.0 B, output_batches=1, build_mem_used=44.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=3, input_batches=2, input_rows=9, avg_fanout=100% (6/6), probe_hit_rate=66.67% (6/9)]
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=24.0 B, output_batches=1]
      :     CooperativeExec

--- a/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
@@ -48,8 +48,8 @@ FROM repro_cccf cccf
 JOIN repro_ti ti ON cccf.company_id = ti.company_id
 GROUP BY company_name
 ORDER BY company_name;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: cccf.company_name
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -59,7 +59,7 @@ ORDER BY company_name;
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[company_name_words@0 as company_name_words], aggr=[count(1) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
            :     CooperativeExec
            :       PgSearchScan: segments=1, query="all"
            :     CooperativeExec
@@ -100,15 +100,15 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT count(DISTINCT company_name)
 FROM repro_cccf cccf
 JOIN repro_ti ti ON cccf.company_id = ti.company_id;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: repro_cccf_idx (cccf), repro_ti_idx (ti)
    Aggregates: COUNT(DISTINCT)(company_name_words)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(DISTINCT cccf_0.company_name_words) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
+     :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
      :     CooperativeExec
      :       PgSearchScan: segments=1, query="all"
      :     CooperativeExec
@@ -151,7 +151,7 @@ JOIN repro_ti ti ON cccf.company_id = ti.company_id;
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[string_agg(cccf_0.company_name_words, ,) ORDER BY [cccf_0.company_name_words ASC NULLS LAST] as agg_0]
      :   SortExec: expr=[company_name_words@0 ASC NULLS LAST], preserve_partitioning=[false]
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
+     :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
      :       CooperativeExec
      :         PgSearchScan: segments=1, query="all"
      :       CooperativeExec

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -648,7 +648,7 @@ WHERE a.id NOT IN (
    Aggregates: COUNT(*), SUM(val)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0, sum(b_3.val) as agg_1]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, a_id@0)], filter=val@1 > threshold@0, projection=[val@3]
+     :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, a_id@0)], filter=val@1 > threshold@0, projection=[val@1]
      :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, aid@0)], null_aware
      :       CooperativeExec
      :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"outermatch","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/alias_quoted_mixed_case.out
+++ b/pg_search/tests/pg_regress/expected/alias_quoted_mixed_case.out
@@ -70,7 +70,7 @@ WHERE "Parent"."owner" = 'user-1';
    Aggregates: COUNT(id)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(parent_0.id) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, child_id@1)], projection=[id@1]
+     :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, child_id@1)], projection=[id@0]
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"term":{"field":"state","value":"active"}}
      :     CooperativeExec
@@ -255,8 +255,8 @@ JOIN repro_5525_child  AS "456"
 GROUP BY "123"."owner"
 ORDER BY "123"."owner"
 LIMIT 5;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: "123".owner
@@ -268,7 +268,7 @@ LIMIT 5;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=5), expr=[owner@0 ASC NULLS LAST], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[owner@1 as owner], aggr=[count(_123_0.id) as agg_0]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, child_id@1)], projection=[id@1, owner@3]
+                 :     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, child_id@1)], projection=[id@0, owner@2]
                  :       CooperativeExec
                  :         PgSearchScan: segments=1, query={"term":{"field":"state","value":"active"}}
                  :       CooperativeExec

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -581,7 +581,7 @@ WHERE p.description @@@ 'wireless'
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, supplier_id@0)], projection=[]
+           :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, supplier_id@0)], projection=[]
            :     CooperativeExec
            :       PgSearchScan: segments=1, query="all"
            :     CooperativeExec

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -83,7 +83,7 @@ WHERE f.content @@@ 'Section';
    Aggregates: COUNT(*)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+     :   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, file_id@0)], projection=[]
      :     CooperativeExec
      :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
@@ -173,7 +173,7 @@ WHERE f.content @@@ 'Section';
      : └──────────────────────────────────────────────────
      :   ┌───── Stage 2 ── tasks=2, partitions=6
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
-     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+     :   │   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -372,7 +372,7 @@ WHERE f.content @@@ 'Section';
      : └──────────────────────────────────────────────────
      :   ┌───── Stage 2 ── tasks=2, partitions=6
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
-     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+     :   │   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1

--- a/tests/tests/aggregate_join.rs
+++ b/tests/tests/aggregate_join.rs
@@ -841,3 +841,165 @@ fn test_group_by_key_field_does_not_widen_group_key(mut conn: PgConnection) {
         "ctid leaked into the aggregate group key; plan was:\n{plan}"
     );
 }
+
+/// Fixture for the stale-document tests.
+///
+/// `autovacuum_enabled = off` matters: these tests depend on the superseded index
+/// document still being present, and the autovacuum daemon would otherwise be free to
+/// remove it mid-test.
+fn setup_stale_doc_tables(conn: &mut PgConnection) {
+    r#"
+    CREATE TABLE stale_products (
+        id INTEGER PRIMARY KEY,
+        description TEXT,
+        category TEXT
+    ) WITH (autovacuum_enabled = off);
+    CREATE TABLE stale_tags (
+        id SERIAL PRIMARY KEY,
+        product_id INTEGER,
+        tag_name TEXT
+    ) WITH (autovacuum_enabled = off);
+    INSERT INTO stale_products (id, description, category) VALUES
+        (1, 'Laptop with fast processor', 'Electronics'),
+        (2, 'Gaming laptop with RGB', 'Electronics'),
+        (3, 'Running shoes for athletes', 'Sports');
+    INSERT INTO stale_tags (product_id, tag_name) VALUES
+        (1, 'tech'), (1, 'computer'),
+        (2, 'tech'), (2, 'gaming'),
+        (3, 'fitness'), (3, 'running');
+    CREATE INDEX stale_products_idx ON stale_products
+    USING paradedb (id, description, category)
+    WITH (
+        key_field='id',
+        text_fields='{"description": {}, "category": {"fast": true}}'
+    );
+    CREATE INDEX stale_tags_idx ON stale_tags
+    USING paradedb (id, product_id, tag_name)
+    WITH (
+        key_field='id',
+        numeric_fields='{"product_id": {"fast": true}}',
+        text_fields='{"tag_name": {"fast": true}}'
+    );
+    SET paradedb.enable_aggregate_custom_scan TO on;
+    "#
+    .execute(conn);
+}
+
+/// Non-key UPDATE, no VACUUM: the stale document carries the *same* key as the live one.
+///
+/// This is the direct duplicate-key case. The key field is unique per heap row but not
+/// per index document, and only `VisibilityChecker` — which `VisibilityMode::Eager` runs
+/// in `batch_scanner::next` and `Deferred` skips — collapses the two back down.
+#[rstest]
+fn test_stale_doc_non_key_update_counts(mut conn: PgConnection) {
+    setup_stale_doc_tables(&mut conn);
+
+    "UPDATE stale_products SET category = 'Computers' WHERE id = 1".execute(&mut conn);
+
+    let query = r#"
+        SELECT p.id, p.category, COUNT(*)
+        FROM stale_products p
+        JOIN stale_tags t ON p.id = t.product_id
+        WHERE p.description @@@ 'laptop OR shoes'
+        GROUP BY p.id, p.category
+        ORDER BY p.id
+    "#;
+
+    let with_custom_scan = query.fetch::<(i32, String, i64)>(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO off".execute(&mut conn);
+    let without_custom_scan = query.fetch::<(i32, String, i64)>(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO on".execute(&mut conn);
+
+    assert_eq!(
+        with_custom_scan, without_custom_scan,
+        "a superseded index document must not inflate counts"
+    );
+    assert_eq!(
+        with_custom_scan,
+        vec![
+            (1, "Computers".into(), 2),
+            (2, "Electronics".into(), 2),
+            (3, "Sports".into(), 2),
+        ]
+    );
+}
+
+/// Key-column UPDATE, no VACUUM: the stale document carries a key that no longer exists.
+///
+/// Uniqueness is not violated here — the stale and live keys differ — so this case is
+/// invisible to a count assertion. What it can corrupt is *which rows* come back, since
+/// the stale document still joins against tags for the old key.
+#[rstest]
+fn test_stale_doc_key_update_rows(mut conn: PgConnection) {
+    setup_stale_doc_tables(&mut conn);
+
+    "UPDATE stale_products SET id = 999 WHERE id = 1".execute(&mut conn);
+
+    let query = r#"
+        SELECT p.id, t.tag_name
+        FROM stale_products p
+        JOIN stale_tags t ON p.id = t.product_id
+        WHERE p.description @@@ 'laptop OR shoes'
+        ORDER BY p.id, t.tag_name
+    "#;
+
+    let with_custom_scan = query.fetch::<(i32, String)>(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO off".execute(&mut conn);
+    let without_custom_scan = query.fetch::<(i32, String)>(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO on".execute(&mut conn);
+
+    assert_eq!(
+        with_custom_scan, without_custom_scan,
+        "a superseded document must not contribute join matches on its old key"
+    );
+    assert!(
+        !with_custom_scan.iter().any(|(id, _)| *id == 1),
+        "id 1 no longer exists; rows were: {with_custom_scan:?}"
+    );
+}
+
+/// Key updated away, then reused by a fresh insert — no VACUUM in between.
+///
+/// The heap stays unique on `id`; the index does not. This is the gap between "unique per
+/// row" and "unique per doc" in one fixture: a stale document and a live document share
+/// key 1 while belonging to different rows, so it is both a genuine duplicate key and a
+/// wrong join result.
+///
+/// These three tests characterize the `VisibilityMode::Eager` gate on
+/// `PgSearchTableProvider::constraints`. They pass today because `Eager` scans filter
+/// visibility before emitting. They are here to fail loudly if the declaration is ever
+/// moved somewhere the superseded document is still in flight.
+#[rstest]
+fn test_stale_doc_key_reuse_after_update(mut conn: PgConnection) {
+    setup_stale_doc_tables(&mut conn);
+
+    "UPDATE stale_products SET id = 999 WHERE id = 1".execute(&mut conn);
+    r#"INSERT INTO stale_products (id, description, category)
+       VALUES (1, 'Laptop with fast processor', 'Refurbished')"#
+        .execute(&mut conn);
+
+    let query = r#"
+        SELECT p.id, p.category, t.tag_name
+        FROM stale_products p
+        JOIN stale_tags t ON p.id = t.product_id
+        WHERE p.description @@@ 'laptop OR shoes'
+        ORDER BY p.id, t.tag_name
+    "#;
+
+    let with_custom_scan = query.fetch::<(i32, String, String)>(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO off".execute(&mut conn);
+    let without_custom_scan = query.fetch::<(i32, String, String)>(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO on".execute(&mut conn);
+
+    assert_eq!(
+        with_custom_scan, without_custom_scan,
+        "the superseded doc for key 1 must not be joined alongside the reinserted row"
+    );
+    assert!(
+        with_custom_scan
+            .iter()
+            .filter(|(id, _, _)| *id == 1)
+            .all(|(_, category, _)| category == "Refurbished"),
+        "only the reinserted row should appear under key 1; rows were: {with_custom_scan:?}"
+    );
+}

--- a/tests/tests/aggregate_join.rs
+++ b/tests/tests/aggregate_join.rs
@@ -758,3 +758,86 @@ fn test_explain_aggregate_join_with_heap_filter(mut conn: PgConnection) {
         "Expected physical plan during EXPLAIN ANALYZE.\nEXPLAIN ANALYZE:\n{analyze}"
     );
 }
+
+/// Regression test for #5654.
+///
+/// `PgSearchTableProvider` declares the BM25 key field unique, which gives
+/// DataFusion a functional dependency from the key to every other column of the
+/// scan. `DataFrame::aggregate` hardcodes `add_implicit_group_by_exprs(true)`,
+/// so once that dependency existed DataFusion appended the dependent columns
+/// (including `ctid`) to the group key. The aggregate scan resolves its output
+/// columns positionally — aggregates are read starting at
+/// `max(group_df_indices) + 1` — so the widened group key shifted every
+/// aggregate one slot right and `COUNT(*)` came back holding a ctid.
+///
+/// Grouping on the key field is what triggers it: no other grouping column
+/// determines the rest of the row.
+#[rstest]
+fn test_group_by_key_field_over_join_counts(mut conn: PgConnection) {
+    setup_join_tables(&mut conn);
+
+    // Products 1, 2, 5 match 'laptop' and product 3 matches 'shoes'; each of the
+    // four carries exactly 2 tags, so every group counts 2.
+    let query = r#"
+        SELECT p.id, p.category, COUNT(*)
+        FROM products p
+        JOIN tags t ON p.id = t.product_id
+        WHERE p.description @@@ 'laptop OR shoes'
+        GROUP BY p.id, p.category
+        ORDER BY p.id
+    "#;
+
+    let with_custom_scan = query.fetch::<(i32, String, i64)>(&mut conn);
+
+    assert_eq!(
+        with_custom_scan,
+        vec![
+            (1, "Electronics".into(), 2),
+            (2, "Electronics".into(), 2),
+            (3, "Sports".into(), 2),
+            (5, "Toys".into(), 2),
+        ],
+        "COUNT(*) must not be displaced by an implicitly widened group key"
+    );
+
+    // And the custom scan must agree with the plain Postgres path.
+    "SET paradedb.enable_aggregate_custom_scan TO off".execute(&mut conn);
+    let without_custom_scan = query.fetch::<(i32, String, i64)>(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO on".execute(&mut conn);
+
+    assert_eq!(
+        with_custom_scan, without_custom_scan,
+        "aggregate custom scan disagrees with the non-custom-scan plan"
+    );
+}
+
+/// The group key must stay exactly what Postgres asked for. Guarding the plan
+/// shape directly catches a reintroduced expansion even if the values happen to
+/// line up for a particular fixture.
+#[rstest]
+fn test_group_by_key_field_does_not_widen_group_key(mut conn: PgConnection) {
+    setup_join_tables(&mut conn);
+
+    let plan = r#"
+        EXPLAIN (COSTS OFF, VERBOSE)
+        SELECT p.id, p.category, COUNT(*)
+        FROM products p
+        JOIN tags t ON p.id = t.product_id
+        WHERE p.description @@@ 'laptop OR shoes'
+        GROUP BY p.id, p.category
+    "#
+    .fetch::<(String,)>(&mut conn)
+    .into_iter()
+    .map(|(line,)| line)
+    .collect::<Vec<_>>()
+    .join("\n");
+
+    assert!(
+        plan.contains("ParadeDB Aggregate Scan"),
+        "expected the aggregate custom scan to be chosen; plan was:\n{plan}"
+    );
+    assert!(
+        !plan.contains("ctid@"),
+        "ctid leaked into the aggregate group key; plan was:\n{plan}"
+    );
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5654

## What

`PgSearchTableProvider` now implements `TableProvider::constraints()`, declaring the BM25
`key_field` as `Constraint::Unique`, so plans built over the scan carry a non-empty
`FunctionalDependencies` instead of an empty one.

No extra plumbing was needed for the `LogicalPlanBuilder::scan` path the ticket mentions —
JoinScan registers via `register_table` -> `ctx.table(alias)`, and `DefaultTableSource`
already forwards `constraints()` through.

## Why

Per the ticket: native simplifications gated on functional dependencies never fired for us.
Declaring the constraint is also a prerequisite for FD-aware Top-K.

Implementing it surfaced two things worth flagging.

**The declaration is gated on `VisibilityMode::Eager`, which excludes JoinScan today.**

The key field is unique per *heap row*, not per *index document*. An UPDATE leaves the
superseded doc in a snapshot-visible segment, so a scan can emit two documents with the
same key value. Under `Eager` visibility, `batch_scanner::next` runs `VisibilityChecker`
per batch and drops the dead one, so the key is unique in the scan's output. Under
`VisibilityMode::Deferred` the scan skips that check by design and
`VisibilityFilterExec` prunes above it — which `visibility_filter.rs` inserts at barrier
points **or at the plan root**. So in the deferred case there is a window in the plan
where the key is genuinely not unique, and DataFusion is entitled to act on whatever we
declare.

I've gated the declaration on `Eager` accordingly. The consequence is that JoinScan gets
nothing today, because `scan_state.rs` configures every source with
`VisibilityMode::Deferred` unconditionally (the only other call site is in `mod tests`).
That's in tension with the ticket's "How?", which names the JoinScan path specifically.

Covering JoinScan properly means declaring the constraint on `VisibilityFilterNode`'s
output schema rather than on the scan, so the FD appears exactly where it becomes true.
That felt like more than this ticket implies, so I've left it out — happy to take it on
here or in a follow-up, whichever you prefer. **If the deferred path is in fact already
deduplicated and I've misread the contract, say so and I'll drop the gate**, since that
would make this considerably more valuable.

The aggregate-on-join path is unaffected by the gate and does get the FD — it doesn't
use deferred visibility at all.

**Declaring uniqueness exposes a latent bug in the aggregate scan.**

`DataFrame::aggregate` hardcodes `add_implicit_group_by_exprs(true)`, so
`add_group_by_exprs_from_dependencies` appends every functionally-dependent column to the
group expression list. Once the key field is unique it determines the whole row, so the
group key grows to the entire scan schema. But `datafusion_project.rs` resolves aggregate
outputs positionally:

```rust
let num_unique_group_cols = group_df_indices.iter().max().map(|&m| m + 1).unwrap_or(0);
let mut df_col_idx = num_unique_group_cols;
```

`group_df_indices` is built pre-optimization, so a widened group key shifts the
aggregates rightward and the projection reads whichever grouping column now occupies the
slot it expects. Grouping on the key field over a join is enough to trigger it:

```sql
SELECT p.id, p.category, COUNT(*)
FROM products p JOIN tags t ON p.id = t.product_id
WHERE p.description @@@ 'laptop OR shoes'
GROUP BY p.id, p.category;
```

Every group has exactly 2 rows. Without the fix, `COUNT(*)` returns `999, 1299, 89, 499`
— the `price` column, truncated into the count slot — and the plan shows
`gby=[id, category, price, rating, ctid]` where only `id, category` were requested. Which
column surfaces depends on the schema; on a narrower fixture it comes back as ctid offsets.

Verified by reverting only this half of the patch and keeping `constraints()`: both new
tests fail exactly as above, and pass again with the full patch. That toggle is also the
proof that the declared constraint reaches DataFusion at all, since nothing else in the
tree can widen a group key.

Fixed by building the aggregate through `LogicalPlanBuilder` with
`add_implicit_group_by_exprs(false)` instead of `DataFrame::aggregate`. Postgres has
already validated and fully enumerated the GROUP BY by that point, so the implicit
expansion has nothing to contribute; functional dependencies still reach the optimizer
via the scan's schema, and only the group-key rewrite is suppressed.

`apply_distinct_group_by` in `joinscan/scan_state.rs` needs the same treatment — an
expansion there would pull each source's ctid into the DISTINCT group key, every input
row would land in its own group, and `min(ctid)` would quietly become an identity. That
one is latent rather than triggered today, given the gate above, but it's the same
failure mode and I'd rather not leave it armed.

## How

Three changes, split across two commits:

1. `fix:` build the aggregate through `LogicalPlanBuilder` with
   `add_implicit_group_by_exprs(false)` in `aggregatescan/datafusion_exec.rs`, and the same
   in `apply_distinct_group_by` in `joinscan/scan_state.rs`. This commit is a no-op on
   today's `main` — without declared constraints there are no dependencies to expand — so
   it is reviewable and revertable on its own.
2. `feat:` implement `constraints()` on `PgSearchTableProvider`, plus regression tests.

The key field's position is resolved by index into `self.fields` rather than by name against
`get_schema()`, because that method returns a different schema depending on
`late_materialization_active`. `configure_deferred_outputs` invalidates the cached value,
since deferring visibility changes the answer.

## Tests

Two regression tests in `tests/tests/aggregate_join.rs`:

- `test_group_by_key_field_over_join_counts` — asserts the counts, and that the custom scan
  agrees with the plan produced under `paradedb.enable_aggregate_custom_scan = off`.
- `test_group_by_key_field_does_not_widen_group_key` — asserts on the plan directly, so a
  reintroduced expansion is caught even when values happen to line up for this fixture.

Locally against `49059a5d`: `aggregate_join` 19/19, `aggregate_custom_scan` 6/6, `joins` 6/6.
`cargo fmt --all -- --check` and `cargo clippy --package pg_search --features pg18 -D warnings`
both clean.


## Which rules start firing

Beyond group-by dependency propagation, the visible effect across the regress suite is
join-type narrowing. Seven expected files needed regenerating, and every hunk is the same
rewrite:

```
- HashJoinExec: mode=CollectLeft, join_type=Inner,     on=[(id@0, product_id@0)]
+ HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, product_id@0)]
```

DataFusion converts inner joins to semi-joins where the probe side's output is not
otherwise needed. That rewrite is only sound when the join key is unique on the eliminated
side, so it could not fire before this change. Affected: `aggregate_join`,
`aggregate_join_alias`, `aggregate_join_semi_anti`, `alias_quoted_mixed_case`,
`join_distinct`, `mpp_aggregate`, `mpp_aggregate_postagg`.

Row counts are unchanged on both sides of every diff (`output_rows=6` before and after);
the `projection=[val@3]` -> `projection=[val@1]` shifts follow from the narrower semi-join
output. Expectations regenerated with `cargo pgrx regress --auto`.
