### PR TITLE
feat: computed global partition boundaries for `CREATE INDEX`.

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -679,7 +679,9 @@ pub fn index_memory_segment(
     mvcc_style: &MvccSatisfies,
 ) -> anyhow::Result<RamDirectory> {
     use crate::index::writer::index::SerialIndexWriter;
-    use crate::postgres::utils::{row_to_search_document, u64_to_item_pointer};
+    use crate::postgres::utils::{
+        resolve_field_value, row_to_search_document, u64_to_item_pointer,
+    };
     use pgrx::{
         PgTupleDesc,
         pg_sys::{
@@ -947,26 +949,16 @@ pub fn index_memory_segment(
             );
 
             row_to_search_document(
-                categorized_fields
-                    .iter()
-                    .map(|(field, categorized)| match categorized.source {
-                        FieldSource::Heap { attno } => {
-                            (values[attno], isnull[attno], field, categorized)
-                        }
-                        FieldSource::Expression { att_idx } => {
-                            let (datum, is_null) = expr_results[att_idx];
-                            (datum, is_null, field, categorized)
-                        }
-                        FieldSource::CompositeField {
-                            expression_idx,
-                            field_idx,
-                            ..
-                        } => {
-                            let (datum, is_null) =
-                                unpacked_composites.get(expression_idx, field_idx);
-                            (datum, is_null, field, categorized)
-                        }
-                    }),
+                categorized_fields.iter().map(|(field, categorized)| {
+                    let (datum, is_null) = resolve_field_value(
+                        &categorized.source,
+                        &values,
+                        &isnull,
+                        &expr_results,
+                        &unpacked_composites,
+                    );
+                    (datum, is_null, field, categorized)
+                }),
                 &mut doc,
                 created_by_version,
             )

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -1,0 +1,718 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Recursive partitioning of the space spanned by an index's `partition_by` fields.
+//!
+//! A [`KdTree`] is an ephemeral routing structure. `CREATE INDEX` builds one on the leader from
+//! a sample of the heap and hands it to every parallel worker, so that all workers cut their
+//! output segments on the same global boundaries. It is never persisted: workers record the
+//! bounding box of each segment they write, and later merges rebuild a routing tree from that
+//! per-segment metadata.
+
+// The routing API is consumed by the partitioned build path, which lands separately.
+#![allow(dead_code)]
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::ops::Bound;
+
+use serde::{Deserialize, Serialize};
+
+use crate::api::FieldName;
+use crate::postgres::pdb_owned_value::PdbOwnedValue;
+use crate::scan::range_partitioning::RangePartitioning;
+
+/// One row projected onto the `partition_by` fields, in the same order as [`KdTree::dims`].
+pub type Point = Vec<PdbOwnedValue>;
+
+/// A binary tree of single-dimension splits whose leaves are the partitions.
+///
+/// Routing rules, shared with [`RangePartitioning::partition_bounds`] so that a one-dimensional
+/// tree and a `RangePartitioning` over the same split points agree on every row:
+///
+/// - at a split on `dim` with value `v`, a row goes left when its value is NULL or `< v`,
+///   and right when it is `>= v`;
+/// - partitions are numbered in left-to-right (in-order) leaf order, so partition 0 holds
+///   the NULLs of the dimension split at the root.
+///
+/// Every leaf therefore covers a half-open bounding box, lower-inclusive and upper-exclusive
+/// on each dimension it was split on, and unbounded on the rest.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KdTree {
+    dims: Vec<FieldName>,
+    root: KdNode,
+    partitions: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum KdNode {
+    Leaf {
+        partition: usize,
+    },
+    Split {
+        dim: usize,
+        #[serde(with = "wire_value")]
+        value: PdbOwnedValue,
+        left: Box<KdNode>,
+        right: Box<KdNode>,
+    },
+}
+
+/// `PdbOwnedValue`'s own serde form goes through tantivy's untagged `OwnedValue`, which turns
+/// every non-negative `I64` into a `U64` on the way back. A split value that changed variant
+/// would no longer compare like the column it came from, so split values travel tagged.
+mod wire_value {
+    use std::net::Ipv6Addr;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::Error};
+
+    use crate::postgres::datetime::PostgresDateTime;
+    use crate::postgres::pdb_owned_value::PdbOwnedValue;
+
+    #[derive(Serialize, Deserialize)]
+    enum WireValue {
+        Str(String),
+        U64(u64),
+        I64(i64),
+        F64(f64),
+        Bool(bool),
+        Date(PostgresDateTime),
+        Bytes(Vec<u8>),
+        IpAddr(Ipv6Addr),
+    }
+
+    pub fn serialize<S: Serializer>(value: &PdbOwnedValue, s: S) -> Result<S::Ok, S::Error> {
+        let wire = match value {
+            PdbOwnedValue::Str(v) => WireValue::Str(v.clone()),
+            PdbOwnedValue::U64(v) => WireValue::U64(*v),
+            PdbOwnedValue::I64(v) => WireValue::I64(*v),
+            PdbOwnedValue::F64(v) => WireValue::F64(*v),
+            PdbOwnedValue::Bool(v) => WireValue::Bool(*v),
+            PdbOwnedValue::Date(v) => WireValue::Date(*v),
+            PdbOwnedValue::Bytes(v) => WireValue::Bytes(v.clone()),
+            PdbOwnedValue::IpAddr(v) => WireValue::IpAddr(*v),
+            other => {
+                return Err(S::Error::custom(format!(
+                    "unsupported partition split value: {other:?}"
+                )));
+            }
+        };
+        wire.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<PdbOwnedValue, D::Error> {
+        Ok(match WireValue::deserialize(d)? {
+            WireValue::Str(v) => PdbOwnedValue::Str(v),
+            WireValue::U64(v) => PdbOwnedValue::U64(v),
+            WireValue::I64(v) => PdbOwnedValue::I64(v),
+            WireValue::F64(v) => PdbOwnedValue::F64(v),
+            WireValue::Bool(v) => PdbOwnedValue::Bool(v),
+            WireValue::Date(v) => PdbOwnedValue::Date(v),
+            WireValue::Bytes(v) => PdbOwnedValue::Bytes(v),
+            WireValue::IpAddr(v) => PdbOwnedValue::IpAddr(v),
+        })
+    }
+}
+
+/// The half-open range a partition covers on one dimension.
+pub type DimBounds = (Bound<PdbOwnedValue>, Bound<PdbOwnedValue>);
+
+impl KdTree {
+    /// A tree with a single partition that every row routes to.
+    pub fn unpartitioned(dims: Vec<FieldName>) -> Self {
+        Self {
+            dims,
+            root: KdNode::Leaf { partition: 0 },
+            partitions: 1,
+        }
+    }
+
+    /// Builds a tree with at most `target_partitions` leaves from a sample of the data.
+    ///
+    /// Each split cuts a box at the quantile that gives both children a share of the sample
+    /// proportional to the number of leaves they will hold, so leaves come out with roughly
+    /// equal row counts even when `target_partitions` is not a power of two. The dimension to
+    /// cut is the one whose values inside the box still span the widest slice of that
+    /// dimension's global distribution (measured by rank, so dimensions of different types are
+    /// comparable); ties go to the earlier `partition_by` field. A box whose points are all
+    /// equal on every dimension cannot be cut and stays a leaf, so the tree can end up with
+    /// fewer partitions than requested when the sample has too few distinct values.
+    ///
+    /// Split values are never NULL, so every leaf's box is expressible as plain range bounds.
+    pub fn from_sample(dims: Vec<FieldName>, sample: Vec<Point>, target_partitions: usize) -> Self {
+        let ndims = dims.len();
+        debug_assert!(
+            sample.iter().all(|p| p.len() == ndims),
+            "every sample point must have one value per partition_by field"
+        );
+        if target_partitions <= 1 || sample.len() < 2 || ndims == 0 {
+            return Self::unpartitioned(dims);
+        }
+
+        let ranks = global_ranks(&sample, ndims);
+        let mut idx: Vec<usize> = (0..sample.len()).collect();
+        let mut builder = Builder {
+            sample: &sample,
+            ranks: &ranks,
+            next_partition: 0,
+        };
+        let root = builder.build(&mut idx, target_partitions);
+        Self {
+            dims,
+            root,
+            partitions: builder.next_partition,
+        }
+    }
+
+    /// The `partition_by` fields, in the order [`Point`]s must be laid out.
+    pub fn dims(&self) -> &[FieldName] {
+        &self.dims
+    }
+
+    pub fn partition_count(&self) -> usize {
+        self.partitions
+    }
+
+    /// The partition a row belongs to. `values` must be laid out like [`Self::dims`].
+    pub fn route(&self, values: &[PdbOwnedValue]) -> usize {
+        debug_assert_eq!(values.len(), self.dims.len());
+        let mut node = &self.root;
+        loop {
+            match node {
+                KdNode::Leaf { partition } => return *partition,
+                KdNode::Split {
+                    dim,
+                    value,
+                    left,
+                    right,
+                } => {
+                    node = if goes_left(&values[*dim], value) {
+                        left
+                    } else {
+                        right
+                    };
+                }
+            }
+        }
+    }
+
+    /// The bounding box of `partition`, one half-open range per dimension of [`Self::dims`].
+    ///
+    /// Returns `None` when `partition` is out of range.
+    pub fn partition_bounds(&self, partition: usize) -> Option<Vec<DimBounds>> {
+        let mut bounds = vec![(Bound::Unbounded, Bound::Unbounded); self.dims.len()];
+        let mut node = &self.root;
+        loop {
+            match node {
+                KdNode::Leaf { partition: p } => {
+                    return (*p == partition).then_some(bounds);
+                }
+                KdNode::Split {
+                    dim,
+                    value,
+                    left,
+                    right,
+                } => {
+                    // Leaves are numbered in-order, so the highest partition in the left
+                    // subtree is one below the lowest in the right subtree.
+                    if partition < first_partition(right) {
+                        bounds[*dim].1 = Bound::Excluded(value.clone());
+                        node = left;
+                    } else {
+                        bounds[*dim].0 = Bound::Included(value.clone());
+                        node = right;
+                    }
+                }
+            }
+        }
+    }
+
+    /// For a tree over a single field, the equivalent [`RangePartitioning`]: its split points
+    /// are this tree's split values in ascending order, and both route every row identically.
+    pub fn to_range_partitioning(&self) -> Option<RangePartitioning> {
+        if self.dims.len() != 1 {
+            return None;
+        }
+        let mut split_points = Vec::with_capacity(self.partitions.saturating_sub(1));
+        collect_split_values(&self.root, &mut split_points);
+        Some(RangePartitioning {
+            partition_by: self.dims[0].clone(),
+            split_points,
+        })
+    }
+}
+
+impl fmt::Display for KdTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let dims = self
+            .dims
+            .iter()
+            .map(|d| d.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "partition_by=[{dims}], partitions={}", self.partitions)?;
+        fmt_node(&self.root, self, 0, f)
+    }
+}
+
+fn fmt_node(node: &KdNode, tree: &KdTree, depth: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match node {
+        KdNode::Leaf { partition } => write!(f, " -> {partition}"),
+        KdNode::Split {
+            dim,
+            value,
+            left,
+            right,
+        } => {
+            let indent = "  ".repeat(depth);
+            let dim = &tree.dims[*dim];
+            write!(f, "\n{indent}{dim} < {value:?}")?;
+            fmt_node(left, tree, depth + 1, f)?;
+            write!(f, "\n{indent}{dim} >= {value:?}")?;
+            fmt_node(right, tree, depth + 1, f)
+        }
+    }
+}
+
+fn goes_left(value: &PdbOwnedValue, split: &PdbOwnedValue) -> bool {
+    matches!(value, PdbOwnedValue::Null) || value.total_cmp(split) == Ordering::Less
+}
+
+fn first_partition(mut node: &KdNode) -> usize {
+    loop {
+        match node {
+            KdNode::Leaf { partition } => return *partition,
+            KdNode::Split { left, .. } => node = left,
+        }
+    }
+}
+
+fn collect_split_values(node: &KdNode, out: &mut Vec<PdbOwnedValue>) {
+    if let KdNode::Split {
+        value, left, right, ..
+    } = node
+    {
+        collect_split_values(left, out);
+        out.push(value.clone());
+        collect_split_values(right, out);
+    }
+}
+
+/// `ranks[dim][i]` is the position of point `i` in the ascending order of dimension `dim`,
+/// with equal values sharing the position of their first occurrence. Rank spread inside a box
+/// is a type-agnostic, distribution-normalized measure of how much of a dimension the box
+/// still covers.
+fn global_ranks(sample: &[Point], ndims: usize) -> Vec<Vec<usize>> {
+    (0..ndims)
+        .map(|dim| {
+            let mut order: Vec<usize> = (0..sample.len()).collect();
+            order.sort_by(|&a, &b| sample[a][dim].total_cmp(&sample[b][dim]));
+            let mut ranks = vec![0; sample.len()];
+            let mut rank = 0;
+            for (pos, &i) in order.iter().enumerate() {
+                if pos > 0
+                    && sample[order[pos - 1]][dim].total_cmp(&sample[i][dim]) != Ordering::Equal
+                {
+                    rank = pos;
+                }
+                ranks[i] = rank;
+            }
+            ranks
+        })
+        .collect()
+}
+
+struct Builder<'a> {
+    sample: &'a [Point],
+    ranks: &'a [Vec<usize>],
+    next_partition: usize,
+}
+
+impl Builder<'_> {
+    fn leaf(&mut self) -> KdNode {
+        let partition = self.next_partition;
+        self.next_partition += 1;
+        KdNode::Leaf { partition }
+    }
+
+    /// Cuts the box holding the points in `idx` into at most `k` leaves.
+    fn build(&mut self, idx: &mut [usize], k: usize) -> KdNode {
+        if k <= 1 || idx.len() < 2 {
+            return self.leaf();
+        }
+        let Some(dim) = self.widest_dim(idx) else {
+            return self.leaf();
+        };
+
+        idx.sort_by(|&a, &b| self.sample[a][dim].total_cmp(&self.sample[b][dim]));
+
+        let k_left = k / 2;
+        let target = idx.len() * k_left / k;
+        let Some(cut) = self.nearest_cut(idx, dim, target) else {
+            return self.leaf();
+        };
+        let value = self.sample[idx[cut]][dim].clone();
+
+        let (left_idx, right_idx) = idx.split_at_mut(cut);
+        let before = self.next_partition;
+        let left = self.build(left_idx, k_left);
+        // A left subtree that ran out of distinct values hands its unused leaves to the right.
+        let k_right = k - (self.next_partition - before);
+        let right = self.build(right_idx, k_right);
+        KdNode::Split {
+            dim,
+            value,
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    /// The dimension whose values inside the box span the largest rank range, or `None` when
+    /// the box is a single point on every dimension.
+    fn widest_dim(&self, idx: &[usize]) -> Option<usize> {
+        let mut best: Option<(usize, usize)> = None;
+        for (dim, ranks) in self.ranks.iter().enumerate() {
+            let (min, max) = idx.iter().fold((usize::MAX, 0), |(lo, hi), &i| {
+                (lo.min(ranks[i]), hi.max(ranks[i]))
+            });
+            let spread = max - min;
+            if spread > 0 && best.is_none_or(|(_, s)| spread > s) {
+                best = Some((dim, spread));
+            }
+        }
+        best.map(|(dim, _)| dim)
+    }
+
+    /// The position in `idx` (sorted on `dim`) closest to `target` where the value changes,
+    /// so that both sides of the cut are non-empty and the split value is the smallest value
+    /// on the right. NULLs sort first and are all equal, so the value at a cut is never NULL.
+    fn nearest_cut(&self, idx: &[usize], dim: usize, target: usize) -> Option<usize> {
+        let changes = |pos: usize| {
+            self.sample[idx[pos - 1]][dim].total_cmp(&self.sample[idx[pos]][dim]) != Ordering::Equal
+        };
+        let target = target.clamp(1, idx.len() - 1);
+        let below = (1..=target).rev().find(|&pos| changes(pos));
+        let above = (target + 1..idx.len()).find(|&pos| changes(pos));
+        match (below, above) {
+            (Some(b), Some(a)) => Some(if target - b <= a - target { b } else { a }),
+            (Some(b), None) => Some(b),
+            (None, Some(a)) => Some(a),
+            (None, None) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dims(names: &[&str]) -> Vec<FieldName> {
+        names
+            .iter()
+            .map(|n| FieldName::from(n.to_string()))
+            .collect()
+    }
+
+    fn i64s(values: impl IntoIterator<Item = i64>) -> Vec<Point> {
+        values
+            .into_iter()
+            .map(|v| vec![PdbOwnedValue::I64(v)])
+            .collect()
+    }
+
+    fn contains(bounds: &[DimBounds], point: &[PdbOwnedValue]) -> bool {
+        bounds.iter().zip(point).all(|((lo, hi), v)| {
+            let above_lo = match lo {
+                Bound::Unbounded => true,
+                Bound::Included(l) => {
+                    !matches!(v, PdbOwnedValue::Null) && v.total_cmp(l) != Ordering::Less
+                }
+                Bound::Excluded(_) => unreachable!("lower bounds are inclusive"),
+            };
+            let below_hi = match hi {
+                Bound::Unbounded => true,
+                Bound::Excluded(h) => {
+                    matches!(v, PdbOwnedValue::Null) || v.total_cmp(h) == Ordering::Less
+                }
+                Bound::Included(_) => unreachable!("upper bounds are exclusive"),
+            };
+            above_lo && below_hi
+        })
+    }
+
+    /// Every sample point routes to a leaf whose box contains it, and every partition id is
+    /// reachable.
+    fn check_invariants(tree: &KdTree, sample: &[Point]) {
+        let mut seen = vec![0usize; tree.partition_count()];
+        for point in sample {
+            let p = tree.route(point);
+            let bounds = tree.partition_bounds(p).expect("partition in range");
+            assert!(
+                contains(&bounds, point),
+                "{point:?} not in bounds of partition {p}: {bounds:?}"
+            );
+            seen[p] += 1;
+        }
+        assert!(
+            seen.iter().all(|&n| n > 0),
+            "empty partitions: {seen:?}\n{tree}"
+        );
+        assert!(tree.partition_bounds(tree.partition_count()).is_none());
+    }
+
+    #[test]
+    fn one_dim_uniform_hits_target_and_balances() {
+        let sample = i64s(0..1000);
+        let tree = KdTree::from_sample(dims(&["id"]), sample.clone(), 4);
+        assert_eq!(tree.partition_count(), 4);
+        check_invariants(&tree, &sample);
+
+        let rp = tree.to_range_partitioning().unwrap();
+        assert_eq!(
+            rp.split_points,
+            vec![
+                PdbOwnedValue::I64(250),
+                PdbOwnedValue::I64(500),
+                PdbOwnedValue::I64(750)
+            ]
+        );
+    }
+
+    #[test]
+    fn non_power_of_two_targets_are_exact_and_balanced() {
+        let sample = i64s(0..3000);
+        for target in [2, 3, 5, 6, 7, 11, 16, 30] {
+            let tree = KdTree::from_sample(dims(&["id"]), sample.clone(), target);
+            assert_eq!(tree.partition_count(), target, "{tree}");
+            check_invariants(&tree, &sample);
+
+            let mut counts = vec![0usize; target];
+            for p in &sample {
+                counts[tree.route(p)] += 1;
+            }
+            let ideal = sample.len() / target;
+            for c in counts {
+                assert!(
+                    c.abs_diff(ideal) <= 1,
+                    "target={target}: counts off ideal {ideal}: {c}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn heavy_duplicates_never_produce_empty_partitions() {
+        // 90% of the rows share one value; the rest are spread out.
+        let mut sample = i64s(std::iter::repeat_n(0, 900));
+        sample.extend(i64s(1..101));
+        let tree = KdTree::from_sample(dims(&["k"]), sample.clone(), 8);
+        assert!(tree.partition_count() <= 8);
+        assert!(tree.partition_count() >= 2, "{tree}");
+        check_invariants(&tree, &sample);
+        // The zeros cannot be split, so they all land in partition 0.
+        assert_eq!(tree.route(&[PdbOwnedValue::I64(0)]), 0);
+    }
+
+    #[test]
+    fn single_distinct_value_stays_one_partition() {
+        let sample = i64s(std::iter::repeat_n(7, 50));
+        let tree = KdTree::from_sample(dims(&["k"]), sample.clone(), 4);
+        assert_eq!(tree.partition_count(), 1);
+        check_invariants(&tree, &sample);
+    }
+
+    #[test]
+    fn degenerate_inputs_are_unpartitioned() {
+        for (sample, target) in [
+            (vec![], 4),
+            (i64s(0..1), 4),
+            (i64s(0..100), 1),
+            (i64s(0..100), 0),
+        ] {
+            let tree = KdTree::from_sample(dims(&["k"]), sample, target);
+            assert_eq!(tree.partition_count(), 1);
+            assert_eq!(tree.route(&[PdbOwnedValue::I64(42)]), 0);
+            assert_eq!(
+                tree.partition_bounds(0).unwrap(),
+                vec![(Bound::Unbounded, Bound::Unbounded)]
+            );
+        }
+    }
+
+    #[test]
+    fn nulls_route_to_the_lowest_partition_and_never_split() {
+        let mut sample = i64s(0..800);
+        sample.extend(std::iter::repeat_n(vec![PdbOwnedValue::Null], 200));
+        let tree = KdTree::from_sample(dims(&["k"]), sample.clone(), 4);
+        assert_eq!(tree.partition_count(), 4);
+        check_invariants(&tree, &sample);
+        assert_eq!(tree.route(&[PdbOwnedValue::Null]), 0);
+        let rp = tree.to_range_partitioning().unwrap();
+        assert!(
+            rp.split_points
+                .iter()
+                .all(|v| !matches!(v, PdbOwnedValue::Null))
+        );
+    }
+
+    #[test]
+    fn one_dim_tree_matches_range_partitioning_semantics() {
+        let mut sample = i64s((0..500).map(|i| i * 3));
+        sample.extend(std::iter::repeat_n(vec![PdbOwnedValue::Null], 20));
+        let tree = KdTree::from_sample(dims(&["k"]), sample, 5);
+        let rp = tree.to_range_partitioning().unwrap();
+        assert_eq!(rp.split_points.len(), tree.partition_count() - 1);
+
+        // Probe values on, around, and away from every split point, plus NULL.
+        let mut probes = vec![
+            PdbOwnedValue::Null,
+            PdbOwnedValue::I64(-1),
+            PdbOwnedValue::I64(10_000),
+        ];
+        for sp in &rp.split_points {
+            let PdbOwnedValue::I64(v) = sp else {
+                unreachable!()
+            };
+            probes.extend([v - 1, *v, v + 1].map(PdbOwnedValue::I64));
+        }
+        for probe in probes {
+            let expected = if matches!(probe, PdbOwnedValue::Null) {
+                0
+            } else {
+                // Partition i holds [split[i-1], split[i]).
+                rp.split_points
+                    .iter()
+                    .take_while(|sp| probe.total_cmp(sp) != Ordering::Less)
+                    .count()
+            };
+            assert_eq!(
+                tree.route(std::slice::from_ref(&probe)),
+                expected,
+                "probe {probe:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn two_independent_dims_alternate() {
+        // A 40x40 grid: both dimensions have identical marginals, so the tie-break picks `x`
+        // at the root, after which `y` spans the full range in each half and gets cut next.
+        let mut sample = Vec::new();
+        for x in 0..40 {
+            for y in 0..40 {
+                sample.push(vec![PdbOwnedValue::I64(x), PdbOwnedValue::I64(y)]);
+            }
+        }
+        let tree = KdTree::from_sample(dims(&["x", "y"]), sample.clone(), 4);
+        assert_eq!(tree.partition_count(), 4);
+        check_invariants(&tree, &sample);
+        assert!(tree.to_range_partitioning().is_none());
+
+        // Each quadrant is bounded on both dimensions.
+        for p in 0..4 {
+            let bounds = tree.partition_bounds(p).unwrap();
+            let bounded = |b: &DimBounds| !matches!(b, (Bound::Unbounded, Bound::Unbounded));
+            assert!(
+                bounds.iter().all(bounded),
+                "partition {p}: {bounds:?}\n{tree}"
+            );
+        }
+        assert_eq!(
+            tree.partition_bounds(0).unwrap(),
+            vec![
+                (Bound::Unbounded, Bound::Excluded(PdbOwnedValue::I64(20))),
+                (Bound::Unbounded, Bound::Excluded(PdbOwnedValue::I64(20))),
+            ]
+        );
+    }
+
+    #[test]
+    fn correlated_dims_are_cut_on_the_first_declared() {
+        // `y` is a function of `x`, so cutting `x` also narrows `y`; the tie-break keeps
+        // choosing `x`, and every leaf still has a disjoint `y` range through its `x` bounds.
+        let sample: Vec<Point> = (0..1000)
+            .map(|x| vec![PdbOwnedValue::I64(x), PdbOwnedValue::I64(x * 2)])
+            .collect();
+        let tree = KdTree::from_sample(dims(&["x", "y"]), sample.clone(), 8);
+        assert_eq!(tree.partition_count(), 8);
+        check_invariants(&tree, &sample);
+        for p in 0..8 {
+            let bounds = tree.partition_bounds(p).unwrap();
+            assert_eq!(bounds[1], (Bound::Unbounded, Bound::Unbounded), "{tree}");
+        }
+    }
+
+    #[test]
+    fn skewed_dim_yields_to_the_wider_one() {
+        // `id` is unique and wider, so the root cuts it; each half still holds both tenants,
+        // so the next cut is on `tenant`, after which its spread is 0 and `id` takes the rest.
+        let sample: Vec<Point> = (0..1000)
+            .map(|i| vec![PdbOwnedValue::I64(i % 2), PdbOwnedValue::I64(i)])
+            .collect();
+        let tree = KdTree::from_sample(dims(&["tenant", "id"]), sample.clone(), 8);
+        assert_eq!(tree.partition_count(), 8);
+        check_invariants(&tree, &sample);
+        let tenant_bounds: Vec<_> = (0..8)
+            .map(|p| tree.partition_bounds(p).unwrap()[0].clone())
+            .collect();
+        assert!(
+            tenant_bounds
+                .iter()
+                .all(|b| b != &(Bound::Unbounded, Bound::Unbounded))
+        );
+    }
+
+    #[test]
+    fn mixed_types_and_serde_round_trip() {
+        let sample: Vec<Point> = (0..300)
+            .map(|i| {
+                vec![
+                    PdbOwnedValue::Str(format!("user-{:04}", i % 37)),
+                    PdbOwnedValue::F64(i as f64 / 7.0),
+                    PdbOwnedValue::Bool(i % 3 == 0),
+                    PdbOwnedValue::I64(i),
+                ]
+            })
+            .collect();
+        let tree = KdTree::from_sample(dims(&["name", "score", "flag", "id"]), sample.clone(), 6);
+        assert_eq!(tree.partition_count(), 6, "{tree}");
+        check_invariants(&tree, &sample);
+
+        // The tree carries an `I64` split (`id` is unique, so it is the widest dimension); the
+        // round trip must hand it back as `I64`, not as tantivy's untagged `U64`.
+        let bytes = serde_json::to_vec(&tree).unwrap();
+        let back: KdTree = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(back, tree);
+        for p in &sample {
+            assert_eq!(back.route(p), tree.route(p));
+        }
+    }
+
+    #[test]
+    fn display_lists_every_split_and_leaf() {
+        let tree = KdTree::from_sample(dims(&["id"]), i64s(0..100), 3);
+        let text = tree.to_string();
+        assert!(
+            text.starts_with("partition_by=[id], partitions=3"),
+            "{text}"
+        );
+        for p in 0..3 {
+            assert!(text.contains(&format!("-> {p}")), "{text}");
+        }
+        assert_eq!(text.matches("id <").count(), 2, "{text}");
+    }
+}

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -66,75 +66,11 @@ enum KdNode {
     },
     Split {
         dim: usize,
-        #[serde(with = "wire_value")]
+        #[serde(with = "crate::postgres::pdb_owned_value::exact_scalar_wire")]
         value: PdbOwnedValue,
         left: Box<KdNode>,
         right: Box<KdNode>,
     },
-}
-
-/// `PdbOwnedValue`'s own serde form goes through tantivy's untagged `OwnedValue`, which turns
-/// every non-negative `I64` into a `U64` on the way back. A split value that changed variant
-/// would no longer compare like the column it came from, so split values travel tagged.
-///
-/// Dates travel as their raw microsecond count. Their string form goes through Postgres's
-/// datetime output, which the tree must not depend on: it is also built and tested outside a
-/// backend.
-mod wire_value {
-    use std::net::Ipv6Addr;
-
-    use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser};
-
-    use crate::postgres::datetime::PostgresDateTime;
-    use crate::postgres::pdb_owned_value::PdbOwnedValue;
-
-    #[derive(Serialize, Deserialize)]
-    enum WireValue {
-        Str(String),
-        U64(u64),
-        I64(i64),
-        Bool(bool),
-        Date(i64),
-        // `f64::to_bits`, so `NaN` and the infinities survive any codec, text or binary.
-        F64Bits(u64),
-        Bytes(Vec<u8>),
-        IpAddr(Ipv6Addr),
-    }
-
-    pub fn serialize<S: Serializer>(value: &PdbOwnedValue, s: S) -> Result<S::Ok, S::Error> {
-        let wire = match value {
-            PdbOwnedValue::Str(v) => WireValue::Str(v.clone()),
-            PdbOwnedValue::U64(v) => WireValue::U64(*v),
-            PdbOwnedValue::I64(v) => WireValue::I64(*v),
-            PdbOwnedValue::F64(v) => WireValue::F64Bits(v.to_bits()),
-            PdbOwnedValue::Bool(v) => WireValue::Bool(*v),
-            PdbOwnedValue::Date(v) => WireValue::Date(v.into_inner()),
-            PdbOwnedValue::Bytes(v) => WireValue::Bytes(v.clone()),
-            PdbOwnedValue::IpAddr(v) => WireValue::IpAddr(*v),
-            other => {
-                return Err(ser::Error::custom(format!(
-                    "unsupported partition split value: {other:?}"
-                )));
-            }
-        };
-        wire.serialize(s)
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<PdbOwnedValue, D::Error> {
-        Ok(match WireValue::deserialize(d)? {
-            WireValue::Str(v) => PdbOwnedValue::Str(v),
-            WireValue::U64(v) => PdbOwnedValue::U64(v),
-            WireValue::I64(v) => PdbOwnedValue::I64(v),
-            WireValue::F64Bits(v) => PdbOwnedValue::F64(f64::from_bits(v)),
-            WireValue::Bool(v) => PdbOwnedValue::Bool(v),
-            WireValue::Date(v) => PdbOwnedValue::Date(
-                PostgresDateTime::try_from_raw(v)
-                    .map_err(|e| de::Error::custom(format!("invalid split date: {e:?}")))?,
-            ),
-            WireValue::Bytes(v) => PdbOwnedValue::Bytes(v),
-            WireValue::IpAddr(v) => PdbOwnedValue::IpAddr(v),
-        })
-    }
 }
 
 /// The half-open range a partition covers on one dimension.

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -33,8 +33,8 @@ use std::ops::Bound;
 use serde::{Deserialize, Serialize};
 
 use crate::api::FieldName;
+use crate::postgres::datetime::PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
-use crate::postgres::types::TantivyValue;
 use crate::scan::range_partitioning::RangePartitioning;
 
 /// One row projected onto the `partition_by` fields, in the same order as [`KdTree::dims`].
@@ -76,10 +76,14 @@ enum KdNode {
 /// `PdbOwnedValue`'s own serde form goes through tantivy's untagged `OwnedValue`, which turns
 /// every non-negative `I64` into a `U64` on the way back. A split value that changed variant
 /// would no longer compare like the column it came from, so split values travel tagged.
+///
+/// Dates travel as their raw microsecond count. Their string form goes through Postgres's
+/// datetime output, which the tree must not depend on: it is also built and tested outside a
+/// backend.
 mod wire_value {
     use std::net::Ipv6Addr;
 
-    use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::Error};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser};
 
     use crate::postgres::datetime::PostgresDateTime;
     use crate::postgres::pdb_owned_value::PdbOwnedValue;
@@ -91,7 +95,7 @@ mod wire_value {
         I64(i64),
         F64(f64),
         Bool(bool),
-        Date(PostgresDateTime),
+        Date(i64),
         Bytes(Vec<u8>),
         IpAddr(Ipv6Addr),
     }
@@ -103,11 +107,11 @@ mod wire_value {
             PdbOwnedValue::I64(v) => WireValue::I64(*v),
             PdbOwnedValue::F64(v) => WireValue::F64(*v),
             PdbOwnedValue::Bool(v) => WireValue::Bool(*v),
-            PdbOwnedValue::Date(v) => WireValue::Date(*v),
+            PdbOwnedValue::Date(v) => WireValue::Date(v.into_inner()),
             PdbOwnedValue::Bytes(v) => WireValue::Bytes(v.clone()),
             PdbOwnedValue::IpAddr(v) => WireValue::IpAddr(*v),
             other => {
-                return Err(S::Error::custom(format!(
+                return Err(ser::Error::custom(format!(
                     "unsupported partition split value: {other:?}"
                 )));
             }
@@ -122,7 +126,10 @@ mod wire_value {
             WireValue::I64(v) => PdbOwnedValue::I64(v),
             WireValue::F64(v) => PdbOwnedValue::F64(v),
             WireValue::Bool(v) => PdbOwnedValue::Bool(v),
-            WireValue::Date(v) => PdbOwnedValue::Date(v),
+            WireValue::Date(v) => PdbOwnedValue::Date(
+                PostgresDateTime::try_from_raw(v)
+                    .map_err(|e| de::Error::custom(format!("invalid split date: {e:?}")))?,
+            ),
             WireValue::Bytes(v) => PdbOwnedValue::Bytes(v),
             WireValue::IpAddr(v) => PdbOwnedValue::IpAddr(v),
         })
@@ -291,16 +298,41 @@ impl fmt::Display for BoundsListing<'_> {
                 .expect("partitions are numbered contiguously");
             for (dim, (lower, upper)) in tree.dims.iter().zip(bounds) {
                 match lower {
-                    Bound::Included(v) => write!(f, " {dim}=[{}", TantivyValue(v))?,
+                    Bound::Included(v) => write!(f, " {dim}=[{}", PlainValue(&v))?,
                     _ => write!(f, " {dim}=[..")?,
                 }
                 match upper {
-                    Bound::Excluded(v) => write!(f, ", {})", TantivyValue(v))?,
+                    Bound::Excluded(v) => write!(f, ", {})", PlainValue(&v))?,
                     _ => write!(f, ", ..)")?,
                 }
             }
         }
         Ok(())
+    }
+}
+
+/// Formats a split value for logs without calling into Postgres, so the tree can be printed
+/// (and unit-tested) outside a backend. Dates render in UTC RFC 3339.
+struct PlainValue<'a>(&'a PdbOwnedValue);
+
+impl fmt::Display for PlainValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            PdbOwnedValue::Str(v) => write!(f, "{v:?}"),
+            PdbOwnedValue::U64(v) => write!(f, "{v}"),
+            PdbOwnedValue::I64(v) => write!(f, "{v}"),
+            PdbOwnedValue::F64(v) => write!(f, "{v}"),
+            PdbOwnedValue::Bool(v) => write!(f, "{v}"),
+            PdbOwnedValue::IpAddr(v) => write!(f, "{v}"),
+            PdbOwnedValue::Date(v) => {
+                let unix_micros = v.into_inner() + PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS;
+                match chrono::DateTime::from_timestamp_micros(unix_micros) {
+                    Some(dt) => write!(f, "{}", dt.to_rfc3339()),
+                    None => write!(f, "{v:?}"),
+                }
+            }
+            other => write!(f, "{other:?}"),
+        }
     }
 }
 
@@ -315,9 +347,9 @@ fn fmt_node(node: &KdNode, tree: &KdTree, depth: usize, f: &mut fmt::Formatter<'
         } => {
             let indent = "  ".repeat(depth);
             let dim = &tree.dims[*dim];
-            write!(f, "\n{indent}{dim} < {value:?}")?;
+            write!(f, "\n{indent}{dim} < {}", PlainValue(value))?;
             fmt_node(left, tree, depth + 1, f)?;
-            write!(f, "\n{indent}{dim} >= {value:?}")?;
+            write!(f, "\n{indent}{dim} >= {}", PlainValue(value))?;
             fmt_node(right, tree, depth + 1, f)
         }
     }
@@ -454,6 +486,7 @@ impl Builder<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::postgres::datetime::PostgresDateTime;
 
     fn dims(names: &[&str]) -> Vec<FieldName> {
         names
@@ -720,10 +753,18 @@ mod tests {
                     PdbOwnedValue::F64(i as f64 / 7.0),
                     PdbOwnedValue::Bool(i % 3 == 0),
                     PdbOwnedValue::I64(i),
+                    // One day apart, starting at the Postgres epoch (2000-01-01).
+                    PdbOwnedValue::Date(
+                        PostgresDateTime::try_from_raw(i * 86_400_000_000).unwrap(),
+                    ),
                 ]
             })
             .collect();
-        let tree = KdTree::from_sample(dims(&["name", "score", "flag", "id"]), sample.clone(), 6);
+        let tree = KdTree::from_sample(
+            dims(&["name", "score", "flag", "id", "day"]),
+            sample.clone(),
+            6,
+        );
         assert_eq!(tree.partition_count(), 6, "{tree}");
         check_invariants(&tree, &sample);
 
@@ -766,6 +807,24 @@ mod tests {
              partition 1: x=[.., 20) y=[20, ..)\n\
              partition 2: x=[20, ..) y=[.., 20)\n\
              partition 3: x=[20, ..) y=[20, ..)"
+        );
+
+        // Dates and strings render readably, without a Postgres backend.
+        let sample: Vec<Point> = (0..100)
+            .map(|i| {
+                vec![
+                    PdbOwnedValue::Date(
+                        PostgresDateTime::try_from_raw(i * 86_400_000_000).unwrap(),
+                    ),
+                    PdbOwnedValue::Str(format!("k{:02}", i / 10)),
+                ]
+            })
+            .collect();
+        let tree = KdTree::from_sample(dims(&["day", "key"]), sample, 2);
+        assert_eq!(
+            tree.bounds_listing().to_string(),
+            "partition 0: day=[.., 2000-02-20T00:00:00+00:00) key=[.., ..)\n\
+             partition 1: day=[2000-02-20T00:00:00+00:00, ..) key=[.., ..)"
         );
     }
 }

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -93,9 +93,10 @@ mod wire_value {
         Str(String),
         U64(u64),
         I64(i64),
-        F64(f64),
         Bool(bool),
         Date(i64),
+        // `f64::to_bits`, so `NaN` and the infinities survive any codec, text or binary.
+        F64Bits(u64),
         Bytes(Vec<u8>),
         IpAddr(Ipv6Addr),
     }
