### PR TITLE
chore: sync #5989 with latest 0.25.x

### DIFF
--- a/pg_search/sql/pg_search--0.25.3--0.25.4.sql
+++ b/pg_search/sql/pg_search--0.25.3--0.25.4.sql
@@ -1,1 +1,19 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.25.4'" to load this file. \quit
+
+-- 0.25.3 -> 0.25.4: add vector_clusters(index regclass, field text), the
+-- per-segment per-cluster posting-list sizes and ball-bound radii, in cluster
+-- order.
+-- The CREATE below is the SchemaBot/pgrx canonical text verbatim (the schema
+-- checker compares statements textually); the DROP keeps the script re-runnable.
+DROP FUNCTION IF EXISTS vector_clusters(regclass, text);
+CREATE  FUNCTION "vector_clusters"(
+	"index" regclass, /* PgRelation */
+	"field" TEXT /* String */
+) RETURNS TABLE (
+	"segno" TEXT,  /* String */
+	"cluster_sizes" bigint[],  /* :: std :: option :: Option < Vec < i64 > > */
+	"cluster_radii" real[]  /* :: std :: option :: Option < Vec < f32 > > */
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'vector_clusters_wrapper';

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -478,6 +478,78 @@ fn vector_info(
     Ok(TableIterator::new(rows))
 }
 
+/// Per-cluster posting-list sizes and ball-bound radii for a single vector
+/// `field` of `index`, one row per segment that stores that field, in cluster
+/// order.
+#[pg_extern]
+#[allow(clippy::type_complexity)]
+fn vector_clusters(
+    index: PgRelation,
+    field: String,
+) -> anyhow::Result<
+    TableIterator<
+        'static,
+        (
+            name!(segno, String),
+            name!(cluster_sizes, Option<Vec<i64>>),
+            name!(cluster_radii, Option<Vec<f32>>),
+        ),
+    >,
+> {
+    // # Safety
+    //
+    // Lock the index relation until the end of this function (read-only,
+    // AccessShareLock) so it is not dropped or altered while we read it —
+    // identical to `index_info`.
+    let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
+    let index_kind = IndexKind::for_index(index.clone())?;
+    if !index.is_usable() {
+        return Ok(TableIterator::new(Vec::new()));
+    }
+
+    let mut rows = Vec::new();
+    for index in index_kind.partitions() {
+        if !index.is_usable() {
+            continue;
+        }
+        let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)?;
+        let resolved = search_reader
+            .schema()
+            .fields()
+            .find_map(|(f, field_entry)| {
+                (field_entry.name() == field
+                    && matches!(
+                        search_reader.schema().get_field_type(field_entry.name()),
+                        Some(SearchFieldType::Vector(..))
+                    ))
+                .then_some(f)
+            });
+        let Some(vector_field) = resolved else {
+            anyhow::bail!("`{field}` is not a vector field of the index");
+        };
+        for segment_reader in search_reader.segment_readers() {
+            let vector_index = segment_reader.vector_index(vector_field)?;
+            if vector_index.info().is_none() {
+                continue;
+            }
+            let sizes = vector_index
+                .cluster_sizes()
+                .map(|sizes| sizes.into_iter().map(i64::from).collect());
+            let radii = vector_index.index().map(|ivf| {
+                let bounds = ivf.bounds();
+                (0..ivf.num_clusters()).map(|c| bounds.ball_r(c)).collect()
+            });
+            rows.push((
+                segment_reader.segment_id().short_uuid_string(),
+                sizes,
+                radii,
+            ));
+        }
+    }
+
+    Ok(TableIterator::new(rows))
+}
+
 /// Returns the list of segments that contain the specified [`pg_sys::ItemPointerData]` heap tuple
 /// identifier.
 ///


### PR DESCRIPTION
## Summary

- merge the current `0.25.x` tip into `backport-5957-to-0.25.x`
- preserve the `vector_clusters` function and migration added by #5980
- remove the stale-base SchemaBot diff without changing the #5957 backport

SchemaBot checks out the pull request head ref directly before comparing it with the current base branch. #5989 was created from `172af31d`, while `0.25.x` then advanced to `c169721a` with #5980. As a result, the head-only schema looked as though it removed `vector_clusters`. Syncing the base branch into the backport makes the head contain both changes.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/backport-5957-to-0.25.x..HEAD`
- verified that the merge tree is the conflict-free combination of the current #5989 head and current `0.25.x`
