### PR TITLE
feat: computed global partition boundaries on the CREATE INDEX leader.

### DIFF
--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -18,6 +18,7 @@
 pub mod directory;
 pub mod fast_fields_helper;
 pub mod merge_policy;
+pub mod partition_tree;
 pub mod reader;
 pub mod search;
 pub mod writer;

--- a/pg_search/src/index/partition_tree.rs
+++ b/pg_search/src/index/partition_tree.rs
@@ -1,0 +1,603 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Ephemeral routing structure for a physically partitioned index build.
+//!
+//! The leader of a `CREATE INDEX` builds one [`PartitionTree`] from a sample of the heap and
+//! hands it to every parallel worker, so all workers slice the `partition_by` space at exactly
+//! the same boundaries. The tree is never persisted: workers record the bounds of the segments
+//! they write, and any later merge derives a fresh tree from that segment metadata.
+
+use std::cmp::Ordering;
+use std::fmt::{self, Display, Formatter};
+use std::net::Ipv6Addr;
+use std::ops::Bound;
+
+use serde::{Deserialize, Serialize};
+
+use crate::api::FieldName;
+use crate::postgres::datetime::PostgresDateTime;
+use crate::postgres::pdb_owned_value::PdbOwnedValue;
+
+/// One sampled row, holding one value per tree dimension in `partition_by` order.
+pub type SampleRow = Vec<PdbOwnedValue>;
+
+/// A KD-tree over the `partition_by` fields of an index. Leaves are numbered left to right, so
+/// with a single dimension the leaf order is the value order and NULLs land in partition 0,
+/// matching `RangePartitioning::partition_bounds`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PartitionTree {
+    dimensions: Vec<FieldName>,
+    root: PartitionNode,
+    num_partitions: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum PartitionNode {
+    Leaf {
+        partition: usize,
+    },
+    Split {
+        dimension: usize,
+        /// Rows with a value below this point (and NULLs) go to `lower`, all others to `upper`.
+        #[serde(with = "tagged_value")]
+        split_point: PdbOwnedValue,
+        lower: Box<PartitionNode>,
+        upper: Box<PartitionNode>,
+    },
+}
+
+/// The interval a partition covers along one dimension. `lower` is inclusive, `upper` is
+/// exclusive. An unbounded `lower` also admits NULLs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DimensionBounds {
+    pub lower: Bound<PdbOwnedValue>,
+    pub upper: Bound<PdbOwnedValue>,
+}
+
+impl PartitionTree {
+    /// Builds a tree with (at most) `target_partitions` leaves of roughly equal row mass.
+    ///
+    /// Splits cycle through the dimensions in `partition_by` order, one per level, and skip a
+    /// dimension that has a single distinct value inside the node. A node that cannot be split
+    /// on any dimension becomes a leaf, so heavily duplicated data can yield fewer partitions
+    /// than requested. Every `rows` entry must have exactly `dimensions.len()` values.
+    pub fn build(
+        dimensions: Vec<FieldName>,
+        rows: Vec<SampleRow>,
+        target_partitions: usize,
+    ) -> Self {
+        let ndims = dimensions.len();
+        debug_assert!(rows.iter().all(|row| row.len() == ndims));
+
+        let mut next_partition = 0;
+        let root = if ndims == 0 {
+            PartitionNode::leaf(&mut next_partition)
+        } else {
+            PartitionNode::build(
+                rows,
+                target_partitions.max(1),
+                0,
+                ndims,
+                &mut next_partition,
+            )
+        };
+        Self {
+            dimensions,
+            root,
+            num_partitions: next_partition,
+        }
+    }
+
+    pub fn dimensions(&self) -> &[FieldName] {
+        &self.dimensions
+    }
+
+    pub fn num_partitions(&self) -> usize {
+        self.num_partitions
+    }
+
+    /// Returns the partition a row belongs to. `values` must be in dimension order.
+    // The partitioned index writer routes every tuple through this; nothing calls it yet.
+    #[allow(dead_code)]
+    pub fn route(&self, values: &[PdbOwnedValue]) -> usize {
+        debug_assert_eq!(values.len(), self.dimensions.len());
+        let mut node = &self.root;
+        loop {
+            match node {
+                PartitionNode::Leaf { partition } => return *partition,
+                PartitionNode::Split {
+                    dimension,
+                    split_point,
+                    lower,
+                    upper,
+                } => {
+                    node = if goes_lower(&values[*dimension], split_point) {
+                        lower
+                    } else {
+                        upper
+                    };
+                }
+            }
+        }
+    }
+
+    /// The hyper-rectangle covered by `partition`, one entry per dimension, or `None` for an
+    /// unknown partition number.
+    pub fn partition_bounds(&self, partition: usize) -> Option<Vec<DimensionBounds>> {
+        let mut bounds = vec![
+            DimensionBounds {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded,
+            };
+            self.dimensions.len()
+        ];
+        let mut node = &self.root;
+        loop {
+            match node {
+                PartitionNode::Leaf { partition: p } => {
+                    return (*p == partition).then_some(bounds);
+                }
+                PartitionNode::Split {
+                    dimension,
+                    split_point,
+                    lower,
+                    upper,
+                } => {
+                    // Leaves are numbered in order, so the leaf we want is on the lower side iff
+                    // its number is below the first leaf number of the upper subtree.
+                    if partition < upper.first_partition() {
+                        bounds[*dimension].upper = Bound::Excluded(split_point.clone());
+                        node = lower;
+                    } else {
+                        bounds[*dimension].lower = Bound::Included(split_point.clone());
+                        node = upper;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl PartitionNode {
+    fn leaf(next_partition: &mut usize) -> Self {
+        let partition = *next_partition;
+        *next_partition += 1;
+        PartitionNode::Leaf { partition }
+    }
+
+    fn first_partition(&self) -> usize {
+        let mut node = self;
+        loop {
+            match node {
+                PartitionNode::Leaf { partition } => return *partition,
+                PartitionNode::Split { lower, .. } => node = lower,
+            }
+        }
+    }
+
+    fn build(
+        mut rows: Vec<SampleRow>,
+        target: usize,
+        depth: usize,
+        ndims: usize,
+        next_partition: &mut usize,
+    ) -> Self {
+        if target <= 1 || rows.len() < 2 {
+            return Self::leaf(next_partition);
+        }
+
+        // Aim the split at the quantile that gives each child its share of the leaves, so an
+        // odd target still ends in equal-mass partitions.
+        let lower_target = target / 2;
+        let upper_target = target - lower_target;
+
+        for offset in 0..ndims {
+            let dimension = (depth + offset) % ndims;
+            rows.sort_by(|a, b| compare_values(&a[dimension], &b[dimension]));
+
+            let Some(split_idx) = choose_split_index(&rows, dimension, lower_target, target) else {
+                continue;
+            };
+
+            let split_point = rows[split_idx][dimension].clone();
+            let upper_rows = rows.split_off(split_idx);
+            let lower = Self::build(rows, lower_target, depth + 1, ndims, next_partition);
+            let upper = Self::build(upper_rows, upper_target, depth + 1, ndims, next_partition);
+            return PartitionNode::Split {
+                dimension,
+                split_point,
+                lower: Box::new(lower),
+                upper: Box::new(upper),
+            };
+        }
+
+        Self::leaf(next_partition)
+    }
+}
+
+/// Picks the index at which `rows` (sorted on `dimension`) is cut so the value at that index
+/// becomes the split point. Both sides must be non-empty and every row equal to the split point
+/// must sit on the upper side, so the cut snaps to the nearest run boundary around the target
+/// quantile. Returns `None` when the dimension has one distinct value (NULLs count as one).
+fn choose_split_index(
+    rows: &[SampleRow],
+    dimension: usize,
+    lower_target: usize,
+    target: usize,
+) -> Option<usize> {
+    let n = rows.len();
+    let k = (n * lower_target / target).clamp(1, n - 1);
+    let at = |i: usize| &rows[i][dimension];
+
+    let run_start = (0..k)
+        .rev()
+        .find(|&i| compare_values(at(i), at(k)) != Ordering::Equal)
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let run_end = (k..n).find(|&i| compare_values(at(i), at(k)) != Ordering::Equal);
+
+    // A split point can never be NULL: NULLs sort first, so a cut inside the NULL run has
+    // `run_start == 0` and only the run end (the first non-NULL value) is a valid cut.
+    match (run_start > 0, run_end) {
+        (true, Some(end)) if k - run_start <= end - k => Some(run_start),
+        (_, Some(end)) => Some(end),
+        (true, None) => Some(run_start),
+        (false, None) => None,
+    }
+}
+
+fn goes_lower(value: &PdbOwnedValue, split_point: &PdbOwnedValue) -> bool {
+    matches!(value, PdbOwnedValue::Null) || compare_values(value, split_point) == Ordering::Less
+}
+
+/// Total order over sample values: NULLs first, then the value order of the field type. Uses
+/// `total_cmp` for floats so NaNs sort deterministically instead of comparing as equal.
+pub fn compare_values(a: &PdbOwnedValue, b: &PdbOwnedValue) -> Ordering {
+    match (a, b) {
+        (PdbOwnedValue::F64(x), PdbOwnedValue::F64(y)) => x.total_cmp(y),
+        _ => a.partial_cmp(b).unwrap_or(Ordering::Equal),
+    }
+}
+
+impl Display for PartitionTree {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for partition in 0..self.num_partitions {
+            let bounds = self
+                .partition_bounds(partition)
+                .expect("partition numbers are contiguous");
+            write!(f, "partition {partition}:")?;
+            for (dimension, DimensionBounds { lower, upper }) in self.dimensions.iter().zip(bounds)
+            {
+                write!(f, " {dimension}=")?;
+                match lower {
+                    Bound::Included(v) => write!(f, "[{}", DisplayValue(&v))?,
+                    _ => write!(f, "[..")?,
+                }
+                match upper {
+                    Bound::Excluded(v) => write!(f, ", {})", DisplayValue(&v))?,
+                    _ => write!(f, ", ..)")?,
+                }
+            }
+            if partition + 1 < self.num_partitions {
+                writeln!(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct DisplayValue<'a>(&'a PdbOwnedValue);
+
+impl Display for DisplayValue<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            PdbOwnedValue::Str(s) => write!(f, "{s:?}"),
+            PdbOwnedValue::U64(v) => write!(f, "{v}"),
+            PdbOwnedValue::I64(v) => write!(f, "{v}"),
+            PdbOwnedValue::F64(v) => write!(f, "{v}"),
+            PdbOwnedValue::Bool(v) => write!(f, "{v}"),
+            PdbOwnedValue::Date(d) => write!(f, "{}us", d.into_inner()),
+            PdbOwnedValue::IpAddr(ip) => write!(f, "{ip}"),
+            other => write!(f, "{other:?}"),
+        }
+    }
+}
+
+/// `PdbOwnedValue`'s own serde form goes through tantivy's `OwnedValue`, which cannot tell a
+/// non-negative `I64` from a `U64` on the way back in. Split points must survive the trip to
+/// the workers exactly, so they are serialized with an explicit variant tag instead.
+mod tagged_value {
+    use super::*;
+
+    #[derive(Serialize, Deserialize)]
+    enum TaggedValue {
+        Str(String),
+        U64(u64),
+        I64(i64),
+        F64(f64),
+        Bool(bool),
+        Date(i64),
+        Bytes(Vec<u8>),
+        IpAddr(Ipv6Addr),
+    }
+
+    pub fn serialize<S: serde::Serializer>(
+        value: &PdbOwnedValue,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let tagged = match value {
+            PdbOwnedValue::Str(s) => TaggedValue::Str(s.clone()),
+            PdbOwnedValue::U64(v) => TaggedValue::U64(*v),
+            PdbOwnedValue::I64(v) => TaggedValue::I64(*v),
+            PdbOwnedValue::F64(v) => TaggedValue::F64(*v),
+            PdbOwnedValue::Bool(v) => TaggedValue::Bool(*v),
+            PdbOwnedValue::Date(d) => TaggedValue::Date(d.into_inner()),
+            PdbOwnedValue::Bytes(b) => TaggedValue::Bytes(b.clone()),
+            PdbOwnedValue::IpAddr(ip) => TaggedValue::IpAddr(*ip),
+            other => {
+                return Err(serde::ser::Error::custom(format!(
+                    "unsupported partition split point: {other:?}"
+                )));
+            }
+        };
+        tagged.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<PdbOwnedValue, D::Error> {
+        Ok(match TaggedValue::deserialize(deserializer)? {
+            TaggedValue::Str(s) => PdbOwnedValue::Str(s),
+            TaggedValue::U64(v) => PdbOwnedValue::U64(v),
+            TaggedValue::I64(v) => PdbOwnedValue::I64(v),
+            TaggedValue::F64(v) => PdbOwnedValue::F64(v),
+            TaggedValue::Bool(v) => PdbOwnedValue::Bool(v),
+            TaggedValue::Date(raw) => PdbOwnedValue::Date(
+                PostgresDateTime::try_from_raw(raw).map_err(serde::de::Error::custom)?,
+            ),
+            TaggedValue::Bytes(b) => PdbOwnedValue::Bytes(b),
+            TaggedValue::IpAddr(ip) => PdbOwnedValue::IpAddr(ip),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dims(names: &[&str]) -> Vec<FieldName> {
+        names
+            .iter()
+            .map(|n| FieldName::from(n.to_string()))
+            .collect()
+    }
+
+    fn i64_rows(values: impl IntoIterator<Item = i64>) -> Vec<SampleRow> {
+        values
+            .into_iter()
+            .map(|v| vec![PdbOwnedValue::I64(v)])
+            .collect()
+    }
+
+    fn contains(bounds: &DimensionBounds, value: &PdbOwnedValue) -> bool {
+        if matches!(value, PdbOwnedValue::Null) {
+            return matches!(bounds.lower, Bound::Unbounded);
+        }
+        let above_lower = match &bounds.lower {
+            Bound::Unbounded => true,
+            Bound::Included(lo) => compare_values(value, lo) != Ordering::Less,
+            Bound::Excluded(_) => unreachable!(),
+        };
+        let below_upper = match &bounds.upper {
+            Bound::Unbounded => true,
+            Bound::Excluded(hi) => compare_values(value, hi) == Ordering::Less,
+            Bound::Included(_) => unreachable!(),
+        };
+        above_lower && below_upper
+    }
+
+    /// Every row must route to the leaf whose bounds contain it, and the leaf mass must be
+    /// within `tolerance` rows of even.
+    fn check_tree(tree: &PartitionTree, rows: &[SampleRow], tolerance: usize) {
+        let mut counts = vec![0usize; tree.num_partitions()];
+        for row in rows {
+            let partition = tree.route(row);
+            counts[partition] += 1;
+            let bounds = tree.partition_bounds(partition).unwrap();
+            for (dim, value) in row.iter().enumerate() {
+                assert!(
+                    contains(&bounds[dim], value),
+                    "row {row:?} routed to partition {partition} with bounds {bounds:?}"
+                );
+            }
+        }
+        let expected = rows.len() / tree.num_partitions();
+        for (partition, count) in counts.iter().enumerate() {
+            assert!(
+                count.abs_diff(expected) <= tolerance,
+                "partition {partition} holds {count} rows, expected about {expected}"
+            );
+        }
+        assert!(tree.partition_bounds(tree.num_partitions()).is_none());
+    }
+
+    #[test]
+    fn one_dimension_matches_value_order() {
+        let rows = i64_rows(0..1000);
+        let tree = PartitionTree::build(dims(&["id"]), rows.clone(), 8);
+        assert_eq!(tree.num_partitions(), 8);
+        check_tree(&tree, &rows, 0);
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(tree.route(row), i / 125);
+        }
+        assert_eq!(
+            tree.partition_bounds(3).unwrap()[0],
+            DimensionBounds {
+                lower: Bound::Included(PdbOwnedValue::I64(375)),
+                upper: Bound::Excluded(PdbOwnedValue::I64(500)),
+            }
+        );
+    }
+
+    #[test]
+    fn odd_target_still_balances() {
+        let rows = i64_rows(0..900);
+        let tree = PartitionTree::build(dims(&["id"]), rows.clone(), 3);
+        assert_eq!(tree.num_partitions(), 3);
+        check_tree(&tree, &rows, 1);
+    }
+
+    #[test]
+    fn two_dimensions_alternate_and_balance() {
+        let rows: Vec<SampleRow> = (0..1024i64)
+            .map(|i| vec![PdbOwnedValue::I64(i), PdbOwnedValue::I64((i * 7919) % 1024)])
+            .collect();
+        let tree = PartitionTree::build(dims(&["a", "b"]), rows.clone(), 8);
+        assert_eq!(tree.num_partitions(), 8);
+        check_tree(&tree, &rows, 8);
+
+        // The root splits `a` at its median, so partitions 0..4 sit below it and 4..8 at or
+        // above it (the third level refines `a` further), and the second level bounds `b` on
+        // at least one side in every partition.
+        let root_split = PdbOwnedValue::I64(512);
+        let bounds: Vec<_> = (0..8).map(|p| tree.partition_bounds(p).unwrap()).collect();
+        assert!(bounds[..4].iter().all(|b| match &b[0].upper {
+            Bound::Excluded(v) => compare_values(v, &root_split) != Ordering::Greater,
+            _ => false,
+        }));
+        assert!(bounds[4..].iter().all(|b| match &b[0].lower {
+            Bound::Included(v) => compare_values(v, &root_split) != Ordering::Less,
+            _ => false,
+        }));
+        assert!(bounds.iter().all(|b| b[1]
+            != DimensionBounds {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded
+            }));
+    }
+
+    #[test]
+    fn nulls_route_to_the_lowest_partition() {
+        let mut rows = i64_rows(0..100);
+        rows.extend((0..10).map(|_| vec![PdbOwnedValue::Null]));
+        let tree = PartitionTree::build(dims(&["id"]), rows.clone(), 4);
+        assert_eq!(tree.num_partitions(), 4);
+        assert_eq!(tree.route(&[PdbOwnedValue::Null]), 0);
+        check_tree(&tree, &rows, 4);
+        // A NULL is never chosen as a split point.
+        for p in 0..4 {
+            let b = &tree.partition_bounds(p).unwrap()[0];
+            assert!(!matches!(b.lower, Bound::Included(PdbOwnedValue::Null)));
+            assert!(!matches!(b.upper, Bound::Excluded(PdbOwnedValue::Null)));
+        }
+    }
+
+    #[test]
+    fn duplicates_stay_on_the_upper_side() {
+        // 90 rows of value 1, 10 rows of value 2: the only cut is between the runs.
+        let mut rows = i64_rows(std::iter::repeat_n(1, 90));
+        rows.extend(i64_rows(std::iter::repeat_n(2, 10)));
+        let tree = PartitionTree::build(dims(&["id"]), rows.clone(), 4);
+        assert_eq!(tree.num_partitions(), 2);
+        assert_eq!(tree.route(&[PdbOwnedValue::I64(1)]), 0);
+        assert_eq!(tree.route(&[PdbOwnedValue::I64(2)]), 1);
+        assert_eq!(tree.route(&[PdbOwnedValue::I64(3)]), 1);
+        assert_eq!(tree.route(&[PdbOwnedValue::I64(0)]), 0);
+    }
+
+    #[test]
+    fn unsplittable_dimension_is_skipped() {
+        let rows: Vec<SampleRow> = (0..100i64)
+            .map(|i| vec![PdbOwnedValue::Bool(true), PdbOwnedValue::I64(i)])
+            .collect();
+        let tree = PartitionTree::build(dims(&["flag", "id"]), rows.clone(), 4);
+        assert_eq!(tree.num_partitions(), 4);
+        check_tree(&tree, &rows, 0);
+        for p in 0..4 {
+            let bounds = tree.partition_bounds(p).unwrap();
+            assert_eq!(bounds[0].lower, Bound::Unbounded);
+            assert_eq!(bounds[0].upper, Bound::Unbounded);
+        }
+    }
+
+    #[test]
+    fn degenerate_inputs_give_one_partition() {
+        for rows in [vec![], i64_rows([7]), i64_rows(std::iter::repeat_n(7, 50))] {
+            let tree = PartitionTree::build(dims(&["id"]), rows, 8);
+            assert_eq!(tree.num_partitions(), 1);
+            assert_eq!(tree.route(&[PdbOwnedValue::I64(1)]), 0);
+        }
+        let tree = PartitionTree::build(vec![], vec![vec![], vec![]], 8);
+        assert_eq!(tree.num_partitions(), 1);
+        let tree = PartitionTree::build(dims(&["id"]), i64_rows(0..100), 0);
+        assert_eq!(tree.num_partitions(), 1);
+    }
+
+    #[test]
+    fn strings_and_floats_order_naturally() {
+        let rows: Vec<SampleRow> = ["apple", "banana", "cherry", "date", "elder", "fig"]
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                vec![
+                    PdbOwnedValue::Str(s.to_string()),
+                    PdbOwnedValue::F64(i as f64),
+                ]
+            })
+            .collect();
+        let tree = PartitionTree::build(dims(&["name", "score"]), rows.clone(), 2);
+        assert_eq!(tree.num_partitions(), 2);
+        assert_eq!(
+            tree.route(&[
+                PdbOwnedValue::Str("aardvark".into()),
+                PdbOwnedValue::F64(9.0)
+            ]),
+            0
+        );
+        assert_eq!(
+            tree.route(&[PdbOwnedValue::Str("zebra".into()), PdbOwnedValue::F64(0.0)]),
+            1
+        );
+        check_tree(&tree, &rows, 0);
+    }
+
+    #[test]
+    fn json_roundtrip_keeps_signed_split_points() {
+        let rows: Vec<SampleRow> = (0..64i64)
+            .map(|i| vec![PdbOwnedValue::I64(i), PdbOwnedValue::U64(i as u64 * 3)])
+            .collect();
+        let tree = PartitionTree::build(dims(&["a", "b"]), rows.clone(), 8);
+        let bytes = serde_json::to_vec(&Some(tree.clone())).unwrap();
+        let back: Option<PartitionTree> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(back.as_ref(), Some(&tree));
+        for row in &rows {
+            assert_eq!(back.as_ref().unwrap().route(row), tree.route(row));
+        }
+        let none: Option<PartitionTree> = serde_json::from_slice(b"null").unwrap();
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn display_lists_every_partition() {
+        let tree = PartitionTree::build(dims(&["id"]), i64_rows(0..100), 4);
+        let text = tree.to_string();
+        assert_eq!(text.lines().count(), 4);
+        assert!(text.starts_with("partition 0: id=[.., 25)"));
+        assert!(text.ends_with("partition 3: id=[75, ..)"));
+    }
+}

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -18,6 +18,7 @@
 use crate::api::version::Version;
 use crate::gucs;
 use crate::index::mvcc::MvccSatisfies;
+use crate::index::partition_tree::PartitionTree;
 use crate::index::writer::index::{
     DiskSpaceGuard, IndexWriterConfig, Mergeable, SearchIndexMerger, SerialIndexWriter,
 };
@@ -27,6 +28,7 @@ use crate::parallel_worker::{
     ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
     WorkerStyle, chunk_range,
 };
+use crate::postgres::build_partitioning::plan_partition_tree;
 use crate::postgres::composite::CompositeSlotValues;
 use crate::postgres::locks::Spinlock;
 use crate::postgres::merge::garbage_collect_index;
@@ -119,6 +121,9 @@ struct ParallelBuild {
     config: WorkerConfig,
     scandesc: ScanDesc,
     coordination: WorkerCoordination,
+    /// The leader's `Option<PartitionTree>`, JSON-encoded so it can travel through the DSM
+    /// as a plain byte array.
+    partition_tree: Vec<u8>,
 }
 
 impl ParallelState for ScanDesc {
@@ -138,12 +143,9 @@ impl ParallelState for ScanDesc {
 impl ParallelBuild {
     fn new(
         heaprel: &PgSearchRelation,
-        indexrel: &PgSearchRelation,
         snapshot: pg_sys::Snapshot,
-        concurrent: bool,
-        current_xid: pg_sys::FullTransactionId,
-        need_wal: bool,
-        next_xid: pg_sys::FullTransactionId,
+        config: WorkerConfig,
+        partition_tree: Option<&PartitionTree>,
     ) -> Self {
         let scandesc = unsafe {
             let size = size_of::<pg_sys::ParallelTableScanDescData>()
@@ -153,23 +155,23 @@ impl ParallelBuild {
             (size, scandesc)
         };
         Self {
-            config: WorkerConfig {
-                heaprelid: heaprel.oid(),
-                indexrelid: indexrel.oid(),
-                concurrent,
-                current_xid,
-                need_wal,
-                next_xid,
-            },
+            config,
             scandesc,
             coordination: Default::default(),
+            partition_tree: serde_json::to_vec(&partition_tree)
+                .expect("partition tree should be serializable"),
         }
     }
 }
 
 impl ParallelProcess for ParallelBuild {
     fn state_values(&self) -> Vec<&dyn ParallelState> {
-        vec![&self.config, &self.scandesc, &self.coordination]
+        vec![
+            &self.config,
+            &self.scandesc,
+            &self.coordination,
+            &self.partition_tree,
+        ]
     }
 }
 
@@ -185,6 +187,9 @@ struct BuildWorker<'a> {
     coordination: &'a mut WorkerCoordination,
     heaprel: PgSearchRelation,
     indexrel: PgSearchRelation,
+    /// The leader's global partition boundaries. Every worker gets the same tree, so the
+    /// segments they write line up in the `partition_by` space.
+    partition_tree: Option<PartitionTree>,
 }
 
 impl ParallelWorker for BuildWorker<'_> {
@@ -204,6 +209,12 @@ impl ParallelWorker for BuildWorker<'_> {
             .object::<WorkerCoordination>(2)
             .expect("should be able to get ProcessCoordination")
             .expect("ProcessCoordination should not be NULL");
+        let partition_tree = state_manager
+            .slice::<u8>(3)
+            .expect("should be able to get the partition tree")
+            .expect("partition tree should not be NULL");
+        let partition_tree = serde_json::from_slice::<Option<PartitionTree>>(partition_tree)
+            .expect("partition tree should deserialize");
 
         unsafe {
             let (heap_lock, index_lock) = if !config.concurrent {
@@ -227,6 +238,7 @@ impl ParallelWorker for BuildWorker<'_> {
                 coordination,
                 heaprel,
                 indexrel,
+                partition_tree,
             }
         }
     }
@@ -252,6 +264,7 @@ impl<'a> BuildWorker<'a> {
         indexrel: &PgSearchRelation,
         config: WorkerConfig,
         coordination: &'a mut WorkerCoordination,
+        partition_tree: Option<PartitionTree>,
     ) -> Self {
         Self {
             config,
@@ -259,6 +272,7 @@ impl<'a> BuildWorker<'a> {
             heaprel: Clone::clone(heaprel),
             indexrel: Clone::clone(indexrel),
             coordination,
+            partition_tree,
         }
     }
 
@@ -277,6 +291,13 @@ impl<'a> BuildWorker<'a> {
             pgrx::debug1!(
                 "build_worker {worker_number}: target_segment_count: {target_segment_count}, nlaunched: {nlaunched}, worker_segment_target: {worker_segment_target}"
             );
+            if let Some(tree) = &self.partition_tree {
+                pgrx::debug1!(
+                    "build_worker {worker_number}: routing over {} partitions of {:?}",
+                    tree.num_partitions(),
+                    tree.dimensions()
+                );
+            }
 
             let mut build_state = WorkerBuildState::new(
                 &self.heaprel,
@@ -663,18 +684,22 @@ pub(super) fn build_index(
         }
     });
 
-    let current_xid = unsafe { pg_sys::GetCurrentFullTransactionId() };
-    let need_wal = indexrel.need_wal();
-    let next_xid = unsafe { pg_sys::ReadNextFullTransactionId() };
-    let process = ParallelBuild::new(
+    let config = WorkerConfig {
+        heaprelid: heaprel.oid(),
+        indexrelid: indexrel.oid(),
+        concurrent,
+        current_xid: unsafe { pg_sys::GetCurrentFullTransactionId() },
+        need_wal: indexrel.need_wal(),
+        next_xid: unsafe { pg_sys::ReadNextFullTransactionId() },
+    };
+    // One segment per partition is what the build converges to, so the partition count follows
+    // the segment target.
+    let partition_tree = plan_partition_tree(
         &heaprel,
         &indexrel,
-        snapshot.0,
-        concurrent,
-        current_xid,
-        need_wal,
-        next_xid,
-    );
+        plan::adjusted_target_segment_count(&heaprel, &indexrel),
+    )?;
+    let process = ParallelBuild::new(&heaprel, snapshot.0, config, partition_tree.as_ref());
     let nworkers = plan::create_index_nworkers(&heaprel, &indexrel);
     pgrx::debug1!("build_index: asked for {nworkers} workers");
 
@@ -743,24 +768,15 @@ pub(super) fn build_index(
         pgrx::debug1!("build_index: not doing a parallel build");
         // not doing a parallel build, so directly instantiate a BuildWorker and serially run the
         // whole build here in this connected backend
-        let heaprelid = heaprel.oid();
-        let indexrelid = indexrel.oid();
-
         let mut coordination: WorkerCoordination = Default::default();
         coordination.set_nlaunched(1);
 
         let mut worker = BuildWorker::new(
             &heaprel,
             &indexrel,
-            WorkerConfig {
-                heaprelid,
-                indexrelid,
-                concurrent,
-                current_xid,
-                need_wal,
-                next_xid,
-            },
+            config,
             &mut coordination,
+            partition_tree,
         );
 
         let (total_tuples, total_merges) = worker.do_build(1, true)?;

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -1,0 +1,439 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Leader-side boundary generation for a `partition_by` index build.
+//!
+//! Before the parallel workers launch, the leader samples the heap the same way `ANALYZE` does
+//! (a random subset of blocks, then a reservoir over their rows) and builds one
+//! [`PartitionTree`] from the sampled `partition_by` values. Sampling the heap rather than
+//! reading `pg_statistic` keeps the boundaries correct for tables that were never analyzed and
+//! for expression fields, and gives the tree the joint distribution it needs to split on more
+//! than one column.
+
+use std::mem::MaybeUninit;
+use std::ptr::null_mut;
+use std::time::Instant;
+
+use anyhow::{Context, bail};
+use pgrx::{check_for_interrupts, pg_sys};
+
+use crate::api::FieldName;
+use crate::api::tokenizers::definitions::pdb::DatumWithType;
+use crate::api::tokenizers::{type_is_alias, type_is_tokenizer};
+use crate::index::partition_tree::{PartitionTree, SampleRow};
+use crate::postgres::composite::CompositeSlotValues;
+use crate::postgres::pdb_owned_value::PdbOwnedValue;
+use crate::postgres::rel::PgSearchRelation;
+use crate::postgres::utils::{
+    collect_composites_for_unpacking, get_field_value, scalar_datum_to_tantivy_value,
+};
+use crate::schema::{CategorizedFieldData, SearchFieldType};
+
+/// A fixed seed makes a rebuild over an unchanged heap reproduce the same boundaries.
+const SAMPLE_SEED: u32 = 0x5EED_1D0C;
+
+/// The `partition_by` fields of an index, in declaration order, with what is needed to pull
+/// their values out of a formed index tuple.
+struct PartitionDimension {
+    field_name: FieldName,
+    field_type: SearchFieldType,
+    categorized: CategorizedFieldData,
+}
+
+/// Computes the global partition boundaries for a `CREATE INDEX` over `heaprel`, or `None`
+/// when the index has no `partition_by` or the build targets a single partition.
+pub(super) fn plan_partition_tree(
+    heaprel: &PgSearchRelation,
+    indexrel: &PgSearchRelation,
+    target_partitions: usize,
+) -> anyhow::Result<Option<PartitionTree>> {
+    let partition_by = indexrel.options().partition_by();
+    if partition_by.is_empty() || target_partitions <= 1 {
+        return Ok(None);
+    }
+
+    let dimensions = partition_dimensions(indexrel, &partition_by)?;
+    let started = Instant::now();
+    let target_rows = sample_target_rows();
+    let rows = unsafe { sample_heap(heaprel, indexrel, &dimensions, target_rows)? };
+    let nsampled = rows.len();
+
+    let tree = PartitionTree::build(partition_by, rows, target_partitions);
+    pgrx::debug1!(
+        "build_index: {} partition boundaries over {nsampled} sampled rows in {:?}\n{tree}",
+        tree.num_partitions(),
+        started.elapsed()
+    );
+    Ok(Some(tree))
+}
+
+/// Same sample size as `ANALYZE`, so the cost of boundary generation is bounded by a setting
+/// the DBA already tunes.
+fn sample_target_rows() -> usize {
+    let statistics_target = unsafe { pg_sys::default_statistics_target }.max(1) as usize;
+    300 * statistics_target
+}
+
+fn partition_dimensions(
+    indexrel: &PgSearchRelation,
+    partition_by: &[FieldName],
+) -> anyhow::Result<Vec<PartitionDimension>> {
+    let schema = indexrel.schema()?;
+    let categorized_fields = schema.categorized_fields();
+    partition_by
+        .iter()
+        .map(|field_name| {
+            let (search_field, categorized) = categorized_fields
+                .iter()
+                .find(|(search_field, _)| search_field.field_name() == field_name)
+                .with_context(|| format!("`partition_by` field `{field_name}` does not exist"))?;
+            let field_type = search_field.field_type();
+            if categorized.is_array
+                || categorized.is_json
+                || matches!(field_type, SearchFieldType::Vector(..))
+            {
+                bail!("`partition_by` field `{field_name}` must be a scalar field");
+            }
+            Ok(PartitionDimension {
+                field_name: field_name.clone(),
+                field_type,
+                categorized: categorized.clone(),
+            })
+        })
+        .collect()
+}
+
+/// Reads a random subset of `heaprel`'s blocks and keeps a uniform reservoir of at most
+/// `target_rows` rows, each reduced to its `partition_by` values.
+unsafe fn sample_heap(
+    heaprel: &PgSearchRelation,
+    indexrel: &PgSearchRelation,
+    dimensions: &[PartitionDimension],
+    target_rows: usize,
+) -> anyhow::Result<Vec<SampleRow>> {
+    let nblocks =
+        pg_sys::RelationGetNumberOfBlocksInFork(heaprel.as_ptr(), pg_sys::ForkNumber::MAIN_FORKNUM);
+    if nblocks == 0 {
+        return Ok(vec![]);
+    }
+
+    let snapshot = pg_sys::RegisterSnapshot(pg_sys::GetTransactionSnapshot());
+    // No `SO_ALLOW_SYNC`: `heap_setscanlimits` needs the start block under our control.
+    let flags = pg_sys::ScanOptions::SO_TYPE_SEQSCAN
+        | pg_sys::ScanOptions::SO_ALLOW_STRAT
+        | pg_sys::ScanOptions::SO_ALLOW_PAGEMODE
+        | pg_sys::ScanOptions::SO_TEMP_SNAPSHOT;
+    let scan = pg_sys::heap_beginscan(heaprel.as_ptr(), snapshot, 0, null_mut(), null_mut(), flags);
+    let slot = pg_sys::table_slot_create(heaprel.as_ptr(), null_mut());
+    let estate = pg_sys::CreateExecutorState();
+    let econtext = pg_sys::MakePerTupleExprContext(estate);
+    (*econtext).ecxt_scantuple = slot;
+    let index_info = indexrel.index_info();
+
+    let mut block_sampler = MaybeUninit::<pg_sys::BlockSamplerData>::zeroed();
+    pg_sys::BlockSampler_Init(
+        block_sampler.as_mut_ptr(),
+        nblocks,
+        target_rows.min(i32::MAX as usize) as i32,
+        SAMPLE_SEED,
+    );
+    let block_sampler = block_sampler.as_mut_ptr();
+    let mut reservoir = Reservoir::new(target_rows, SAMPLE_SEED);
+
+    let mut values = [pg_sys::Datum::null(); pg_sys::INDEX_MAX_KEYS as usize];
+    let mut isnull = [false; pg_sys::INDEX_MAX_KEYS as usize];
+
+    let mut scan_started = false;
+    let result = (|| -> anyhow::Result<()> {
+        while pg_sys::BlockSampler_HasMore(block_sampler) {
+            check_for_interrupts!();
+            let block = pg_sys::BlockSampler_Next(block_sampler);
+            if scan_started {
+                pg_sys::heap_rescan(scan, null_mut(), false, false, false, false);
+            }
+            scan_started = true;
+            pg_sys::heap_setscanlimits(scan, block, 1);
+
+            while pg_sys::heap_getnextslot(scan, pg_sys::ScanDirection::ForwardScanDirection, slot)
+            {
+                pg_sys::FormIndexDatum(
+                    index_info,
+                    slot,
+                    estate,
+                    values.as_mut_ptr(),
+                    isnull.as_mut_ptr(),
+                );
+                let row = partition_values(dimensions, values.as_mut_ptr(), isnull.as_mut_ptr())?;
+                reservoir.offer(row);
+                pg_sys::MemoryContextReset((*econtext).ecxt_per_tuple_memory);
+            }
+        }
+        Ok(())
+    })();
+
+    pg_sys::heap_endscan(scan);
+    pg_sys::ExecDropSingleTupleTableSlot(slot);
+    pg_sys::FreeExecutorState(estate);
+
+    result?;
+    Ok(reservoir.into_rows())
+}
+
+/// Extracts the `partition_by` values of one formed index tuple, converted exactly as the
+/// index writer would store them so the workers' routing and these boundaries agree.
+unsafe fn partition_values(
+    dimensions: &[PartitionDimension],
+    values: *mut pg_sys::Datum,
+    isnull: *mut bool,
+) -> anyhow::Result<SampleRow> {
+    let unpacked_composites = CompositeSlotValues::from_composites(
+        collect_composites_for_unpacking(dimensions.iter().map(|d| &d.categorized), values, isnull),
+    );
+    dimensions
+        .iter()
+        .map(|dimension| {
+            let categorized = &dimension.categorized;
+            let (datum, is_null) = get_field_value(
+                &categorized.source,
+                categorized.attno,
+                values,
+                isnull,
+                &unpacked_composites,
+            );
+            if is_null {
+                return Ok(PdbOwnedValue::Null);
+            }
+            let pg_type = categorized.pg_type.value();
+            let datum = if type_is_alias(pg_type) || type_is_tokenizer(pg_type) {
+                DatumWithType::get_underlying_type(datum).0
+            } else {
+                datum
+            };
+            let value =
+                scalar_datum_to_tantivy_value(datum, dimension.field_type, categorized.base_oid)
+                    .with_context(|| {
+                        format!(
+                            "could not read `partition_by` field `{}`",
+                            dimension.field_name
+                        )
+                    })?;
+            Ok(value.0)
+        })
+        .collect()
+}
+
+/// Uniform reservoir sample (Algorithm R) over the rows of the sampled blocks. Rows within a
+/// block are correlated (they were inserted together), so keeping every row of fewer blocks
+/// would skew the quantiles.
+struct Reservoir {
+    capacity: usize,
+    seen: u64,
+    rows: Vec<SampleRow>,
+    prng: pg_sys::pg_prng_state,
+}
+
+impl Reservoir {
+    fn new(capacity: usize, seed: u32) -> Self {
+        let mut prng = MaybeUninit::<pg_sys::pg_prng_state>::zeroed();
+        unsafe { pg_sys::pg_prng_seed(prng.as_mut_ptr(), seed as u64) };
+        Self {
+            capacity,
+            seen: 0,
+            rows: Vec::with_capacity(capacity),
+            prng: unsafe { prng.assume_init() },
+        }
+    }
+
+    fn offer(&mut self, row: SampleRow) {
+        self.seen += 1;
+        if self.rows.len() < self.capacity {
+            self.rows.push(row);
+            return;
+        }
+        let slot = unsafe { pg_sys::pg_prng_uint64_range(&mut self.prng, 0, self.seen - 1) };
+        if (slot as usize) < self.capacity {
+            self.rows[slot as usize] = row;
+        }
+    }
+
+    fn into_rows(self) -> Vec<SampleRow> {
+        self.rows
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use pgrx::prelude::*;
+    use std::ops::Bound;
+
+    fn relations(table: &str, index: &str) -> (PgSearchRelation, PgSearchRelation) {
+        let heap_oid = Spi::get_one::<pg_sys::Oid>(&format!("SELECT '{table}'::regclass::oid"))
+            .unwrap()
+            .unwrap();
+        let index_oid = Spi::get_one::<pg_sys::Oid>(&format!("SELECT '{index}'::regclass::oid"))
+            .unwrap()
+            .unwrap();
+        (
+            PgSearchRelation::open(heap_oid),
+            PgSearchRelation::open(index_oid),
+        )
+    }
+
+    fn i64_bound(bound: &Bound<PdbOwnedValue>) -> Option<i64> {
+        match bound {
+            Bound::Included(PdbOwnedValue::I64(v)) | Bound::Excluded(PdbOwnedValue::I64(v)) => {
+                Some(*v)
+            }
+            Bound::Unbounded => None,
+            other => panic!("unexpected bound {other:?}"),
+        }
+    }
+
+    /// A table small enough that every block is sampled and no row is evicted from the
+    /// reservoir yields exact quantiles, so the boundaries are fully determined by the data.
+    #[pg_test]
+    fn plan_partition_tree_splits_evenly() {
+        Spi::run(
+            r#"
+            CREATE TABLE ptree (id SERIAL PRIMARY KEY, owner_id INT, body TEXT);
+            INSERT INTO ptree (owner_id, body)
+            SELECT (i * 7919) % 1000, 'row ' || i FROM generate_series(1, 4000) i;
+            CREATE INDEX ptree_idx ON ptree USING bm25 (id, owner_id, body)
+            WITH (key_field = 'id', partition_by = 'id,owner_id');
+            "#,
+        )
+        .unwrap();
+
+        let (heaprel, indexrel) = relations("ptree", "ptree_idx");
+        let tree = plan_partition_tree(&heaprel, &indexrel, 8)
+            .unwrap()
+            .expect("partition_by is set, so a tree is planned");
+        assert_eq!(tree.num_partitions(), 8);
+        assert_eq!(
+            tree.dimensions()
+                .iter()
+                .map(|f| f.to_string())
+                .collect::<Vec<_>>(),
+            vec!["id", "owner_id"]
+        );
+
+        // The root split is on `id` at its median; the second level splits `owner_id` and the
+        // third refines `id`, so the median shows up as the outer `id` bound of the four
+        // partitions adjacent to it.
+        let bounds = |p: usize| tree.partition_bounds(p).unwrap();
+        assert_eq!(i64_bound(&bounds(1)[0].upper), Some(2001));
+        assert_eq!(i64_bound(&bounds(3)[0].upper), Some(2001));
+        assert_eq!(i64_bound(&bounds(4)[0].lower), Some(2001));
+        assert_eq!(i64_bound(&bounds(6)[0].lower), Some(2001));
+
+        // Every partition holds about a quarter of the table on `id` (the second `id` split
+        // is the median of an `owner_id` half, so it is a few rows off) and exactly half of
+        // it on `owner_id`.
+        for partition in 0..8 {
+            let bounds = tree.partition_bounds(partition).unwrap();
+            let id_span = i64_bound(&bounds[0].upper).unwrap_or(4001)
+                - i64_bound(&bounds[0].lower).unwrap_or(1);
+            assert!(
+                (980..=1020).contains(&id_span),
+                "partition {partition}: {bounds:?}"
+            );
+            let owner_span = i64_bound(&bounds[1].upper).unwrap_or(1000)
+                - i64_bound(&bounds[1].lower).unwrap_or(0);
+            assert_eq!(owner_span, 500, "partition {partition}: {bounds:?}");
+        }
+
+        // Routing a real row lands in the partition whose bounds contain it.
+        let partition = tree.route(&[PdbOwnedValue::I64(2500), PdbOwnedValue::I64(10)]);
+        let bounds = tree.partition_bounds(partition).unwrap();
+        assert!(i64_bound(&bounds[0].lower).unwrap() <= 2500);
+        assert!(i64_bound(&bounds[0].upper).unwrap_or(i64::MAX) > 2500);
+        assert!(i64_bound(&bounds[1].lower).unwrap_or(i64::MIN) <= 10);
+        assert!(i64_bound(&bounds[1].upper).unwrap() > 10);
+    }
+
+    #[pg_test]
+    fn plan_partition_tree_handles_expressions_nulls_and_text() {
+        Spi::run(
+            r#"
+            CREATE TABLE ptree_expr (id SERIAL PRIMARY KEY, name TEXT, created_at TIMESTAMP);
+            INSERT INTO ptree_expr (name, created_at)
+            SELECT CASE WHEN i % 10 = 0 THEN NULL ELSE chr(97 + (i % 26)) || i END,
+                   '2020-01-01'::timestamp + (i || ' minutes')::interval
+            FROM generate_series(1, 2600) i;
+            CREATE INDEX ptree_expr_idx ON ptree_expr
+            USING bm25 (id, (name::pdb.literal), created_at)
+            WITH (key_field = 'id', partition_by = 'name,created_at');
+            "#,
+        )
+        .unwrap();
+
+        let (heaprel, indexrel) = relations("ptree_expr", "ptree_expr_idx");
+        let tree = plan_partition_tree(&heaprel, &indexrel, 4)
+            .unwrap()
+            .unwrap();
+        assert_eq!(tree.num_partitions(), 4);
+
+        // NULL names route to the first partition, and text split points are real strings.
+        assert_eq!(tree.route(&[PdbOwnedValue::Null, PdbOwnedValue::Null]), 0);
+        let mid = tree.partition_bounds(2).unwrap();
+        assert!(matches!(
+            mid[0].lower,
+            Bound::Included(PdbOwnedValue::Str(_))
+        ));
+        assert!(
+            matches!(mid[1].lower, Bound::Included(PdbOwnedValue::Date(_)))
+                || matches!(mid[1].upper, Bound::Excluded(PdbOwnedValue::Date(_)))
+        );
+    }
+
+    #[pg_test]
+    fn plan_partition_tree_skips_unpartitioned_and_single_target() {
+        Spi::run(
+            r#"
+            CREATE TABLE ptree_plain (id SERIAL PRIMARY KEY, body TEXT);
+            INSERT INTO ptree_plain (body) SELECT 'row ' || i FROM generate_series(1, 100) i;
+            CREATE INDEX ptree_plain_idx ON ptree_plain USING bm25 (id, body)
+            WITH (key_field = 'id');
+            CREATE TABLE ptree_part (id SERIAL PRIMARY KEY, body TEXT);
+            INSERT INTO ptree_part (body) SELECT 'row ' || i FROM generate_series(1, 100) i;
+            CREATE INDEX ptree_part_idx ON ptree_part USING bm25 (id, body)
+            WITH (key_field = 'id', partition_by = 'id');
+            "#,
+        )
+        .unwrap();
+
+        let (heaprel, indexrel) = relations("ptree_plain", "ptree_plain_idx");
+        assert!(
+            plan_partition_tree(&heaprel, &indexrel, 8)
+                .unwrap()
+                .is_none()
+        );
+
+        let (heaprel, indexrel) = relations("ptree_part", "ptree_part_idx");
+        assert!(
+            plan_partition_tree(&heaprel, &indexrel, 1)
+                .unwrap()
+                .is_none()
+        );
+        let tree = plan_partition_tree(&heaprel, &indexrel, 4)
+            .unwrap()
+            .unwrap();
+        assert_eq!(tree.num_partitions(), 4);
+    }
+}

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -50,6 +50,7 @@ mod vacuum;
 mod validate;
 
 mod build_parallel;
+mod build_partitioning;
 pub mod catalog;
 pub mod composite;
 mod condition_variable;

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -30,7 +30,7 @@ use crate::postgres::composite::{
 use crate::postgres::customscan::orderby::text_lower_funcoid;
 use crate::postgres::deparse::deparse_expr;
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::types::TantivyValue;
+use crate::postgres::types::{TantivyValue, TantivyValueError};
 use crate::postgres::var::find_vars;
 use crate::schema::{CategorizedFieldData, SearchField, SearchFieldType};
 use crate::vector::PgVector;
@@ -832,22 +832,11 @@ pub unsafe fn row_to_search_document<'a>(
             };
             document.add_vector(search_field.field(), &vec);
         } else {
-            let tv = match search_field.field_type() {
-                SearchFieldType::Numeric64(_, scale) => {
-                    TantivyValue::try_from_numeric_i64(actual_datum, scale)
-                }
-                SearchFieldType::NumericBytes(..) => {
-                    TantivyValue::try_from_numeric_bytes(actual_datum)
-                }
-                // Legacy pre-v0.22.0 indexes stored NUMERIC as F64 in the tantivy schema.
-                SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
-                    TantivyValue::try_from_numeric_f64(actual_datum)
-                }
-                _ => TantivyValue::try_from_datum(actual_datum, *base_oid),
-            }
-            .unwrap_or_else(|e| {
-                panic!("could not parse field `{}`: {e}", search_field.field_name())
-            });
+            let tv =
+                scalar_datum_to_tantivy_value(actual_datum, search_field.field_type(), *base_oid)
+                    .unwrap_or_else(|e| {
+                        panic!("could not parse field `{}`: {e}", search_field.field_name())
+                    });
             document.add_field_value(
                 search_field.field(),
                 &tv.into_tantivy_value(created_by_version),
@@ -855,6 +844,24 @@ pub unsafe fn row_to_search_document<'a>(
         }
     }
     Ok(())
+}
+
+/// Converts a non-NULL, non-array, non-JSON index datum (already unwrapped from any
+/// `pdb.alias`/tokenizer type) into the value the index stores for `field_type`.
+pub unsafe fn scalar_datum_to_tantivy_value(
+    datum: pg_sys::Datum,
+    field_type: SearchFieldType,
+    base_oid: PgOid,
+) -> Result<TantivyValue, TantivyValueError> {
+    match field_type {
+        SearchFieldType::Numeric64(_, scale) => TantivyValue::try_from_numeric_i64(datum, scale),
+        SearchFieldType::NumericBytes(..) => TantivyValue::try_from_numeric_bytes(datum),
+        // Legacy pre-v0.22.0 indexes stored NUMERIC as F64 in the tantivy schema.
+        SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
+            TantivyValue::try_from_numeric_f64(datum)
+        }
+        _ => TantivyValue::try_from_datum(datum, base_oid),
+    }
 }
 
 pub fn convert_pg_date_string(typeoid: PgOid, date_string: &str) -> PostgresDateTime {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5736

## What

This PR makes the `CREATE INDEX` leader compute one global set of partition boundaries for a `partition_by` index and hand it to every parallel worker.

The boundaries are a KD-tree (`PartitionTree`) over the `partition_by` fields, built from a sample of the heap before the workers launch. Workers deserialize it and, for now, only log it. Routing tuples into per-partition segments is #5737.

## Why

If each worker partitioned its own tuple stream from local data, the boundaries would differ between workers, and the segments would not line up in the `partition_by` space. M3 would then have to merge across misaligned edges. One tree, computed once on the leader, keeps every worker's segments aligned.

The tree is ephemeral. It is not persisted; the workers will record the bounds of the segments they write, and later merges derive a fresh routing tree from that metadata.

## How

- `pg_search/src/index/partition_tree.rs`: `PartitionTree`, a serde-able KD-tree over `PdbOwnedValue`.
  - `build(dimensions, rows, target_partitions)` splits recursively, cycling through the dimensions in `partition_by` order. Each split sits at the quantile that gives both children their share of the leaves, so an odd target still ends in equal-mass partitions. A dimension with a single distinct value inside a node is skipped, and a node that can't be split on any dimension becomes a leaf.
  - `route(values)` and `partition_bounds(partition)` are the two consumers of the tree. NULLs sort first and route to the lower side, which matches `RangePartitioning::partition_bounds`. Leaves are numbered left to right, so with one dimension the leaf order is the value order.
  - Split points are serialized with an explicit variant tag. `PdbOwnedValue`'s own serde form goes through tantivy's `OwnedValue`, which turns a non-negative `I64` into a `U64` on the way back in.
- `pg_search/src/postgres/build_partitioning.rs`: the leader side. `plan_partition_tree` samples the heap the way `ANALYZE` does (`BlockSampler` over `300 * default_statistics_target` blocks, then a reservoir of that many rows), forms the index tuple for each sampled row with `FormIndexDatum`, and converts the `partition_by` values with the same code path the writer uses. The target partition count is `adjusted_target_segment_count`, since one segment per partition is what the build converges to.
  - I went with heap sampling rather than `pg_statistic`. The KD-tree needs the joint distribution to split on more than one column, `pg_statistic` only has marginals, has nothing for expression fields, and is empty for a table that was never analyzed (the common case right after a bulk load). The sample size is the same one `ANALYZE` uses, so the cost is bounded by a knob the DBA already tunes. A fixed seed makes a rebuild over an unchanged heap reproduce the same boundaries.
- `pg_search/src/postgres/build_parallel.rs`: the tree travels as a JSON-encoded `Vec<u8>` state entry in the DSM. `BuildWorker` reads it in `new_parallel_worker` (and gets it directly on the serial path) and logs the partition count and dimensions at `debug1`. The leader logs the full boundary list at `debug1`.
- `pg_search/src/postgres/utils.rs`: pulled the scalar datum conversion out of `row_to_search_document` into `scalar_datum_to_tantivy_value`, so the sampler and the writer share it.

With `client_min_messages = debug1`, a 300k-row table with `partition_by = 'id,owner_id'` and `target_segment_count = 8` logs:

```
DEBUG:  build_index: 8 partition boundaries over 30000 sampled rows in 474.2225ms
partition 0: id=[.., 74632) owner_id=[.., 49842)
partition 1: id=[74632, 150855) owner_id=[.., 49842)
partition 2: id=[.., 73817) owner_id=[49842, ..)
partition 3: id=[73817, 150855) owner_id=[49842, ..)
partition 4: id=[150855, 225813) owner_id=[.., 49753)
partition 5: id=[225813, ..) owner_id=[.., 49753)
partition 6: id=[150855, 225364) owner_id=[49753, ..)
partition 7: id=[225364, ..) owner_id=[49753, ..)
DEBUG:  build_worker 1: routing over 8 partitions of [FieldName("id"), FieldName("owner_id")]
```

Cost of the sample, measured on my laptop while other builds were running: 0.5s of a 7.3s build at 300k rows (every block gets sampled at that size), and 4.5s of a 111s build at 3M rows (499 MB, 30000 of 63829 blocks).

## Tests

- Unit tests for `PartitionTree`: value order in one dimension, odd targets, two dimensions, NULLs, duplicate-heavy data, an unsplittable dimension, degenerate inputs, text and float keys, JSON round trip of signed split points, and `Display`.
- `#[pg_test]`s for `plan_partition_tree`: exact split points on a table small enough that the sample is the whole table, an expression field with NULLs and a timestamp, and the two cases that must return `None` (no `partition_by`, single-partition target).
- Manually checked `CREATE INDEX`, `REINDEX`, and `CREATE INDEX CONCURRENTLY` on PG16 and PG18 with the parallel and serial build paths.