@@ -105,7 +106,7 @@ mod wire_value {
             PdbOwnedValue::Str(v) => WireValue::Str(v.clone()),
             PdbOwnedValue::U64(v) => WireValue::U64(*v),
             PdbOwnedValue::I64(v) => WireValue::I64(*v),
-            PdbOwnedValue::F64(v) => WireValue::F64(*v),
+            PdbOwnedValue::F64(v) => WireValue::F64Bits(v.to_bits()),
             PdbOwnedValue::Bool(v) => WireValue::Bool(*v),
             PdbOwnedValue::Date(v) => WireValue::Date(v.into_inner()),
             PdbOwnedValue::Bytes(v) => WireValue::Bytes(v.clone()),
@@ -124,7 +125,7 @@ mod wire_value {
             WireValue::Str(v) => PdbOwnedValue::Str(v),
             WireValue::U64(v) => PdbOwnedValue::U64(v),
             WireValue::I64(v) => PdbOwnedValue::I64(v),
-            WireValue::F64(v) => PdbOwnedValue::F64(v),
+            WireValue::F64Bits(v) => PdbOwnedValue::F64(f64::from_bits(v)),
             WireValue::Bool(v) => PdbOwnedValue::Bool(v),
             WireValue::Date(v) => PdbOwnedValue::Date(
                 PostgresDateTime::try_from_raw(v)
@@ -151,14 +152,16 @@ impl KdTree {
 
     /// Builds a tree with at most `target_partitions` leaves from a sample of the data.
     ///
-    /// Each split cuts a box at the quantile that gives both children a share of the sample
-    /// proportional to the number of leaves they will hold, so leaves come out with roughly
-    /// equal row counts even when `target_partitions` is not a power of two. The dimension to
-    /// cut is the one whose values inside the box still span the widest slice of that
-    /// dimension's global distribution (measured by rank, so dimensions of different types are
-    /// comparable); ties go to the earlier `partition_by` field. A box whose points are all
-    /// equal on every dimension cannot be cut and stays a leaf, so the tree can end up with
-    /// fewer partitions than requested when the sample has too few distinct values.
+    /// Each split goes on the dimension whose values inside the box still span the widest slice
+    /// of that dimension's global distribution (measured by rank, so dimensions of different
+    /// types are comparable); ties go to the earlier `partition_by` field. The cut sits at the
+    /// quantile that gives both children a share of the sample proportional to the leaves they
+    /// will hold, so a single wide dimension splits into roughly equal leaves even when
+    /// `target_partitions` is not a power of two. Leaf sizes can still come out uneven when a
+    /// low-cardinality dimension wins a split: cutting it buys pruning on that dimension, at the
+    /// cost of balance. A box whose points are all equal on every dimension cannot be cut and
+    /// stays a leaf, so the tree can end up with fewer partitions than requested when the sample
+    /// has too few distinct values.
     ///
     /// Split values are never NULL, so every leaf's box is expressible as plain range bounds.
     pub fn from_sample(dims: Vec<FieldName>, sample: Vec<Point>, target_partitions: usize) -> Self {
@@ -325,8 +328,13 @@ impl fmt::Display for PlainValue<'_> {
             PdbOwnedValue::Bool(v) => write!(f, "{v}"),
             PdbOwnedValue::IpAddr(v) => write!(f, "{v}"),
             PdbOwnedValue::Date(v) => {
-                let unix_micros = v.into_inner() + PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS;
-                match chrono::DateTime::from_timestamp_micros(unix_micros) {
+                // `infinity`/`-infinity` timestamps sit at `i64::MIN/MAX`, so the epoch shift
+                // can overflow; fall back to the raw value rather than abort the build.
+                match v
+                    .into_inner()
+                    .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
+                    .and_then(chrono::DateTime::from_timestamp_micros)
+                {
                     Some(dt) => write!(f, "{}", dt.to_rfc3339()),
                     None => write!(f, "{v:?}"),
                 }
@@ -770,11 +778,44 @@ mod tests {
 
         // The tree carries an `I64` split (`id` is unique, so it is the widest dimension); the
         // round trip must hand it back as `I64`, not as tantivy's untagged `U64`.
-        let bytes = serde_json::to_vec(&tree).unwrap();
-        let back: KdTree = serde_json::from_slice(&bytes).unwrap();
+        let bytes = postcard::to_allocvec(&tree).unwrap();
+        let back: KdTree = postcard::from_bytes(&bytes).unwrap();
         assert_eq!(back, tree);
         for p in &sample {
             assert_eq!(back.route(p), tree.route(p));
+        }
+    }
+
+    #[test]
+    fn non_finite_float_split_values_round_trip() {
+        // A float column can hold `Infinity`/`NaN`, and `total_cmp` sorts them to the ends, so
+        // they can become split values. The wire form must reproduce them bit for bit.
+        let mut sample: Vec<Point> = (0..200)
+            .map(|i| vec![PdbOwnedValue::F64(i as f64)])
+            .collect();
+        sample.extend(std::iter::repeat_n(
+            vec![PdbOwnedValue::F64(f64::INFINITY)],
+            50,
+        ));
+        sample.extend(std::iter::repeat_n(
+            vec![PdbOwnedValue::F64(f64::NEG_INFINITY)],
+            50,
+        ));
+        sample.extend(std::iter::repeat_n(vec![PdbOwnedValue::F64(f64::NAN)], 50));
+        let tree = KdTree::from_sample(dims(&["x"]), sample.clone(), 6);
+        check_invariants(&tree, &sample);
+
+        // `PartialEq` treats `NaN != NaN`, so compare the re-serialized bytes rather than the
+        // trees: equal bytes means every split value, `NaN` included, round-tripped bit for bit.
+        let bytes = postcard::to_allocvec(&tree).unwrap();
+        let back: KdTree = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(postcard::to_allocvec(&back).unwrap(), bytes);
+        for probe in [f64::INFINITY, f64::NEG_INFINITY, f64::NAN, 0.0, 199.0] {
+            assert_eq!(
+                back.route(&[PdbOwnedValue::F64(probe)]),
+                tree.route(&[PdbOwnedValue::F64(probe)]),
+                "probe {probe}"
+            );
         }
     }
 

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -23,9 +23,6 @@
 //! bounding box of each segment they write, and later merges rebuild a routing tree from that
 //! per-segment metadata.
 
-// The routing API is consumed by the partitioned build path, which lands separately.
-#![allow(dead_code)]
-
 use std::cmp::Ordering;
 use std::fmt;
 use std::ops::Bound;
@@ -124,7 +121,10 @@ impl KdTree {
         }
     }
 
+    // `dims`, `route`, and `to_range_partitioning` are the routing API the partitioned scan and
+    // merge paths will call. They stay unused here until those land.
     /// The `partition_by` fields, in the order [`Point`]s must be laid out.
+    #[allow(dead_code)]
     pub fn dims(&self) -> &[FieldName] {
         &self.dims
     }
@@ -134,6 +134,7 @@ impl KdTree {
     }
 
     /// The partition a row belongs to. `values` must be laid out like [`Self::dims`].
+    #[allow(dead_code)]
     pub fn route(&self, values: &[PdbOwnedValue]) -> usize {
         debug_assert_eq!(values.len(), self.dims.len());
         let mut node = &self.root;
@@ -195,6 +196,7 @@ impl KdTree {
 
     /// For a tree over a single field, the equivalent [`RangePartitioning`]: its split points
     /// are this tree's split values in ascending order, and both route every row identically.
+    #[allow(dead_code)]
     pub fn to_range_partitioning(&self) -> Option<RangePartitioning> {
         if self.dims.len() != 1 {
             return None;
@@ -268,6 +270,7 @@ fn fmt_node(node: &KdNode, tree: &KdTree, depth: usize, f: &mut fmt::Formatter<'
     }
 }
 
+#[allow(dead_code)] // reached through `route`
 fn goes_left(value: &PdbOwnedValue, split: &PdbOwnedValue) -> bool {
     matches!(value, PdbOwnedValue::Null) || value.total_cmp(split) == Ordering::Less
 }
@@ -281,6 +284,7 @@ fn first_partition(mut node: &KdNode) -> usize {
     }
 }
 
+#[allow(dead_code)] // reached through `to_range_partitioning`
 fn collect_split_values(node: &KdNode, out: &mut Vec<PdbOwnedValue>) {
     if let KdNode::Split {
         value, left, right, ..

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::FieldName;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
+use crate::postgres::types::TantivyValue;
 use crate::scan::range_partitioning::RangePartitioning;
 
 /// One row projected onto the `partition_by` fields, in the same order as [`KdTree::dims`].
@@ -241,6 +242,12 @@ impl KdTree {
         }
     }
 
+    /// One line per partition with its bounding box, for logs: `partition 3: id=[150, 300)
+    /// tenant_id=[.., 42)`. [`Display`](fmt::Display) shows the same tree by its splits instead.
+    pub fn bounds_listing(&self) -> impl fmt::Display + '_ {
+        BoundsListing(self)
+    }
+
     /// For a tree over a single field, the equivalent [`RangePartitioning`]: its split points
     /// are this tree's split values in ascending order, and both route every row identically.
     pub fn to_range_partitioning(&self) -> Option<RangePartitioning> {
@@ -266,6 +273,34 @@ impl fmt::Display for KdTree {
             .join(", ");
         write!(f, "partition_by=[{dims}], partitions={}", self.partitions)?;
         fmt_node(&self.root, self, 0, f)
+    }
+}
+
+struct BoundsListing<'a>(&'a KdTree);
+
+impl fmt::Display for BoundsListing<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let tree = self.0;
+        for partition in 0..tree.partitions {
+            if partition > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "partition {partition}:")?;
+            let bounds = tree
+                .partition_bounds(partition)
+                .expect("partitions are numbered contiguously");
+            for (dim, (lower, upper)) in tree.dims.iter().zip(bounds) {
+                match lower {
+                    Bound::Included(v) => write!(f, " {dim}=[{}", TantivyValue(v))?,
+                    _ => write!(f, " {dim}=[..")?,
+                }
+                match upper {
+                    Bound::Excluded(v) => write!(f, ", {})", TantivyValue(v))?,
+                    _ => write!(f, ", ..)")?,
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -714,5 +749,23 @@ mod tests {
             assert!(text.contains(&format!("-> {p}")), "{text}");
         }
         assert_eq!(text.matches("id <").count(), 2, "{text}");
+    }
+
+    #[test]
+    fn bounds_listing_shows_one_box_per_partition() {
+        let mut sample = Vec::new();
+        for x in 0..40 {
+            for y in 0..40 {
+                sample.push(vec![PdbOwnedValue::I64(x), PdbOwnedValue::I64(y)]);
+            }
+        }
+        let tree = KdTree::from_sample(dims(&["x", "y"]), sample, 4);
+        assert_eq!(
+            tree.bounds_listing().to_string(),
+            "partition 0: x=[.., 20) y=[.., 20)\n\
+             partition 1: x=[.., 20) y=[20, ..)\n\
+             partition 2: x=[20, ..) y=[.., 20)\n\
+             partition 3: x=[20, ..) y=[20, ..)"
+        );
     }
 }

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -33,7 +33,6 @@ use std::ops::Bound;
 use serde::{Deserialize, Serialize};
 
 use crate::api::FieldName;
-use crate::postgres::datetime::PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::scan::range_partitioning::RangePartitioning;
 
@@ -237,46 +236,16 @@ impl fmt::Display for BoundsListing<'_> {
                 .expect("partitions are numbered contiguously");
             for (dim, (lower, upper)) in tree.dims.iter().zip(bounds) {
                 match lower {
-                    Bound::Included(v) => write!(f, " {dim}=[{}", PlainValue(&v))?,
+                    Bound::Included(v) => write!(f, " {dim}=[{}", v.plain_display())?,
                     _ => write!(f, " {dim}=[..")?,
                 }
                 match upper {
-                    Bound::Excluded(v) => write!(f, ", {})", PlainValue(&v))?,
+                    Bound::Excluded(v) => write!(f, ", {})", v.plain_display())?,
                     _ => write!(f, ", ..)")?,
                 }
             }
         }
         Ok(())
-    }
-}
-
-/// Formats a split value for logs without calling into Postgres, so the tree can be printed
-/// (and unit-tested) outside a backend. Dates render in UTC RFC 3339.
-struct PlainValue<'a>(&'a PdbOwnedValue);
-
-impl fmt::Display for PlainValue<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            PdbOwnedValue::Str(v) => write!(f, "{v:?}"),
-            PdbOwnedValue::U64(v) => write!(f, "{v}"),
-            PdbOwnedValue::I64(v) => write!(f, "{v}"),
-            PdbOwnedValue::F64(v) => write!(f, "{v}"),
-            PdbOwnedValue::Bool(v) => write!(f, "{v}"),
-            PdbOwnedValue::IpAddr(v) => write!(f, "{v}"),
-            PdbOwnedValue::Date(v) => {
-                // `infinity`/`-infinity` timestamps sit at `i64::MIN/MAX`, so the epoch shift
-                // can overflow; fall back to the raw value rather than abort the build.
-                match v
-                    .into_inner()
-                    .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
-                    .and_then(chrono::DateTime::from_timestamp_micros)
-                {
-                    Some(dt) => write!(f, "{}", dt.to_rfc3339()),
-                    None => write!(f, "{v:?}"),
-                }
-            }
-            other => write!(f, "{other:?}"),
-        }
     }
 }
 
