### PR TITLE
fix(mpp): replay the leader's segment view in every parallel reader

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -263,7 +263,9 @@ impl<'a> ParallelAggregationWorker<'a> {
             &indexrel,
             self.query.clone(),
             false,
-            MvccSatisfies::ParallelWorker(SegmentView::from_ids(segment_ids.iter().copied())),
+            MvccSatisfies::ParallelWorker(SegmentView::from_unordered_ids(
+                segment_ids.iter().copied(),
+            )),
             NonNull::new(context_ptr),
             planstate.and_then(NonNull::new),
             self.query.needs_tokenizer(),

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -25,7 +25,7 @@ use crate::aggregate::interrupt_collector::InterruptableCollector;
 use crate::aggregate::mvcc_collector::MVCCFilterCollector;
 use crate::api::HashSet;
 use crate::api::version::VersionInfo;
-use crate::index::mvcc::MvccSatisfies;
+use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::index::reader::index::SearchIndexReader;
 use crate::launch_parallel_process;
 use crate::parallel_worker::ParallelStateManager;
@@ -263,7 +263,7 @@ impl<'a> ParallelAggregationWorker<'a> {
             &indexrel,
             self.query.clone(),
             false,
-            MvccSatisfies::ParallelWorker(segment_ids.clone()),
+            MvccSatisfies::ParallelWorker(SegmentView::from_ids(segment_ids.iter().copied())),
             NonNull::new(context_ptr),
             planstate.and_then(NonNull::new),
             self.query.needs_tokenizer(),

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -87,7 +87,9 @@ pub struct SegmentViewEntry {
 /// materialized per open.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SegmentViewDocs {
-    /// Fixed on disk; the counts only feed stats (EXPLAIN's per-segment doc counts).
+    /// Fixed on disk, so a replaying reader gets the same documents from the segment id alone.
+    /// The counts ride along only because `EXPLAIN ANALYZE` renders per-segment doc counts out
+    /// of the shared state rather than out of a reader.
     Immutable { max_doc: u32, num_deleted_docs: u32 },
     /// Materialized per open from the log prefix the bound selects; every replaying reader
     /// must use the same bound.

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -68,16 +68,77 @@ pub struct MutableSegmentBound {
     pub num_deleted_docs: u32,
 }
 
+impl MutableSegmentBound {
+    /// Docs the materialized segment exposes: Adds minus Removes.
+    pub fn live_docs(self) -> u32 {
+        self.max_doc - self.num_deleted_docs
+    }
+}
+
 /// One segment of a [`SegmentView`], in the origin reader's ordinal position.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentViewEntry {
     pub id: SegmentId,
-    /// `SegmentReader::max_doc()` of the origin reader.
-    pub max_doc: u32,
-    /// `SegmentReader::num_deleted_docs()` of the origin reader.
-    pub num_deleted_docs: u32,
-    /// Set for a mutable segment: the bound the origin reader materialized it from.
-    pub mutable: Option<MutableSegmentBound>,
+    pub docs: SegmentViewDocs,
+}
+
+/// What the origin reader knew about the segment's documents. Mirrors the
+/// [`SegmentMetaEntryContent`] split: immutable content is fixed on disk, mutable content is
+/// materialized per open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentViewDocs {
+    /// Fixed on disk; the counts only feed stats (EXPLAIN's per-segment doc counts).
+    Immutable { max_doc: u32, num_deleted_docs: u32 },
+    /// Materialized per open from the log prefix the bound selects; every replaying reader
+    /// must use the same bound.
+    Mutable(MutableSegmentBound),
+    /// Nothing known: the view only pins the segment set. See
+    /// [`SegmentView::from_unordered_ids`].
+    IdOnly,
+}
+
+impl SegmentViewDocs {
+    /// What `SegmentReader::max_doc()` reports for this segment under this view.
+    pub fn max_doc(self) -> u32 {
+        match self {
+            SegmentViewDocs::Immutable { max_doc, .. } => max_doc,
+            SegmentViewDocs::Mutable(bound) => bound.live_docs(),
+            SegmentViewDocs::IdOnly => 0,
+        }
+    }
+
+    /// What `SegmentReader::num_deleted_docs()` reports for this segment under this view.
+    /// Zero for a mutable segment: materialization skips removed ctids instead of carrying
+    /// a delete bitset.
+    pub fn num_deleted_docs(self) -> u32 {
+        match self {
+            SegmentViewDocs::Immutable {
+                num_deleted_docs, ..
+            } => num_deleted_docs,
+            SegmentViewDocs::Mutable(_) | SegmentViewDocs::IdOnly => 0,
+        }
+    }
+
+    pub fn mutable_bound(self) -> Option<MutableSegmentBound> {
+        match self {
+            SegmentViewDocs::Mutable(bound) => Some(bound),
+            _ => None,
+        }
+    }
+}
+
+impl SegmentViewEntry {
+    pub fn max_doc(&self) -> u32 {
+        self.docs.max_doc()
+    }
+
+    pub fn num_deleted_docs(&self) -> u32 {
+        self.docs.num_deleted_docs()
+    }
+
+    pub fn mutable_bound(&self) -> Option<MutableSegmentBound> {
+        self.docs.mutable_bound()
+    }
 }
 
 /// A reader's segment view, frozen so other readers of the same index can replay it.
@@ -123,12 +184,14 @@ impl SegmentView {
                 .iter()
                 .map(|reader| {
                     let id = reader.segment_id();
-                    SegmentViewEntry {
-                        id,
-                        max_doc: reader.max_doc(),
-                        num_deleted_docs: reader.num_deleted_docs(),
-                        mutable: mutable.get(&id).copied(),
-                    }
+                    let docs = match mutable.get(&id) {
+                        Some(bound) => SegmentViewDocs::Mutable(*bound),
+                        None => SegmentViewDocs::Immutable {
+                            max_doc: reader.max_doc(),
+                            num_deleted_docs: reader.num_deleted_docs(),
+                        },
+                    };
+                    SegmentViewEntry { id, docs }
                 })
                 .collect(),
         )
@@ -142,9 +205,7 @@ impl SegmentView {
             ids.into_iter()
                 .map(|id| SegmentViewEntry {
                     id,
-                    max_doc: 0,
-                    num_deleted_docs: 0,
-                    mutable: None,
+                    docs: SegmentViewDocs::IdOnly,
                 })
                 .collect(),
         )
@@ -177,7 +238,7 @@ impl SegmentView {
 
     pub fn mutable_bound(&self, id: &SegmentId) -> Option<MutableSegmentBound> {
         self.ordinal_of(id)
-            .and_then(|ord| self.inner.entries[ord].mutable)
+            .and_then(|ord| self.inner.entries[ord].mutable_bound())
     }
 }
 
@@ -1213,10 +1274,10 @@ mod tests {
         let mutable: Vec<_> = view
             .entries()
             .iter()
-            .filter(|e| e.mutable.is_some())
+            .filter(|e| e.mutable_bound().is_some())
             .collect();
         assert_eq!(mutable.len(), 1, "one mutable segment expected");
-        assert_eq!(mutable[0].max_doc, 5);
+        assert_eq!(mutable[0].max_doc(), 5);
         let origin_ids: Vec<_> = origin
             .segment_readers()
             .iter()

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -57,11 +57,13 @@ use tantivy::{Directory, IndexMeta, SegmentMeta, TantivyError};
 /// which creates less lock contention than allocating one block at a time.
 pub const BUFWRITER_CAPACITY: usize = bm25_max_free_space() * MAX_BUFFERS_TO_EXTEND_BY;
 
-/// The meta-entry header of a mutable segment as one reader loaded it. A mutable segment is
-/// materialized from the heap on open, from the prefix of its add/remove log these two counts
-/// bound, so two opens agree on the segment's `DocId` space only if they use the same pair.
+/// The `(max_doc, num_deleted_docs)` pair of a mutable segment's meta entry as one reader
+/// loaded it. A mutable segment is materialized from the heap on open, from the prefix of its
+/// add/remove log these two counts bound, so two opens agree on the segment's `DocId` space
+/// only if they use the same pair. Distinct from [`SegmentMetaEntry::mutable_snapshot`], which
+/// returns the ctid set a bound selects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MutableSegmentSnapshot {
+pub struct MutableSegmentBound {
     pub max_doc: u32,
     pub num_deleted_docs: u32,
 }
@@ -74,8 +76,8 @@ pub struct SegmentViewEntry {
     pub max_doc: u32,
     /// `SegmentReader::num_deleted_docs()` of the origin reader.
     pub num_deleted_docs: u32,
-    /// Set for a mutable segment: the header the origin reader materialized it from.
-    pub mutable: Option<MutableSegmentSnapshot>,
+    /// Set for a mutable segment: the bound the origin reader materialized it from.
+    pub mutable: Option<MutableSegmentBound>,
 }
 
 /// A reader's segment view, frozen so other readers of the same index can replay it.
@@ -86,9 +88,16 @@ pub struct SegmentViewEntry {
 /// meaningful against the reader that produced them, so every reader of one source in one query
 /// must expose the same ordinal order and, for mutable segments, materialize the same document
 /// set. Opening with [`MvccSatisfies::ParallelWorker`] over this view gives that: the listed
-/// segments in the listed order, mutable segments bounded by the origin's header.
+/// segments in the listed order, mutable segments bounded by the origin's view.
+///
+/// The data sits behind an `Arc`, so clones are cheap even at thousands of segments.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SegmentView {
+    inner: Arc<SegmentViewInner>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default)]
+struct SegmentViewInner {
     entries: Vec<SegmentViewEntry>,
     ordinals: HashMap<SegmentId, usize>,
 }
@@ -100,13 +109,15 @@ impl SegmentView {
             .enumerate()
             .map(|(ord, e)| (e.id, ord))
             .collect();
-        Self { entries, ordinals }
+        Self {
+            inner: Arc::new(SegmentViewInner { entries, ordinals }),
+        }
     }
 
-    /// Capture the view of `segment_readers` (in ordinal order), taking mutable headers from
+    /// Capture the view of `segment_readers` (in ordinal order), taking mutable bounds from
     /// `directory`. Both must come from the same open.
     pub fn capture(segment_readers: &[tantivy::SegmentReader], directory: &MVCCDirectory) -> Self {
-        let mutable = directory.mutable_snapshots();
+        let mutable = directory.mutable_bounds();
         Self::new(
             segment_readers
                 .iter()
@@ -123,9 +134,10 @@ impl SegmentView {
         )
     }
 
-    /// A view that only pins the segment set. It carries no replay data, so it is only for
-    /// readers whose addresses never leave the process (a `paradedb.aggregate` worker).
-    pub fn from_ids(ids: impl IntoIterator<Item = SegmentId>) -> Self {
+    /// A view that only pins the segment set. Ordinal order is the iterator's (arbitrary for a
+    /// set), and it carries no replay data, so it is only for readers whose addresses never
+    /// leave the process (a `paradedb.aggregate` worker).
+    pub fn from_unordered_ids(ids: impl IntoIterator<Item = SegmentId>) -> Self {
         Self::new(
             ids.into_iter()
                 .map(|id| SegmentViewEntry {
@@ -139,33 +151,33 @@ impl SegmentView {
     }
 
     pub fn entries(&self) -> &[SegmentViewEntry] {
-        &self.entries
+        &self.inner.entries
     }
 
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.inner.entries.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.inner.entries.is_empty()
     }
 
     pub fn contains(&self, id: &SegmentId) -> bool {
-        self.ordinals.contains_key(id)
+        self.inner.ordinals.contains_key(id)
     }
 
     pub fn ids(&self) -> impl Iterator<Item = SegmentId> + '_ {
-        self.entries.iter().map(|e| e.id)
+        self.inner.entries.iter().map(|e| e.id)
     }
 
     /// The origin reader's ordinal for `id`.
     pub fn ordinal_of(&self, id: &SegmentId) -> Option<usize> {
-        self.ordinals.get(id).copied()
+        self.inner.ordinals.get(id).copied()
     }
 
-    pub fn mutable_snapshot(&self, id: &SegmentId) -> Option<MutableSegmentSnapshot> {
+    pub fn mutable_bound(&self, id: &SegmentId) -> Option<MutableSegmentBound> {
         self.ordinal_of(id)
-            .and_then(|ord| self.entries[ord].mutable)
+            .and_then(|ord| self.inner.entries[ord].mutable)
     }
 }
 
@@ -271,8 +283,8 @@ impl MVCCDirectory {
         }
     }
 
-    /// The header each loaded mutable segment was materialized from.
-    pub fn mutable_snapshots(&self) -> HashMap<SegmentId, MutableSegmentSnapshot> {
+    /// The bound each loaded mutable segment was materialized from.
+    pub fn mutable_bounds(&self) -> HashMap<SegmentId, MutableSegmentBound> {
         self.all_entries
             .lock()
             .iter()
@@ -280,7 +292,7 @@ impl MVCCDirectory {
                 LoadedSegmentMetaEntry::Persisted { .. } => None,
                 LoadedSegmentMetaEntry::Memory { meta, .. } => Some((
                     *id,
-                    MutableSegmentSnapshot {
+                    MutableSegmentBound {
                         max_doc: meta.max_doc(),
                         num_deleted_docs: meta.num_deleted_docs() as u32,
                     },
@@ -682,7 +694,7 @@ impl Directory for MVCCDirectory {
                         // doc-count sort would break ties in list order, and both the list order
                         // and the counts can have moved since the view was captured.
                         MvccSatisfies::ParallelWorker(view) => {
-                            loaded.meta.segments.sort_by_key(|meta| {
+                            loaded.meta.segments.sort_unstable_by_key(|meta| {
                                 view.ordinal_of(&meta.id())
                                     .expect("load_metas: segment not in the parallel view")
                             });

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -57,13 +57,126 @@ use tantivy::{Directory, IndexMeta, SegmentMeta, TantivyError};
 /// which creates less lock contention than allocating one block at a time.
 pub const BUFWRITER_CAPACITY: usize = bm25_max_free_space() * MAX_BUFFERS_TO_EXTEND_BY;
 
+/// The meta-entry header of a mutable segment as one reader loaded it. A mutable segment is
+/// materialized from the heap on open, from the prefix of its add/remove log these two counts
+/// bound, so two opens agree on the segment's `DocId` space only if they use the same pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MutableSegmentSnapshot {
+    pub max_doc: u32,
+    pub num_deleted_docs: u32,
+}
+
+/// One segment of a [`SegmentView`], in the origin reader's ordinal position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentViewEntry {
+    pub id: SegmentId,
+    /// `SegmentReader::max_doc()` of the origin reader.
+    pub max_doc: u32,
+    /// `SegmentReader::num_deleted_docs()` of the origin reader.
+    pub num_deleted_docs: u32,
+    /// Set for a mutable segment: the header the origin reader materialized it from.
+    pub mutable: Option<MutableSegmentSnapshot>,
+}
+
+/// A reader's segment view, frozen so other readers of the same index can replay it.
+///
+/// Packed `(segment_ord, doc_id)` addresses and per-segment term ordinals travel between
+/// readers opened in different processes (a JoinScan leader, its MPP workers, the readers a
+/// worker rebuilds for a scan that sits behind a network boundary). Those addresses are only
+/// meaningful against the reader that produced them, so every reader of one source in one query
+/// must expose the same ordinal order and, for mutable segments, materialize the same document
+/// set. Opening with [`MvccSatisfies::ParallelWorker`] over this view gives that: the listed
+/// segments in the listed order, mutable segments bounded by the origin's header.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SegmentView {
+    entries: Vec<SegmentViewEntry>,
+    ordinals: HashMap<SegmentId, usize>,
+}
+
+impl SegmentView {
+    pub fn new(entries: Vec<SegmentViewEntry>) -> Self {
+        let ordinals = entries
+            .iter()
+            .enumerate()
+            .map(|(ord, e)| (e.id, ord))
+            .collect();
+        Self { entries, ordinals }
+    }
+
+    /// Capture the view of `segment_readers` (in ordinal order), taking mutable headers from
+    /// `directory`. Both must come from the same open.
+    pub fn capture(segment_readers: &[tantivy::SegmentReader], directory: &MVCCDirectory) -> Self {
+        let mutable = directory.mutable_snapshots();
+        Self::new(
+            segment_readers
+                .iter()
+                .map(|reader| {
+                    let id = reader.segment_id();
+                    SegmentViewEntry {
+                        id,
+                        max_doc: reader.max_doc(),
+                        num_deleted_docs: reader.num_deleted_docs(),
+                        mutable: mutable.get(&id).copied(),
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    /// A view that only pins the segment set. It carries no replay data, so it is only for
+    /// readers whose addresses never leave the process (a `paradedb.aggregate` worker).
+    pub fn from_ids(ids: impl IntoIterator<Item = SegmentId>) -> Self {
+        Self::new(
+            ids.into_iter()
+                .map(|id| SegmentViewEntry {
+                    id,
+                    max_doc: 0,
+                    num_deleted_docs: 0,
+                    mutable: None,
+                })
+                .collect(),
+        )
+    }
+
+    pub fn entries(&self) -> &[SegmentViewEntry] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn contains(&self, id: &SegmentId) -> bool {
+        self.ordinals.contains_key(id)
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = SegmentId> + '_ {
+        self.entries.iter().map(|e| e.id)
+    }
+
+    /// The origin reader's ordinal for `id`.
+    pub fn ordinal_of(&self, id: &SegmentId) -> Option<usize> {
+        self.ordinals.get(id).copied()
+    }
+
+    pub fn mutable_snapshot(&self, id: &SegmentId) -> Option<MutableSegmentSnapshot> {
+        self.ordinal_of(id)
+            .and_then(|ord| self.entries[ord].mutable)
+    }
+}
+
 /// Describes how a `MVCCDirectory` should resolve segment visibility.  Note that
 /// this enum is purposely non-cloneable.  Wrap it with an [`Arc`] if you need that.  Because of
 /// the [`MvccSatisfies::ParallelWorker`] variant, cloning could be incredibly expensive when
 /// an index has many (thousands!) of segments.
 #[derive(Debug, PartialEq, Eq)]
 pub enum MvccSatisfies {
-    ParallelWorker(HashSet<SegmentId>),
+    /// Replay exactly the given view; see [`SegmentView`].
+    ParallelWorker(SegmentView),
     LargestSegment,
     Snapshot,
     Vacuum,
@@ -137,11 +250,8 @@ unsafe impl Send for MVCCDirectory {}
 unsafe impl Sync for MVCCDirectory {}
 
 impl MVCCDirectory {
-    pub fn parallel_worker(
-        index_relation: &PgSearchRelation,
-        segment_ids: HashSet<SegmentId>,
-    ) -> Self {
-        Self::with_mvcc_style(index_relation, MvccSatisfies::ParallelWorker(segment_ids))
+    pub fn parallel_worker(index_relation: &PgSearchRelation, view: SegmentView) -> Self {
+        Self::with_mvcc_style(index_relation, MvccSatisfies::ParallelWorker(view))
     }
 
     pub fn with_mvcc_style(index_relation: &PgSearchRelation, mvcc_style: MvccSatisfies) -> Self {
@@ -159,6 +269,24 @@ impl MVCCDirectory {
             heap_fetch_state: Default::default(),
             expression_state: Default::default(),
         }
+    }
+
+    /// The header each loaded mutable segment was materialized from.
+    pub fn mutable_snapshots(&self) -> HashMap<SegmentId, MutableSegmentSnapshot> {
+        self.all_entries
+            .lock()
+            .iter()
+            .filter_map(|(id, lsme)| match lsme {
+                LoadedSegmentMetaEntry::Persisted { .. } => None,
+                LoadedSegmentMetaEntry::Memory { meta, .. } => Some((
+                    *id,
+                    MutableSegmentSnapshot {
+                        max_doc: meta.max_doc(),
+                        num_deleted_docs: meta.num_deleted_docs() as u32,
+                    },
+                )),
+            })
+            .collect()
     }
 
     /// If the given SegmentId is a mutable segment, return true.
@@ -548,28 +676,44 @@ impl Directory for MVCCDirectory {
                         })
                         .collect();
 
-                    // Sort the segments in ascending order by how long we think they'll take to
-                    // query.
-                    // * for immutable, smallest to largest by document count
-                    // * followed by mutable/in-memory, since they're indexed at read time, so
-                    //   their doc count is not comparable.
-                    //
-                    // When segments are claimed by workers they're claimed from back-to-front
-                    // and our goal is to have the most expensive segments claimed first to reduce
-                    // stragglers.
-                    //
-                    // TODO: I don't love doing this here, but it's the last place where we can
-                    // (easily) determine which segments are memory segments. If we found a better
-                    // way to identify a `SegmentReader` as being in-memory, then we could put it
-                    // back in parallel worker initialization.
-                    loaded.meta.segments.sort_unstable_by_key(|meta| {
-                        match all_entries.get(&meta.id()).unwrap() {
-                            LoadedSegmentMetaEntry::Persisted { meta, .. } => meta.num_docs(),
-                            LoadedSegmentMetaEntry::Memory { meta, .. } => {
-                                (u32::MAX as usize) + meta.num_docs()
-                            }
+                    match &*self.mvcc_style {
+                        // The view came from a reader that already ordered these segments, and
+                        // the addresses in flight were packed against that order. Replay it: a
+                        // doc-count sort would break ties in list order, and both the list order
+                        // and the counts can have moved since the view was captured.
+                        MvccSatisfies::ParallelWorker(view) => {
+                            loaded.meta.segments.sort_by_key(|meta| {
+                                view.ordinal_of(&meta.id())
+                                    .expect("load_metas: segment not in the parallel view")
+                            });
                         }
-                    });
+                        // Sort the segments in ascending order by how long we think they'll
+                        // take to query.
+                        // * for immutable, smallest to largest by document count
+                        // * followed by mutable/in-memory, since they're indexed at read time,
+                        //   so their doc count is not comparable.
+                        //
+                        // When segments are claimed by workers they're claimed from
+                        // back-to-front and our goal is to have the most expensive segments
+                        // claimed first to reduce stragglers.
+                        //
+                        // TODO: I don't love doing this here, but it's the last place where we
+                        // can (easily) determine which segments are memory segments. If we found
+                        // a better way to identify a `SegmentReader` as being in-memory, then we
+                        // could put it back in parallel worker initialization.
+                        _ => {
+                            loaded.meta.segments.sort_unstable_by_key(|meta| {
+                                match all_entries.get(&meta.id()).unwrap() {
+                                    LoadedSegmentMetaEntry::Persisted { meta, .. } => {
+                                        meta.num_docs()
+                                    }
+                                    LoadedSegmentMetaEntry::Memory { meta, .. } => {
+                                        (u32::MAX as usize) + meta.num_docs()
+                                    }
+                                }
+                            });
+                        }
+                    }
 
                     *self.all_entries.lock() = all_entries;
 
@@ -1020,5 +1164,88 @@ mod tests {
         assert!(entry.positions.is_some());
         assert!(entry.terms.is_some());
         assert!(entry.delete.is_none());
+    }
+
+    /// A reader replaying a [`SegmentView`] must expose the view's ordinal order and, for a
+    /// mutable segment, the document set the view's origin materialized, even after the
+    /// segment's log has grown. This is what keeps packed `DocAddress`es comparable across
+    /// the readers a JoinScan opens in different processes.
+    #[pg_test]
+    unsafe fn test_segment_view_replays_origin_reader() {
+        use crate::index::reader::index::SearchIndexReader;
+
+        Spi::run("CREATE TABLE t (id SERIAL8, data TEXT);").unwrap();
+        // Two immutable segments of unequal size, then a small batch that lands in the
+        // mutable segment.
+        Spi::run("SET paradedb.global_mutable_segment_rows = 0;").unwrap();
+        Spi::run(
+            "CREATE INDEX t_idx ON t USING paradedb (id, data) \
+             WITH (key_field = 'id', layer_sizes = '0', background_layer_sizes = '0')",
+        )
+        .unwrap();
+        Spi::run("INSERT INTO t (data) SELECT 'a' FROM generate_series(1, 30);").unwrap();
+        Spi::run("INSERT INTO t (data) SELECT 'b' FROM generate_series(1, 10);").unwrap();
+        Spi::run("RESET paradedb.global_mutable_segment_rows;").unwrap();
+        Spi::run("INSERT INTO t (data) SELECT 'c' FROM generate_series(1, 5);").unwrap();
+
+        let relation_oid: pg_sys::Oid =
+            Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
+                .expect("spi should succeed")
+                .unwrap();
+        let indexrel = PgSearchRelation::open(relation_oid);
+
+        let origin =
+            SearchIndexReader::empty(&indexrel, MvccSatisfies::Snapshot).expect("open origin");
+        let view = origin.segment_view();
+        assert_eq!(view.len(), 3);
+        let mutable: Vec<_> = view
+            .entries()
+            .iter()
+            .filter(|e| e.mutable.is_some())
+            .collect();
+        assert_eq!(mutable.len(), 1, "one mutable segment expected");
+        assert_eq!(mutable[0].max_doc, 5);
+        let origin_ids: Vec<_> = origin
+            .segment_readers()
+            .iter()
+            .map(|r| r.segment_id())
+            .collect();
+
+        // The mutable segment's log grows past the captured view.
+        Spi::run("INSERT INTO t (data) SELECT 'd' FROM generate_series(1, 7);").unwrap();
+        let fresh =
+            SearchIndexReader::empty(&indexrel, MvccSatisfies::Snapshot).expect("open fresh");
+        let fresh_mutable = fresh
+            .segment_readers()
+            .iter()
+            .find(|r| r.segment_id() == mutable[0].id)
+            .expect("mutable segment still there");
+        assert_eq!(
+            fresh_mutable.max_doc(),
+            12,
+            "a plain snapshot sees the new rows"
+        );
+
+        // A replaying reader sees what the origin saw.
+        let replay = SearchIndexReader::empty(&indexrel, MvccSatisfies::ParallelWorker(view))
+            .expect("open replay");
+        let replay_ids: Vec<_> = replay
+            .segment_readers()
+            .iter()
+            .map(|r| r.segment_id())
+            .collect();
+        assert_eq!(replay_ids, origin_ids, "ordinal order replays the origin");
+        for (o, r) in origin
+            .segment_readers()
+            .iter()
+            .zip(replay.segment_readers())
+        {
+            assert_eq!(
+                o.max_doc(),
+                r.max_doc(),
+                "segment {} doc space",
+                o.segment_id()
+            );
+        }
     }
 }

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -361,11 +361,11 @@ pub unsafe fn load_metas(
 
     loop {
         // Find all relevant segments in this list.
-        segment_metas.for_each(|bman, entry| {
+        segment_metas.for_each(|bman, mut entry| {
             // nobody sees recyclable segments
             let accept = !entry.recyclable(bman) && (
                 // parallel workers only see a specific set of segments.  This relies on the leader having kept a pin on them
-                matches!(solve_mvcc, MvccSatisfies::ParallelWorker(only_these) if only_these.contains(&entry.segment_id()))
+                matches!(solve_mvcc, MvccSatisfies::ParallelWorker(view) if view.contains(&entry.segment_id()))
 
                     // vacuum sees everything that hasn't been deleted by a merge
                     || (matches!(solve_mvcc, MvccSatisfies::Vacuum) && entry.xmax() == pg_sys::InvalidTransactionId)
@@ -379,6 +379,18 @@ pub unsafe fn load_metas(
             if !accept {
                 return;
             };
+
+            // Replay the view's materialization bound so this reader's `DocId`s for the mutable
+            // segment line up with the reader that captured the view.
+            if let MvccSatisfies::ParallelWorker(view) = solve_mvcc
+                && let Some(snapshot) = view.mutable_snapshot(&entry.segment_id())
+            {
+                let segment_id = entry.segment_id();
+                if let Err(e) = entry.rewind_mutable(snapshot.max_doc, snapshot.num_deleted_docs)
+                {
+                    panic!("load_metas: cannot replay the parallel view for segment {segment_id}: {e}");
+                }
+            }
 
             total_segments += 1;
             total_docs += entry.num_docs();
@@ -410,9 +422,7 @@ pub unsafe fn load_metas(
         });
 
         match solve_mvcc {
-            MvccSatisfies::ParallelWorker(only_these)
-                if alive_entries.len() != only_these.len() =>
-            {
+            MvccSatisfies::ParallelWorker(view) if alive_entries.len() != view.len() => {
                 // If we haven't tried the `segment_metas_garbage` list, try that next.
                 if !exhausted_metas_lists
                     && let Some(garbage) = MetaPage::open(indexrel).segment_metas_garbage()
@@ -428,11 +438,12 @@ pub unsafe fn load_metas(
                 //
                 // TODO (after some testing):  This situation does indeed happen and I believe that points to a bug, but
                 //        I don't know where it's coming from.  As such, cancelling the query is the expedient decision.
-                let missing = only_these
+                let expected = view.ids().collect::<HashSet<SegmentId>>();
+                let missing = expected
                     .difference(&alive_entries.iter().map(|s| s.segment_id()).collect())
                     .cloned()
                     .collect::<HashSet<SegmentId>>();
-                let found = only_these.difference(&missing).collect::<HashSet<_>>();
+                let found = expected.difference(&missing).collect::<HashSet<_>>();
 
                 panic!(
                     "load_metas: MvccSatisfies::ParallelWorker didn't load the correct segments. \
@@ -440,17 +451,18 @@ pub unsafe fn load_metas(
                 );
             }
             #[cfg(debug_assertions)]
-            MvccSatisfies::ParallelWorker(only_these) => {
+            MvccSatisfies::ParallelWorker(view) => {
                 // In debug mode only, actually do a set comparison to determine that we got the
                 // exact expected segments.
                 let actual = alive_entries
                     .iter()
                     .map(|s| s.segment_id())
                     .collect::<HashSet<_>>();
+                let expected = view.ids().collect::<HashSet<_>>();
                 assert_eq!(
-                    &actual, only_these,
+                    actual, expected,
                     "Got the wrong segments in parallel worker: \
-                     actual: {actual:?}, expected: {only_these:?}"
+                     actual: {actual:?}, expected: {expected:?}"
                 );
                 break;
             }

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -383,11 +383,10 @@ pub unsafe fn load_metas(
             // Replay the view's materialization bound so this reader's `DocId`s for the mutable
             // segment line up with the reader that captured the view.
             if let MvccSatisfies::ParallelWorker(view) = solve_mvcc
-                && let Some(snapshot) = view.mutable_snapshot(&entry.segment_id())
+                && let Some(bound) = view.mutable_bound(&entry.segment_id())
             {
                 let segment_id = entry.segment_id();
-                if let Err(e) = entry.rewind_mutable(snapshot.max_doc, snapshot.num_deleted_docs)
-                {
+                if let Err(e) = entry.rewind_mutable(bound.max_doc, bound.num_deleted_docs) {
                     panic!("load_metas: cannot replay the parallel view for segment {segment_id}: {e}");
                 }
             }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -27,7 +27,7 @@ use crate::api::operator::keyset::KeySet;
 use crate::api::version::Version;
 use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::FFHelper;
-use crate::index::mvcc::MvccSatisfies;
+use crate::index::mvcc::{MVCCDirectory, MvccSatisfies, SegmentView};
 use crate::index::reader::io_stats;
 use crate::index::reader::scorer::{DeferredScorer, LazyWeight, ScorerIter};
 use crate::index::reader::sort_by_range::SortByRange;
@@ -365,6 +365,9 @@ pub struct SearchIndexReader {
     total_docs: u64,
     index_created_by_version: Option<Version>,
     segment_ordinal_by_id: HashMap<SegmentId, SegmentOrdinal>,
+    /// The directory `underlying_index` opened over; kept to capture this reader's
+    /// [`SegmentView`].
+    directory: MVCCDirectory,
 
     // [`PinnedBuffer`] has a Drop impl, so we hold onto it but don't otherwise use it
     //
@@ -377,6 +380,7 @@ pub struct SearchIndexReader {
 /// JoinScan initialization without requiring executor state.
 pub struct SearchIndexManifest {
     searcher: Searcher,
+    directory: MVCCDirectory,
     _cleanup_lock: Arc<PinnedBuffer>,
 }
 
@@ -394,6 +398,7 @@ impl Clone for SearchIndexReader {
             total_docs: self.total_docs,
             index_created_by_version: self.index_created_by_version,
             segment_ordinal_by_id: self.segment_ordinal_by_id.clone(),
+            directory: self.directory.clone(),
             _cleanup_lock: self._cleanup_lock.clone(),
         }
     }
@@ -401,6 +406,7 @@ impl Clone for SearchIndexReader {
 
 struct IndexComponents {
     cleanup_lock: Arc<PinnedBuffer>,
+    directory: MVCCDirectory,
     index: Index,
     reader: IndexReader,
     searcher: Searcher,
@@ -438,6 +444,7 @@ impl SearchIndexReader {
 
         Ok(IndexComponents {
             cleanup_lock,
+            directory,
             index,
             reader,
             searcher,
@@ -486,6 +493,7 @@ impl SearchIndexReader {
             Self::open_index_components(index_relation, mvcc_style, needs_tokenizer_manager)?;
         let IndexComponents {
             cleanup_lock,
+            directory,
             index,
             reader,
             searcher,
@@ -534,6 +542,7 @@ impl SearchIndexReader {
             total_docs,
             index_created_by_version,
             segment_ordinal_by_id: segment_ord_by_id,
+            directory,
             _cleanup_lock: cleanup_lock,
         })
     }
@@ -544,6 +553,12 @@ impl SearchIndexReader {
             .iter()
             .map(|r| r.segment_id())
             .collect()
+    }
+
+    /// This reader's segment view, for other readers to replay through
+    /// [`MvccSatisfies::ParallelWorker`].
+    pub fn segment_view(&self) -> SegmentView {
+        SegmentView::capture(self.searcher.segment_readers(), &self.directory)
     }
 
     pub fn need_scores(&self) -> bool {
@@ -1729,12 +1744,15 @@ impl SearchIndexManifest {
             SearchIndexReader::open_index_components(index_relation, mvcc_style, false)?;
         Ok(Self {
             searcher: components.searcher,
+            directory: components.directory,
             _cleanup_lock: components.cleanup_lock,
         })
     }
 
-    pub fn segment_readers(&self) -> &[SegmentReader] {
-        self.searcher.segment_readers()
+    /// This manifest's segment view, for other readers to replay through
+    /// [`MvccSatisfies::ParallelWorker`].
+    pub fn segment_view(&self) -> SegmentView {
+        SegmentView::capture(self.searcher.segment_readers(), &self.directory)
     }
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -26,6 +26,7 @@
 
 use super::join_targetlist::AggOrderByEntry;
 use crate::index::fast_fields_helper::WhichFastField;
+use crate::index::mvcc::SegmentView;
 use crate::postgres::customscan::aggregatescan::join_targetlist::{
     AggKind, JoinAggregateEntry, JoinAggregateTargetList,
 };
@@ -84,7 +85,7 @@ pub async fn build_join_aggregate_plan(
     ctx: &SessionContext,
     expr_context: Option<*mut pg_sys::ExprContext>,
     planstate: Option<*mut pg_sys::PlanState>,
-    is_mpp: bool,
+    mpp_views: Option<&[SegmentView]>,
 ) -> Result<(datafusion::logical_expr::LogicalPlan, Vec<usize>)> {
     // Step 1: Build the join DataFrame from the RelNode tree
     let df = build_relnode_df(
@@ -95,7 +96,7 @@ pub async fn build_join_aggregate_plan(
         custom_scan_tlist,
         expr_context,
         planstate,
-        is_mpp,
+        mpp_views,
     )
     .await?;
 
@@ -288,15 +289,21 @@ fn build_relnode_df<'a>(
     custom_scan_tlist: *mut pg_sys::List,
     expr_context: Option<*mut pg_sys::ExprContext>,
     planstate: Option<*mut pg_sys::PlanState>,
-    is_mpp: bool,
+    mpp_views: Option<&'a [SegmentView]>,
 ) -> LocalBoxFuture<'a, Result<DataFrame>> {
     async move {
         match node {
             RelNode::Scan(source) => {
                 let plan_position = source.plan_position;
-                let df =
-                    build_source_df(ctx, source, plan_position, expr_context, planstate, is_mpp)
-                        .await?;
+                let df = build_source_df(
+                    ctx,
+                    source,
+                    plan_position,
+                    expr_context,
+                    planstate,
+                    mpp_views,
+                )
+                .await?;
                 let alias =
                     RelationAlias::new(source.scan_info.alias.as_deref()).execution(plan_position);
                 Ok(df.alias(&alias)?)
@@ -310,7 +317,7 @@ fn build_relnode_df<'a>(
                     custom_scan_tlist,
                     expr_context,
                     planstate,
-                    is_mpp,
+                    mpp_views,
                 )
                 .await?;
                 let right_df = build_relnode_df(
@@ -321,7 +328,7 @@ fn build_relnode_df<'a>(
                     custom_scan_tlist,
                     expr_context,
                     planstate,
-                    is_mpp,
+                    mpp_views,
                 )
                 .await?;
 
@@ -336,7 +343,7 @@ fn build_relnode_df<'a>(
                     custom_scan_tlist,
                     expr_context,
                     planstate,
-                    is_mpp,
+                    mpp_views,
                 )
                 .await?;
 
@@ -529,7 +536,7 @@ async fn build_source_df(
     plan_position: usize,
     expr_context: Option<*mut pg_sys::ExprContext>,
     planstate: Option<*mut pg_sys::PlanState>,
-    is_mpp: bool,
+    mpp_views: Option<&[SegmentView]>,
 ) -> Result<DataFrame> {
     let scan_info = source.scan_info.clone();
 
@@ -590,9 +597,18 @@ async fn build_source_df(
 
     // MPP-aware provider setup. Every source gets its segments sliced across PG
     // parallel workers via `parallel_state.checkout_segment_for_source(plan_position)`
-    // when `is_mpp` is true.
-    let source_idx = if is_mpp { Some(plan_position) } else { None };
+    // when this is an MPP plan.
+    let source_idx = mpp_views.map(|_| plan_position);
     let mut provider = PgSearchTableProvider::new(scan_info, fields, source_idx);
+    // The leader claims segments out of the DSM pool the same manifests populate, so its own
+    // reader has to replay the same view. This plan never crosses the codec that injects the
+    // view for JoinScan, so do it here.
+    if let Some(views) = mpp_views {
+        let view = views.get(plan_position).unwrap_or_else(|| {
+            panic!("missing segment view for aggregate source at plan_position {plan_position}")
+        });
+        provider.set_segment_view(view.clone());
+    }
     if let crate::scan::ScanMode::Tagged { local_queries, .. } = &source.scan_info.mode {
         for tq in local_queries {
             provider.add_match_tag_column(&tq.tag_name);

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1126,17 +1126,19 @@ impl AggregateScan {
         crate::postgres::customscan::mpp::launch::launch_mpp_aggregate(physical, args)
     }
 
-    /// Build the aggregate's DataFusion physical plan under `ctx`. `is_mpp` marks that parallel
-    /// execution is being attempted and stamps each provider's per-source dispatch metadata
-    /// (`is_parallel`, `mpp_source_idx`); the worker-bound stage encodes carry that metadata, so
-    /// it must be present on the plan the dispatch payload is derived from. The serial fallback
-    /// plans without it. An associated fn (not a closure) so the `df_state` borrow it takes
-    /// ends at each call site, freeing `state` for the MPP launch in between.
+    /// Build the aggregate's DataFusion physical plan under `ctx`. `mpp_views` marks that
+    /// parallel execution is being attempted and stamps each provider's per-source dispatch
+    /// metadata (`is_parallel`, `mpp_source_idx`); the worker-bound stage encodes carry that
+    /// metadata, so it must be present on the plan the dispatch payload is derived from. It also
+    /// carries the views the providers replay, which are the same manifests `launch_mpp` puts in
+    /// the DSM. The serial fallback plans without it. An associated fn (not a closure) so the
+    /// `df_state` borrow it takes ends at each call site, freeing `state` for the MPP launch in
+    /// between.
     fn build_agg_physical_plan(
         df_state: &mut scan_state::DataFusionAggState,
         runtime: &tokio::runtime::Runtime,
         ctx: &datafusion::prelude::SessionContext,
-        is_mpp: bool,
+        mpp_views: Option<&[SegmentView]>,
         runtime_expr_context: Option<*mut pg_sys::ExprContext>,
         runtime_planstate: Option<*mut pg_sys::PlanState>,
     ) -> Arc<dyn ExecutionPlan> {
@@ -1154,7 +1156,7 @@ impl AggregateScan {
                 ctx,
                 runtime_expr_context,
                 runtime_planstate,
-                is_mpp,
+                mpp_views,
             )
             .await?;
             df_state.group_df_indices = group_df_indices;
@@ -1230,7 +1232,7 @@ impl AggregateScan {
                         ctx,
                         Some(expr_context.as_ptr()),
                         None,
-                        false,
+                        None,
                     )
                     .await?;
                     build_physical_plan(ctx, logical).await
@@ -1811,6 +1813,19 @@ impl AggregateScan {
             } else {
                 create_aggregate_session_context()
             };
+            // Capture before the `df_state` borrow below. `prepare_mpp` pinned the manifests at
+            // begin, so these are the views `launch_mpp` ships to the workers.
+            let mpp_views: Vec<SegmentView> = if is_mpp {
+                Self::ensure_source_manifests(state);
+                state
+                    .custom_state()
+                    .source_manifests
+                    .iter()
+                    .map(|m| m.segment_view())
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
             let t_plan = std::time::Instant::now();
             let physical_plan = {
@@ -1823,7 +1838,7 @@ impl AggregateScan {
                     df_state,
                     &runtime,
                     &plan_ctx,
-                    is_mpp,
+                    is_mpp.then_some(mpp_views.as_slice()),
                     runtime_expr_context,
                     runtime_planstate,
                 )
@@ -1864,7 +1879,7 @@ impl AggregateScan {
                             df_state,
                             &runtime,
                             &serial_ctx,
-                            false,
+                            None,
                             runtime_expr_context,
                             runtime_planstate,
                         );

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -63,7 +63,7 @@ use crate::gucs;
 
 use crate::aggregate::{NULL_SENTINEL_MAX, NULL_SENTINEL_MIN};
 use crate::customscan::aggregatescan::build::AggregateCSClause;
-use crate::index::mvcc::MvccSatisfies;
+use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::ParallelScanArgs;
 use crate::postgres::PgSearchRelation;
@@ -1110,11 +1110,11 @@ impl AggregateScan {
         // Manifests were captured in `prepare_mpp` (begin); `ensure` is idempotent.
         Self::ensure_source_manifests(state);
 
-        let all_sources: Vec<&[tantivy::SegmentReader]> = state
+        let all_sources: Vec<SegmentView> = state
             .custom_state()
             .source_manifests
             .iter()
-            .map(|m| m.segment_readers())
+            .map(|m| m.segment_view())
             .collect();
         let args = ParallelScanArgs {
             all_sources,

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -67,7 +67,7 @@ use crate::postgres::customscan::orderby::{
     PathKeyInfo, UnusableReason, extract_pathkey_styles_with_sortability_check,
 };
 use crate::postgres::customscan::parallel::{
-    RowEstimate, compute_nworkers, list_segment_ids, max_useful_workers,
+    RowEstimate, compute_nworkers, max_useful_workers, segment_view,
 };
 use crate::postgres::customscan::projections::{
     inject_placeholders, maybe_needs_const_projections, pullout_funcexprs,
@@ -153,7 +153,7 @@ impl BaseScan {
                     // this is because the workers pick a specific segment to query that
                     // is known to be held open/pinned by the leader but might not pass a ::Snapshot
                     // visibility test due to concurrent merges/garbage collects
-                    MvccSatisfies::ParallelWorker(list_segment_ids(parallel_state))
+                    MvccSatisfies::ParallelWorker(segment_view(parallel_state))
                 } else {
                     // We are in a worker, but this is not a parallel-aware scan (e.g. we are running
                     // a serial scan inside a parallel worker, like in a Parallel Nested Loop Join).

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -197,20 +197,20 @@ impl BaseScanState {
         serde_json::to_value(&self.base_search_query_input)
     }
 
-    pub fn parallel_scan_args(&self) -> ParallelScanArgs<'_> {
+    pub fn parallel_scan_args(&self) -> ParallelScanArgs {
         let query = serde_json::to_vec(self.search_query_input())
             .expect("should be able to serialize query");
 
-        let segment_readers = self
+        let segment_view = self
             .search_reader
             .as_ref()
             .expect("search reader must be initialized to build parallel serialization data")
-            .segment_readers();
+            .segment_view();
 
         let with_aggregates = !self.window_aggregates.is_empty();
 
         ParallelScanArgs {
-            all_sources: vec![segment_readers],
+            all_sources: vec![segment_view],
             query,
             with_aggregates,
             with_segment_info: true,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -169,7 +169,7 @@ use self::scan_state::{
 };
 use crate::api::HashSet;
 use crate::api::OrderByFeature;
-use crate::index::mvcc::MvccSatisfies;
+use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags};
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
@@ -796,6 +796,41 @@ impl JoinScan {
         state.custom_state_mut().source_manifests = manifests;
     }
 
+    /// Build the plan_position → segment view list every reader of a source replays.
+    ///
+    /// This is keyed by plan_position rather than indexrelid because it is a
+    /// per-source contract, not just a per-index one. The same index can appear
+    /// more than once in one JoinScan plan; in parallel execution those source
+    /// copies can also carry different canonical segment sets (partitioned vs
+    /// replicated). If this were keyed only by indexrelid, one source could
+    /// inject another source's segment set and make packed DocAddresses resolve
+    /// against the wrong segment ordering.
+    ///
+    /// The manifests are also what populates the DSM, so the leader's providers and every
+    /// worker reader open the same view.
+    fn build_index_segment_views(
+        state: &mut CustomScanStateWrapper<Self>,
+        _join_clause: &JoinCSClause,
+        plan_sources: &[&build::JoinSource],
+    ) -> Vec<SegmentView> {
+        Self::ensure_source_manifests(state);
+        (0..plan_sources.len())
+            .map(|plan_position| {
+                state
+                    .custom_state()
+                    .source_manifests
+                    .get(plan_position)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "missing source manifest for join source at plan_position \
+                             {plan_position}"
+                        )
+                    })
+                    .segment_view()
+            })
+            .collect()
+    }
+
     /// Whether any `SearchQueryInput` reachable from `join_clause` — scan-node queries AND
     /// `join_level_predicates` — still carries a Param or PostgresExpression(SubPlan) the
     /// executor needs to resolve. Clause-wide (not per-source): a cross-relation predicate
@@ -856,11 +891,11 @@ impl JoinScan {
         physical: &Arc<dyn ExecutionPlan>,
     ) -> Option<crate::postgres::customscan::mpp::glue::MppLeaderState> {
         Self::ensure_source_manifests(state);
-        let all_sources: Vec<&[tantivy::SegmentReader]> = state
+        let all_sources: Vec<SegmentView> = state
             .custom_state()
             .source_manifests
             .iter()
-            .map(|manifest| manifest.segment_readers())
+            .map(|manifest| manifest.segment_view())
             .collect();
         let args = ParallelScanArgs {
             all_sources,
@@ -1296,6 +1331,7 @@ impl CustomScan for JoinScan {
                     None,
                     Some(expr_context.as_ptr()),
                     None,
+                    vec![],
                 )
                 .expect("Failed to deserialize logical plan");
                 runtime
@@ -1411,6 +1447,9 @@ impl CustomScan for JoinScan {
                     .clone()
                     .expect("Logical plan is required");
 
+                let index_segment_views =
+                    Self::build_index_segment_views(state, &join_clause, &plan_sources);
+
                 // For parameterized LIMIT/OFFSET, the planning-time logical plan has no Limit
                 // node. Resolve the fetch once; each planning pass below injects it (before
                 // physical planning) so SegmentedTopKRule can detect SortExec(fetch=K) and
@@ -1443,6 +1482,7 @@ impl CustomScan for JoinScan {
                             None,
                             Some(runtime_context),
                             Some(planstate),
+                            index_segment_views.clone(),
                         )
                         .expect("Failed to deserialize logical plan");
                         let logical_plan = match runtime_fetch {
@@ -1508,6 +1548,7 @@ impl CustomScan for JoinScan {
                                 None,
                                 Some(runtime_context),
                                 Some(planstate),
+                                index_segment_views.clone(),
                             )
                             .expect("Failed to deserialize serial fallback logical plan");
                             let logical_plan = match runtime_fetch {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -219,14 +219,14 @@ pub struct JoinScanState {
     pub stream_built_at: Option<std::time::Instant>,
 
     /// Captured source manifests held by the leader. Serves two purposes:
-    /// 1. Provides the segment readers `launch_mpp` needs (via `ParallelScanArgs`) to size
+    /// 1. Provides the segment views `launch_mpp` needs (via `ParallelScanArgs`) to size
     ///    and populate the shared `ParallelScanState` in DSM.
     /// 2. Keeps the underlying Tantivy buffer pins alive for the full duration of the
     ///    scan, preventing background merges from recycling the canonical segments.
     ///
     /// Must live on `JoinScanState` (not as a local in the launch) because the
     /// buffer pins must survive from DSM population through `exec_custom_scan`,
-    /// where workers reopen the same segments via `MvccSatisfies::ParallelWorker(ids)`.
+    /// where workers reopen the same segments via `MvccSatisfies::ParallelWorker(view)`.
     /// Dropping manifests early would release the pins and allow segment recycling
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -71,6 +71,7 @@ use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use pgrx::pg_sys;
 
 use crate::index::fast_fields_helper::{FFHelper, for_each_segment};
+use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::postgres::customscan::joinscan::CtidColumn;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
@@ -756,13 +757,13 @@ impl VisibilityFilterExec {
 
     /// Rebuild from a dispatch descriptor, re-wiring the per-plan_position ctid resolvers from
     /// the scans the worker decoded below this node. A position whose scan sits behind a network
-    /// boundary rebuilds its resolver instead: a helper over that index's canonical segment view
+    /// boundary rebuilds its resolver instead: a helper replaying that source's segment view
     /// resolves any address a producer packed (ctid access needs no field layout).
     pub(crate) fn decode_for_dispatch(
         buf: &[u8],
         input: Arc<dyn ExecutionPlan>,
         ctid_resolvers: Vec<(usize, u32, Arc<FFHelper>)>,
-        index_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
+        index_segment_views: &[SegmentView],
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let (plan_pos_oids, table_names, resolver_indexes): VisibilityDispatchPayload =
             serde_json::from_slice(buf).map_err(|e| {
@@ -778,16 +779,16 @@ impl VisibilityFilterExec {
             if ctid_resolvers.iter().any(|(pos, _, _)| *pos == plan_pos) {
                 continue;
             }
-            let ids = index_segment_ids.get(plan_pos).cloned().ok_or_else(|| {
+            let view = index_segment_views.get(plan_pos).cloned().ok_or_else(|| {
                 DataFusionError::Internal(format!(
-                    "VisibilityFilterExec dispatch: missing canonical segment ids for \
+                    "VisibilityFilterExec dispatch: missing segment view for \
                      plan_position {plan_pos}"
                 ))
             })?;
             let ffhelper = crate::scan::tantivy_lookup_exec::open_rebuilt_ffhelper(
                 indexrelid,
                 &[],
-                crate::index::mvcc::MvccSatisfies::ParallelWorker(ids),
+                MvccSatisfies::ParallelWorker(view),
             )?;
             exec.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
         }
@@ -1554,7 +1555,7 @@ mod tests {
         let bytes =
             serialize_logical_plan(&wrapped).expect("VisibilityFilterNode should serialize");
         let ctx = TaskContext::default();
-        let decoded = deserialize_logical_plan_with_runtime(&bytes, &ctx, None, None, None)
+        let decoded = deserialize_logical_plan_with_runtime(&bytes, &ctx, None, None, None, vec![])
             .expect("VisibilityFilterNode should deserialize");
 
         let LogicalPlan::Extension(ext) = &decoded else {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -40,9 +40,8 @@ use datafusion_distributed::{
 };
 use futures::{FutureExt, StreamExt};
 use pgrx::pg_sys;
-use tantivy::index::SegmentId;
 
-use crate::api::HashSet;
+use crate::index::mvcc::SegmentView;
 use crate::postgres::customscan::datafusion::memory::{build_runtime_env, create_memory_pool};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::PartitionSink;
@@ -295,14 +294,14 @@ pub(crate) fn run_mpp_worker(
     let plan_bytes = &worker_session.plan_bytes;
     let this_proc = worker_mesh.this_proc;
 
-    // Build per-source canonical segment ID sets from the populated ParallelScanState.
+    // Build per-source segment views from the populated ParallelScanState.
     // Workers will then claim individual segments via `checkout_segment_for_source` inside their
     // `PgSearchTableProvider`.
-    let mut index_segment_ids: Vec<HashSet<SegmentId>> =
-        vec![HashSet::default(); plan_sources_count];
+    let mut index_segment_views: Vec<SegmentView> =
+        vec![SegmentView::default(); plan_sources_count];
     if let Some(ps) = parallel_state {
-        for (i, slot) in index_segment_ids.iter_mut().enumerate() {
-            *slot = unsafe { (*ps).segment_ids_for_source_unlocked(i) };
+        for (i, slot) in index_segment_views.iter_mut().enumerate() {
+            *slot = unsafe { (*ps).segment_view_for_source_unlocked(i) };
         }
     }
 
@@ -371,7 +370,7 @@ pub(crate) fn run_mpp_worker(
             &set_plan.plan_proto,
             &decode_ctx,
             parallel_state,
-            index_segment_ids.to_vec(),
+            index_segment_views.to_vec(),
             Some(expr_context_guard.as_ptr()),
             &DeduplicatingProtoConverter {},
         ) {

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -357,8 +357,7 @@ fn launch_mpp(
         MPP_MQ_SIZE,
     )?;
 
-    // Populate the ParallelScanState in place while the DSM is mapped and the leader still holds
-    // the source manifests `args` borrows.
+    // Populate the ParallelScanState in place while the DSM is mapped.
     let scan_ptr = match launcher.state_manager().slice_mut::<u8>(SCAN_IDX) {
         Ok(Some(s)) => s.as_mut_ptr() as *mut ParallelScanState,
         _ => pgrx::error!("mpp: parallel scan state region missing"),

--- a/pg_search/src/postgres/customscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/parallel.rs
@@ -17,7 +17,7 @@
 
 use crate::api::Cardinality;
 
-use crate::api::HashSet;
+use crate::index::mvcc::SegmentView;
 
 use crate::postgres::ParallelScanState;
 
@@ -175,6 +175,6 @@ pub unsafe fn checkout_segment_for_source(
     (*pscan_state).checkout_segment_for_source(source_idx)
 }
 
-pub unsafe fn list_segment_ids(pscan_state: *mut ParallelScanState) -> HashSet<SegmentId> {
-    (*pscan_state).segments().into_keys().collect()
+pub unsafe fn segment_view(pscan_state: *mut ParallelScanState) -> SegmentView {
+    (*pscan_state).segment_view()
 }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -168,12 +168,13 @@ const SEGMENT_CLAIM_UNCLAIMED: i32 = -2;
 /// `all_docs_flags` value: `all_max_docs`/`all_deleted_docs` hold the mutable segment's bound.
 const SEGMENT_FLAG_MUTABLE: u8 = 1;
 
-/// `all_docs_flags` value: the entry only pins the segment id; both count slots are zero.
-const SEGMENT_FLAG_ID_ONLY: u8 = 2;
-
 /// The wire format of one [`SegmentViewDocs`] in the payload: a flag byte plus the two `u32`
 /// count slots whose meaning the flag selects. `encode_docs` and `decode_docs` are the only
 /// readers of this convention.
+///
+/// [`SegmentViewDocs::IdOnly`] has no encoding on purpose. A reader that replays a view has to
+/// reproduce the origin's documents, and an id-only view carries nothing to reproduce them
+/// from, so it must stay inside the process that built it.
 fn encode_docs(docs: SegmentViewDocs) -> (u8, u32, u32) {
     match docs {
         SegmentViewDocs::Immutable {
@@ -183,7 +184,9 @@ fn encode_docs(docs: SegmentViewDocs) -> (u8, u32, u32) {
         SegmentViewDocs::Mutable(bound) => {
             (SEGMENT_FLAG_MUTABLE, bound.max_doc, bound.num_deleted_docs)
         }
-        SegmentViewDocs::IdOnly => (SEGMENT_FLAG_ID_ONLY, 0, 0),
+        SegmentViewDocs::IdOnly => {
+            panic!("an id-only segment view cannot be shared: it has no documents to replay")
+        }
     }
 }
 
@@ -194,7 +197,6 @@ fn decode_docs(flag: u8, max_doc: u32, num_deleted_docs: u32) -> SegmentViewDocs
             max_doc,
             num_deleted_docs,
         }),
-        SEGMENT_FLAG_ID_ONLY => SegmentViewDocs::IdOnly,
         _ => SegmentViewDocs::Immutable {
             max_doc,
             num_deleted_docs,

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -20,8 +20,8 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::ops::Range;
 
-use crate::api::{HashMap, HashSet};
 use crate::gucs;
+use crate::index::mvcc::{MutableSegmentSnapshot, SegmentView, SegmentViewEntry};
 use crate::postgres::build::is_bm25_index;
 use crate::postgres::condition_variable::ConditionVariable;
 use crate::postgres::locks::Spinlock;
@@ -30,7 +30,6 @@ use crate::postgres::shared_threshold::ParallelScanThresholdState;
 use crate::query::SearchQueryInput;
 
 use pgrx::*;
-use tantivy::SegmentReader;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use tantivy::index::SegmentId;
 
@@ -166,6 +165,9 @@ const SEGMENT_ID_SIZE: usize = 16;
 
 const SEGMENT_CLAIM_UNCLAIMED: i32 = -2;
 
+/// `all_flags` bit: the segment is mutable and its header travels in the mutable arrays.
+const SEGMENT_FLAG_MUTABLE: u8 = 1;
+
 /// Max JSON bytes stored per primary segment for EXPLAIN info in DSM.
 const SEGMENT_INFO_MAX_PER_SEG: usize = 1024;
 
@@ -189,10 +191,20 @@ struct ParallelScanPayloadLayout {
     /// multi-source MPP plan be partitioned across workers, not just the planner-chosen
     /// partitioning source.
     remaining_by_source: Range<usize>,
-    /// One `u32` per segment in the partitioning source: deleted doc count.
-    primary_deleted_docs: Range<usize>,
-    /// One `u32` per segment in the partitioning source: max doc count.
-    primary_max_docs: Range<usize>,
+    /// One `u32` per segment (all sources, `all_ids` order): the leader reader's
+    /// `num_deleted_docs()`.
+    all_deleted_docs: Range<usize>,
+    /// One `u32` per segment (all sources, `all_ids` order): the leader reader's `max_doc()`.
+    all_max_docs: Range<usize>,
+    /// One `u8` per segment (all sources, `all_ids` order): [`SEGMENT_FLAG_MUTABLE`] when the
+    /// segment is mutable and the two arrays below hold its header.
+    all_flags: Range<usize>,
+    /// One `u32` per segment (all sources, `all_ids` order): a mutable segment's header
+    /// `max_doc` as the leader loaded it; zero otherwise.
+    all_mutable_max_docs: Range<usize>,
+    /// One `u32` per segment (all sources, `all_ids` order): a mutable segment's header
+    /// `num_deleted_docs` as the leader loaded it; zero otherwise.
+    all_mutable_deleted_docs: Range<usize>,
     /// One `i32` per segment in the partitioning source: which worker claimed it.
     /// Sized to `primary_nsegments` (the first source), so subsequent sources
     /// have no slot here. Read by [`ParallelScanState::explain_data`] to populate the "Parallel
@@ -242,17 +254,28 @@ impl ParallelScanPayloadLayout {
         let (layout, remaining_offset) = layout.extend(remaining_layout)?;
         let remaining_range = remaining_offset..(remaining_offset + remaining_layout.size());
 
-        // Deleted doc counts for the partitioning source only: [u32; primary_nsegments].
-        let primary_del_layout = Layout::array::<u32>(primary_nsegments)?;
-        let (layout, primary_del_offset) = layout.extend(primary_del_layout)?;
-        let primary_deleted_docs_range =
-            primary_del_offset..(primary_del_offset + primary_del_layout.size());
+        // Per-segment view data for every source: [u32; total_segs] x 4 and [u8; total_segs].
+        let all_del_layout = Layout::array::<u32>(total_segs)?;
+        let (layout, all_del_offset) = layout.extend(all_del_layout)?;
+        let all_deleted_docs_range = all_del_offset..(all_del_offset + all_del_layout.size());
 
-        // Max doc counts for the partitioning source only: [u32; primary_nsegments].
-        let primary_max_layout = Layout::array::<u32>(primary_nsegments)?;
-        let (layout, primary_max_offset) = layout.extend(primary_max_layout)?;
-        let primary_max_docs_range =
-            primary_max_offset..(primary_max_offset + primary_max_layout.size());
+        let all_max_layout = Layout::array::<u32>(total_segs)?;
+        let (layout, all_max_offset) = layout.extend(all_max_layout)?;
+        let all_max_docs_range = all_max_offset..(all_max_offset + all_max_layout.size());
+
+        let all_flags_layout = Layout::array::<u8>(total_segs)?;
+        let (layout, all_flags_offset) = layout.extend(all_flags_layout)?;
+        let all_flags_range = all_flags_offset..(all_flags_offset + all_flags_layout.size());
+
+        let all_mut_max_layout = Layout::array::<u32>(total_segs)?;
+        let (layout, all_mut_max_offset) = layout.extend(all_mut_max_layout)?;
+        let all_mutable_max_docs_range =
+            all_mut_max_offset..(all_mut_max_offset + all_mut_max_layout.size());
+
+        let all_mut_del_layout = Layout::array::<u32>(total_segs)?;
+        let (layout, all_mut_del_offset) = layout.extend(all_mut_del_layout)?;
+        let all_mutable_deleted_docs_range =
+            all_mut_del_offset..(all_mut_del_offset + all_mut_del_layout.size());
 
         // Claims for the partitioning source only: [i32; primary_nsegments].
         let claims_layout = Layout::array::<i32>(primary_nsegments)?;
@@ -299,8 +322,11 @@ impl ParallelScanPayloadLayout {
             all_counts: all_counts_range,
             all_ids: all_ids_range,
             remaining_by_source: remaining_range,
-            primary_deleted_docs: primary_deleted_docs_range,
-            primary_max_docs: primary_max_docs_range,
+            all_deleted_docs: all_deleted_docs_range,
+            all_max_docs: all_max_docs_range,
+            all_flags: all_flags_range,
+            all_mutable_max_docs: all_mutable_max_docs_range,
+            all_mutable_deleted_docs: all_mutable_deleted_docs_range,
             claims: claims_range,
             segment_info_lens,
             segment_info_data,
@@ -326,7 +352,7 @@ struct ParallelScanPayload {
 impl ParallelScanPayload {
     fn init(
         &mut self,
-        all_sources: &[&[SegmentReader]],
+        all_sources: &[SegmentView],
         query: &[u8],
         with_aggregates: bool,
         with_segment_info: bool,
@@ -355,48 +381,62 @@ impl ParallelScanPayload {
             *target = source.len() as u32;
         }
 
-        // All segment IDs concatenated.
+        // Every source's view, flattened in ascending source-index order. Each source keeps its
+        // leader ordinal order so workers can replay it.
+        let entries: Vec<&SegmentViewEntry> =
+            all_sources.iter().flat_map(|s| s.entries()).collect();
         let ids_range = self.layout.all_ids.clone();
         let ids_slice: &mut [[u8; SEGMENT_ID_SIZE]] =
             bytemuck::try_cast_slice_mut(&mut self.data_mut()[ids_range]).unwrap();
-        let mut flat_offset = 0;
-        for source in all_sources.iter() {
-            for (reader, target) in source.iter().zip(ids_slice[flat_offset..].iter_mut()) {
-                let mut writer = &mut target[..];
-                writer
-                    .write_all(reader.segment_id().uuid_bytes())
-                    .expect("failed to write segment bytes");
-            }
-            flat_offset += source.len();
+        for (entry, target) in entries.iter().zip(ids_slice.iter_mut()) {
+            target.copy_from_slice(entry.id.uuid_bytes());
         }
-
-        // Deleted doc counts for the partitioning source only.
-        let del_range = self.layout.primary_deleted_docs.clone();
+        let del_range = self.layout.all_deleted_docs.clone();
         let del_slice: &mut [u32] =
             bytemuck::try_cast_slice_mut(&mut self.data_mut()[del_range]).unwrap();
-        let primary_source = all_sources.first().expect("primary source empty");
-        for (reader, target) in primary_source.iter().zip(del_slice.iter_mut()) {
-            *target = reader.num_deleted_docs();
+        for (entry, target) in entries.iter().zip(del_slice.iter_mut()) {
+            *target = entry.num_deleted_docs;
         }
-
-        // Max doc counts for the partitioning source only.
-        let max_range = self.layout.primary_max_docs.clone();
+        let max_range = self.layout.all_max_docs.clone();
         let max_slice: &mut [u32] =
             bytemuck::try_cast_slice_mut(&mut self.data_mut()[max_range]).unwrap();
-        for (reader, target) in primary_source.iter().zip(max_slice.iter_mut()) {
-            *target = reader.max_doc();
+        for (entry, target) in entries.iter().zip(max_slice.iter_mut()) {
+            *target = entry.max_doc;
+        }
+        let flags_range = self.layout.all_flags.clone();
+        for (entry, target) in entries.iter().zip(self.data_mut()[flags_range].iter_mut()) {
+            *target = if entry.mutable.is_some() {
+                SEGMENT_FLAG_MUTABLE
+            } else {
+                0
+            };
+        }
+        let mut_max_range = self.layout.all_mutable_max_docs.clone();
+        let mut_max_slice: &mut [u32] =
+            bytemuck::try_cast_slice_mut(&mut self.data_mut()[mut_max_range]).unwrap();
+        for (entry, target) in entries.iter().zip(mut_max_slice.iter_mut()) {
+            *target = entry.mutable.map_or(0, |m| m.max_doc);
+        }
+        let mut_del_range = self.layout.all_mutable_deleted_docs.clone();
+        let mut_del_slice: &mut [u32] =
+            bytemuck::try_cast_slice_mut(&mut self.data_mut()[mut_del_range]).unwrap();
+        for (entry, target) in entries.iter().zip(mut_del_slice.iter_mut()) {
+            *target = entry.mutable.map_or(0, |m| m.num_deleted_docs);
         }
 
-        // Initialize claims (only for the partitioning source).
-        for claim in self.claims_mut().iter_mut() {
-            *claim = SEGMENT_CLAIM_UNCLAIMED;
-        }
+        // Claims for the partitioning source only.
+        let claims_range = self.layout.claims.clone();
+        let claims_slice: &mut [i32] =
+            bytemuck::try_cast_slice_mut(&mut self.data_mut()[claims_range]).unwrap();
+        claims_slice.fill(SEGMENT_CLAIM_UNCLAIMED);
 
-        // Clear per-segment EXPLAIN info slots.
-        for len in self.segment_info_lens_mut().iter_mut() {
-            *len = 0;
-        }
+        // Per-segment EXPLAIN info lengths start at zero (none recorded yet).
+        let info_lens_range = self.layout.segment_info_lens.clone();
+        let info_lens_slice: &mut [u32] =
+            bytemuck::try_cast_slice_mut(&mut self.data_mut()[info_lens_range]).unwrap();
+        info_lens_slice.fill(0);
 
+        // Remaining-by-source starts at each source's full count.
         let remaining_range = self.layout.remaining_by_source.clone();
         let remaining_slice: &mut [u32] =
             bytemuck::try_cast_slice_mut(&mut self.data_mut()[remaining_range]).unwrap();
@@ -447,12 +487,51 @@ impl ParallelScanPayload {
         &all[offset..offset + count]
     }
 
+    /// A `[u32; total_segs]` array of the payload, sliced to `source_idx`.
+    fn source_u32s(&self, range: Range<usize>, source_idx: usize) -> &[u32] {
+        let offset = self.source_flat_offset(source_idx);
+        let count = self.all_counts()[source_idx] as usize;
+        let all: &[u32] = bytemuck::try_cast_slice(&self.data()[range]).unwrap();
+        &all[offset..offset + count]
+    }
+
+    fn source_flags(&self, source_idx: usize) -> &[u8] {
+        let offset = self.source_flat_offset(source_idx);
+        let count = self.all_counts()[source_idx] as usize;
+        &self.data()[self.layout.all_flags.clone()][offset..offset + count]
+    }
+
+    /// Rebuild the leader's [`SegmentView`] for `source_idx`.
+    fn source_view(&self, source_idx: usize) -> SegmentView {
+        let ids = self.source_ids(source_idx);
+        let deleted = self.source_u32s(self.layout.all_deleted_docs.clone(), source_idx);
+        let max_docs = self.source_u32s(self.layout.all_max_docs.clone(), source_idx);
+        let flags = self.source_flags(source_idx);
+        let mut_max = self.source_u32s(self.layout.all_mutable_max_docs.clone(), source_idx);
+        let mut_del = self.source_u32s(self.layout.all_mutable_deleted_docs.clone(), source_idx);
+        SegmentView::new(
+            (0..ids.len())
+                .map(|i| SegmentViewEntry {
+                    id: SegmentId::from_bytes(ids[i]),
+                    max_doc: max_docs[i],
+                    num_deleted_docs: deleted[i],
+                    mutable: (flags[i] & SEGMENT_FLAG_MUTABLE != 0).then_some(
+                        MutableSegmentSnapshot {
+                            max_doc: mut_max[i],
+                            num_deleted_docs: mut_del[i],
+                        },
+                    ),
+                })
+                .collect(),
+        )
+    }
+
     fn primary_deleted_docs(&self) -> &[u32] {
-        bytemuck::try_cast_slice(&self.data()[self.layout.primary_deleted_docs.clone()]).unwrap()
+        self.source_u32s(self.layout.all_deleted_docs.clone(), 0)
     }
 
     fn primary_max_docs(&self) -> &[u32] {
-        bytemuck::try_cast_slice(&self.data()[self.layout.primary_max_docs.clone()]).unwrap()
+        self.source_u32s(self.layout.all_max_docs.clone(), 0)
     }
 
     fn remaining_by_source_mut(&mut self) -> &mut [u32] {
@@ -552,9 +631,11 @@ impl ParallelScanPayload {
     }
 }
 
-pub struct ParallelScanArgs<'a> {
-    /// All sources in ascending source-index order. For basescan this is a single element.
-    all_sources: Vec<&'a [SegmentReader]>,
+pub struct ParallelScanArgs {
+    /// The leader's segment view of every source, in ascending source-index order. For basescan
+    /// this is a single element. Workers replay each view, so all participants agree on the
+    /// per-source segment ordinals and mutable-segment contents.
+    all_sources: Vec<SegmentView>,
     query: Vec<u8>,
     with_aggregates: bool,
     /// Whether to allocate the per-segment EXPLAIN telemetry slots
@@ -563,7 +644,7 @@ pub struct ParallelScanArgs<'a> {
     with_segment_info: bool,
 }
 
-impl<'a> ParallelScanArgs<'a> {
+impl ParallelScanArgs {
     fn all_nsegments(&self) -> Vec<usize> {
         self.all_sources.iter().map(|s| s.len()).collect()
     }
@@ -683,7 +764,7 @@ impl ParallelScanState {
     /// waiting in `wait_for_initialization()`.
     fn populate(
         &mut self,
-        all_sources: &[&[SegmentReader]],
+        all_sources: &[SegmentView],
         query: &[u8],
         with_aggregates: bool,
         with_segment_info: bool,
@@ -954,21 +1035,13 @@ impl ParallelScanState {
         }
     }
 
-    /// Returns a map of segment IDs to their deleted document counts.
+    /// The leader's segment view of the partitioning source.
     ///
     /// This method will wait (spin) until the leader has initialized the segment data.
     /// This is necessary for parallel index scans where workers may call this before
     /// the leader has finished initializing the parallel state.
-    pub fn segments(&mut self) -> HashMap<SegmentId, u32> {
-        // Wait for initialization, then read segment data while holding the mutex.
-        self.wait_for_initialization();
-
-        let _mutex = self.acquire_mutex();
-        let mut segments = HashMap::default();
-        for i in 0..self.nsegments {
-            segments.insert(self.segment_id(i), self.num_deleted_docs(i));
-        }
-        segments
+    pub fn segment_view(&mut self) -> SegmentView {
+        self.segment_view_for_source(0)
     }
 
     /// Wait for parallel state to be initialized by the leader.
@@ -1113,23 +1186,19 @@ impl ParallelScanState {
         // rescans.
     }
 
-    /// Per-source frozen segment set for `MvccSatisfies::ParallelWorker(ids)`. Lives
+    /// Per-source frozen segment view for `MvccSatisfies::ParallelWorker(view)`. Lives
     /// in the shared payload so workers don't need a codec channel for it. Waits for
     /// leader init; otherwise a racing worker reads zero IDs.
-    pub fn segment_ids_for_source(&mut self, source_idx: usize) -> HashSet<SegmentId> {
+    pub fn segment_view_for_source(&mut self, source_idx: usize) -> SegmentView {
         self.wait_for_initialization();
-        self.segment_ids_for_source_unlocked(source_idx)
+        self.segment_view_for_source_unlocked(source_idx)
     }
 
-    /// Read-only sibling of [`Self::segment_ids_for_source`] for callers that already
-    /// know initialization is complete. No mutex acquire because the IDs are immutable
+    /// Read-only sibling of [`Self::segment_view_for_source`] for callers that already
+    /// know initialization is complete. No mutex acquire because the view is immutable
     /// after `populate`.
-    pub fn segment_ids_for_source_unlocked(&self, source_idx: usize) -> HashSet<SegmentId> {
-        self.payload
-            .source_ids(source_idx)
-            .iter()
-            .map(|b| SegmentId::from_bytes(*b))
-            .collect()
+    pub fn segment_view_for_source_unlocked(&self, source_idx: usize) -> SegmentView {
+        self.payload.source_view(source_idx)
     }
 
     /// Return the total number of segments for a given source, waiting for initialization

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -21,7 +21,7 @@ use std::io::Write;
 use std::ops::Range;
 
 use crate::gucs;
-use crate::index::mvcc::{MutableSegmentSnapshot, SegmentView, SegmentViewEntry};
+use crate::index::mvcc::{MutableSegmentBound, SegmentView, SegmentViewEntry};
 use crate::postgres::build::is_bm25_index;
 use crate::postgres::condition_variable::ConditionVariable;
 use crate::postgres::locks::Spinlock;
@@ -516,7 +516,7 @@ impl ParallelScanPayload {
                     max_doc: max_docs[i],
                     num_deleted_docs: deleted[i],
                     mutable: (flags[i] & SEGMENT_FLAG_MUTABLE != 0).then_some(
-                        MutableSegmentSnapshot {
+                        MutableSegmentBound {
                             max_doc: mut_max[i],
                             num_deleted_docs: mut_del[i],
                         },
@@ -1195,8 +1195,9 @@ impl ParallelScanState {
     }
 
     /// Read-only sibling of [`Self::segment_view_for_source`] for callers that already
-    /// know initialization is complete. No mutex acquire because the view is immutable
-    /// after `populate`.
+    /// know initialization is complete. No mutex acquire: only `populate` writes the payload,
+    /// and a repopulate (a parallel rescan) happens after PostgreSQL has finished every
+    /// worker, so no reader can overlap the rewrite.
     pub fn segment_view_for_source_unlocked(&self, source_idx: usize) -> SegmentView {
         self.payload.source_view(source_idx)
     }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -21,7 +21,7 @@ use std::io::Write;
 use std::ops::Range;
 
 use crate::gucs;
-use crate::index::mvcc::{MutableSegmentBound, SegmentView, SegmentViewEntry};
+use crate::index::mvcc::{MutableSegmentBound, SegmentView, SegmentViewDocs, SegmentViewEntry};
 use crate::postgres::build::is_bm25_index;
 use crate::postgres::condition_variable::ConditionVariable;
 use crate::postgres::locks::Spinlock;
@@ -165,8 +165,42 @@ const SEGMENT_ID_SIZE: usize = 16;
 
 const SEGMENT_CLAIM_UNCLAIMED: i32 = -2;
 
-/// `all_flags` bit: the segment is mutable and its header travels in the mutable arrays.
+/// `all_docs_flags` value: `all_max_docs`/`all_deleted_docs` hold the mutable segment's bound.
 const SEGMENT_FLAG_MUTABLE: u8 = 1;
+
+/// `all_docs_flags` value: the entry only pins the segment id; both count slots are zero.
+const SEGMENT_FLAG_ID_ONLY: u8 = 2;
+
+/// The wire format of one [`SegmentViewDocs`] in the payload: a flag byte plus the two `u32`
+/// count slots whose meaning the flag selects. `encode_docs` and `decode_docs` are the only
+/// readers of this convention.
+fn encode_docs(docs: SegmentViewDocs) -> (u8, u32, u32) {
+    match docs {
+        SegmentViewDocs::Immutable {
+            max_doc,
+            num_deleted_docs,
+        } => (0, max_doc, num_deleted_docs),
+        SegmentViewDocs::Mutable(bound) => {
+            (SEGMENT_FLAG_MUTABLE, bound.max_doc, bound.num_deleted_docs)
+        }
+        SegmentViewDocs::IdOnly => (SEGMENT_FLAG_ID_ONLY, 0, 0),
+    }
+}
+
+/// Inverse of [`encode_docs`].
+fn decode_docs(flag: u8, max_doc: u32, num_deleted_docs: u32) -> SegmentViewDocs {
+    match flag {
+        SEGMENT_FLAG_MUTABLE => SegmentViewDocs::Mutable(MutableSegmentBound {
+            max_doc,
+            num_deleted_docs,
+        }),
+        SEGMENT_FLAG_ID_ONLY => SegmentViewDocs::IdOnly,
+        _ => SegmentViewDocs::Immutable {
+            max_doc,
+            num_deleted_docs,
+        },
+    }
+}
 
 /// Max JSON bytes stored per primary segment for EXPLAIN info in DSM.
 const SEGMENT_INFO_MAX_PER_SEG: usize = 1024;
@@ -191,20 +225,14 @@ struct ParallelScanPayloadLayout {
     /// multi-source MPP plan be partitioned across workers, not just the planner-chosen
     /// partitioning source.
     remaining_by_source: Range<usize>,
-    /// One `u32` per segment (all sources, `all_ids` order): the leader reader's
-    /// `num_deleted_docs()`.
-    all_deleted_docs: Range<usize>,
-    /// One `u32` per segment (all sources, `all_ids` order): the leader reader's `max_doc()`.
+    /// One `u32` per segment (all sources, `all_ids` order): the first count slot of the
+    /// segment's [`SegmentViewDocs`]; see [`encode_docs`].
     all_max_docs: Range<usize>,
-    /// One `u8` per segment (all sources, `all_ids` order): [`SEGMENT_FLAG_MUTABLE`] when the
-    /// segment is mutable and the two arrays below hold its header.
-    all_flags: Range<usize>,
-    /// One `u32` per segment (all sources, `all_ids` order): a mutable segment's header
-    /// `max_doc` as the leader loaded it; zero otherwise.
-    all_mutable_max_docs: Range<usize>,
-    /// One `u32` per segment (all sources, `all_ids` order): a mutable segment's header
-    /// `num_deleted_docs` as the leader loaded it; zero otherwise.
-    all_mutable_deleted_docs: Range<usize>,
+    /// One `u32` per segment (all sources, `all_ids` order): the second count slot.
+    all_deleted_docs: Range<usize>,
+    /// One `u8` per segment (all sources, `all_ids` order): which [`SegmentViewDocs`] variant
+    /// the two count slots hold.
+    all_docs_flags: Range<usize>,
     /// One `i32` per segment in the partitioning source: which worker claimed it.
     /// Sized to `primary_nsegments` (the first source), so subsequent sources
     /// have no slot here. Read by [`ParallelScanState::explain_data`] to populate the "Parallel
@@ -254,28 +282,18 @@ impl ParallelScanPayloadLayout {
         let (layout, remaining_offset) = layout.extend(remaining_layout)?;
         let remaining_range = remaining_offset..(remaining_offset + remaining_layout.size());
 
-        // Per-segment view data for every source: [u32; total_segs] x 4 and [u8; total_segs].
-        let all_del_layout = Layout::array::<u32>(total_segs)?;
-        let (layout, all_del_offset) = layout.extend(all_del_layout)?;
-        let all_deleted_docs_range = all_del_offset..(all_del_offset + all_del_layout.size());
-
+        // Per-segment view docs for every source: [u32; total_segs] x 2 and [u8; total_segs].
         let all_max_layout = Layout::array::<u32>(total_segs)?;
         let (layout, all_max_offset) = layout.extend(all_max_layout)?;
         let all_max_docs_range = all_max_offset..(all_max_offset + all_max_layout.size());
 
+        let all_del_layout = Layout::array::<u32>(total_segs)?;
+        let (layout, all_del_offset) = layout.extend(all_del_layout)?;
+        let all_deleted_docs_range = all_del_offset..(all_del_offset + all_del_layout.size());
+
         let all_flags_layout = Layout::array::<u8>(total_segs)?;
         let (layout, all_flags_offset) = layout.extend(all_flags_layout)?;
-        let all_flags_range = all_flags_offset..(all_flags_offset + all_flags_layout.size());
-
-        let all_mut_max_layout = Layout::array::<u32>(total_segs)?;
-        let (layout, all_mut_max_offset) = layout.extend(all_mut_max_layout)?;
-        let all_mutable_max_docs_range =
-            all_mut_max_offset..(all_mut_max_offset + all_mut_max_layout.size());
-
-        let all_mut_del_layout = Layout::array::<u32>(total_segs)?;
-        let (layout, all_mut_del_offset) = layout.extend(all_mut_del_layout)?;
-        let all_mutable_deleted_docs_range =
-            all_mut_del_offset..(all_mut_del_offset + all_mut_del_layout.size());
+        let all_docs_flags_range = all_flags_offset..(all_flags_offset + all_flags_layout.size());
 
         // Claims for the partitioning source only: [i32; primary_nsegments].
         let claims_layout = Layout::array::<i32>(primary_nsegments)?;
@@ -322,11 +340,9 @@ impl ParallelScanPayloadLayout {
             all_counts: all_counts_range,
             all_ids: all_ids_range,
             remaining_by_source: remaining_range,
-            all_deleted_docs: all_deleted_docs_range,
             all_max_docs: all_max_docs_range,
-            all_flags: all_flags_range,
-            all_mutable_max_docs: all_mutable_max_docs_range,
-            all_mutable_deleted_docs: all_mutable_deleted_docs_range,
+            all_deleted_docs: all_deleted_docs_range,
+            all_docs_flags: all_docs_flags_range,
             claims: claims_range,
             segment_info_lens,
             segment_info_data,
@@ -391,37 +407,22 @@ impl ParallelScanPayload {
         for (entry, target) in entries.iter().zip(ids_slice.iter_mut()) {
             target.copy_from_slice(entry.id.uuid_bytes());
         }
-        let del_range = self.layout.all_deleted_docs.clone();
-        let del_slice: &mut [u32] =
-            bytemuck::try_cast_slice_mut(&mut self.data_mut()[del_range]).unwrap();
-        for (entry, target) in entries.iter().zip(del_slice.iter_mut()) {
-            *target = entry.num_deleted_docs;
-        }
+        let encoded: Vec<(u8, u32, u32)> = entries.iter().map(|e| encode_docs(e.docs)).collect();
         let max_range = self.layout.all_max_docs.clone();
         let max_slice: &mut [u32] =
             bytemuck::try_cast_slice_mut(&mut self.data_mut()[max_range]).unwrap();
-        for (entry, target) in entries.iter().zip(max_slice.iter_mut()) {
-            *target = entry.max_doc;
+        for ((_, max, _), target) in encoded.iter().zip(max_slice.iter_mut()) {
+            *target = *max;
         }
-        let flags_range = self.layout.all_flags.clone();
-        for (entry, target) in entries.iter().zip(self.data_mut()[flags_range].iter_mut()) {
-            *target = if entry.mutable.is_some() {
-                SEGMENT_FLAG_MUTABLE
-            } else {
-                0
-            };
+        let del_range = self.layout.all_deleted_docs.clone();
+        let del_slice: &mut [u32] =
+            bytemuck::try_cast_slice_mut(&mut self.data_mut()[del_range]).unwrap();
+        for ((_, _, del), target) in encoded.iter().zip(del_slice.iter_mut()) {
+            *target = *del;
         }
-        let mut_max_range = self.layout.all_mutable_max_docs.clone();
-        let mut_max_slice: &mut [u32] =
-            bytemuck::try_cast_slice_mut(&mut self.data_mut()[mut_max_range]).unwrap();
-        for (entry, target) in entries.iter().zip(mut_max_slice.iter_mut()) {
-            *target = entry.mutable.map_or(0, |m| m.max_doc);
-        }
-        let mut_del_range = self.layout.all_mutable_deleted_docs.clone();
-        let mut_del_slice: &mut [u32] =
-            bytemuck::try_cast_slice_mut(&mut self.data_mut()[mut_del_range]).unwrap();
-        for (entry, target) in entries.iter().zip(mut_del_slice.iter_mut()) {
-            *target = entry.mutable.map_or(0, |m| m.num_deleted_docs);
+        let flags_range = self.layout.all_docs_flags.clone();
+        for ((flag, _, _), target) in encoded.iter().zip(self.data_mut()[flags_range].iter_mut()) {
+            *target = *flag;
         }
 
         // Claims for the partitioning source only.
@@ -495,43 +496,36 @@ impl ParallelScanPayload {
         &all[offset..offset + count]
     }
 
-    fn source_flags(&self, source_idx: usize) -> &[u8] {
+    fn source_docs_flags(&self, source_idx: usize) -> &[u8] {
         let offset = self.source_flat_offset(source_idx);
         let count = self.all_counts()[source_idx] as usize;
-        &self.data()[self.layout.all_flags.clone()][offset..offset + count]
+        &self.data()[self.layout.all_docs_flags.clone()][offset..offset + count]
     }
 
     /// Rebuild the leader's [`SegmentView`] for `source_idx`.
     fn source_view(&self, source_idx: usize) -> SegmentView {
         let ids = self.source_ids(source_idx);
-        let deleted = self.source_u32s(self.layout.all_deleted_docs.clone(), source_idx);
         let max_docs = self.source_u32s(self.layout.all_max_docs.clone(), source_idx);
-        let flags = self.source_flags(source_idx);
-        let mut_max = self.source_u32s(self.layout.all_mutable_max_docs.clone(), source_idx);
-        let mut_del = self.source_u32s(self.layout.all_mutable_deleted_docs.clone(), source_idx);
+        let deleted = self.source_u32s(self.layout.all_deleted_docs.clone(), source_idx);
+        let flags = self.source_docs_flags(source_idx);
         SegmentView::new(
             (0..ids.len())
                 .map(|i| SegmentViewEntry {
                     id: SegmentId::from_bytes(ids[i]),
-                    max_doc: max_docs[i],
-                    num_deleted_docs: deleted[i],
-                    mutable: (flags[i] & SEGMENT_FLAG_MUTABLE != 0).then_some(
-                        MutableSegmentBound {
-                            max_doc: mut_max[i],
-                            num_deleted_docs: mut_del[i],
-                        },
-                    ),
+                    docs: decode_docs(flags[i], max_docs[i], deleted[i]),
                 })
                 .collect(),
         )
     }
 
-    fn primary_deleted_docs(&self) -> &[u32] {
-        self.source_u32s(self.layout.all_deleted_docs.clone(), 0)
-    }
-
-    fn primary_max_docs(&self) -> &[u32] {
-        self.source_u32s(self.layout.all_max_docs.clone(), 0)
+    /// The [`SegmentViewDocs`] of one primary-source segment, for EXPLAIN's per-segment
+    /// reader-level doc counts.
+    fn primary_docs(&self, i: usize) -> SegmentViewDocs {
+        decode_docs(
+            self.source_docs_flags(0)[i],
+            self.source_u32s(self.layout.all_max_docs.clone(), 0)[i],
+            self.source_u32s(self.layout.all_deleted_docs.clone(), 0)[i],
+        )
     }
 
     fn remaining_by_source_mut(&mut self) -> &mut [u32] {
@@ -1158,11 +1152,11 @@ impl ParallelScanState {
     }
 
     fn num_deleted_docs(&self, i: usize) -> u32 {
-        self.payload.primary_deleted_docs()[i]
+        self.payload.primary_docs(i).num_deleted_docs()
     }
 
     fn segment_max_docs(&self, i: usize) -> u32 {
-        self.payload.primary_max_docs()[i]
+        self.payload.primary_docs(i).max_doc()
     }
 
     fn query(&self) -> anyhow::Result<Option<SearchQueryInput>> {

--- a/pg_search/src/postgres/parallel.rs
+++ b/pg_search/src/postgres/parallel.rs
@@ -134,7 +134,7 @@ pub unsafe fn maybe_init_parallel_scan(
             );
             return None;
         }
-        state.populate(&[searcher.segment_readers()], &[], false, false);
+        state.populate(&[searcher.segment_view()], &[], false, false);
     }
     Some(unsafe { pg_sys::ParallelWorkerNumber })
 }

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -15,10 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::api::HashSet;
 use crate::api::operator::searchqueryinput_typoid;
 use crate::index::fast_fields_helper::{FFHelper, FFType, resolve_ctid};
-use crate::index::mvcc::MvccSatisfies;
+use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::index::reader::index::{MultiSegmentSearchResults, SearchIndexReader};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::metadata::MetaPage;
@@ -27,7 +26,6 @@ use crate::query::SearchQueryInput;
 
 use pgrx::pg_sys::IndexScanDesc;
 use pgrx::*;
-use tantivy::index::SegmentId;
 
 pub struct Bm25ScanState {
     fast_fields: FFHelper,
@@ -183,12 +181,12 @@ pub extern "C-unwind" fn amrescan(
             // This is because workers pick specific segments to query that are known to be
             // held open/pinned by the leader, but might not pass a ::Snapshot visibility
             // test due to concurrent merges/garbage collects.
-            let segment_ids = wait_for_segment_ids(scan);
+            let view = wait_for_segment_view(scan);
             SearchIndexReader::open(
                 &indexrel,
                 search_query_input,
                 false,
-                MvccSatisfies::ParallelWorker(segment_ids),
+                MvccSatisfies::ParallelWorker(view),
             )
             .expect("amrescan: worker should be able to open a SearchIndexReader")
         } else {
@@ -432,15 +430,15 @@ pub unsafe extern "C-unwind" fn amgetbitmap(
     cnt
 }
 
-/// Wait for parallel scan state to be initialized by the leader, then return the segment IDs.
+/// Wait for parallel scan state to be initialized by the leader, then return its segment view.
 /// This ensures workers see the exact same segments as the leader, preventing race conditions
 /// where workers might see different segments due to concurrent merges.
-unsafe fn wait_for_segment_ids(scan: IndexScanDesc) -> HashSet<SegmentId> {
+unsafe fn wait_for_segment_view(scan: IndexScanDesc) -> SegmentView {
     let state = get_parallel_scan_state(scan)
-        .expect("wait_for_segment_ids called but no parallel scan state");
+        .expect("wait_for_segment_view called but no parallel scan state");
 
-    // segments() internally calls wait_for_initialization() and returns segment IDs
-    state.segments().into_keys().collect()
+    // segment_view() internally calls wait_for_initialization()
+    state.segment_view()
 }
 
 /// Get the parallel scan state from an IndexScanDesc, if it's a parallel scan.

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -490,6 +490,21 @@ impl SegmentMetaEntry {
         Ok(())
     }
 
+    /// Rewind a mutable entry to the `(max_doc, num_deleted_docs)` another reader loaded it
+    /// with, so [`Self::mutable_snapshot`] replays that reader's prefix of the add/remove log.
+    /// The log is append-only, so an older pair always names a prefix of what is there now.
+    pub fn rewind_mutable(&mut self, max_doc: u32, num_deleted_docs: u32) -> Result<(), &str> {
+        let SegmentMetaEntryContent::Mutable(content) = &mut self.content else {
+            return Err("Cannot rewind a non-mutable segment");
+        };
+        if max_doc > self.header.max_doc || num_deleted_docs > content.num_deleted_docs {
+            return Err("Cannot rewind a mutable segment forward");
+        }
+        self.header.max_doc = max_doc;
+        content.num_deleted_docs = num_deleted_docs;
+        Ok(())
+    }
+
     /// Return a snapshot of the ctids which were valid when this SegmentMetaEntry was opened.
     pub fn mutable_snapshot(&self, indexrel: &PgSearchRelation) -> Result<Vec<u64>, &str> {
         let SegmentMetaEntryContent::Mutable(content) = &self.content else {

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -221,9 +221,17 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         if provider.source_idx().is_some() {
             provider.set_parallel_state(self.parallel_state);
         }
+        // Same contract as `try_decode_pg_search_udf`: an empty list means this decode has no
+        // views to offer (plain EXPLAIN), but a short list is a bug, and falling back to a
+        // snapshot open would silently break the address exchange.
         if let Some(plan_position) = provider.segment_view_position()
-            && let Some(view) = self.index_segment_views.get(plan_position)
+            && !self.index_segment_views.is_empty()
         {
+            let view = self.index_segment_views.get(plan_position).ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "missing canonical segment view for plan_position {plan_position}"
+                ))
+            })?;
             provider.set_segment_view(view.clone());
         }
         provider.set_expr_context(self.expr_context);

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -216,23 +216,22 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         let mut provider: PgSearchTableProvider = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("Failed to deserialize PgSearchTableProvider: {e}"))
         })?;
-        // MPP sources also call `checkout_segment_for_source` against
-        // `parallel_state`, so inject the pointer for them too.
-        if provider.source_idx().is_some() {
+        if let Some(plan_position) = provider.source_idx() {
+            // MPP sources also call `checkout_segment_for_source` against
+            // `parallel_state`, so inject the pointer for them too.
             provider.set_parallel_state(self.parallel_state);
-        }
-        // Same contract as `try_decode_pg_search_udf`: an empty list means this decode has no
-        // views to offer (plain EXPLAIN), but a short list is a bug, and falling back to a
-        // snapshot open would silently break the address exchange.
-        if let Some(plan_position) = provider.segment_view_position()
-            && !self.index_segment_views.is_empty()
-        {
-            let view = self.index_segment_views.get(plan_position).ok_or_else(|| {
-                DataFusionError::Internal(format!(
-                    "missing canonical segment view for plan_position {plan_position}"
-                ))
-            })?;
-            provider.set_segment_view(view.clone());
+
+            // An empty list means this decode has no views to offer (plain EXPLAIN), but a
+            // short list is a bug, and falling back to a snapshot open would silently break
+            // the address exchange with the workers.
+            if !self.index_segment_views.is_empty() {
+                let view = self.index_segment_views.get(plan_position).ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "missing canonical segment view for plan_position {plan_position}"
+                    ))
+                })?;
+                provider.set_segment_view(view.clone());
+            }
         }
         provider.set_expr_context(self.expr_context);
         provider.set_planstate(self.planstate);

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -27,6 +27,7 @@ use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use datafusion_proto::protobuf::DfSchema;
 use pgrx::pg_sys::{ExprContext, Oid, PlanState};
 
+use crate::index::mvcc::SegmentView;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterNode;
 use crate::scan::late_materialization::{DeferredField, LateMaterializeNode};
@@ -44,6 +45,10 @@ struct PgSearchExtensionCodec {
     expr_context: Option<*mut ExprContext>,
     /// Executor planstate, needed to initialize runtime Postgres expressions in source queries.
     planstate: Option<*mut PlanState>,
+    /// The leader's segment view of every join source, indexed by plan_position. Every reader
+    /// a decoded plan opens for a source replays its view, so packed addresses stay comparable
+    /// across the leader and its workers.
+    index_segment_views: Vec<SegmentView>,
 }
 
 unsafe impl Send for PgSearchExtensionCodec {}
@@ -216,6 +221,11 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         if provider.source_idx().is_some() {
             provider.set_parallel_state(self.parallel_state);
         }
+        if let Some(plan_position) = provider.segment_view_position()
+            && let Some(view) = self.index_segment_views.get(plan_position)
+        {
+            provider.set_segment_view(view.clone());
+        }
         provider.set_expr_context(self.expr_context);
         provider.set_planstate(self.planstate);
         Ok(Arc::new(provider))
@@ -298,11 +308,13 @@ pub fn deserialize_logical_plan_with_runtime(
     parallel_state: Option<*mut ParallelScanState>,
     expr_context: Option<*mut ExprContext>,
     planstate: Option<*mut PlanState>,
+    index_segment_views: Vec<SegmentView>,
 ) -> Result<LogicalPlan> {
     let codec = PgSearchExtensionCodec {
         parallel_state,
         expr_context,
         planstate,
+        index_segment_views,
     };
     datafusion_proto::bytes::logical_plan_from_bytes_with_extension_codec(bytes, ctx, &codec)
 }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -64,7 +64,7 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::explain::ExplainFormat;
-use crate::postgres::customscan::parallel::list_segment_ids;
+use crate::postgres::customscan::parallel::segment_view;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::{SortByDirection, SortByField};
 use crate::postgres::rel::PgSearchRelation;
@@ -625,9 +625,9 @@ impl PgSearchScanPlan {
         // list from `ParallelScanState`; a standard parallel scan (source_idx None) reads
         // the worker's full segment list. Mirrors the MVCC dispatch in `scan_inner`.
         let mvcc = match (descriptor.source_idx, parallel_state) {
-            (None, Some(ps)) => MvccSatisfies::ParallelWorker(unsafe { list_segment_ids(ps) }),
+            (None, Some(ps)) => MvccSatisfies::ParallelWorker(unsafe { segment_view(ps) }),
             (Some(idx), Some(ps)) => {
-                MvccSatisfies::ParallelWorker(unsafe { (*ps).segment_ids_for_source(idx) })
+                MvccSatisfies::ParallelWorker(unsafe { (*ps).segment_view_for_source(idx) })
             }
             (_, None) => MvccSatisfies::Snapshot,
         };

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -37,10 +37,10 @@ use datafusion_proto::physical_plan::{
     PhysicalPlanNodeExt, PhysicalProtoConverterExtension,
 };
 use datafusion_proto::protobuf::PhysicalPlanNode;
-use tantivy::index::SegmentId;
 
-use crate::api::{HashMap, HashSet};
+use crate::api::HashMap;
 use crate::index::fast_fields_helper::FFHelper;
+use crate::index::mvcc::SegmentView;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::datafusion::numeric_agg;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
@@ -67,8 +67,9 @@ pub struct PgSearchPhysicalExtensionCodec {
     /// Worker's `ParallelScanState`, used to resolve the scan's MVCC segment set and to claim
     /// segments at runtime.
     parallel_state: Option<*mut ParallelScanState>,
-    /// Canonical segment ID sets for all join sources, indexed by `plan_position`.
-    index_segment_ids: Vec<HashSet<SegmentId>>,
+    /// The leader's segment view of every join source, indexed by `plan_position`, for the
+    /// rebuilt ctid resolvers on decode.
+    index_segment_views: Vec<SegmentView>,
     /// The `ExprContext` workers use to evaluate heap filters.
     expr_context: Option<*mut pgrx::pg_sys::ExprContext>,
 }
@@ -111,7 +112,7 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                     payload,
                     input,
                     resolvers,
-                    &self.index_segment_ids,
+                    &self.index_segment_views,
                 )
             }
             TAG_TANTIVY_LOOKUP => {
@@ -136,7 +137,7 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                     ffhelpers,
                     resolvers,
                     ctx,
-                    &self.index_segment_ids,
+                    &self.index_segment_views,
                     self.parallel_state,
                     proto_converter,
                 )
@@ -388,13 +389,13 @@ pub fn deserialize_physical_plan_with_runtime(
     bytes: &[u8],
     ctx: &TaskContext,
     parallel_state: Option<*mut ParallelScanState>,
-    index_segment_ids: Vec<HashSet<SegmentId>>,
+    index_segment_views: Vec<SegmentView>,
     expr_context: Option<*mut pgrx::pg_sys::ExprContext>,
     proto_converter: &dyn PhysicalProtoConverterExtension,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let codec = combined_codec(PgSearchPhysicalExtensionCodec {
         parallel_state,
-        index_segment_ids,
+        index_segment_views,
         expr_context,
     });
     let proto = <PhysicalPlanNode as prost::Message>::decode(bytes).map_err(|e| {

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -72,6 +72,7 @@
 
 use crate::api::HashMap;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, FFType, NULL_TERM_ORDINAL};
+use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::postgres::customscan::joinscan::build::CtidColumn;
 use crate::postgres::customscan::joinscan::visibility_filter::{
     DeferredCtidMaterializationState, materialize_deferred_ctid,
@@ -404,7 +405,7 @@ impl SegmentedTopKExec {
         ffhelpers: HashMap<u32, Arc<FFHelper>>,
         ctid_resolvers: Vec<(usize, u32, Arc<FFHelper>)>,
         ctx: &TaskContext,
-        index_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
+        index_segment_views: &[SegmentView],
         parallel_state: Option<*mut crate::postgres::ParallelScanState>,
         proto_converter: &dyn datafusion_proto::physical_plan::PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -508,16 +509,16 @@ impl SegmentedTopKExec {
                     if ctid_resolvers.iter().any(|(pos, _, _)| *pos == plan_pos) {
                         continue;
                     }
-                    let ids = index_segment_ids.get(plan_pos).cloned().ok_or_else(|| {
+                    let view = index_segment_views.get(plan_pos).cloned().ok_or_else(|| {
                         DataFusionError::Internal(format!(
-                            "SegmentedTopKExec dispatch: missing canonical segment ids for \
+                            "SegmentedTopKExec dispatch: missing segment view for \
                              plan_position {plan_pos}"
                         ))
                     })?;
                     let ffhelper = crate::scan::tantivy_lookup_exec::open_rebuilt_ffhelper(
                         indexrelid,
                         &[],
-                        crate::index::mvcc::MvccSatisfies::ParallelWorker(ids),
+                        MvccSatisfies::ParallelWorker(view),
                     )?;
                     vd.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
                 }

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -124,9 +124,9 @@ pub struct PgSearchTableProvider {
     /// ignores parallel state segments and yields statically partitioned streams.
     range_sample: Option<RangePartitioningSample>,
 
-    /// The segment view this source's reader replays when it is one of a JoinScan's sources.
-    /// Backend-local (a plan's readers do not travel), so re-injected by the codec on
-    /// deserialization; see [`Self::segment_view_position`].
+    /// The segment view this source's reader replays, for an MPP source whose workers resolve
+    /// the addresses it packs. Backend-local (a plan's readers do not travel), so re-injected
+    /// by the codec on deserialization, keyed by `source_idx`.
     #[serde(skip)]
     segment_view: Option<SegmentView>,
 }
@@ -233,13 +233,6 @@ impl PgSearchTableProvider {
 
     pub(crate) fn source_idx(&self) -> Option<usize> {
         self.source_idx
-    }
-
-    /// The JoinScan plan position whose segment view this source replays, if any. An MPP source
-    /// is addressed by `source_idx`; a serial source only takes part in an address exchange
-    /// (with `SearchPredicateUDF`) when its visibility is deferred.
-    pub(crate) fn segment_view_position(&self) -> Option<usize> {
-        self.source_idx.or(self.deferred_ctid_plan_position())
     }
 
     pub(crate) fn set_segment_view(&mut self, view: SegmentView) {

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -666,27 +666,16 @@ impl PgSearchTableProvider {
             query.init_postgres_expressions(planstate);
             query.solve_postgres_expressions(expr_context);
         }
-        // MVCC dispatch:
+        // Replay the view the codec injected for this source, when there is one: the leader's
+        // reader then matches the manifest the DSM was populated from. Any other reader opens a
+        // plain snapshot.
         //
-        // Parallel worker (`parallel_state` Some, not the leader): replay this source's segment
-        // view from `ParallelScanState`.
-        //
-        // Otherwise, replay the view the codec injected for this source, when there is one: the
-        // leader's reader then matches the manifest the DSM was populated from, and a serial
-        // reader matches the predicate UDF's. Any other reader opens a plain snapshot.
-        let mvcc_style = match parallel_state {
-            Some(parallel_state) if unsafe { pg_sys::ParallelWorkerNumber } != -1 => {
-                let view = unsafe {
-                    (*parallel_state).segment_view_for_source(
-                        self.source_idx.expect("parallel_state implies source_idx"),
-                    )
-                };
-                MvccSatisfies::ParallelWorker(view)
-            }
-            _ => match self.segment_view.clone() {
-                Some(view) => MvccSatisfies::ParallelWorker(view),
-                None => MvccSatisfies::Snapshot,
-            },
+        // Workers never reach this. An MPP worker decodes physical plans, and plans build
+        // address-free, so `parallel_state` is still null here and arrives on the physical scan
+        // later through `stamp_parallel_state`.
+        let mvcc_style = match self.segment_view.clone() {
+            Some(view) => MvccSatisfies::ParallelWorker(view),
+            None => MvccSatisfies::Snapshot,
         };
 
         let reader = SearchIndexReader::open_with_context(

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::HashSet;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, WhichFastField};
-use crate::index::mvcc::MvccSatisfies;
+use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::ParallelScanState;
 use crate::postgres::heap::VisibilityChecker;
@@ -123,6 +123,12 @@ pub struct PgSearchTableProvider {
     /// Explicit range partitioning configuration. When present, the provider
     /// ignores parallel state segments and yields statically partitioned streams.
     range_sample: Option<RangePartitioningSample>,
+
+    /// The segment view this source's reader replays when it is one of a JoinScan's sources.
+    /// Backend-local (a plan's readers do not travel), so re-injected by the codec on
+    /// deserialization; see [`Self::segment_view_position`].
+    #[serde(skip)]
+    segment_view: Option<SegmentView>,
 }
 
 mod atomic_bool_serde {
@@ -162,6 +168,7 @@ impl Clone for PgSearchTableProvider {
             ),
             source_idx: self.source_idx,
             range_sample: self.range_sample.clone(),
+            segment_view: self.segment_view.clone(),
         }
     }
 }
@@ -187,6 +194,7 @@ impl PgSearchTableProvider {
             late_materialization_active: AtomicBool::new(false),
             source_idx,
             range_sample: None,
+            segment_view: None,
         }
     }
 
@@ -225,6 +233,17 @@ impl PgSearchTableProvider {
 
     pub(crate) fn source_idx(&self) -> Option<usize> {
         self.source_idx
+    }
+
+    /// The JoinScan plan position whose segment view this source replays, if any. An MPP source
+    /// is addressed by `source_idx`; a serial source only takes part in an address exchange
+    /// (with `SearchPredicateUDF`) when its visibility is deferred.
+    pub(crate) fn segment_view_position(&self) -> Option<usize> {
+        self.source_idx.or(self.deferred_ctid_plan_position())
+    }
+
+    pub(crate) fn set_segment_view(&mut self, view: SegmentView) {
+        self.segment_view = Some(view);
     }
 
     fn enable_deferred_columns(&mut self, required_early_columns: &HashSet<String>) {
@@ -654,27 +673,27 @@ impl PgSearchTableProvider {
             query.init_postgres_expressions(planstate);
             query.solve_postgres_expressions(expr_context);
         }
-        // MVCC dispatch by `source_idx`:
+        // MVCC dispatch:
         //
-        // Parallel worker or leader (`source_idx` Some):
-        // Retrieve the specific frozen segment IDs for this source from `ParallelScanState`.
+        // Parallel worker (`parallel_state` Some, not the leader): replay this source's segment
+        // view from `ParallelScanState`.
         //
-        // Serial (otherwise): Snapshot.
-
-        let mvcc_style = if let Some(parallel_state) = parallel_state {
-            unsafe {
-                if pg_sys::ParallelWorkerNumber == -1 {
-                    // Leader only sees snapshot-visible segments
-                    MvccSatisfies::Snapshot
-                } else {
-                    let ids = (*parallel_state).segment_ids_for_source(
+        // Otherwise, replay the view the codec injected for this source, when there is one: the
+        // leader's reader then matches the manifest the DSM was populated from, and a serial
+        // reader matches the predicate UDF's. Any other reader opens a plain snapshot.
+        let mvcc_style = match parallel_state {
+            Some(parallel_state) if unsafe { pg_sys::ParallelWorkerNumber } != -1 => {
+                let view = unsafe {
+                    (*parallel_state).segment_view_for_source(
                         self.source_idx.expect("parallel_state implies source_idx"),
-                    );
-                    MvccSatisfies::ParallelWorker(ids)
-                }
+                    )
+                };
+                MvccSatisfies::ParallelWorker(view)
             }
-        } else {
-            MvccSatisfies::Snapshot
+            _ => match self.segment_view.clone() {
+                Some(view) => MvccSatisfies::ParallelWorker(view),
+                None => MvccSatisfies::Snapshot,
+            },
         };
 
         let reader = SearchIndexReader::open_with_context(

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -201,7 +201,7 @@ pub(crate) fn rebuild_mvcc(
             )
         })?;
         Ok(MvccSatisfies::ParallelWorker(unsafe {
-            (*ps).segment_ids_for_source(source_idx)
+            (*ps).segment_view_for_source(source_idx)
         }))
     } else {
         Ok(MvccSatisfies::Snapshot)

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -69,6 +69,10 @@ pub struct TantivyLookupExec {
     input: Arc<dyn ExecutionPlan>,
     deferred_fields: Vec<PhysicalDeferredField>,
     decoders: Vec<DecoderInfo>,
+    /// Keyed by index relid, so a self-join folds both aliases onto one helper. Term ordinals
+    /// and doc ids are per-reader, so the surviving helper decodes the other alias correctly
+    /// only while both sources share a segment view. Keying by `(plan_position, indexrelid)`
+    /// would remove the aliasing.
     ffhelpers: HashMap<u32, Arc<FFHelper>>,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan_mutable.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan_mutable.out
@@ -26,16 +26,10 @@ CREATE TABLE mpp_mut_test (
 );
 CREATE INDEX mpp_mut_test_idx ON mpp_mut_test
 USING paradedb (id, message, category_id)
-WITH (
-    key_field = 'id',
-    numeric_fields = '{"category_id": {"fast": true}}'
-);
+WITH (key_field = 'id');
 CREATE INDEX mpp_mut_categories_idx ON mpp_mut_categories
-USING paradedb (id, name)
-WITH (
-    key_field = 'id',
-    text_fields = '{"name": {"fast": true, "tokenizer": {"type": "raw"}}}'
-);
+USING paradedb (id, (name::pdb.literal))
+WITH (key_field = 'id');
 -- Several immutable segments on the probe side so the join runs on
 -- multiple MPP tasks; the categories stay in a mutable segment (default
 -- `mutable_segment_rows`) and get updated in place, which appends to
@@ -224,10 +218,7 @@ CREATE TABLE mpp_mut_test_small (
 );
 CREATE INDEX mpp_mut_test_small_idx ON mpp_mut_test_small
 USING paradedb (id, message, category_id)
-WITH (
-    key_field = 'id',
-    numeric_fields = '{"category_id": {"fast": true}}'
-);
+WITH (key_field = 'id');
 SET paradedb.global_mutable_segment_rows = 0;
 INSERT INTO mpp_mut_test_small (message, category_id)
 SELECT message, category_id FROM mpp_mut_test ORDER BY id;

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan_mutable.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan_mutable.out
@@ -78,8 +78,8 @@ JOIN mpp_mut_categories c ON t.category_id = c.id
 WHERE t.message @@@ 'beer'
 ORDER BY t.id
 LIMIT 25;
-                                                                                               QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t.id, t.message, c.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -94,9 +94,9 @@ LIMIT 25;
            :     VisibilityFilterExec: tables=[c, t]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all"
+           :           PgSearchScan: table=c, segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=t, segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT t.id, t.message, c.name
@@ -144,8 +144,8 @@ JOIN mpp_mut_categories c ON t.category_id = c.id
 WHERE t.message @@@ 'beer'
 ORDER BY t.id
 LIMIT 25;
-                                                                                                  QUERY PLAN                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t.id, t.message, c.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -167,14 +167,14 @@ LIMIT 25;
            :   │       CoalescePartitionsExec
            :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :   │       DistributedLeafExec:
-           :   │         t0: PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
-           :   │         t1: PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
-           :   │         t2: PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           :   │         t0: PgSearchScan: table=t, segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           :   │         t1: PgSearchScan: table=t, segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           :   │         t2: PgSearchScan: table=t, segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: segments=1, query="all"
+           :     │     t0: PgSearchScan: table=c, segments=1, query="all"
            :     └──────────────────────────────────────────────────
 (30 rows)
 
@@ -257,8 +257,8 @@ JOIN mpp_mut_categories c ON t.category_id = c.id
 WHERE t.message @@@ 'beer'
 ORDER BY t.id
 LIMIT 25;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t.id, t.message, c.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -278,14 +278,14 @@ LIMIT 25;
            : │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=1, input_tasks=3
            : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            : │             DistributedLeafExec:
-           : │               t0: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           : │               t0: PgSearchScan: table=t, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
            : └──────────────────────────────────────────────────
            :   ┌───── Stage 1 ── tasks=3, partitions=3
            :   │ BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
            :   │   DistributedLeafExec:
-           :   │     t0: PgSearchScan: segments=3, query="all"
-           :   │     t1: PgSearchScan: segments=3, query="all"
-           :   │     t2: PgSearchScan: segments=3, query="all"
+           :   │     t0: PgSearchScan: table=c, segments=3, query="all"
+           :   │     t1: PgSearchScan: table=c, segments=3, query="all"
+           :   │     t2: PgSearchScan: table=c, segments=3, query="all"
            :   └──────────────────────────────────────────────────
 (28 rows)
 

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan_mutable.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan_mutable.out
@@ -1,0 +1,329 @@
+-- =====================================================================
+-- MPP JoinScan whose broadcast side keeps its rows in a mutable segment.
+--
+-- The stage that joins resolves the broadcast side's packed
+-- `DocAddress`es with a reader it opens itself. A mutable segment is
+-- materialized from the heap per open, so that reader has to replay the
+-- leader's segment view (ordinal order and the mutable segment's
+-- add/remove log prefix) or its `DocId`s won't line up with the ones the
+-- producer packed. Same query shape as issue #5988.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 3;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+CREATE TABLE mpp_mut_categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+CREATE TABLE mpp_mut_test (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    message TEXT,
+    category_id INTEGER NOT NULL
+);
+CREATE INDEX mpp_mut_test_idx ON mpp_mut_test
+USING paradedb (id, message, category_id)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"category_id": {"fast": true}}'
+);
+CREATE INDEX mpp_mut_categories_idx ON mpp_mut_categories
+USING paradedb (id, name)
+WITH (
+    key_field = 'id',
+    text_fields = '{"name": {"fast": true, "tokenizer": {"type": "raw"}}}'
+);
+-- Several immutable segments on the probe side so the join runs on
+-- multiple MPP tasks; the categories stay in a mutable segment (default
+-- `mutable_segment_rows`) and get updated in place, which appends to
+-- that segment's log.
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_mut_test (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(1, 1000) AS s(i);
+INSERT INTO mpp_mut_test (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(1001, 2000) AS s(i);
+INSERT INTO mpp_mut_test (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(2001, 3000) AS s(i);
+RESET paradedb.global_mutable_segment_rows;
+INSERT INTO mpp_mut_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(1, 100) AS s(i);
+UPDATE mpp_mut_categories SET name = name || ' (updated)' WHERE id <= 10;
+ANALYZE mpp_mut_test;
+ANALYZE mpp_mut_categories;
+SELECT count(*) AS segments, bool_or(mutable) AS has_mutable
+FROM paradedb.index_info('mpp_mut_categories_idx');
+ segments | has_mutable 
+----------+-------------
+        1 | t
+(1 row)
+
+-- Serial baseline.
+SET max_parallel_workers_per_gather TO 0;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+                                                                                               QUERY PLAN                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: t.id, t.message, c.name
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: t.id, t.message, c.name
+         Relation Tree: c INNER t
+         Join Cond: t.category_id = c.id
+         Limit: 25
+         Order By: t.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=25), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[c, t]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
+
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+ id |       message       |         name          
+----+---------------------+-----------------------
+  1 | beer wine 1         | category 2 (updated)
+  2 | beer cheese 2       | category 3 (updated)
+  3 | beer 3              | category 4 (updated)
+  8 | beer wine cheese 8  | category 9 (updated)
+  9 | beer wine 9         | category 10 (updated)
+ 10 | beer cheese 10      | category 11
+ 11 | beer 11             | category 12
+ 16 | beer wine cheese 16 | category 17
+ 17 | beer wine 17        | category 18
+ 18 | beer cheese 18      | category 19
+ 19 | beer 19             | category 20
+ 24 | beer wine cheese 24 | category 25
+ 25 | beer wine 25        | category 26
+ 26 | beer cheese 26      | category 27
+ 27 | beer 27             | category 28
+ 32 | beer wine cheese 32 | category 33
+ 33 | beer wine 33        | category 34
+ 34 | beer cheese 34      | category 35
+ 35 | beer 35             | category 36
+ 40 | beer wine cheese 40 | category 41
+ 41 | beer wine 41        | category 42
+ 42 | beer cheese 42      | category 43
+ 43 | beer 43             | category 44
+ 48 | beer wine cheese 48 | category 49
+ 49 | beer wine 49        | category 50
+(25 rows)
+
+-- MPP: the categories scan runs in its own stage and is broadcast to the
+-- stage that joins and checks visibility.
+SET max_parallel_workers_per_gather TO 3;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+                                                                                                  QUERY PLAN                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: t.id, t.message, c.name
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: t.id, t.message, c.name
+         Relation Tree: c INNER t
+         Join Cond: t.category_id = c.id
+         Limit: 25
+         Order By: t.id asc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           : │   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=25
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── tasks=3, partitions=3
+           :   │ SortExec: TopK(fetch=25), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
+           :   │   VisibilityFilterExec: tables=[c, t]
+           :   │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+           :   │       CoalescePartitionsExec
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │       DistributedLeafExec:
+           :   │         t0: PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           :   │         t1: PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           :   │         t2: PgSearchScan: segments=3, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── tasks=1, partitions=3
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=1, query="all"
+           :     └──────────────────────────────────────────────────
+(30 rows)
+
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+ id |       message       |         name          
+----+---------------------+-----------------------
+  1 | beer wine 1         | category 2 (updated)
+  2 | beer cheese 2       | category 3 (updated)
+  3 | beer 3              | category 4 (updated)
+  8 | beer wine cheese 8  | category 9 (updated)
+  9 | beer wine 9         | category 10 (updated)
+ 10 | beer cheese 10      | category 11
+ 11 | beer 11             | category 12
+ 16 | beer wine cheese 16 | category 17
+ 17 | beer wine 17        | category 18
+ 18 | beer cheese 18      | category 19
+ 19 | beer 19             | category 20
+ 24 | beer wine cheese 24 | category 25
+ 25 | beer wine 25        | category 26
+ 26 | beer cheese 26      | category 27
+ 27 | beer 27             | category 28
+ 32 | beer wine cheese 32 | category 33
+ 33 | beer wine 33        | category 34
+ 34 | beer cheese 34      | category 35
+ 35 | beer 35             | category 36
+ 40 | beer wine cheese 40 | category 41
+ 41 | beer wine 41        | category 42
+ 42 | beer cheese 42      | category 43
+ 43 | beer 43             | category 44
+ 48 | beer wine cheese 48 | category 49
+ 49 | beer wine 49        | category 50
+(25 rows)
+
+-- Same join with the probe side in one segment: the join and its
+-- visibility check now run on the leader, whose categories reader opened
+-- at plan time, while the categories scan is still distributed. The
+-- leader replays the same view the workers get from the DSM.
+CREATE TABLE mpp_mut_test_small (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    message TEXT,
+    category_id INTEGER NOT NULL
+);
+CREATE INDEX mpp_mut_test_small_idx ON mpp_mut_test_small
+USING paradedb (id, message, category_id)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"category_id": {"fast": true}}'
+);
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_mut_test_small (message, category_id)
+SELECT message, category_id FROM mpp_mut_test ORDER BY id;
+RESET paradedb.global_mutable_segment_rows;
+-- Two immutable category segments plus the mutable one so the categories
+-- scan spans several MPP tasks.
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_mut_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(101, 150) AS s(i);
+INSERT INTO mpp_mut_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(151, 200) AS s(i);
+RESET paradedb.global_mutable_segment_rows;
+UPDATE mpp_mut_categories SET name = name || ' (updated again)' WHERE id <= 5;
+ANALYZE mpp_mut_test_small;
+ANALYZE mpp_mut_categories;
+SELECT count(*) AS segments, bool_or(mutable) AS has_mutable
+FROM paradedb.index_info('mpp_mut_categories_idx');
+ segments | has_mutable 
+----------+-------------
+        3 | t
+(1 row)
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test_small t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: t.id, t.message, c.name
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: t.id, t.message, c.name
+         Relation Tree: c INNER t
+         Join Cond: t.category_id = c.id
+         Limit: 25
+         Order By: t.id asc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           : │   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=25
+           : │     SortExec: TopK(fetch=25), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
+           : │       VisibilityFilterExec: tables=[c, t]
+           : │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+           : │           CoalescePartitionsExec
+           : │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=1, input_tasks=3
+           : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           : │             DistributedLeafExec:
+           : │               t0: PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 1 ── tasks=3, partitions=3
+           :   │ BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
+           :   │   DistributedLeafExec:
+           :   │     t0: PgSearchScan: segments=3, query="all"
+           :   │     t1: PgSearchScan: segments=3, query="all"
+           :   │     t2: PgSearchScan: segments=3, query="all"
+           :   └──────────────────────────────────────────────────
+(28 rows)
+
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test_small t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+ id |       message       |                 name                 
+----+---------------------+--------------------------------------
+  1 | beer wine 1         | category 2 (updated) (updated again)
+  2 | beer cheese 2       | category 3 (updated) (updated again)
+  3 | beer 3              | category 4 (updated) (updated again)
+  8 | beer wine cheese 8  | category 9 (updated)
+  9 | beer wine 9         | category 10 (updated)
+ 10 | beer cheese 10      | category 11
+ 11 | beer 11             | category 12
+ 16 | beer wine cheese 16 | category 17
+ 17 | beer wine 17        | category 18
+ 18 | beer cheese 18      | category 19
+ 19 | beer 19             | category 20
+ 24 | beer wine cheese 24 | category 25
+ 25 | beer wine 25        | category 26
+ 26 | beer cheese 26      | category 27
+ 27 | beer 27             | category 28
+ 32 | beer wine cheese 32 | category 33
+ 33 | beer wine 33        | category 34
+ 34 | beer cheese 34      | category 35
+ 35 | beer 35             | category 36
+ 40 | beer wine cheese 40 | category 41
+ 41 | beer wine 41        | category 42
+ 42 | beer cheese 42      | category 43
+ 43 | beer 43             | category 44
+ 48 | beer wine cheese 48 | category 49
+ 49 | beer wine 49        | category 50
+(25 rows)
+
+DROP TABLE mpp_mut_test_small;
+DROP TABLE mpp_mut_test;
+DROP TABLE mpp_mut_categories;

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan_mutable.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan_mutable.sql
@@ -1,0 +1,166 @@
+-- =====================================================================
+-- MPP JoinScan whose broadcast side keeps its rows in a mutable segment.
+--
+-- The stage that joins resolves the broadcast side's packed
+-- `DocAddress`es with a reader it opens itself. A mutable segment is
+-- materialized from the heap per open, so that reader has to replay the
+-- leader's segment view (ordinal order and the mutable segment's
+-- add/remove log prefix) or its `DocId`s won't line up with the ones the
+-- producer packed. Same query shape as issue #5988.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 3;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+CREATE TABLE mpp_mut_categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+CREATE TABLE mpp_mut_test (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    message TEXT,
+    category_id INTEGER NOT NULL
+);
+
+CREATE INDEX mpp_mut_test_idx ON mpp_mut_test
+USING paradedb (id, message, category_id)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"category_id": {"fast": true}}'
+);
+CREATE INDEX mpp_mut_categories_idx ON mpp_mut_categories
+USING paradedb (id, name)
+WITH (
+    key_field = 'id',
+    text_fields = '{"name": {"fast": true, "tokenizer": {"type": "raw"}}}'
+);
+
+-- Several immutable segments on the probe side so the join runs on
+-- multiple MPP tasks; the categories stay in a mutable segment (default
+-- `mutable_segment_rows`) and get updated in place, which appends to
+-- that segment's log.
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_mut_test (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(1, 1000) AS s(i);
+INSERT INTO mpp_mut_test (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(1001, 2000) AS s(i);
+INSERT INTO mpp_mut_test (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(2001, 3000) AS s(i);
+RESET paradedb.global_mutable_segment_rows;
+
+INSERT INTO mpp_mut_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(1, 100) AS s(i);
+UPDATE mpp_mut_categories SET name = name || ' (updated)' WHERE id <= 10;
+
+ANALYZE mpp_mut_test;
+ANALYZE mpp_mut_categories;
+
+SELECT count(*) AS segments, bool_or(mutable) AS has_mutable
+FROM paradedb.index_info('mpp_mut_categories_idx');
+
+-- Serial baseline.
+SET max_parallel_workers_per_gather TO 0;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+
+-- MPP: the categories scan runs in its own stage and is broadcast to the
+-- stage that joins and checks visibility.
+SET max_parallel_workers_per_gather TO 3;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+
+-- Same join with the probe side in one segment: the join and its
+-- visibility check now run on the leader, whose categories reader opened
+-- at plan time, while the categories scan is still distributed. The
+-- leader replays the same view the workers get from the DSM.
+CREATE TABLE mpp_mut_test_small (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    message TEXT,
+    category_id INTEGER NOT NULL
+);
+CREATE INDEX mpp_mut_test_small_idx ON mpp_mut_test_small
+USING paradedb (id, message, category_id)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"category_id": {"fast": true}}'
+);
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_mut_test_small (message, category_id)
+SELECT message, category_id FROM mpp_mut_test ORDER BY id;
+RESET paradedb.global_mutable_segment_rows;
+
+-- Two immutable category segments plus the mutable one so the categories
+-- scan spans several MPP tasks.
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_mut_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(101, 150) AS s(i);
+INSERT INTO mpp_mut_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(151, 200) AS s(i);
+RESET paradedb.global_mutable_segment_rows;
+UPDATE mpp_mut_categories SET name = name || ' (updated again)' WHERE id <= 5;
+
+ANALYZE mpp_mut_test_small;
+ANALYZE mpp_mut_categories;
+
+SELECT count(*) AS segments, bool_or(mutable) AS has_mutable
+FROM paradedb.index_info('mpp_mut_categories_idx');
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test_small t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+
+SELECT t.id, t.message, c.name
+FROM mpp_mut_test_small t
+JOIN mpp_mut_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25;
+
+DROP TABLE mpp_mut_test_small;
+DROP TABLE mpp_mut_test;
+DROP TABLE mpp_mut_categories;

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan_mutable.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan_mutable.sql
@@ -30,16 +30,10 @@ CREATE TABLE mpp_mut_test (
 
 CREATE INDEX mpp_mut_test_idx ON mpp_mut_test
 USING paradedb (id, message, category_id)
-WITH (
-    key_field = 'id',
-    numeric_fields = '{"category_id": {"fast": true}}'
-);
+WITH (key_field = 'id');
 CREATE INDEX mpp_mut_categories_idx ON mpp_mut_categories
-USING paradedb (id, name)
-WITH (
-    key_field = 'id',
-    text_fields = '{"name": {"fast": true, "tokenizer": {"type": "raw"}}}'
-);
+USING paradedb (id, (name::pdb.literal))
+WITH (key_field = 'id');
 
 -- Several immutable segments on the probe side so the join runs on
 -- multiple MPP tasks; the categories stay in a mutable segment (default
@@ -121,10 +115,7 @@ CREATE TABLE mpp_mut_test_small (
 );
 CREATE INDEX mpp_mut_test_small_idx ON mpp_mut_test_small
 USING paradedb (id, message, category_id)
-WITH (
-    key_field = 'id',
-    numeric_fields = '{"category_id": {"fast": true}}'
-);
+WITH (key_field = 'id');
 SET paradedb.global_mutable_segment_rows = 0;
 INSERT INTO mpp_mut_test_small (message, category_id)
 SELECT message, category_id FROM mpp_mut_test ORDER BY id;

--- a/tests/tests/mpp_joinscan_concurrent.rs
+++ b/tests/tests/mpp_joinscan_concurrent.rs
@@ -136,7 +136,9 @@ const WORKER_EXPECTED_IDS: &str =
 const RUN_FOR: Duration = Duration::from_secs(20);
 const READERS: usize = 3;
 // Every Nth reader iteration runs the query under EXPLAIN ANALYZE instead, whose output shows
-// whether the launch actually went distributed or fell back to serial (a worker-starved host).
+// whether the launch actually went distributed or fell back to serial. Anchored on the FIRST
+// iteration: a loaded host may only get through a handful of iterations, and the final assert
+// needs at least one sample.
 const EXPLAIN_EVERY: usize = 25;
 
 async fn explain(conn: &mut PgConnection, analyze: bool, query: &str) -> Result<String> {
@@ -207,6 +209,9 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
                     panic!("writer failed: {e}");
                 }
                 updates.fetch_add(1, Ordering::Relaxed);
+                // Yield so the writer doesn't starve the readers on a loaded host; the race
+                // window only needs the log to move between two opens, not a firehose.
+                sleep(Duration::from_millis(5)).await;
             }
         })
     };
@@ -230,7 +235,7 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
                 } else {
                     (WORKER_QUERY, &expected_worker)
                 };
-                if i.is_multiple_of(EXPLAIN_EVERY) {
+                if i % EXPLAIN_EVERY == 1 {
                     // EXPLAIN ANALYZE executes the query too; a serial fallback shows a plan
                     // without DistributedExec. Count rather than fail: a starved host may
                     // legitimately fall back sometimes, but never going distributed at all

--- a/tests/tests/mpp_joinscan_concurrent.rs
+++ b/tests/tests/mpp_joinscan_concurrent.rs
@@ -56,12 +56,14 @@ CREATE TABLE mppc_test_multi (
 );
 
 CREATE INDEX mppc_test_idx ON mppc_test USING paradedb (id, message, category_id)
-WITH (key_field = 'id', numeric_fields = '{"category_id": {"fast": true}}');
+WITH (key_field = 'id');
 CREATE INDEX mppc_test_multi_idx ON mppc_test_multi USING paradedb (id, message, category_id)
-WITH (key_field = 'id', numeric_fields = '{"category_id": {"fast": true}}');
-CREATE INDEX mppc_categories_idx ON mppc_categories USING paradedb (id, name)
-WITH (key_field = 'id', text_fields = '{"name": {"fast": true, "tokenizer": {"type": "raw"}}}',
-      layer_sizes = '0', background_layer_sizes = '0');
+WITH (key_field = 'id');
+-- Zeroed layer sizes keep the merge policy off both paths, so the build side holds its two
+-- immutable segments and its mutable one for the whole run. A merge would swap the segment set
+-- under the readers and hide what this test measures.
+CREATE INDEX mppc_categories_idx ON mppc_categories USING paradedb (id, (name::pdb.literal))
+WITH (key_field = 'id', layer_sizes = '0', background_layer_sizes = '0');
 
 SET paradedb.global_mutable_segment_rows = 0;
 INSERT INTO mppc_categories (id, name)
@@ -108,8 +110,10 @@ SET parallel_setup_cost TO 0;
 SET parallel_tuple_cost TO 0;
 "#;
 
+// `t.category_id` rides along so each row can prove which category it joined to. A resolver
+// that lands on the wrong address still returns a well-formed name, so only the id catches it.
 const LEADER_QUERY: &str = r#"
-SELECT t.id, c.name
+SELECT t.id, t.category_id, c.name
 FROM mppc_test t
 JOIN mppc_categories c ON t.category_id = c.id
 WHERE t.message @@@ 'beer'
@@ -118,7 +122,7 @@ LIMIT 25
 "#;
 
 const WORKER_QUERY: &str = r#"
-SELECT t.id, c.name
+SELECT t.id, t.category_id, c.name
 FROM mppc_test_multi t
 JOIN mppc_categories c ON t.category_id = c.id
 WHERE t.message @@@ 'beer'
@@ -253,7 +257,7 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
                     queries.fetch_add(1, Ordering::Relaxed);
                     continue;
                 }
-                let rows: Result<Vec<(i64, String)>, _> =
+                let rows: Result<Vec<(i64, i32, String)>, _> =
                     sqlx::query_as(query).fetch_all(&mut conn).await;
                 match rows {
                     Err(e) => failures
@@ -261,18 +265,23 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
                         .unwrap()
                         .push(format!("reader {reader_id}: query failed: {e}")),
                     Ok(rows) => {
-                        let ids: Vec<i64> = rows.iter().map(|(id, _)| *id).collect();
+                        let ids: Vec<i64> = rows.iter().map(|(id, _, _)| *id).collect();
                         if &ids != expected {
                             failures.lock().unwrap().push(format!(
                                 "reader {reader_id}: ids {ids:?} != expected {expected:?}"
                             ));
                         }
-                        if let Some((id, name)) =
-                            rows.iter().find(|(_, name)| !name.starts_with("category "))
-                        {
-                            failures.lock().unwrap().push(format!(
-                                "reader {reader_id}: row {id} joined a bad category name {name:?}"
-                            ));
+                        // The writer only appends a ` v<n>` suffix, so the id prefix stays.
+                        for (id, category_id, name) in &rows {
+                            let expected_name = format!("category {category_id}");
+                            if *name != expected_name
+                                && !name.starts_with(&format!("{expected_name} v"))
+                            {
+                                failures.lock().unwrap().push(format!(
+                                    "reader {reader_id}: row {id} wanted category \
+                                     {category_id} but joined {name:?}"
+                                ));
+                            }
                         }
                     }
                 }

--- a/tests/tests/mpp_joinscan_concurrent.rs
+++ b/tests/tests/mpp_joinscan_concurrent.rs
@@ -1,0 +1,226 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! An MPP JoinScan whose broadcast build side keeps rows in a mutable segment, run while another
+//! connection keeps updating that side. The node that checks visibility resolves the build side's
+//! packed `DocAddress`es with a reader it opened itself (here the leader, whose reader opens at
+//! plan time, well before the workers open theirs). A mutable segment is materialized per open, so
+//! unless every reader replays the leader's segment view, the addresses one reader packed land in
+//! another reader's shorter (or differently ordered) `DocId` space: a bitpacker overflow panic, or
+//! a silently wrong ctid.
+
+use anyhow::Result;
+use rstest::*;
+use sqlx::{AssertSqlSafe, Executor, PgConnection};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+use tests::fixtures::*;
+use tokio::time::sleep;
+
+// The build side (`categories`) has two immutable segments plus the mutable one the writer keeps
+// growing, so its scan is distributed and broadcast. The probe side stays in one segment, which
+// keeps the join and its visibility check on the leader: the leader opened its `categories`
+// reader at plan time, and the workers open theirs only after they attach, so an update between
+// the two is easy to land.
+const SETUP_SQL: &str = r#"
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
+
+CREATE TABLE mppc_categories (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE mppc_test (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    message TEXT,
+    category_id INTEGER NOT NULL
+);
+
+CREATE INDEX mppc_test_idx ON mppc_test USING paradedb (id, message, category_id)
+WITH (key_field = 'id', numeric_fields = '{"category_id": {"fast": true}}');
+CREATE INDEX mppc_categories_idx ON mppc_categories USING paradedb (id, name)
+WITH (key_field = 'id', text_fields = '{"name": {"fast": true, "tokenizer": {"type": "raw"}}}',
+      layer_sizes = '0', background_layer_sizes = '0');
+
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mppc_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(1, 50) AS s(i);
+INSERT INTO mppc_categories (id, name)
+SELECT i, 'category ' || i::text FROM generate_series(51, 100) AS s(i);
+INSERT INTO mppc_test (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(1, 5000) AS s(i);
+RESET paradedb.global_mutable_segment_rows;
+
+-- Start the build side's mutable log before the readers do.
+UPDATE mppc_categories SET name = 'category ' || id::text || ' v0' WHERE id <= 10;
+
+ANALYZE mppc_test;
+ANALYZE mppc_categories;
+"#;
+
+// Forces the join through MPP and zeroes the parallel costs so the planner always picks it.
+const MPP_GUCS: &str = r#"
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 2;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+"#;
+
+const JOIN_QUERY: &str = r#"
+SELECT t.id, c.name
+FROM mppc_test t
+JOIN mppc_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25
+"#;
+
+// Every category id in 1..=100 exists, so the join never drops a `beer` row and the answer is the
+// 25 smallest matching ids whatever the writers do to the category names.
+const EXPECTED_IDS_QUERY: &str = r#"
+SELECT id FROM mppc_test WHERE message LIKE '%beer%' ORDER BY id LIMIT 25
+"#;
+
+const RUN_FOR: Duration = Duration::from_secs(20);
+const READERS: usize = 3;
+
+async fn assert_query_plans_as_mpp(conn: &mut PgConnection) -> Result<()> {
+    let rows: Vec<(String,)> = sqlx::query_as(AssertSqlSafe(format!(
+        "EXPLAIN (COSTS OFF, VERBOSE) {JOIN_QUERY}"
+    )))
+    .fetch_all(&mut *conn)
+    .await?;
+    let explain = rows
+        .into_iter()
+        .map(|(line,)| line)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        explain.contains("DistributedExec"),
+        "the join must plan as DistributedExec:\n{explain}"
+    );
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<()> {
+    let mut setup = database.connection().await;
+    setup.execute(SETUP_SQL).await?;
+    setup.execute(MPP_GUCS).await?;
+    assert_query_plans_as_mpp(&mut setup).await?;
+
+    let expected_ids: Vec<i64> = sqlx::query_scalar(EXPECTED_IDS_QUERY)
+        .fetch_all(&mut setup)
+        .await?;
+    assert_eq!(expected_ids.len(), 25);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let queries = Arc::new(AtomicUsize::new(0));
+    let updates = Arc::new(AtomicUsize::new(0));
+    let failures = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+    // One writer keeps the build side's mutable segment growing: every UPDATE appends to its
+    // add/remove log, which is what moves the segment's `DocId` space between two opens.
+    let writer = {
+        let mut conn = database.connection().await;
+        let stop = Arc::clone(&stop);
+        let updates = Arc::clone(&updates);
+        tokio::spawn(async move {
+            let mut n = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                n += 1;
+                let sql = format!(
+                    "UPDATE mppc_categories SET name = 'category ' || id::text || ' v{n}' \
+                     WHERE id <= 10"
+                );
+                if let Err(e) = conn.execute(AssertSqlSafe(sql)).await {
+                    panic!("writer failed: {e}");
+                }
+                updates.fetch_add(1, Ordering::Relaxed);
+            }
+        })
+    };
+
+    let mut readers = Vec::new();
+    for reader_id in 0..READERS {
+        let mut conn = database.connection().await;
+        conn.execute(MPP_GUCS).await?;
+        let stop = Arc::clone(&stop);
+        let queries = Arc::clone(&queries);
+        let failures = Arc::clone(&failures);
+        let expected_ids = expected_ids.clone();
+        readers.push(tokio::spawn(async move {
+            while !stop.load(Ordering::Relaxed) {
+                let rows: Result<Vec<(i64, String)>, _> =
+                    sqlx::query_as(JOIN_QUERY).fetch_all(&mut conn).await;
+                match rows {
+                    Err(e) => failures
+                        .lock()
+                        .unwrap()
+                        .push(format!("reader {reader_id}: query failed: {e}")),
+                    Ok(rows) => {
+                        let ids: Vec<i64> = rows.iter().map(|(id, _)| *id).collect();
+                        if ids != expected_ids {
+                            failures.lock().unwrap().push(format!(
+                                "reader {reader_id}: ids {ids:?} != expected {expected_ids:?}"
+                            ));
+                        }
+                        if let Some((id, name)) =
+                            rows.iter().find(|(_, name)| !name.starts_with("category "))
+                        {
+                            failures.lock().unwrap().push(format!(
+                                "reader {reader_id}: row {id} joined a bad category name {name:?}"
+                            ));
+                        }
+                    }
+                }
+                queries.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+
+    let start = Instant::now();
+    while start.elapsed() < RUN_FOR {
+        sleep(Duration::from_millis(200)).await;
+        if !failures.lock().unwrap().is_empty() {
+            break;
+        }
+    }
+    stop.store(true, Ordering::Relaxed);
+    for reader in readers {
+        reader.await?;
+    }
+    writer.await?;
+
+    let failures = failures.lock().unwrap().clone();
+    assert!(
+        failures.is_empty(),
+        "{} of {} MPP join queries failed under {} concurrent updates; first: {}",
+        failures.len(),
+        queries.load(Ordering::Relaxed),
+        updates.load(Ordering::Relaxed),
+        failures[0]
+    );
+    assert!(
+        queries.load(Ordering::Relaxed) > 0 && updates.load(Ordering::Relaxed) > 0,
+        "the readers and the writer must both have run"
+    );
+    Ok(())
+}

--- a/tests/tests/mpp_joinscan_concurrent.rs
+++ b/tests/tests/mpp_joinscan_concurrent.rs
@@ -15,13 +15,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! An MPP JoinScan whose broadcast build side keeps rows in a mutable segment, run while another
-//! connection keeps updating that side. The node that checks visibility resolves the build side's
-//! packed `DocAddress`es with a reader it opened itself (here the leader, whose reader opens at
-//! plan time, well before the workers open theirs). A mutable segment is materialized per open, so
-//! unless every reader replays the leader's segment view, the addresses one reader packed land in
-//! another reader's shorter (or differently ordered) `DocId` space: a bitpacker overflow panic, or
-//! a silently wrong ctid.
+//! MPP JoinScans whose broadcast build side keeps rows in a mutable segment, run while another
+//! connection keeps updating that side. The node that checks visibility resolves the build
+//! side's packed `DocAddress`es with a reader it opened itself, and a mutable segment is
+//! materialized per open, so unless every reader replays the leader's segment view the
+//! addresses one reader packed land in another reader's shorter (or differently ordered)
+//! `DocId` space: a bitpacker overflow panic, or a silently wrong ctid.
+//!
+//! Two probe tables give the two consumer placements. The single-segment probe keeps the join
+//! and its visibility check on the leader, whose `categories` reader opens at plan time, well
+//! before the workers open theirs; that wide window is what makes this test fail fast without
+//! the replay. The multi-segment probe pushes the join into a worker stage, so the resolver is
+//! rebuilt in a worker, the shape from the original report.
 
 use anyhow::Result;
 use rstest::*;
@@ -33,10 +38,8 @@ use tests::fixtures::*;
 use tokio::time::sleep;
 
 // The build side (`categories`) has two immutable segments plus the mutable one the writer keeps
-// growing, so its scan is distributed and broadcast. The probe side stays in one segment, which
-// keeps the join and its visibility check on the leader: the leader opened its `categories`
-// reader at plan time, and the workers open theirs only after they attach, so an update between
-// the two is easy to land.
+// growing, so its scan is distributed and broadcast. `mppc_test` stays in one segment (the
+// leader-hosted shape); `mppc_test_multi` spans three (the worker-hosted shape).
 const SETUP_SQL: &str = r#"
 CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 
@@ -46,8 +49,15 @@ CREATE TABLE mppc_test (
     message TEXT,
     category_id INTEGER NOT NULL
 );
+CREATE TABLE mppc_test_multi (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    message TEXT,
+    category_id INTEGER NOT NULL
+);
 
 CREATE INDEX mppc_test_idx ON mppc_test USING paradedb (id, message, category_id)
+WITH (key_field = 'id', numeric_fields = '{"category_id": {"fast": true}}');
+CREATE INDEX mppc_test_multi_idx ON mppc_test_multi USING paradedb (id, message, category_id)
 WITH (key_field = 'id', numeric_fields = '{"category_id": {"fast": true}}');
 CREATE INDEX mppc_categories_idx ON mppc_categories USING paradedb (id, name)
 WITH (key_field = 'id', text_fields = '{"name": {"fast": true, "tokenizer": {"type": "raw"}}}',
@@ -63,12 +73,28 @@ SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
               'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
        1 + (i % 100)
 FROM generate_series(1, 5000) AS s(i);
+INSERT INTO mppc_test_multi (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(1, 5000) AS s(i);
+INSERT INTO mppc_test_multi (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(5001, 10000) AS s(i);
+INSERT INTO mppc_test_multi (message, category_id)
+SELECT (ARRAY['beer wine cheese', 'beer wine', 'beer cheese', 'beer',
+              'wine cheese', 'wine', 'cheese', 'bread butter'])[1 + (i % 8)] || ' ' || i::text,
+       1 + (i % 100)
+FROM generate_series(10001, 15000) AS s(i);
 RESET paradedb.global_mutable_segment_rows;
 
 -- Start the build side's mutable log before the readers do.
 UPDATE mppc_categories SET name = 'category ' || id::text || ' v0' WHERE id <= 10;
 
 ANALYZE mppc_test;
+ANALYZE mppc_test_multi;
 ANALYZE mppc_categories;
 "#;
 
@@ -82,7 +108,7 @@ SET parallel_setup_cost TO 0;
 SET parallel_tuple_cost TO 0;
 "#;
 
-const JOIN_QUERY: &str = r#"
+const LEADER_QUERY: &str = r#"
 SELECT t.id, c.name
 FROM mppc_test t
 JOIN mppc_categories c ON t.category_id = c.id
@@ -91,31 +117,43 @@ ORDER BY t.id
 LIMIT 25
 "#;
 
-// Every category id in 1..=100 exists, so the join never drops a `beer` row and the answer is the
-// 25 smallest matching ids whatever the writers do to the category names.
-const EXPECTED_IDS_QUERY: &str = r#"
-SELECT id FROM mppc_test WHERE message LIKE '%beer%' ORDER BY id LIMIT 25
+const WORKER_QUERY: &str = r#"
+SELECT t.id, c.name
+FROM mppc_test_multi t
+JOIN mppc_categories c ON t.category_id = c.id
+WHERE t.message @@@ 'beer'
+ORDER BY t.id
+LIMIT 25
 "#;
+
+// Every category id in 1..=100 exists, so the join never drops a `beer` row and the answer is the
+// 25 smallest matching ids whatever the writer does to the category names.
+const LEADER_EXPECTED_IDS: &str =
+    "SELECT id FROM mppc_test WHERE message LIKE '%beer%' ORDER BY id LIMIT 25";
+const WORKER_EXPECTED_IDS: &str =
+    "SELECT id FROM mppc_test_multi WHERE message LIKE '%beer%' ORDER BY id LIMIT 25";
 
 const RUN_FOR: Duration = Duration::from_secs(20);
 const READERS: usize = 3;
+// Every Nth reader iteration runs the query under EXPLAIN ANALYZE instead, whose output shows
+// whether the launch actually went distributed or fell back to serial (a worker-starved host).
+const EXPLAIN_EVERY: usize = 25;
 
-async fn assert_query_plans_as_mpp(conn: &mut PgConnection) -> Result<()> {
-    let rows: Vec<(String,)> = sqlx::query_as(AssertSqlSafe(format!(
-        "EXPLAIN (COSTS OFF, VERBOSE) {JOIN_QUERY}"
-    )))
-    .fetch_all(&mut *conn)
-    .await?;
-    let explain = rows
+async fn explain(conn: &mut PgConnection, analyze: bool, query: &str) -> Result<String> {
+    let options = if analyze {
+        "ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF"
+    } else {
+        "VERBOSE, COSTS OFF"
+    };
+    let rows: Vec<(String,)> =
+        sqlx::query_as(AssertSqlSafe(format!("EXPLAIN ({options}) {query}")))
+            .fetch_all(&mut *conn)
+            .await?;
+    Ok(rows
         .into_iter()
         .map(|(line,)| line)
         .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        explain.contains("DistributedExec"),
-        "the join must plan as DistributedExec:\n{explain}"
-    );
-    Ok(())
+        .join("\n"))
 }
 
 #[rstest]
@@ -124,16 +162,31 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
     let mut setup = database.connection().await;
     setup.execute(SETUP_SQL).await?;
     setup.execute(MPP_GUCS).await?;
-    assert_query_plans_as_mpp(&mut setup).await?;
 
-    let expected_ids: Vec<i64> = sqlx::query_scalar(EXPECTED_IDS_QUERY)
+    let leader_plan = explain(&mut setup, false, LEADER_QUERY).await?;
+    assert!(
+        leader_plan.contains("DistributedExec"),
+        "the leader-hosted join must plan as DistributedExec:\n{leader_plan}"
+    );
+    let worker_plan = explain(&mut setup, false, WORKER_QUERY).await?;
+    assert!(
+        worker_plan.contains("DistributedExec") && worker_plan.contains("Stage 2"),
+        "the worker-hosted join must plan with the join in a worker stage:\n{worker_plan}"
+    );
+
+    let expected_leader: Vec<i64> = sqlx::query_scalar(LEADER_EXPECTED_IDS)
         .fetch_all(&mut setup)
         .await?;
-    assert_eq!(expected_ids.len(), 25);
+    let expected_worker: Vec<i64> = sqlx::query_scalar(WORKER_EXPECTED_IDS)
+        .fetch_all(&mut setup)
+        .await?;
+    assert_eq!(expected_leader.len(), 25);
+    assert_eq!(expected_worker.len(), 25);
 
     let stop = Arc::new(AtomicBool::new(false));
     let queries = Arc::new(AtomicUsize::new(0));
     let updates = Arc::new(AtomicUsize::new(0));
+    let distributed = Arc::new(AtomicUsize::new(0));
     let failures = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
 
     // One writer keeps the build side's mutable segment growing: every UPDATE appends to its
@@ -164,12 +217,39 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
         conn.execute(MPP_GUCS).await?;
         let stop = Arc::clone(&stop);
         let queries = Arc::clone(&queries);
+        let distributed = Arc::clone(&distributed);
         let failures = Arc::clone(&failures);
-        let expected_ids = expected_ids.clone();
+        let expected_leader = expected_leader.clone();
+        let expected_worker = expected_worker.clone();
         readers.push(tokio::spawn(async move {
+            let mut i = 0usize;
             while !stop.load(Ordering::Relaxed) {
+                i += 1;
+                let (query, expected) = if i.is_multiple_of(2) {
+                    (LEADER_QUERY, &expected_leader)
+                } else {
+                    (WORKER_QUERY, &expected_worker)
+                };
+                if i.is_multiple_of(EXPLAIN_EVERY) {
+                    // EXPLAIN ANALYZE executes the query too; a serial fallback shows a plan
+                    // without DistributedExec. Count rather than fail: a starved host may
+                    // legitimately fall back sometimes, but never going distributed at all
+                    // means this test exercised nothing.
+                    match explain(&mut conn, true, query).await {
+                        Ok(plan) if plan.contains("DistributedExec") => {
+                            distributed.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Ok(_) => {}
+                        Err(e) => failures
+                            .lock()
+                            .unwrap()
+                            .push(format!("reader {reader_id}: explain analyze failed: {e}")),
+                    }
+                    queries.fetch_add(1, Ordering::Relaxed);
+                    continue;
+                }
                 let rows: Result<Vec<(i64, String)>, _> =
-                    sqlx::query_as(JOIN_QUERY).fetch_all(&mut conn).await;
+                    sqlx::query_as(query).fetch_all(&mut conn).await;
                 match rows {
                     Err(e) => failures
                         .lock()
@@ -177,9 +257,9 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
                         .push(format!("reader {reader_id}: query failed: {e}")),
                     Ok(rows) => {
                         let ids: Vec<i64> = rows.iter().map(|(id, _)| *id).collect();
-                        if ids != expected_ids {
+                        if &ids != expected {
                             failures.lock().unwrap().push(format!(
-                                "reader {reader_id}: ids {ids:?} != expected {expected_ids:?}"
+                                "reader {reader_id}: ids {ids:?} != expected {expected:?}"
                             ));
                         }
                         if let Some((id, name)) =
@@ -221,6 +301,12 @@ async fn mpp_joinscan_survives_mutable_build_side_churn(database: Db) -> Result<
     assert!(
         queries.load(Ordering::Relaxed) > 0 && updates.load(Ordering::Relaxed) > 0,
         "the readers and the writer must both have run"
+    );
+    assert!(
+        distributed.load(Ordering::Relaxed) > 0,
+        "no query ran distributed; the test exercised nothing (queries={}, updates={})",
+        queries.load(Ordering::Relaxed),
+        updates.load(Ordering::Relaxed)
     );
     Ok(())
 }


### PR DESCRIPTION
This PR makes every reader a query opens for one index source replay the same segment view, so packed `DocAddress`es stay valid across processes.

Closes #5988.

## Why

Stressgres hit `remote task 2.0 failed: range end index 18446744073709551613 out of range for slice of length 8` on the JoinScan MPP path. Packed `(segment_ord, doc_id)` addresses are only meaningful against the reader that packed them, but the consumer side (a rebuilt `FFHelper` behind a network boundary, the leader-hosted `VisibilityFilterExec`, `SearchPredicateUDF`) opens its own reader over the same segment id set. Two opens don't expose the same `DocId` space:

- A mutable segment is materialized per open, bounded by the `(max_doc, num_deleted_docs)` its meta entry holds at that moment. Concurrent DML moves that bound between the producer's open and the consumer's, so a `doc_id` past the shorter view overflows tantivy's bitpacker, or resolves to the wrong ctid when the counts happen to match.
- Segment ordinals come from an unstable doc-count sort, so they can permute between opens.

## What

- `MvccSatisfies::ParallelWorker` now has a `SegmentView`: the origin reader's segments in ordinal order, plus each mutable segment's `(max_doc, num_deleted_docs)` bound. `load_metas` rewinds mutable entries to that bound (the log is append-only, so it always is a prefix) and orders segments by the view.
- `ParallelScanState` sends every source's view; the JoinScan leader's providers, `SearchPredicateUDF`, the worker scans, and the rebuilt resolvers all replay that view.
- `paradedb.aggregate` workers keep an id-only view; their addresses never leave the process.

## Tests

A `pg_test` for the view replay (`test_segment_view_replays_origin_reader`), an `mpp_joinscan_mutable` regress covering the worker-hosted and leader-hosted shapes, and a concurrent integration test (`mpp_joinscan_concurrent.rs`) that fails on the base commit within a second and also catches the silent wrong-result variant.
