### PR TITLE
fix(mpp): cap shm drain buffers using work_mem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,8 +2091,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-distributed"
-version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-11-004258#aaf1a8129623ad7e1991173fe0fa5cb22a6d1656"
+version = "3.0.0"
+source = "git+https://github.com/nshah067/datafusion-distributed?rev=5433c958ea7ff9d825f0ed4c47f3f501d8385f96#5433c958ea7ff9d825f0ed4c47f3f501d8385f96"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -95,7 +95,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-11-004258", default-features = false }
+datafusion-distributed = { git = "https://github.com/nshah067/datafusion-distributed", rev = "5433c958ea7ff9d825f0ed4c47f3f501d8385f96", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -182,16 +182,21 @@ pub unsafe fn leader_setup(
     let interrupt: Arc<dyn Interrupt> = Arc::new(PgInterrupt);
     // Register the leader as receiver so producers' wakeups resolve to this backend's procLatch.
     let token = unsafe { self_receiver_token() };
+    // Cap shm drain buffers independently of the per-fragment operator WorkMemMemoryPool.
+    // Over the limit the affected channel errors; the drain never blocks, so cooperative send
+    // cannot deadlock.
+    let drain_buffer_budget_bytes = Some(unsafe { pg_sys::work_mem as usize * 1024 });
     // `mpp_trace` reads a pgrx GucSetting, which requires the backend thread. Safe here
     // because this runs synchronously on the leader backend from `launch_mpp`, before any
     // tokio runtime spins up.
     let t_setup = crate::gucs::mpp_trace().then(std::time::Instant::now);
     let session = unsafe {
-        shm::leader_setup(
+        shm::leader_setup_with_drain_budget(
             coordinate,
             n_procs,
             mpp_queue_size(),
             &dispatch_payload,
+            drain_buffer_budget_bytes,
             wakeup,
             token,
             interrupt,
@@ -381,12 +386,22 @@ pub unsafe fn worker_setup(
     let interrupt: Arc<dyn Interrupt> = Arc::new(PgInterrupt);
     // Register before the transport starts polling, so a producer racing ahead sees a valid token.
     let token = unsafe { self_receiver_token() };
+    let drain_buffer_budget_bytes = Some(unsafe { pg_sys::work_mem as usize * 1024 });
     // Same backend-thread story as `leader_setup`: this runs on the parallel-worker backend
     // before tokio starts.
     let t_setup = crate::gucs::mpp_trace().then(std::time::Instant::now);
-    let session =
-        unsafe { shm::worker_setup(coordinate, region_total, proc_idx, wakeup, token, interrupt) }
-            .map_err(|e| e.to_string())?;
+    let session = unsafe {
+        shm::worker_setup_with_drain_budget(
+            coordinate,
+            region_total,
+            proc_idx,
+            drain_buffer_budget_bytes,
+            wakeup,
+            token,
+            interrupt,
+        )
+    }
+    .map_err(|e| e.to_string())?;
     if let Some(t) = t_setup {
         pgrx::warning!(
             "mpp trace: worker_setup (attach) took {:.3} ms",


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5881
- Stacked on [paradedb/datafusion-distributed#82](https://github.com/paradedb/datafusion-distributed/pull/82)

## What

Caps each MPP process's shared-memory drain buffers at PostgreSQL's `work_mem` limit.

## Why

Cooperative drain buffers were unbounded, so broadcast-heavy MPP queries could accumulate batches until the backend or host ran out of memory. The drain cannot block when full because that would recreate the symmetric-send deadlock it exists to prevent.

## How

- Passes `work_mem` in bytes to the leader and worker shm setup paths.
- Uses the dedicated drain-buffer memory budget introduced by the stacked `datafusion-distributed` PR.
- Fails the affected channel with a resource-exhausted query error when the budget is exceeded while allowing cooperative draining to continue.

## Tests

- `cargo check -p pg_search`
- Repository pre-commit hooks (`fmt`, `clippy`, `cargo check`, and `cargo doc`)

Made with [Cursor](https://cursor.com)