@@ -291,9 +260,9 @@ fn fmt_node(node: &KdNode, tree: &KdTree, depth: usize, f: &mut fmt::Formatter<'
         } => {
             let indent = "  ".repeat(depth);
             let dim = &tree.dims[*dim];
-            write!(f, "\n{indent}{dim} < {}", PlainValue(value))?;
+            write!(f, "\n{indent}{dim} < {}", value.plain_display())?;
             fmt_node(left, tree, depth + 1, f)?;
-            write!(f, "\n{indent}{dim} >= {}", PlainValue(value))?;
+            write!(f, "\n{indent}{dim} >= {}", value.plain_display())?;
             fmt_node(right, tree, depth + 1, f)
         }
     }

--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod directory;
 pub mod fast_fields_helper;
+pub mod kdtree;
 pub mod merge_policy;
 pub mod reader;
 pub mod search;

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -704,7 +704,11 @@ pub(super) fn build_index(
         plan::adjusted_target_segment_count(&heaprel, &indexrel),
     )?;
     if let Some(partitioning) = &partitioning {
-        pgrx::debug1!("build_index: partition boundaries: {partitioning}");
+        pgrx::debug1!(
+            "build_index: {} partition boundaries:\n{}",
+            partitioning.partition_count(),
+            partitioning.bounds_listing()
+        );
     }
     let partitioning_bytes = match &partitioning {
         Some(partitioning) => serde_json::to_vec(partitioning)?,

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -121,7 +121,7 @@ struct ParallelBuild {
     config: WorkerConfig,
     scandesc: ScanDesc,
     coordination: WorkerCoordination,
-    /// The leader's global partition boundaries, serialized with `serde_json`. Empty when the
+    /// The leader's global partition boundaries, serialized with `postcard`. Empty when the
     /// index has no `partition_by`.
     partitioning: Vec<u8>,
 }
@@ -185,7 +185,7 @@ fn deserialize_partitioning(bytes: &[u8]) -> Option<KdTree> {
         return None;
     }
     Some(
-        serde_json::from_slice(bytes)
+        postcard::from_bytes(bytes)
             .unwrap_or_else(|e| panic!("could not deserialize partition boundaries: {e}")),
     )
 }
