### PR TITLE
chore: Prepare 0.25.3.

### DIFF
--- a/docs/changelog/0.25.3.mdx
+++ b/docs/changelog/0.25.3.mdx
@@ -1,0 +1,33 @@
+---
+title: 0.25.3
+noindex: true
+---
+
+## New Features 🎉
+
+- Aggregates over `NUMERIC` columns are now pushed down into the ParadeDB index.
+- Queries containing `Param` and `SubPlan` expressions are now solved on the leader before MPP dispatch, so more
+  plan shapes execute over MPP.
+- `EXPLAIN (ANALYZE, VERBOSE)` now attributes vector search buffer hits and reads to cluster routing versus
+  cluster probing.
+
+## Performance Improvements 🚀
+
+- Faster counts for unfiltered and single-term-filter queries.
+- Cardinality aggregations over string fields now defer visibility checks, speeding up aggregations over
+  fully-visible segments.
+
+## Stability Improvements 💪
+
+- Fixed dropped `pdb.agg` filters, and improved the warnings emitted when an aggregate cannot be pushed down.
+- Unsortable `top_hits.sort` fields are now rejected at plan time instead of failing during execution.
+- `partition_by` is now preserved on AggregateScan for range co-partitioned joins.
+- Scaling a PgSearchScan node now declares only the partition assigned to it.
+- The final index build merge now runs even when the last insert flushed at the document cap.
+- Prebuilt binaries are now published for macOS 26 (Tahoe). macOS 14 (Sonoma) binaries are no longer published.
+
+## New Contributors 👋
+
+- [**nshah067**](https://github.com/nshah067)
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.25.3).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -38,7 +38,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.25.2-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.25.3-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -41,7 +41,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.25.2` with the `pg_search` version you wish to install and
+  You can replace `0.25.3` with the `pg_search` version you wish to install and
   `18` with the version of Postgres you are using.
 </Note>
 
@@ -49,49 +49,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 26.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/postgresql-18-pg-search_0.25.2-1PARADEDB-resolute_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-18-pg-search_0.25.3-1PARADEDB-resolute_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/postgresql-18-pg-search_0.25.2-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-18-pg-search_0.25.3-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/postgresql-18-pg-search_0.25.2-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-18-pg-search_0.25.3-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/postgresql-18-pg-search_0.25.2-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-18-pg-search_0.25.3-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/pg_search_18-0.25.2-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/pg_search_18-0.25.3-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/pg_search_18-0.25.2-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/pg_search_18-0.25.3-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 26 (Tahoe)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/pg_search@18--0.25.2.arm64_tahoe.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/pg_search@18--0.25.3.arm64_tahoe.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.2/pg_search@18--0.25.2.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.3/pg_search@18--0.25.3.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -38,7 +38,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.25.2`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.25.3`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -80,10 +80,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.25.2
+docker pull paradedb/paradedb:0.25.3
 ```
 
-The latest version of the Docker image should be `0.25.2`.
+The latest version of the Docker image should be `0.25.3`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -100,7 +100,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.25.2';
+ALTER EXTENSION pg_search UPDATE TO '0.25.3';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.25.2",
+        "version": "v0.25.3",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -358,6 +358,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.25.3",
                   "changelog/0.25.2",
                   "changelog/0.25.1",
                   "changelog/0.25.0",


### PR DESCRIPTION
# Description

Prepares the `0.25.3` release: adds the changelog and bumps the version references in the docs.

`Cargo.toml`/`Cargo.lock` are already at `0.25.3`, and `pg_search--0.25.2--0.25.3.sql` already exists on `main`, so this PR is docs-only. The `datafusion-distributed` snapshot tag is unchanged from `0.25.2`, so `cargoHash` also stays put.

The changelog is built from the commits on `origin/0.25.x` since `chore: Prepare 0.25.2. (#5927)`.