### PR TITLE
chore: Post `0.25.2` release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -2844,7 +2844,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -4954,7 +4954,7 @@ checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "macros"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -7802,7 +7802,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -8199,7 +8199,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -8367,7 +8367,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.25.2"
+version = "0.25.3"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-fOYMUbbBdJEDVO6zvGTNCKoAglfAqWdmrnIN+JY5dns=";
+  cargoHash = "sha256-Up62p6HU0EZGdDX75+1oBIBuUtNM4m0INjO3x9WUO+g=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.25.2--0.25.3.sql
+++ b/pg_search/sql/pg_search--0.25.2--0.25.3.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.3'" to load this file. \quit


### PR DESCRIPTION
# Description

Bump `0.25.x` to `0.25.3` and seed the `0.25.2` -> `0.25.3` migration script.

`v0.25.2` is tagged but the branch was never bumped, so SchemaBot resolves the current migration file to the already-shipped `pg_search--0.25.1--0.25.2.sql`. That blocks any schema-changing backport to `0.25.x` (first hit: #5980).

Mirrors #5527 (`chore: Post `0.24.2` release.`).