@@ -711,7 +711,7 @@ pub(super) fn build_index(
         );
     }
     let partitioning_bytes = match &partitioning {
-        Some(partitioning) => serde_json::to_vec(partitioning)?,
+        Some(partitioning) => postcard::to_allocvec(partitioning)?,
         None => Vec::new(),
     };
 

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -215,8 +215,8 @@ impl ParallelWorker for BuildWorker<'_> {
             .expect("ParallelTableScanDesc should not be NULL");
         let coordination = state_manager
             .object::<WorkerCoordination>(2)
-            .expect("should be able to get ProcessCoordination")
-            .expect("ProcessCoordination should not be NULL");
+            .expect("should be able to get WorkerCoordination")
+            .expect("WorkerCoordination should not be NULL");
         let partitioning = state_manager
             .slice::<u8>(3)
             .expect("should be able to get partitioning bytes")
@@ -697,6 +697,8 @@ pub(super) fn build_index(
     };
 
     // Boundaries are fixed before any worker starts, so every worker cuts on the same ones.
+    // TODO(M3): the target segment count doubles as the partition count for now; rename the
+    // reloption to `partition_count` once partitioned storage lands.
     let partitioning = plan_partition_boundaries(
         &heaprel,
         &indexrel,

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -17,6 +17,7 @@
 
 use crate::api::version::Version;
 use crate::gucs;
+use crate::index::kdtree::KdTree;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::writer::index::{
     DiskSpaceGuard, IndexWriterConfig, Mergeable, SearchIndexMerger, SerialIndexWriter,
@@ -27,6 +28,7 @@ use crate::parallel_worker::{
     ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
     WorkerStyle, chunk_range,
 };
+use crate::postgres::build_partitioning::plan_partition_boundaries;
 use crate::postgres::composite::CompositeSlotValues;
 use crate::postgres::locks::Spinlock;
 use crate::postgres::merge::garbage_collect_index;
@@ -119,6 +121,9 @@ struct ParallelBuild {
     config: WorkerConfig,
     scandesc: ScanDesc,
     coordination: WorkerCoordination,
+    /// The leader's global partition boundaries, serialized with `serde_json`. Empty when the
+    /// index has no `partition_by`.
+    partitioning: Vec<u8>,
 }
 
 impl ParallelState for ScanDesc {
@@ -138,12 +143,9 @@ impl ParallelState for ScanDesc {
 impl ParallelBuild {
     fn new(
         heaprel: &PgSearchRelation,
-        indexrel: &PgSearchRelation,
         snapshot: pg_sys::Snapshot,
-        concurrent: bool,
-        current_xid: pg_sys::FullTransactionId,
-        need_wal: bool,
-        next_xid: pg_sys::FullTransactionId,
+        config: WorkerConfig,
+        partitioning: Vec<u8>,
     ) -> Self {
         let scandesc = unsafe {
             let size = size_of::<pg_sys::ParallelTableScanDescData>()
@@ -153,23 +155,22 @@ impl ParallelBuild {
             (size, scandesc)
         };
         Self {
-            config: WorkerConfig {
-                heaprelid: heaprel.oid(),
-                indexrelid: indexrel.oid(),
-                concurrent,
-                current_xid,
-                need_wal,
-                next_xid,
-            },
+            config,
             scandesc,
             coordination: Default::default(),
+            partitioning,
         }
     }
 }
 
 impl ParallelProcess for ParallelBuild {
     fn state_values(&self) -> Vec<&dyn ParallelState> {
-        vec![&self.config, &self.scandesc, &self.coordination]
+        vec![
+            &self.config,
+            &self.scandesc,
+            &self.coordination,
+            &self.partitioning,
+        ]
     }
 }
 
@@ -179,12 +180,24 @@ struct WorkerResponse {
     nmerges: usize,
 }
 
+fn deserialize_partitioning(bytes: &[u8]) -> Option<KdTree> {
+    if bytes.is_empty() {
+        return None;
+    }
+    Some(
+        serde_json::from_slice(bytes)
+            .unwrap_or_else(|e| panic!("could not deserialize partition boundaries: {e}")),
+    )
+}
+
 struct BuildWorker<'a> {
     config: WorkerConfig,
     table_scan_desc: Option<NonNull<pg_sys::TableScanDescData>>,
     coordination: &'a mut WorkerCoordination,
     heaprel: PgSearchRelation,
     indexrel: PgSearchRelation,
+    /// Global partition boundaries computed by the leader; `None` without `partition_by`.
+    partitioning: Option<KdTree>,
 }
 
 impl ParallelWorker for BuildWorker<'_> {
@@ -204,6 +217,11 @@ impl ParallelWorker for BuildWorker<'_> {
             .object::<WorkerCoordination>(2)
             .expect("should be able to get ProcessCoordination")
             .expect("ProcessCoordination should not be NULL");
+        let partitioning = state_manager
+            .slice::<u8>(3)
+            .expect("should be able to get partitioning bytes")
+            .expect("partitioning bytes should not be NULL");
+        let partitioning = deserialize_partitioning(partitioning);
 
         unsafe {
             let (heap_lock, index_lock) = if !config.concurrent {
@@ -227,6 +245,7 @@ impl ParallelWorker for BuildWorker<'_> {
                 coordination,
                 heaprel,
                 indexrel,
+                partitioning,
             }
         }
     }
@@ -252,6 +271,7 @@ impl<'a> BuildWorker<'a> {
         indexrel: &PgSearchRelation,
         config: WorkerConfig,
         coordination: &'a mut WorkerCoordination,
+        partitioning: Option<KdTree>,
     ) -> Self {
         Self {
             config,
@@ -259,6 +279,7 @@ impl<'a> BuildWorker<'a> {
             heaprel: Clone::clone(heaprel),
             indexrel: Clone::clone(indexrel),
             coordination,
+            partitioning,
         }
     }
 
@@ -277,6 +298,9 @@ impl<'a> BuildWorker<'a> {
             pgrx::debug1!(
                 "build_worker {worker_number}: target_segment_count: {target_segment_count}, nlaunched: {nlaunched}, worker_segment_target: {worker_segment_target}"
             );
+            if let Some(partitioning) = &self.partitioning {
+                pgrx::debug1!("build_worker {worker_number}: partition boundaries: {partitioning}");
+            }
 
             let mut build_state = WorkerBuildState::new(
                 &self.heaprel,
@@ -663,18 +687,31 @@ pub(super) fn build_index(
         }
     });
 
-    let current_xid = unsafe { pg_sys::GetCurrentFullTransactionId() };
-    let need_wal = indexrel.need_wal();
-    let next_xid = unsafe { pg_sys::ReadNextFullTransactionId() };
-    let process = ParallelBuild::new(
+    let config = WorkerConfig {
+        heaprelid: heaprel.oid(),
+        indexrelid: indexrel.oid(),
+        concurrent,
+        current_xid: unsafe { pg_sys::GetCurrentFullTransactionId() },
+        need_wal: indexrel.need_wal(),
+        next_xid: unsafe { pg_sys::ReadNextFullTransactionId() },
+    };
+
+    // Boundaries are fixed before any worker starts, so every worker cuts on the same ones.
+    let partitioning = plan_partition_boundaries(
         &heaprel,
         &indexrel,
         snapshot.0,
-        concurrent,
-        current_xid,
-        need_wal,
-        next_xid,
-    );
+        plan::adjusted_target_segment_count(&heaprel, &indexrel),
+    )?;
+    if let Some(partitioning) = &partitioning {
+        pgrx::debug1!("build_index: partition boundaries: {partitioning}");
+    }
+    let partitioning_bytes = match &partitioning {
+        Some(partitioning) => serde_json::to_vec(partitioning)?,
+        None => Vec::new(),
+    };
+
+    let process = ParallelBuild::new(&heaprel, snapshot.0, config, partitioning_bytes);
     let nworkers = plan::create_index_nworkers(&heaprel, &indexrel);
     pgrx::debug1!("build_index: asked for {nworkers} workers");
 
@@ -743,25 +780,11 @@ pub(super) fn build_index(
         pgrx::debug1!("build_index: not doing a parallel build");
         // not doing a parallel build, so directly instantiate a BuildWorker and serially run the
         // whole build here in this connected backend
-        let heaprelid = heaprel.oid();
-        let indexrelid = indexrel.oid();
-
         let mut coordination: WorkerCoordination = Default::default();
         coordination.set_nlaunched(1);
 
-        let mut worker = BuildWorker::new(
-            &heaprel,
-            &indexrel,
-            WorkerConfig {
-                heaprelid,
-                indexrelid,
-                concurrent,
-                current_xid,
-                need_wal,
-                next_xid,
-            },
-            &mut coordination,
-        );
+        let mut worker =
+            BuildWorker::new(&heaprel, &indexrel, config, &mut coordination, partitioning);
 
         let (total_tuples, total_merges) = worker.do_build(1, true)?;
         pgrx::debug1!("build_index: total_tuples: {total_tuples}, total_merges: {total_merges}");

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -172,6 +172,8 @@ unsafe fn sample_partition_fields(
 
     let mut sample: Vec<Point> = Vec::new();
     let mut seen_rows = 0usize;
+    let mut indexed_offsets: Vec<pg_sys::OffsetNumber> = Vec::new();
+    let mut result: anyhow::Result<()> = Ok(());
     unsafe {
         while pg_sys::BlockSampler_HasMore(addr_of_mut!(sampler)) {
             check_for_interrupts!();
@@ -184,29 +186,38 @@ unsafe fn sample_partition_fields(
                 pg_sys::ReadBufferMode::RBM_NORMAL,
                 std::ptr::null_mut(),
             );
+
+            // Under the content lock, only test visibility (which also sets hint bits) and record
+            // the offsets to index. Detoast, expression evaluation, and projection run afterward
+            // under the pin alone, so a concurrent writer or a re-entrant index expression never
+            // waits on this page's lock across that work.
             pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32);
             let page = pg_sys::BufferGetPage(buffer);
             let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
+            indexed_offsets.clear();
+            for offset in pg_sys::FirstOffsetNumber..=max_offset {
+                let item_id = pg_sys::PageGetItemId(page, offset);
+                if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
+                    continue;
+                }
+                let mut t_self = pg_sys::ItemPointerData::default();
+                item_pointer_set_all(&mut t_self, blockno, offset);
+                let mut tuple = pg_sys::HeapTupleData {
+                    t_len: (*item_id).lp_len(),
+                    t_self,
+                    t_tableOid: heaprel.oid(),
+                    t_data: pg_sys::PageGetItem(page, item_id).cast(),
+                };
+                if is_indexed(addr_of_mut!(tuple), buffer) {
+                    indexed_offsets.push(offset);
+                }
+            }
+            pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32);
 
-            per_block_context.switch_to(|_| {
-                for offset in pg_sys::FirstOffsetNumber..=max_offset {
-                    let item_id = pg_sys::PageGetItemId(page, offset);
-                    if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
-                        continue;
-                    }
-
-                    let mut t_self = pg_sys::ItemPointerData::default();
-                    item_pointer_set_all(&mut t_self, blockno, offset);
-                    let mut tuple = pg_sys::HeapTupleData {
-                        t_len: (*item_id).lp_len(),
-                        t_self,
-                        t_tableOid: heaprel.oid(),
-                        t_data: pg_sys::PageGetItem(page, item_id).cast(),
-                    };
-                    if !is_indexed(addr_of_mut!(tuple), buffer) {
-                        continue;
-                    }
-
+            // The pin blocks pruning and eviction, so the line pointers and tuple data recorded
+            // above stay valid while we read them here.
+            let block_result = per_block_context.switch_to(|_| {
+                for &offset in &indexed_offsets {
                     // Decide whether this row makes the sample before paying to project it.
                     seen_rows += 1;
                     let target_slot = if sample.len() < MAX_SAMPLE_ROWS {
@@ -219,6 +230,15 @@ unsafe fn sample_partition_fields(
                         Some(j)
                     };
 
+                    let item_id = pg_sys::PageGetItemId(page, offset);
+                    let mut t_self = pg_sys::ItemPointerData::default();
+                    item_pointer_set_all(&mut t_self, blockno, offset);
+                    let mut tuple = pg_sys::HeapTupleData {
+                        t_len: (*item_id).lp_len(),
+                        t_self,
+                        t_tableOid: heaprel.oid(),
+                        t_data: pg_sys::PageGetItem(page, item_id).cast(),
+                    };
                     pg_sys::ExecStoreBufferHeapTuple(addr_of_mut!(tuple), slot, buffer);
                     pg_sys::slot_getallattrs(slot);
                     let values = std::slice::from_raw_parts((*slot).tts_values, natts);
@@ -228,10 +248,11 @@ unsafe fn sample_partition_fields(
                         .map(|state| state.evaluate(slot))
                         .unwrap_or_default();
 
-                    let point = project_row(&fields, values, isnull, &expr_results)?;
-                    // The stored pointer targets this iteration's `tuple`; drop it before that
-                    // goes out of scope.
+                    let point = project_row(&fields, values, isnull, &expr_results);
+                    // The stored pointer targets this iteration's `tuple`; clear it before that
+                    // goes out of scope, on the error path too.
                     pg_sys::ExecClearTuple(slot);
+                    let point = point?;
 
                     match target_slot {
                         None => sample.push(point),
@@ -239,15 +260,19 @@ unsafe fn sample_partition_fields(
                     }
                 }
                 anyhow::Ok(())
-            })?;
+            });
             per_block_context.reset();
-
-            pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32);
             pg_sys::ReleaseBuffer(buffer);
+
+            if let Err(e) = block_result {
+                result = Err(e);
+                break;
+            }
         }
         pg_sys::ExecDropSingleTupleTableSlot(slot);
     }
 
+    result?;
     Ok(sample)
 }
 
@@ -378,7 +403,7 @@ mod tests {
             .unwrap();
         assert_eq!(again, tree);
 
-        // Under 1024 blocks and 30k rows, the sample is the whole table, so every partition
+        // Under 4096 blocks and 30k rows, the sample is the whole table, so every partition
         // gets an equal share of the real rows.
         let counts = route_all(&tree, "sample_src", "id, tenant_id");
         for count in &counts {
@@ -487,5 +512,63 @@ mod tests {
         .unwrap()
         .unwrap();
         assert_eq!(count, 800);
+    }
+
+    /// A wide, externally TOASTed text key plus a timestamp key, with NULLs in both dimensions.
+    /// Confirms the sampler detoasts under the pin, converts a timestamp, and routes NULLs low.
+    #[pg_test]
+    fn boundaries_detoast_text_and_timestamp_keys_with_nulls() {
+        Spi::run(
+            r#"
+            CREATE TABLE sample_wide (id BIGSERIAL PRIMARY KEY, label TEXT, created TIMESTAMP);
+            ALTER TABLE sample_wide ALTER COLUMN label SET STORAGE EXTERNAL;
+            INSERT INTO sample_wide (label, created)
+            SELECT
+                CASE WHEN i % 11 = 0 THEN NULL
+                     ELSE repeat(md5(i::text) || md5((i * 3)::text), 40) || lpad(i::text, 10, '0')
+                END,
+                CASE WHEN i % 7 = 0 THEN NULL
+                     ELSE timestamp '2020-01-01' + make_interval(mins => i)
+                END
+            FROM generate_series(1, 4000) i;
+            CREATE INDEX sample_wide_idx ON sample_wide
+                USING paradedb (id, (label::pdb.literal), created)
+                WITH (key_field = 'id', partition_by = 'label, created');
+            "#,
+        )
+        .unwrap();
+
+        let (heaprel, indexrel) = open_rels("sample_wide", "sample_wide_idx");
+        let tree = plan_partition_boundaries(&heaprel, &indexrel, snapshot_any(), 4)
+            .unwrap()
+            .expect("index declares partition_by");
+        assert_eq!(tree.dims().len(), 2);
+        assert!((2..=4).contains(&tree.partition_count()), "{tree}");
+        // NULLs in both dimensions route to the lowest partition.
+        assert_eq!(tree.route(&[PdbOwnedValue::Null, PdbOwnedValue::Null]), 0);
+
+        // Every `label` split value is a fully detoasted string of the generated width, not a
+        // truncated or corrupt copy. `32 * 2` hex chars, repeated 40 times, plus a 10-char tail.
+        let label_width = 32 * 2 * 40 + 10;
+        let mut saw_label_split = false;
+        for p in 0..tree.partition_count() {
+            for (dim, (lower, upper)) in tree.partition_bounds(p).unwrap().into_iter().enumerate() {
+                for bound in [lower, upper] {
+                    let value = match bound {
+                        std::ops::Bound::Included(v) | std::ops::Bound::Excluded(v) => Some(v),
+                        std::ops::Bound::Unbounded => None,
+                    };
+                    if let Some(PdbOwnedValue::Str(s)) = value {
+                        assert_eq!(dim, 0, "only the label dimension carries string splits");
+                        assert_eq!(s.len(), label_width, "detoasted label has the wrong length");
+                        saw_label_split = true;
+                    }
+                }
+            }
+        }
+        assert!(
+            saw_label_split,
+            "expected at least one label split value: {tree}"
+        );
     }
 }

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -37,9 +37,10 @@ use rand::{RngExt, SeedableRng};
 use crate::api::FieldName;
 use crate::index::kdtree::{KdTree, Point};
 use crate::postgres::composite::CompositeSlotValues;
-use crate::postgres::heap::ExpressionState;
+use crate::postgres::heap::{ExpressionState, HeapBufferPin};
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::rel::PgSearchRelation;
+use crate::postgres::storage::buffer::BorrowedBuffer;
 use crate::postgres::utils::{FieldSource, scalar_datum_to_tantivy_value, unwrap_alias_datum};
 use crate::schema::{CategorizedFieldData, SearchField};
 
@@ -96,45 +97,6 @@ struct SampledField {
     field: SearchField,
     categorized: CategorizedFieldData,
 }
-
-/// Releases the `ReadBufferExtended` pin on drop. `impl_safe_drop!` skips the release while the
-/// thread is unwinding, since the aborting transaction frees the pin itself.
-struct HeapBufferPin(pg_sys::Buffer);
-
-impl HeapBufferPin {
-    unsafe fn read(heaprel: &PgSearchRelation, blockno: pg_sys::BlockNumber) -> Self {
-        Self(pg_sys::ReadBufferExtended(
-            heaprel.as_ptr(),
-            pg_sys::ForkNumber::MAIN_FORKNUM,
-            blockno,
-            pg_sys::ReadBufferMode::RBM_NORMAL,
-            std::ptr::null_mut(),
-        ))
-    }
-
-    fn buffer(&self) -> pg_sys::Buffer {
-        self.0
-    }
-}
-
-crate::impl_safe_drop!(HeapBufferPin, |self| {
-    unsafe { pg_sys::ReleaseBuffer(self.0) };
-});
-
-/// Holds a buffer's shared content lock for its scope, releasing it on drop. The abort path is
-/// covered by `LWLockReleaseAll`, so `impl_safe_drop!` skips the unlock while unwinding.
-struct SharedContentLock(pg_sys::Buffer);
-
-impl SharedContentLock {
-    unsafe fn acquire(buffer: pg_sys::Buffer) -> Self {
-        pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32);
-        Self(buffer)
-    }
-}
-
-crate::impl_safe_drop!(SharedContentLock, |self| {
-    unsafe { pg_sys::LockBuffer(self.0, pg_sys::BUFFER_LOCK_UNLOCK as i32) };
-});
 
 /// Reads a random subset of `heaprel`'s blocks and projects every row the build will index
 /// onto `partition_by`, in that order.
@@ -228,7 +190,7 @@ unsafe fn sample_partition_fields(
             // waits on this page's lock across that work.
             indexed_offsets.clear();
             {
-                let _content_lock = SharedContentLock::acquire(buf);
+                let _content_lock = BorrowedBuffer::from_pg(buf);
                 let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
                 for offset in pg_sys::FirstOffsetNumber..=max_offset {
                     let item_id = pg_sys::PageGetItemId(page, offset);

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -97,6 +97,45 @@ struct SampledField {
     categorized: CategorizedFieldData,
 }
 
+/// Releases the `ReadBufferExtended` pin on drop. `impl_safe_drop!` skips the release while the
+/// thread is unwinding, since the aborting transaction frees the pin itself.
+struct HeapBufferPin(pg_sys::Buffer);
+
+impl HeapBufferPin {
+    unsafe fn read(heaprel: &PgSearchRelation, blockno: pg_sys::BlockNumber) -> Self {
+        Self(pg_sys::ReadBufferExtended(
+            heaprel.as_ptr(),
+            pg_sys::ForkNumber::MAIN_FORKNUM,
+            blockno,
+            pg_sys::ReadBufferMode::RBM_NORMAL,
+            std::ptr::null_mut(),
+        ))
+    }
+
+    fn buffer(&self) -> pg_sys::Buffer {
+        self.0
+    }
+}
+
+crate::impl_safe_drop!(HeapBufferPin, |self| {
+    unsafe { pg_sys::ReleaseBuffer(self.0) };
+});
+
+/// Holds a buffer's shared content lock for its scope, releasing it on drop. The abort path is
+/// covered by `LWLockReleaseAll`, so `impl_safe_drop!` skips the unlock while unwinding.
+struct SharedContentLock(pg_sys::Buffer);
+
+impl SharedContentLock {
+    unsafe fn acquire(buffer: pg_sys::Buffer) -> Self {
+        pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32);
+        Self(buffer)
+    }
+}
+
+crate::impl_safe_drop!(SharedContentLock, |self| {
+    unsafe { pg_sys::LockBuffer(self.0, pg_sys::BUFFER_LOCK_UNLOCK as i32) };
+});
+
 /// Reads a random subset of `heaprel`'s blocks and projects every row the build will index
 /// onto `partition_by`, in that order.
 unsafe fn sample_partition_fields(
@@ -179,40 +218,36 @@ unsafe fn sample_partition_fields(
             check_for_interrupts!();
             let blockno = pg_sys::BlockSampler_Next(addr_of_mut!(sampler));
 
-            let buffer = pg_sys::ReadBufferExtended(
-                heaprel.as_ptr(),
-                pg_sys::ForkNumber::MAIN_FORKNUM,
-                blockno,
-                pg_sys::ReadBufferMode::RBM_NORMAL,
-                std::ptr::null_mut(),
-            );
+            let buffer = HeapBufferPin::read(heaprel, blockno);
+            let buf = buffer.buffer();
+            let page = pg_sys::BufferGetPage(buf);
 
             // Under the content lock, only test visibility (which also sets hint bits) and record
             // the offsets to index. Detoast, expression evaluation, and projection run afterward
             // under the pin alone, so a concurrent writer or a re-entrant index expression never
             // waits on this page's lock across that work.
-            pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32);
-            let page = pg_sys::BufferGetPage(buffer);
-            let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
             indexed_offsets.clear();
-            for offset in pg_sys::FirstOffsetNumber..=max_offset {
-                let item_id = pg_sys::PageGetItemId(page, offset);
-                if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
-                    continue;
-                }
-                let mut t_self = pg_sys::ItemPointerData::default();
-                item_pointer_set_all(&mut t_self, blockno, offset);
-                let mut tuple = pg_sys::HeapTupleData {
-                    t_len: (*item_id).lp_len(),
-                    t_self,
-                    t_tableOid: heaprel.oid(),
-                    t_data: pg_sys::PageGetItem(page, item_id).cast(),
-                };
-                if is_indexed(addr_of_mut!(tuple), buffer) {
-                    indexed_offsets.push(offset);
+            {
+                let _content_lock = SharedContentLock::acquire(buf);
+                let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
+                for offset in pg_sys::FirstOffsetNumber..=max_offset {
+                    let item_id = pg_sys::PageGetItemId(page, offset);
+                    if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
+                        continue;
+                    }
+                    let mut t_self = pg_sys::ItemPointerData::default();
+                    item_pointer_set_all(&mut t_self, blockno, offset);
+                    let mut tuple = pg_sys::HeapTupleData {
+                        t_len: (*item_id).lp_len(),
+                        t_self,
+                        t_tableOid: heaprel.oid(),
+                        t_data: pg_sys::PageGetItem(page, item_id).cast(),
+                    };
+                    if is_indexed(addr_of_mut!(tuple), buf) {
+                        indexed_offsets.push(offset);
+                    }
                 }
             }
-            pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32);
 
             // The pin blocks pruning and eviction, so the line pointers and tuple data recorded
             // above stay valid while we read them here.
@@ -239,7 +274,7 @@ unsafe fn sample_partition_fields(
                         t_tableOid: heaprel.oid(),
                         t_data: pg_sys::PageGetItem(page, item_id).cast(),
                     };
-                    pg_sys::ExecStoreBufferHeapTuple(addr_of_mut!(tuple), slot, buffer);
+                    pg_sys::ExecStoreBufferHeapTuple(addr_of_mut!(tuple), slot, buf);
                     pg_sys::slot_getallattrs(slot);
                     let values = std::slice::from_raw_parts((*slot).tts_values, natts);
                     let isnull = std::slice::from_raw_parts((*slot).tts_isnull, natts);
@@ -262,12 +297,12 @@ unsafe fn sample_partition_fields(
                 anyhow::Ok(())
             });
             per_block_context.reset();
-            pg_sys::ReleaseBuffer(buffer);
 
             if let Err(e) = block_result {
                 result = Err(e);
                 break;
             }
+            // `buffer` drops here, releasing the pin, on both the normal and the break paths.
         }
         pg_sys::ExecDropSingleTupleTableSlot(slot);
     }

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -30,7 +30,8 @@
 use std::ptr::addr_of_mut;
 
 use pgrx::{PgMemoryContexts, check_for_interrupts, pg_sys};
-use rand::RngExt;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
 
 use crate::api::FieldName;
 use crate::index::kdtree::{KdTree, Point};
@@ -50,6 +51,9 @@ const MAX_SAMPLE_BLOCKS: u32 = 4096;
 /// default statistics target. Rows beyond it are reservoir-sampled so the kept set stays
 /// uniform over the visited blocks.
 const MAX_SAMPLE_ROWS: usize = 30_000;
+
+/// A fixed seed makes a rebuild over an unchanged heap reproduce the same boundaries.
+const SAMPLE_SEED: u32 = 0x5EED_1D0C;
 
 /// Computes the global partition boundaries for a build of `indexrel`, or `None` when the
 /// index does not declare `partition_by`.
@@ -153,12 +157,12 @@ unsafe fn sample_partition_fields(
             addr_of_mut!(sampler),
             nblocks,
             nblocks.min(MAX_SAMPLE_BLOCKS) as i32,
-            rand::random::<u32>(),
+            SAMPLE_SEED,
         );
         sampler
     };
 
-    let mut rng = rand::rng();
+    let mut rng = StdRng::seed_from_u64(SAMPLE_SEED as u64);
     let mut per_block_context = PgMemoryContexts::new("pg_search partition sampling");
     let slot = unsafe {
         pg_sys::MakeTupleTableSlot(heaprel.rd_att, &raw const pg_sys::TTSOpsBufferHeapTuple)
@@ -365,6 +369,12 @@ mod tests {
             .expect("index declares partition_by");
         assert_eq!(tree.partition_count(), 8, "{tree}");
         assert_eq!(tree.dims().len(), 2);
+
+        // Same heap, same seed, same boundaries.
+        let again = plan_partition_boundaries(&heaprel, &indexrel, snapshot_any(), 8)
+            .unwrap()
+            .unwrap();
+        assert_eq!(again, tree);
 
         // Under 1024 blocks and 30k rows, the sample is the whole table, so every partition
         // gets an equal share of the real rows.

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -29,6 +29,7 @@
 
 use std::ptr::addr_of_mut;
 
+use pgrx::itemptr::item_pointer_set_all;
 use pgrx::{PgMemoryContexts, check_for_interrupts, pg_sys};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -194,13 +195,14 @@ unsafe fn sample_partition_fields(
                         continue;
                     }
 
+                    let mut t_self = pg_sys::ItemPointerData::default();
+                    item_pointer_set_all(&mut t_self, blockno, offset);
                     let mut tuple = pg_sys::HeapTupleData {
                         t_len: (*item_id).lp_len(),
-                        t_self: pg_sys::ItemPointerData::default(),
+                        t_self,
                         t_tableOid: heaprel.oid(),
                         t_data: pg_sys::PageGetItem(page, item_id).cast(),
                     };
-                    pg_sys::ItemPointerSet(addr_of_mut!(tuple.t_self), blockno, offset);
                     if !is_indexed(addr_of_mut!(tuple), buffer) {
                         continue;
                     }

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -1,0 +1,479 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Global partition boundaries for `CREATE INDEX`.
+//!
+//! Parallel build workers each see an arbitrary slice of the heap, so boundaries chosen from
+//! worker-local data would not line up across workers. The leader instead samples the heap
+//! once, before any worker starts, and builds one [`KdTree`] over the `partition_by` fields
+//! that every worker then routes with.
+//!
+//! The sample is taken from the heap rather than from `pg_statistic`: a freshly loaded table
+//! usually has no statistics yet, expression fields never have any, and per-column histograms
+//! only describe marginals, while a recursive split needs the joint distribution of the
+//! `partition_by` fields.
+
+use std::ptr::addr_of_mut;
+
+use pgrx::{PgMemoryContexts, check_for_interrupts, pg_sys};
+use rand::RngExt;
+
+use crate::api::FieldName;
+use crate::index::kdtree::{KdTree, Point};
+use crate::postgres::composite::CompositeSlotValues;
+use crate::postgres::heap::ExpressionState;
+use crate::postgres::pdb_owned_value::PdbOwnedValue;
+use crate::postgres::rel::PgSearchRelation;
+use crate::postgres::utils::{FieldSource, scalar_datum_to_tantivy_value, unwrap_alias_datum};
+use crate::schema::{CategorizedFieldData, SearchField};
+
+/// Upper bound on the heap blocks read for the sample. Blocks are chosen uniformly at random,
+/// so a table physically ordered by a `partition_by` field still yields a spread of positions
+/// across its key range.
+const MAX_SAMPLE_BLOCKS: u32 = 4096;
+
+/// Upper bound on the rows kept from the sampled blocks, the same size `ANALYZE` uses at the
+/// default statistics target. Rows beyond it are reservoir-sampled so the kept set stays
+/// uniform over the visited blocks.
+const MAX_SAMPLE_ROWS: usize = 30_000;
+
+/// Computes the global partition boundaries for a build of `indexrel`, or `None` when the
+/// index does not declare `partition_by`.
+///
+/// `snapshot` is the one the build scan itself uses: `SnapshotAny` for a plain build, or the
+/// registered MVCC snapshot of a `CONCURRENTLY` build. The sample then covers the same rows the
+/// workers are about to index. `target_partitions` is the number of leaves to aim for; the tree
+/// can come out smaller when the sample lacks the distinct values to cut further (see
+/// [`KdTree::from_sample`]).
+pub(super) fn plan_partition_boundaries(
+    heaprel: &PgSearchRelation,
+    indexrel: &PgSearchRelation,
+    snapshot: pg_sys::Snapshot,
+    target_partitions: usize,
+) -> anyhow::Result<Option<KdTree>> {
+    let partition_by = indexrel.options().partition_by();
+    if partition_by.is_empty() {
+        return Ok(None);
+    }
+    if target_partitions <= 1 {
+        return Ok(Some(KdTree::unpartitioned(partition_by)));
+    }
+
+    let sample = unsafe { sample_partition_fields(heaprel, indexrel, snapshot, &partition_by)? };
+    pgrx::debug1!(
+        "plan_partition_boundaries: sampled {} rows for partition_by={partition_by:?}, target_partitions={target_partitions}",
+        sample.len()
+    );
+    Ok(Some(KdTree::from_sample(
+        partition_by,
+        sample,
+        target_partitions,
+    )))
+}
+
+/// Where a `partition_by` field's value comes from for a heap tuple, plus what it takes to
+/// turn that datum into the value the index stores.
+struct SampledField {
+    field: SearchField,
+    categorized: CategorizedFieldData,
+}
+
+/// Reads a random subset of `heaprel`'s blocks and projects every row the build will index
+/// onto `partition_by`, in that order.
+unsafe fn sample_partition_fields(
+    heaprel: &PgSearchRelation,
+    indexrel: &PgSearchRelation,
+    snapshot: pg_sys::Snapshot,
+    partition_by: &[FieldName],
+) -> anyhow::Result<Vec<Point>> {
+    let schema = indexrel.schema()?;
+    let categorized_fields = schema.categorized_fields();
+    let fields = partition_by
+        .iter()
+        .map(|name| {
+            categorized_fields
+                .iter()
+                .find(|(field, _)| field.field_name() == name)
+                .map(|(field, categorized)| SampledField {
+                    field: field.clone(),
+                    categorized: categorized.clone(),
+                })
+                .ok_or_else(|| anyhow::anyhow!("partition_by field `{name}` is not indexed"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    drop(categorized_fields);
+
+    let nblocks = unsafe {
+        pg_sys::RelationGetNumberOfBlocksInFork(heaprel.as_ptr(), pg_sys::ForkNumber::MAIN_FORKNUM)
+    };
+    if nblocks == 0 {
+        return Ok(Vec::new());
+    }
+
+    // A plain build scans with `SnapshotAny` and lets `HeapTupleSatisfiesVacuum` drop only the
+    // dead tuples, so the sample applies the same test; an MVCC snapshot is applied directly.
+    let snapshot_is_any =
+        unsafe { (*snapshot).snapshot_type == pg_sys::SnapshotType::SNAPSHOT_ANY };
+    let oldest_xmin = if snapshot_is_any {
+        unsafe { pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr()) }
+    } else {
+        pg_sys::InvalidTransactionId
+    };
+    let is_indexed = |tuple: *mut pg_sys::HeapTupleData, buffer: pg_sys::Buffer| unsafe {
+        if snapshot_is_any {
+            pg_sys::HeapTupleSatisfiesVacuum(tuple, oldest_xmin, buffer)
+                != pg_sys::HTSV_Result::HEAPTUPLE_DEAD
+        } else {
+            pg_sys::HeapTupleSatisfiesVisibility(tuple, snapshot, buffer)
+        }
+    };
+
+    let needs_expressions = fields
+        .iter()
+        .any(|f| !matches!(f.categorized.source, FieldSource::Heap { .. }));
+    let expression_state = needs_expressions.then(|| ExpressionState::new(indexrel));
+
+    let mut sampler = unsafe {
+        let mut sampler: pg_sys::BlockSamplerData = std::mem::zeroed();
+        pg_sys::BlockSampler_Init(
+            addr_of_mut!(sampler),
+            nblocks,
+            nblocks.min(MAX_SAMPLE_BLOCKS) as i32,
+            rand::random::<u32>(),
+        );
+        sampler
+    };
+
+    let mut rng = rand::rng();
+    let mut per_block_context = PgMemoryContexts::new("pg_search partition sampling");
+    let slot = unsafe {
+        pg_sys::MakeTupleTableSlot(heaprel.rd_att, &raw const pg_sys::TTSOpsBufferHeapTuple)
+    };
+    let natts = unsafe { (*heaprel.rd_att).natts as usize };
+
+    let mut sample: Vec<Point> = Vec::new();
+    let mut seen_rows = 0usize;
+    unsafe {
+        while pg_sys::BlockSampler_HasMore(addr_of_mut!(sampler)) {
+            check_for_interrupts!();
+            let blockno = pg_sys::BlockSampler_Next(addr_of_mut!(sampler));
+
+            let buffer = pg_sys::ReadBufferExtended(
+                heaprel.as_ptr(),
+                pg_sys::ForkNumber::MAIN_FORKNUM,
+                blockno,
+                pg_sys::ReadBufferMode::RBM_NORMAL,
+                std::ptr::null_mut(),
+            );
+            pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32);
+            let page = pg_sys::BufferGetPage(buffer);
+            let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
+
+            per_block_context.switch_to(|_| {
+                for offset in pg_sys::FirstOffsetNumber..=max_offset {
+                    let item_id = pg_sys::PageGetItemId(page, offset);
+                    if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
+                        continue;
+                    }
+
+                    let mut tuple = pg_sys::HeapTupleData {
+                        t_len: (*item_id).lp_len(),
+                        t_self: pg_sys::ItemPointerData::default(),
+                        t_tableOid: heaprel.oid(),
+                        t_data: pg_sys::PageGetItem(page, item_id).cast(),
+                    };
+                    pg_sys::ItemPointerSet(addr_of_mut!(tuple.t_self), blockno, offset);
+                    if !is_indexed(addr_of_mut!(tuple), buffer) {
+                        continue;
+                    }
+
+                    // Decide whether this row makes the sample before paying to project it.
+                    seen_rows += 1;
+                    let target_slot = if sample.len() < MAX_SAMPLE_ROWS {
+                        None
+                    } else {
+                        let j = rng.random_range(0..seen_rows);
+                        if j >= MAX_SAMPLE_ROWS {
+                            continue;
+                        }
+                        Some(j)
+                    };
+
+                    pg_sys::ExecStoreBufferHeapTuple(addr_of_mut!(tuple), slot, buffer);
+                    pg_sys::slot_getallattrs(slot);
+                    let values = std::slice::from_raw_parts((*slot).tts_values, natts);
+                    let isnull = std::slice::from_raw_parts((*slot).tts_isnull, natts);
+                    let expr_results = expression_state
+                        .as_ref()
+                        .map(|state| state.evaluate(slot))
+                        .unwrap_or_default();
+
+                    let point = project_row(&fields, values, isnull, &expr_results)?;
+                    // The stored pointer targets this iteration's `tuple`; drop it before that
+                    // goes out of scope.
+                    pg_sys::ExecClearTuple(slot);
+
+                    match target_slot {
+                        None => sample.push(point),
+                        Some(j) => sample[j] = point,
+                    }
+                }
+                anyhow::Ok(())
+            })?;
+            per_block_context.reset();
+
+            pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32);
+            pg_sys::ReleaseBuffer(buffer);
+        }
+        pg_sys::ExecDropSingleTupleTableSlot(slot);
+    }
+
+    Ok(sample)
+}
+
+/// Projects one deformed heap row (plus its evaluated index expressions) onto the sampled
+/// fields, converting each datum the same way the index writer does.
+unsafe fn project_row(
+    fields: &[SampledField],
+    values: &[pg_sys::Datum],
+    isnull: &[bool],
+    expr_results: &[(pg_sys::Datum, bool)],
+) -> anyhow::Result<Point> {
+    let unpacked_composites = unsafe {
+        CompositeSlotValues::from_composites(fields.iter().filter_map(|f| {
+            if let FieldSource::CompositeField {
+                expression_idx,
+                composite_type_oid,
+                ..
+            } = f.categorized.source
+            {
+                let (datum, is_null) = expr_results[expression_idx];
+                Some((expression_idx, datum, is_null, composite_type_oid))
+            } else {
+                None
+            }
+        }))
+    };
+
+    fields
+        .iter()
+        .map(|f| {
+            let (datum, is_null) = match f.categorized.source {
+                FieldSource::Heap { attno } => (values[attno], isnull[attno]),
+                FieldSource::Expression { att_idx } => expr_results[att_idx],
+                FieldSource::CompositeField {
+                    expression_idx,
+                    field_idx,
+                    ..
+                } => unpacked_composites.get(expression_idx, field_idx),
+            };
+            if is_null {
+                return Ok(PdbOwnedValue::Null);
+            }
+            let datum = unsafe { unwrap_alias_datum(datum, f.categorized.pg_type) };
+            let value = unsafe {
+                scalar_datum_to_tantivy_value(datum, f.field.field_type(), f.categorized.base_oid)
+            }
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "could not sample partition_by field `{}`: {e}",
+                    f.field.field_name()
+                )
+            })?;
+            Ok(value.0)
+        })
+        .collect()
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use pgrx::datum::DatumWithOid;
+    use pgrx::prelude::*;
+
+    /// The snapshot a plain (non-concurrent) build scans with.
+    fn snapshot_any() -> pg_sys::Snapshot {
+        &raw mut pg_sys::SnapshotAnyData
+    }
+
+    fn open_rels(table: &str, index: &str) -> (PgSearchRelation, PgSearchRelation) {
+        let heap_oid = Spi::get_one::<pg_sys::Oid>(&format!("SELECT '{table}'::regclass::oid"))
+            .unwrap()
+            .unwrap();
+        let index_oid = Spi::get_one::<pg_sys::Oid>(&format!("SELECT '{index}'::regclass::oid"))
+            .unwrap()
+            .unwrap();
+        (
+            PgSearchRelation::open(heap_oid),
+            PgSearchRelation::open(index_oid),
+        )
+    }
+
+    /// Routes every row of `table` through `tree` and returns the per-partition counts.
+    fn route_all(tree: &KdTree, table: &str, columns: &str) -> Vec<usize> {
+        let mut counts = vec![0usize; tree.partition_count()];
+        Spi::connect(|client| {
+            let args: [DatumWithOid; 0] = [];
+            let rows = client.select(&format!("SELECT {columns} FROM {table}"), None, &args)?;
+            for row in rows {
+                let point: Point = (1..=row.columns())
+                    .map(|i| match row.get::<i64>(i)? {
+                        Some(v) => Ok(PdbOwnedValue::I64(v)),
+                        None => Ok(PdbOwnedValue::Null),
+                    })
+                    .collect::<Result<_, pgrx::spi::Error>>()?;
+                counts[tree.route(&point)] += 1;
+            }
+            Ok::<(), pgrx::spi::Error>(())
+        })
+        .unwrap();
+        counts
+    }
+
+    #[pg_test]
+    fn boundaries_from_heap_sample_balance_the_table() {
+        Spi::run(
+            r#"
+            CREATE TABLE sample_src (id BIGSERIAL PRIMARY KEY, tenant_id BIGINT, name TEXT);
+            INSERT INTO sample_src (tenant_id, name)
+            SELECT (i * 7919) % 100, 'row ' || i FROM generate_series(1, 20000) i;
+            CREATE INDEX sample_src_idx ON sample_src
+                USING paradedb (id, tenant_id, name)
+                WITH (key_field = 'id', partition_by = 'id, tenant_id');
+            "#,
+        )
+        .unwrap();
+
+        let (heaprel, indexrel) = open_rels("sample_src", "sample_src_idx");
+        let tree = plan_partition_boundaries(&heaprel, &indexrel, snapshot_any(), 8)
+            .unwrap()
+            .expect("index declares partition_by");
+        assert_eq!(tree.partition_count(), 8, "{tree}");
+        assert_eq!(tree.dims().len(), 2);
+
+        // Under 1024 blocks and 30k rows, the sample is the whole table, so every partition
+        // gets an equal share of the real rows.
+        let counts = route_all(&tree, "sample_src", "id, tenant_id");
+        for count in &counts {
+            assert!(
+                (2000..=3000).contains(count),
+                "unbalanced partitions: {counts:?}\n{tree}"
+            );
+        }
+
+        // Both declared fields end up cutting the space.
+        let bounded_dims = (0..8)
+            .flat_map(|p| tree.partition_bounds(p).unwrap())
+            .filter(|b| !matches!(b, (std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)))
+            .count();
+        assert!(bounded_dims > 8, "{tree}");
+    }
+
+    #[pg_test]
+    fn boundaries_follow_expression_fields_and_nulls() {
+        Spi::run(
+            r#"
+            CREATE TABLE sample_expr (id BIGSERIAL PRIMARY KEY, base BIGINT);
+            INSERT INTO sample_expr (base)
+            SELECT CASE WHEN i % 10 = 0 THEN NULL ELSE i END FROM generate_series(1, 5000) i;
+            CREATE INDEX sample_expr_idx ON sample_expr
+                USING paradedb (id, ((base * 2)::pdb.alias('doubled')))
+                WITH (key_field = 'id', partition_by = 'doubled');
+            "#,
+        )
+        .unwrap();
+
+        let (heaprel, indexrel) = open_rels("sample_expr", "sample_expr_idx");
+        let tree = plan_partition_boundaries(&heaprel, &indexrel, snapshot_any(), 4)
+            .unwrap()
+            .expect("index declares partition_by");
+        assert_eq!(tree.partition_count(), 4, "{tree}");
+
+        // Split values come from the expression, so they are even numbers inside its range.
+        let rp = tree.to_range_partitioning().unwrap();
+        for sp in &rp.split_points {
+            let PdbOwnedValue::I64(v) = sp else {
+                panic!("expected an I64 split point, got {sp:?}");
+            };
+            assert!(*v % 2 == 0 && (2..=10_000).contains(v), "{tree}");
+        }
+        assert_eq!(tree.route(&[PdbOwnedValue::Null]), 0);
+        let counts = route_all(&tree, "sample_expr", "base * 2");
+        assert!(counts.iter().all(|&c| c > 0), "{counts:?}\n{tree}");
+    }
+
+    #[pg_test]
+    fn no_partition_by_yields_no_tree_and_tiny_targets_stay_single() {
+        Spi::run(
+            r#"
+            CREATE TABLE sample_plain (id BIGSERIAL PRIMARY KEY, v BIGINT);
+            INSERT INTO sample_plain (v) SELECT i FROM generate_series(1, 100) i;
+            CREATE INDEX sample_plain_idx ON sample_plain USING paradedb (id, v)
+                WITH (key_field = 'id');
+            CREATE TABLE sample_empty (id BIGSERIAL PRIMARY KEY, v BIGINT);
+            CREATE INDEX sample_empty_idx ON sample_empty USING paradedb (id, v)
+                WITH (key_field = 'id', partition_by = 'v');
+            "#,
+        )
+        .unwrap();
+
+        let (heaprel, indexrel) = open_rels("sample_plain", "sample_plain_idx");
+        assert!(
+            plan_partition_boundaries(&heaprel, &indexrel, snapshot_any(), 8)
+                .unwrap()
+                .is_none()
+        );
+
+        let (heaprel, indexrel) = open_rels("sample_empty", "sample_empty_idx");
+        let tree = plan_partition_boundaries(&heaprel, &indexrel, snapshot_any(), 8)
+            .unwrap()
+            .expect("index declares partition_by");
+        assert_eq!(tree.partition_count(), 1);
+        let tree = plan_partition_boundaries(&heaprel, &indexrel, snapshot_any(), 1)
+            .unwrap()
+            .expect("index declares partition_by");
+        assert_eq!(tree.partition_count(), 1);
+    }
+
+    /// The whole leader-to-worker path: a parallel build on a partitioned index computes and
+    /// ships the boundaries without disturbing the build itself.
+    #[pg_test]
+    fn parallel_build_with_partition_by_succeeds() {
+        Spi::run("SET max_parallel_workers = 8;").unwrap();
+        Spi::run("SET max_parallel_maintenance_workers = 4;").unwrap();
+        Spi::run("SET maintenance_work_mem = '256MB';").unwrap();
+        Spi::run(
+            r#"
+            CREATE TABLE sample_parallel (id BIGSERIAL PRIMARY KEY, tenant_id BIGINT, body TEXT);
+            INSERT INTO sample_parallel (tenant_id, body)
+            SELECT i % 50, repeat('lorem ipsum dolor sit amet ', 20) FROM generate_series(1, 40000) i;
+            CREATE INDEX sample_parallel_idx ON sample_parallel
+                USING paradedb (id, tenant_id, body)
+                WITH (key_field = 'id', partition_by = 'tenant_id, id', target_segment_count = 8);
+            "#,
+        )
+        .unwrap();
+
+        let count = Spi::get_one::<i64>(
+            "SELECT count(*) FROM sample_parallel WHERE body @@@ 'lorem' AND tenant_id = 3",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(count, 800);
+    }
+}

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -41,7 +41,9 @@ use crate::postgres::heap::{ExpressionState, HeapBufferPin};
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::buffer::BorrowedBuffer;
-use crate::postgres::utils::{FieldSource, scalar_datum_to_tantivy_value, unwrap_alias_datum};
+use crate::postgres::utils::{
+    FieldSource, resolve_field_value, scalar_datum_to_tantivy_value, unwrap_alias_datum,
+};
 use crate::schema::{CategorizedFieldData, SearchField};
 
 /// Upper bound on the heap blocks read for the sample. Blocks are chosen uniformly at random,
@@ -300,15 +302,13 @@ unsafe fn project_row(
     fields
         .iter()
         .map(|f| {
-            let (datum, is_null) = match f.categorized.source {
-                FieldSource::Heap { attno } => (values[attno], isnull[attno]),
-                FieldSource::Expression { att_idx } => expr_results[att_idx],
-                FieldSource::CompositeField {
-                    expression_idx,
-                    field_idx,
-                    ..
-                } => unpacked_composites.get(expression_idx, field_idx),
-            };
+            let (datum, is_null) = resolve_field_value(
+                &f.categorized.source,
+                values,
+                isnull,
+                expr_results,
+                &unpacked_composites,
+            );
             if is_null {
                 return Ok(PdbOwnedValue::Null);
             }

--- a/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
+++ b/pg_search/src/postgres/customscan/joinscan/range_partitioning_rule.rs
@@ -360,13 +360,7 @@ fn named_field_arrow_type(
 /// Sorts points ascending so that `RangePartitioningSample::build` produces
 /// sequential ranges.
 fn sort_sample_points(points: &mut [PdbOwnedValue]) {
-    points.sort_unstable_by(|a, b| {
-        if let (PdbOwnedValue::F64(f1), PdbOwnedValue::F64(f2)) = (a, b) {
-            f1.total_cmp(f2)
-        } else {
-            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-        }
-    });
+    points.sort_unstable_by(PdbOwnedValue::total_cmp);
 }
 
 /// Samples both sides of the join and merges the two distributions, so the split

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -111,6 +111,16 @@ impl PostgresDateTime {
         self.0.into_inner()
     }
 
+    /// Formats as UTC RFC 3339 without a Postgres output function, so it runs outside a backend.
+    /// Returns `None` when the offset does not fit a `chrono` timestamp (the far extremes and the
+    /// `infinity` sentinels).
+    pub fn to_rfc3339(self) -> Option<String> {
+        let unix_micros = self
+            .into_inner()
+            .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)?;
+        chrono::DateTime::from_timestamp_micros(unix_micros).map(|dt| dt.to_rfc3339())
+    }
+
     pub fn try_from_raw(raw: i64) -> Result<Self, DateTimeConversionError> {
         let ts = pgrx::datum::Timestamp::try_from(raw)
             .map_err(|_| DateTimeConversionError::OutOfRange)?;

--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -23,6 +23,40 @@ use crate::postgres::utils;
 use pgrx::PgList;
 use pgrx::pg_sys;
 
+/// A pinned heap buffer that releases its pin on drop. It stays off the index block tracker
+/// that `PinnedBuffer` feeds. That tracker keys blocks by number with no relation, so a heap
+/// pin would collide with the index's tracked blocks under the `block_tracker` feature, and a
+/// `CREATE INDEX` reads the heap while its own index buffers are tracked.
+pub(crate) struct HeapBufferPin(pg_sys::Buffer);
+
+impl HeapBufferPin {
+    /// Reads and pins `blockno` of `heaprel`'s main fork.
+    ///
+    /// # Safety
+    /// `heaprel` must stay open for the lifetime of the returned pin.
+    pub(crate) unsafe fn read(heaprel: &PgSearchRelation, blockno: pg_sys::BlockNumber) -> Self {
+        Self(pg_sys::ReadBufferExtended(
+            heaprel.as_ptr(),
+            pg_sys::ForkNumber::MAIN_FORKNUM,
+            blockno,
+            pg_sys::ReadBufferMode::RBM_NORMAL,
+            std::ptr::null_mut(),
+        ))
+    }
+
+    pub(crate) fn buffer(&self) -> pg_sys::Buffer {
+        self.0
+    }
+}
+
+crate::impl_safe_drop!(HeapBufferPin, |self| {
+    unsafe {
+        if crate::postgres::utils::IsTransactionState() {
+            pg_sys::ReleaseBuffer(self.0);
+        }
+    }
+});
+
 /// Helper to validate that a "ctid" is currently visible to a snapshot.
 ///
 /// When querying BM25 indexes, individual ctid entries may be stale. After an UPDATE,

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -50,6 +50,7 @@ mod vacuum;
 mod validate;
 
 mod build_parallel;
+mod build_partitioning;
 pub mod catalog;
 pub mod composite;
 mod condition_variable;

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -59,14 +59,27 @@ impl PdbOwnedValue {
     /// that read it do, `NaN` included. A merged two-side join sample can tag one integer column
     /// `I64` on one side and `U64` on the other, so those compare by value. Everything else
     /// follows the derived `PartialOrd`; a column never mixes an integer with a float, so that
-    /// pairing does not arise.
+    /// pairing does not arise (a `debug_assert!` guards it).
     pub fn total_cmp(&self, other: &Self) -> std::cmp::Ordering {
         use tantivy::columnar::MonotonicallyMappableToU64;
         match (self, other) {
             (Self::F64(a), Self::F64(b)) => a.to_u64().cmp(&b.to_u64()),
             (Self::I64(a), Self::U64(b)) => (*a as i128).cmp(&(*b as i128)),
             (Self::U64(a), Self::I64(b)) => (*a as i128).cmp(&(*b as i128)),
-            _ => self.partial_cmp(other).unwrap_or(std::cmp::Ordering::Equal),
+            _ => {
+                // The derived order ranks by variant, not value, so a float against an integer
+                // would sort by declaration order. That pairing can't reach here, so catch it
+                // rather than rank it wrong in silence.
+                debug_assert!(
+                    !matches!(
+                        (self, other),
+                        (Self::F64(_), Self::I64(_) | Self::U64(_))
+                            | (Self::I64(_) | Self::U64(_), Self::F64(_))
+                    ),
+                    "total_cmp got a float against an integer: {self:?} vs {other:?}"
+                );
+                self.partial_cmp(other).unwrap_or(std::cmp::Ordering::Equal)
+            }
         }
     }
 

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -520,3 +520,141 @@ impl TryFrom<serde_json::Value> for PdbOwnedValue {
         Ok(pdb_value)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+    use std::net::Ipv6Addr;
+
+    #[test]
+    fn total_cmp_orders_across_numeric_variants() {
+        // NULL sorts first.
+        assert_eq!(
+            PdbOwnedValue::Null.total_cmp(&PdbOwnedValue::I64(0)),
+            Ordering::Less
+        );
+        // `I64`/`U64` compare by value, not by variant.
+        assert_eq!(
+            PdbOwnedValue::I64(-1).total_cmp(&PdbOwnedValue::U64(0)),
+            Ordering::Less
+        );
+        assert_eq!(
+            PdbOwnedValue::U64(5).total_cmp(&PdbOwnedValue::I64(5)),
+            Ordering::Equal
+        );
+        assert_eq!(
+            PdbOwnedValue::I64(10).total_cmp(&PdbOwnedValue::U64(3)),
+            Ordering::Greater
+        );
+        // Integers compare against floats by value.
+        assert_eq!(
+            PdbOwnedValue::I64(2).total_cmp(&PdbOwnedValue::F64(2.5)),
+            Ordering::Less
+        );
+        assert_eq!(
+            PdbOwnedValue::F64(2.5).total_cmp(&PdbOwnedValue::I64(2)),
+            Ordering::Greater
+        );
+        assert_eq!(
+            PdbOwnedValue::U64(2).total_cmp(&PdbOwnedValue::F64(2.0)),
+            Ordering::Equal
+        );
+        assert_eq!(
+            PdbOwnedValue::F64(2.0).total_cmp(&PdbOwnedValue::U64(2)),
+            Ordering::Equal
+        );
+        // `NaN` has a fixed place (via `f64::total_cmp`, so no panic and no `Equal` surprise).
+        assert_eq!(
+            PdbOwnedValue::F64(f64::NAN).total_cmp(&PdbOwnedValue::F64(1.0)),
+            Ordering::Greater
+        );
+        // Non-numeric variants fall through to the derived order.
+        assert_eq!(
+            PdbOwnedValue::Str("a".into()).total_cmp(&PdbOwnedValue::Str("b".into())),
+            Ordering::Less
+        );
+    }
+
+    // Round-trips a value through `exact_scalar_wire` and `postcard`, the way a partition split
+    // value travels over the DSM.
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Wire(#[serde(with = "super::exact_scalar_wire")] PdbOwnedValue);
+
+    fn round_trip(value: &PdbOwnedValue) -> PdbOwnedValue {
+        let bytes = postcard::to_allocvec(&Wire(value.clone())).unwrap();
+        postcard::from_bytes::<Wire>(&bytes).unwrap().0
+    }
+
+    #[test]
+    fn exact_scalar_wire_preserves_every_scalar_variant() {
+        let cases = [
+            PdbOwnedValue::Str("héllo \"world\"".into()),
+            PdbOwnedValue::U64(u64::MAX),
+            // A non-negative `I64` must not come back as `U64` (the tantivy default serde bug).
+            PdbOwnedValue::I64(1000),
+            PdbOwnedValue::I64(-42),
+            PdbOwnedValue::F64(3.5),
+            PdbOwnedValue::F64(f64::INFINITY),
+            PdbOwnedValue::F64(f64::NEG_INFINITY),
+            PdbOwnedValue::Bool(true),
+            PdbOwnedValue::Bytes(vec![0, 1, 255]),
+            PdbOwnedValue::IpAddr(Ipv6Addr::LOCALHOST),
+            PdbOwnedValue::Date(PostgresDateTime::try_from_raw(123_456).unwrap()),
+        ];
+        for value in &cases {
+            assert_eq!(&round_trip(value), value, "did not round-trip: {value:?}");
+        }
+        // `PartialEq` treats `NaN != NaN`, so check the bit pattern survived instead.
+        assert!(matches!(
+            round_trip(&PdbOwnedValue::F64(f64::NAN)),
+            PdbOwnedValue::F64(f) if f.is_nan()
+        ));
+    }
+
+    #[test]
+    fn exact_scalar_wire_rejects_non_scalar_variants() {
+        #[derive(serde::Serialize)]
+        struct W(#[serde(with = "super::exact_scalar_wire")] PdbOwnedValue);
+        for value in [PdbOwnedValue::Null, PdbOwnedValue::Array(vec![])] {
+            assert!(postcard::to_allocvec(&W(value)).is_err());
+        }
+    }
+
+    #[test]
+    fn plain_display_renders_without_a_backend() {
+        assert_eq!(
+            PdbOwnedValue::Str("x\"y".into())
+                .plain_display()
+                .to_string(),
+            "\"x\\\"y\""
+        );
+        assert_eq!(PdbOwnedValue::I64(-7).plain_display().to_string(), "-7");
+        assert_eq!(PdbOwnedValue::U64(7).plain_display().to_string(), "7");
+        assert_eq!(
+            PdbOwnedValue::Bool(false).plain_display().to_string(),
+            "false"
+        );
+        assert_eq!(PdbOwnedValue::F64(1.5).plain_display().to_string(), "1.5");
+        assert_eq!(
+            PdbOwnedValue::IpAddr(Ipv6Addr::LOCALHOST)
+                .plain_display()
+                .to_string(),
+            "::1"
+        );
+        // A date at the Postgres epoch renders as RFC 3339 UTC.
+        let epoch = PostgresDateTime::try_from_raw(0).unwrap();
+        assert_eq!(
+            PdbOwnedValue::Date(epoch).plain_display().to_string(),
+            "2000-01-01T00:00:00+00:00"
+        );
+        // NULL and composites fall back to `Debug` rather than panic.
+        assert_eq!(PdbOwnedValue::Null.plain_display().to_string(), "Null");
+        assert!(
+            !PdbOwnedValue::Object(vec![])
+                .plain_display()
+                .to_string()
+                .is_empty()
+        );
+    }
+}

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -58,6 +58,11 @@ impl PdbOwnedValue {
     /// with `f64::total_cmp` (so NaN has a fixed place), and integer variants compare by value
     /// across `I64`/`U64`/`F64`, since the same column can surface as either through
     /// deserialization. Everything else follows the derived `PartialOrd`.
+    ///
+    /// Not a true total order once a set mixes `F64` with integers past 2^53: the `as f64` casts
+    /// lose precision, so two distinct integers can tie with the same float. Callers today never
+    /// mix those variants inside one dimension (`SearchFieldType` keys the conversion, and the
+    /// wire round trip only swaps `I64`/`U64`, which the `i128` arms compare exactly).
     pub fn total_cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
         match (self, other) {

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -54,6 +54,24 @@ pub enum PdbOwnedValue {
 impl Eq for PdbOwnedValue {}
 
 impl PdbOwnedValue {
+    /// A total order usable for sorting and range routing: NULL sorts first, floats compare
+    /// with `f64::total_cmp` (so NaN has a fixed place), and integer variants compare by value
+    /// across `I64`/`U64`/`F64`, since the same column can surface as either through
+    /// deserialization. Everything else follows the derived `PartialOrd`.
+    pub fn total_cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (self, other) {
+            (Self::F64(a), Self::F64(b)) => a.total_cmp(b),
+            (Self::I64(a), Self::U64(b)) => (*a as i128).cmp(&(*b as i128)),
+            (Self::U64(a), Self::I64(b)) => (*a as i128).cmp(&(*b as i128)),
+            (Self::I64(a), Self::F64(b)) => (*a as f64).total_cmp(b),
+            (Self::F64(a), Self::I64(b)) => a.total_cmp(&(*b as f64)),
+            (Self::U64(a), Self::F64(b)) => (*a as f64).total_cmp(b),
+            (Self::F64(a), Self::U64(b)) => a.total_cmp(&(*b as f64)),
+            _ => self.partial_cmp(other).unwrap_or(Ordering::Equal),
+        }
+    }
+
     pub fn into_tantivy_value(self, index_created_by_version: Option<Version>) -> OwnedValue {
         match self {
             PdbOwnedValue::Date(date) => {

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -25,7 +25,7 @@ use serde::ser::SerializeMap;
 use tantivy::schema::{Facet, OwnedValue};
 
 use crate::api::version::{Version, VersionInfo};
-use crate::postgres::datetime::PostgresDateTime;
+use crate::postgres::datetime::{PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS, PostgresDateTime};
 use crate::postgres::types::TantivyValueError;
 use crate::schema::SearchFieldType;
 
@@ -437,6 +437,45 @@ pub(crate) mod exact_scalar_wire {
             WireValue::Bytes(v) => PdbOwnedValue::Bytes(v),
             WireValue::IpAddr(v) => PdbOwnedValue::IpAddr(v),
         })
+    }
+}
+
+impl PdbOwnedValue {
+    /// A `Display` that renders this value for logs without calling into Postgres, so it works
+    /// outside a backend. The complementary `TantivyValue` `Display` routes dates through
+    /// Postgres output functions; this one renders dates as UTC RFC 3339 via `chrono` instead.
+    /// Strings are quoted so a value reads unambiguously in a log line, and the composite and
+    /// unsupported variants fall back to `Debug`.
+    pub(crate) fn plain_display(&self) -> impl std::fmt::Display + '_ {
+        PlainDisplay(self)
+    }
+}
+
+struct PlainDisplay<'a>(&'a PdbOwnedValue);
+
+impl std::fmt::Display for PlainDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            PdbOwnedValue::Str(v) => write!(f, "{v:?}"),
+            PdbOwnedValue::U64(v) => write!(f, "{v}"),
+            PdbOwnedValue::I64(v) => write!(f, "{v}"),
+            PdbOwnedValue::F64(v) => write!(f, "{v}"),
+            PdbOwnedValue::Bool(v) => write!(f, "{v}"),
+            PdbOwnedValue::IpAddr(v) => write!(f, "{v}"),
+            PdbOwnedValue::Date(v) => {
+                // `infinity`/`-infinity` timestamps sit at `i64::MIN/MAX`, so the epoch shift can
+                // overflow; fall back to the raw value rather than abort the caller.
+                match v
+                    .into_inner()
+                    .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
+                    .and_then(chrono::DateTime::from_timestamp_micros)
+                {
+                    Some(dt) => write!(f, "{}", dt.to_rfc3339()),
+                    None => write!(f, "{v:?}"),
+                }
+            }
+            other => write!(f, "{other:?}"),
+        }
     }
 }
 

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -25,7 +25,7 @@ use serde::ser::SerializeMap;
 use tantivy::schema::{Facet, OwnedValue};
 
 use crate::api::version::{Version, VersionInfo};
-use crate::postgres::datetime::{PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS, PostgresDateTime};
+use crate::postgres::datetime::PostgresDateTime;
 use crate::postgres::types::TantivyValueError;
 use crate::schema::SearchFieldType;
 
@@ -54,26 +54,19 @@ pub enum PdbOwnedValue {
 impl Eq for PdbOwnedValue {}
 
 impl PdbOwnedValue {
-    /// A total order usable for sorting and range routing: NULL sorts first, floats compare
-    /// with `f64::total_cmp` (so NaN has a fixed place), and integer variants compare by value
-    /// across `I64`/`U64`/`F64`, since the same column can surface as either through
-    /// deserialization. Everything else follows the derived `PartialOrd`.
-    ///
-    /// Not a true total order once a set mixes `F64` with integers past 2^53: the `as f64` casts
-    /// lose precision, so two distinct integers can tie with the same float. Callers today never
-    /// mix those variants inside one dimension (`SearchFieldType` keys the conversion, and the
-    /// wire round trip only swaps `I64`/`U64`, which the `i128` arms compare exactly).
+    /// A total order for sorting and range routing. NULL sorts first. Floats use the same
+    /// monotonic `u64` mapping as `TopK` and `RangeQuery`, so a boundary orders the way the scans
+    /// that read it do, `NaN` included. A merged two-side join sample can tag one integer column
+    /// `I64` on one side and `U64` on the other, so those compare by value. Everything else
+    /// follows the derived `PartialOrd`; a column never mixes an integer with a float, so that
+    /// pairing does not arise.
     pub fn total_cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
+        use tantivy::columnar::MonotonicallyMappableToU64;
         match (self, other) {
-            (Self::F64(a), Self::F64(b)) => a.total_cmp(b),
+            (Self::F64(a), Self::F64(b)) => a.to_u64().cmp(&b.to_u64()),
             (Self::I64(a), Self::U64(b)) => (*a as i128).cmp(&(*b as i128)),
             (Self::U64(a), Self::I64(b)) => (*a as i128).cmp(&(*b as i128)),
-            (Self::I64(a), Self::F64(b)) => (*a as f64).total_cmp(b),
-            (Self::F64(a), Self::I64(b)) => a.total_cmp(&(*b as f64)),
-            (Self::U64(a), Self::F64(b)) => (*a as f64).total_cmp(b),
-            (Self::F64(a), Self::U64(b)) => a.total_cmp(&(*b as f64)),
-            _ => self.partial_cmp(other).unwrap_or(Ordering::Equal),
+            _ => self.partial_cmp(other).unwrap_or(std::cmp::Ordering::Equal),
         }
     }
 
@@ -398,7 +391,8 @@ pub(crate) mod exact_scalar_wire {
         I64(i64),
         Bool(bool),
         Date(i64),
-        // `f64::to_bits`, so `NaN` and the infinities survive any codec, text or binary.
+        // The wire needs the exact value back, not an order, so it carries `f64::to_bits`
+        // (not the ordering `u64` mapping `total_cmp` uses). `NaN` and the infinities survive.
         F64Bits(u64),
         Bytes(Vec<u8>),
         IpAddr(Ipv6Addr),
@@ -462,18 +456,10 @@ impl std::fmt::Display for PlainDisplay<'_> {
             PdbOwnedValue::F64(v) => write!(f, "{v}"),
             PdbOwnedValue::Bool(v) => write!(f, "{v}"),
             PdbOwnedValue::IpAddr(v) => write!(f, "{v}"),
-            PdbOwnedValue::Date(v) => {
-                // `infinity`/`-infinity` timestamps sit at `i64::MIN/MAX`, so the epoch shift can
-                // overflow; fall back to the raw value rather than abort the caller.
-                match v
-                    .into_inner()
-                    .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
-                    .and_then(chrono::DateTime::from_timestamp_micros)
-                {
-                    Some(dt) => write!(f, "{}", dt.to_rfc3339()),
-                    None => write!(f, "{v:?}"),
-                }
-            }
+            PdbOwnedValue::Date(v) => match v.to_rfc3339() {
+                Some(s) => write!(f, "{s}"),
+                None => write!(f, "{v:?}"),
+            },
             other => write!(f, "{other:?}"),
         }
     }
@@ -547,28 +533,19 @@ mod tests {
             PdbOwnedValue::I64(10).total_cmp(&PdbOwnedValue::U64(3)),
             Ordering::Greater
         );
-        // Integers compare against floats by value.
-        assert_eq!(
-            PdbOwnedValue::I64(2).total_cmp(&PdbOwnedValue::F64(2.5)),
-            Ordering::Less
-        );
-        assert_eq!(
-            PdbOwnedValue::F64(2.5).total_cmp(&PdbOwnedValue::I64(2)),
-            Ordering::Greater
-        );
-        assert_eq!(
-            PdbOwnedValue::U64(2).total_cmp(&PdbOwnedValue::F64(2.0)),
-            Ordering::Equal
-        );
-        assert_eq!(
-            PdbOwnedValue::F64(2.0).total_cmp(&PdbOwnedValue::U64(2)),
-            Ordering::Equal
-        );
-        // `NaN` has a fixed place (via `f64::total_cmp`, so no panic and no `Equal` surprise).
-        assert_eq!(
-            PdbOwnedValue::F64(f64::NAN).total_cmp(&PdbOwnedValue::F64(1.0)),
-            Ordering::Greater
-        );
+        // Floats order by the monotonic mapping: -inf < finite < +inf < NaN, with a fixed
+        // place for NaN (no panic, no `Equal` surprise).
+        let ordered = [
+            PdbOwnedValue::F64(f64::NEG_INFINITY),
+            PdbOwnedValue::F64(-1.0),
+            PdbOwnedValue::F64(0.0),
+            PdbOwnedValue::F64(1.0),
+            PdbOwnedValue::F64(f64::INFINITY),
+            PdbOwnedValue::F64(f64::NAN),
+        ];
+        for pair in ordered.windows(2) {
+            assert_eq!(pair[0].total_cmp(&pair[1]), Ordering::Less, "{pair:?}");
+        }
         // Non-numeric variants fall through to the derived order.
         assert_eq!(
             PdbOwnedValue::Str("a".into()).total_cmp(&PdbOwnedValue::Str("b".into())),

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -374,6 +374,72 @@ impl<'de> serde::Deserialize<'de> for PdbOwnedValue {
     }
 }
 
+/// The exact, lossless serde form for the scalar variants of [`PdbOwnedValue`], for callers that
+/// must reconstruct a value bit for bit (partition boundaries shipped over the DSM wire). The
+/// `Serialize`/`Deserialize` impls above route through tantivy's `OwnedValue`, which is lossy: a
+/// non-negative `I64` comes back as `U64`, and a non-finite `F64` becomes `null` under JSON.
+///
+/// Scalar values only. It errors on `Null` and the composite variants (`Array`, `Object`,
+/// `Facet`, `PreTokStr`), which never appear as partition split values. `F64` travels as its
+/// bits and dates as their raw microseconds, so both survive any codec without calling into
+/// Postgres. Use through `#[serde(with = "...")]` on a `PdbOwnedValue` field.
+pub(crate) mod exact_scalar_wire {
+    use std::net::Ipv6Addr;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser};
+
+    use super::PdbOwnedValue;
+    use crate::postgres::datetime::PostgresDateTime;
+
+    #[derive(Serialize, Deserialize)]
+    enum WireValue {
+        Str(String),
+        U64(u64),
+        I64(i64),
+        Bool(bool),
+        Date(i64),
+        // `f64::to_bits`, so `NaN` and the infinities survive any codec, text or binary.
+        F64Bits(u64),
+        Bytes(Vec<u8>),
+        IpAddr(Ipv6Addr),
+    }
+
+    pub(crate) fn serialize<S: Serializer>(value: &PdbOwnedValue, s: S) -> Result<S::Ok, S::Error> {
+        let wire = match value {
+            PdbOwnedValue::Str(v) => WireValue::Str(v.clone()),
+            PdbOwnedValue::U64(v) => WireValue::U64(*v),
+            PdbOwnedValue::I64(v) => WireValue::I64(*v),
+            PdbOwnedValue::F64(v) => WireValue::F64Bits(v.to_bits()),
+            PdbOwnedValue::Bool(v) => WireValue::Bool(*v),
+            PdbOwnedValue::Date(v) => WireValue::Date(v.into_inner()),
+            PdbOwnedValue::Bytes(v) => WireValue::Bytes(v.clone()),
+            PdbOwnedValue::IpAddr(v) => WireValue::IpAddr(*v),
+            other => {
+                return Err(ser::Error::custom(format!(
+                    "unsupported partition split value: {other:?}"
+                )));
+            }
+        };
+        wire.serialize(s)
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<PdbOwnedValue, D::Error> {
+        Ok(match WireValue::deserialize(d)? {
+            WireValue::Str(v) => PdbOwnedValue::Str(v),
+            WireValue::U64(v) => PdbOwnedValue::U64(v),
+            WireValue::I64(v) => PdbOwnedValue::I64(v),
+            WireValue::F64Bits(v) => PdbOwnedValue::F64(f64::from_bits(v)),
+            WireValue::Bool(v) => PdbOwnedValue::Bool(v),
+            WireValue::Date(v) => PdbOwnedValue::Date(
+                PostgresDateTime::try_from_raw(v)
+                    .map_err(|e| de::Error::custom(format!("invalid split date: {e:?}")))?,
+            ),
+            WireValue::Bytes(v) => PdbOwnedValue::Bytes(v),
+            WireValue::IpAddr(v) => PdbOwnedValue::IpAddr(v),
+        })
+    }
+}
+
 impl From<String> for PdbOwnedValue {
     fn from(value: String) -> Self {
         Self::Str(value)

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -59,7 +59,7 @@ impl PdbOwnedValue {
     /// that read it do, `NaN` included. A merged two-side join sample can tag one integer column
     /// `I64` on one side and `U64` on the other, so those compare by value. Everything else
     /// follows the derived `PartialOrd`; a column never mixes an integer with a float, so that
-    /// pairing does not arise (a `debug_assert!` guards it).
+    /// pairing does not arise (an `assert!` guards it).
     pub fn total_cmp(&self, other: &Self) -> std::cmp::Ordering {
         use tantivy::columnar::MonotonicallyMappableToU64;
         match (self, other) {
@@ -70,7 +70,7 @@ impl PdbOwnedValue {
                 // The derived order ranks by variant, not value, so a float against an integer
                 // would sort by declaration order. That pairing can't reach here, so catch it
                 // rather than rank it wrong in silence.
-                debug_assert!(
+                assert!(
                     !matches!(
                         (self, other),
                         (Self::F64(_), Self::I64(_) | Self::U64(_))

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -30,7 +30,7 @@ use crate::postgres::composite::{
 use crate::postgres::customscan::orderby::text_lower_funcoid;
 use crate::postgres::deparse::deparse_expr;
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::types::TantivyValue;
+use crate::postgres::types::{TantivyValue, TantivyValueError};
 use crate::postgres::var::find_vars;
 use crate::schema::{CategorizedFieldData, SearchField, SearchFieldType};
 use crate::vector::PgVector;
@@ -784,11 +784,7 @@ pub unsafe fn row_to_search_document<'a>(
         }
 
         // For pdb.alias/tokenizer types, get the underlying type if it's not a text type.
-        let actual_datum = if type_is_alias(pg_type.value()) || type_is_tokenizer(pg_type.value()) {
-            unsafe { DatumWithType::get_underlying_type(datum).0 }
-        } else {
-            datum
-        };
+        let actual_datum = unsafe { unwrap_alias_datum(datum, *pg_type) };
 
         if *is_array {
             let converted_array = match search_field.field_type() {
@@ -832,18 +828,8 @@ pub unsafe fn row_to_search_document<'a>(
             };
             document.add_vector(search_field.field(), &vec);
         } else {
-            let tv = match search_field.field_type() {
-                SearchFieldType::Numeric64(_, scale) => {
-                    TantivyValue::try_from_numeric_i64(actual_datum, scale)
-                }
-                SearchFieldType::NumericBytes(..) => {
-                    TantivyValue::try_from_numeric_bytes(actual_datum)
-                }
-                // Legacy pre-v0.22.0 indexes stored NUMERIC as F64 in the tantivy schema.
-                SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
-                    TantivyValue::try_from_numeric_f64(actual_datum)
-                }
-                _ => TantivyValue::try_from_datum(actual_datum, *base_oid),
+            let tv = unsafe {
+                scalar_datum_to_tantivy_value(actual_datum, search_field.field_type(), *base_oid)
             }
             .unwrap_or_else(|e| {
                 panic!("could not parse field `{}`: {e}", search_field.field_name())
@@ -855,6 +841,35 @@ pub unsafe fn row_to_search_document<'a>(
         }
     }
     Ok(())
+}
+
+/// Converts a non-NULL, single-valued (non-array, non-JSON, non-vector) index datum into the
+/// value the index stores for its field. `datum` must already have any `pdb.alias` /
+/// tokenizer wrapper type stripped, see [`unwrap_alias_datum`].
+pub unsafe fn scalar_datum_to_tantivy_value(
+    datum: pg_sys::Datum,
+    field_type: SearchFieldType,
+    base_oid: PgOid,
+) -> Result<TantivyValue, TantivyValueError> {
+    match field_type {
+        SearchFieldType::Numeric64(_, scale) => TantivyValue::try_from_numeric_i64(datum, scale),
+        SearchFieldType::NumericBytes(..) => TantivyValue::try_from_numeric_bytes(datum),
+        // Legacy pre-v0.22.0 indexes stored NUMERIC as F64 in the tantivy schema.
+        SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
+            TantivyValue::try_from_numeric_f64(datum)
+        }
+        _ => TantivyValue::try_from_datum(datum, base_oid),
+    }
+}
+
+/// For `pdb.alias` / tokenizer typed index attributes, returns the datum of the underlying
+/// type; other datums pass through unchanged.
+pub unsafe fn unwrap_alias_datum(datum: pg_sys::Datum, pg_type: PgOid) -> pg_sys::Datum {
+    if type_is_alias(pg_type.value()) || type_is_tokenizer(pg_type.value()) {
+        DatumWithType::get_underlying_type(datum).0
+    } else {
+        datum
+    }
 }
 
 pub fn convert_pg_date_string(typeoid: PgOid, date_string: &str) -> PostgresDateTime {

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -353,6 +353,28 @@ pub unsafe fn get_field_value(
     }
 }
 
+/// Resolves an index field's `(datum, is_null)` from a deformed heap tuple and its evaluated
+/// index expressions. The boundary sampler and the mutable-segment materialization both project
+/// the same field sources, so they share this instead of matching `FieldSource` in each place.
+/// This is not [`get_field_value`], which indexes a single formed-tuple array by index attno.
+pub unsafe fn resolve_field_value(
+    source: &FieldSource,
+    values: &[pg_sys::Datum],
+    isnull: &[bool],
+    expr_results: &[(pg_sys::Datum, bool)],
+    unpacked_composites: &CompositeSlotValues,
+) -> (pg_sys::Datum, bool) {
+    match source {
+        FieldSource::Heap { attno } => (values[*attno], isnull[*attno]),
+        FieldSource::Expression { att_idx } => expr_results[*att_idx],
+        FieldSource::CompositeField {
+            expression_idx,
+            field_idx,
+            ..
+        } => unpacked_composites.get(*expression_idx, *field_idx),
+    }
+}
+
 /// Represents the metadata extracted from an index attribute
 #[derive(Debug)]
 pub struct ExtractedFieldAttribute {

--- a/pg_search/src/scan/range_partitioning.rs
+++ b/pg_search/src/scan/range_partitioning.rs
@@ -188,7 +188,9 @@ impl RangePartitioningSample {
     /// is capped at `sample_points.len() + 1`.
     pub fn build(&self, target_partitions: usize) -> RangePartitioning {
         debug_assert!(
-            self.sample_points.windows(2).all(|w| w[0] <= w[1]),
+            self.sample_points
+                .windows(2)
+                .all(|w| w[0].total_cmp(&w[1]) != std::cmp::Ordering::Greater),
             "RangePartitioningSample requires sample_points to be sorted ascending"
         );
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5736

## What

The `CREATE INDEX` leader now computes global partition boundaries for a `partition_by` index and passes them to the parallel build workers. The boundaries are a recursive KD-tree over the `partition_by` fields, built once from a heap sample. Workers deserialize the tree and log it at `DEBUG1`; routing on it is #5737.

## Why

Each parallel worker gets an arbitrary slice of the heap. If workers picked boundaries from their own tuples, segments wouldn't line up and later merges would fix the edges. One set of boundaries fixed before any worker starts keeps a fresh index's segments aligned.

## How

- `index/kdtree.rs` (new, Postgres-free): `KdTree::from_sample` splits recursively. Each cut is the quantile that gives both children a share of the sample proportional to their leaves; the dimension is the one spanning the widest slice of its global distribution (by rank, so mixed types compare), ties to the earlier field. Low-cardinality data can yield fewer than `target` leaves. Routing matches `RangePartitioning::partition_bounds` (NULL and `< split` left, `>= split` right, in-order leaves); in one dimension it *is* a `RangePartitioning`. `route`/`partition_bounds`/`partition_count` are the #5737 API.
- `postgres/build_partitioning.rs` (new): the leader samples the heap, not `pg_statistic`. `BlockSampler` over <= 4096 blocks, reservoir to 30k rows (the `ANALYZE` size), converted through the writer's own path so expression/aliased fields work.
- `build_parallel.rs`: leaf count is `adjusted_target_segment_count`. The tree ships as a binary Vec.

## Tests

- `kdtree.rs` and `pdb_owned_value.rs` unit test
- `build_partitioning.rs` `pg_test`s
