### PR TITLE
docs: use stable test table procedure

### DIFF
--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run ParadeDB example queries
         run: |
-          psql -h localhost -U testuser -d testdb -c "CALL paradedb.create_paradedb_test_table(schema_name => 'public', table_name => 'mock_items');"
+          psql -h localhost -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
           psql -h localhost -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
           psql -h localhost -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
           psql -h localhost -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"

--- a/docs/deploy/ci/gitlab-ci.mdx
+++ b/docs/deploy/ci/gitlab-ci.mdx
@@ -17,7 +17,7 @@ paradedb-in-gitlab-ci:
     POSTGRES_DB: testdb
     POSTGRES_HOST_AUTH_METHOD: trust
   script:
-    - psql -h "postgres" -U testuser -d testdb -c "CALL paradedb.create_paradedb_test_table(schema_name => 'public', table_name => 'mock_items');"
+    - psql -h "postgres" -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
     - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
     - psql -h "postgres" -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
     - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -12,7 +12,7 @@ ParadeDB comes with a helpful procedure that creates a table populated with mock
 you get started. Run the following command to create this table.
 
 ```sql
-CALL paradedb.create_paradedb_test_table(
+CALL paradedb.create_bm25_test_table(
   schema_name => 'public',
   table_name => 'mock_items'
 );
@@ -183,7 +183,7 @@ Create and populate `mock_items`:
 
 ```ts
 await db.execute(sql`
-  CALL paradedb.create_paradedb_test_table(
+  CALL paradedb.create_bm25_test_table(
     schema_name => 'public',
     table_name => 'mock_items'
   )
@@ -317,7 +317,7 @@ from django.db import connection
 
 with connection.cursor() as cursor:
     cursor.execute("""
-        CALL paradedb.create_paradedb_test_table(
+        CALL paradedb.create_bm25_test_table(
           schema_name => 'public',
           table_name  => 'mock_items_tmp'
         );
@@ -509,7 +509,7 @@ def upgrade() -> None:
     """Upgrade schema."""
     op.execute(
         """
-        CALL paradedb.create_paradedb_test_table(
+        CALL paradedb.create_bm25_test_table(
           schema_name => 'public',
           table_name => 'mock_items'
         )
@@ -633,7 +633,7 @@ Update the generated migration to create `mock_items`:
 ```ruby db/migrate/*_create_mock_items_table.rb
 def up
   execute <<~SQL
-    CALL paradedb.create_paradedb_test_table(
+    CALL paradedb.create_bm25_test_table(
       schema_name => 'public',
       table_name => 'mock_items'
     );
@@ -885,7 +885,7 @@ Open the generated migration in `Migrations/*_CreateMockItems.cs` and add this s
 
 ```cs
 migrationBuilder.Sql("""
-    CALL paradedb.create_paradedb_test_table(
+    CALL paradedb.create_bm25_test_table(
       schema_name => 'public',
       table_name  => 'mock_items_tmp'
     );

--- a/docs/documentation/joins/overview.mdx
+++ b/docs/documentation/joins/overview.mdx
@@ -45,7 +45,7 @@ If any checks fail, ParadeDB will emit a `NOTICE` explaining why and fall back t
 To demonstrate, let's create a second table called `orders` that can be joined with `mock_items`:
 
 ```sql
-CALL paradedb.create_paradedb_test_table(
+CALL paradedb.create_bm25_test_table(
   schema_name => 'public',
   table_name => 'orders',
   table_type => 'Orders'

--- a/docs/documentation/sorting/score.mdx
+++ b/docs/documentation/sorting/score.mdx
@@ -170,7 +170,7 @@ While BM25 scores will be returned as long as `description` is indexed, includin
 First, let's create a second table called `orders` that can be joined with `mock_items`:
 
 ```sql
-CALL paradedb.create_paradedb_test_table(
+CALL paradedb.create_bm25_test_table(
   schema_name => 'public',
   table_name => 'orders',
   table_type => 'Orders'


### PR DESCRIPTION
## What

Updates the public docs to use `paradedb.create_bm25_test_table` instead of `paradedb.create_paradedb_test_table`.

This updates the five docs files changed by #5903:

- GitHub Actions CI
- GitLab CI
- Configure your Environment
- Joins Overview
- Score / sorting docs

## Why

The rename in #5903 landed on `main` but was intentionally not cherry-picked to `0.25.x`. As a result, the current stable release (`0.25.3`) still exposes `paradedb.create_bm25_test_table`, while the live docs advertise `paradedb.create_paradedb_test_table`.

That makes the documented quickstart fail for stable users, as reported in #5994.

Until the rename ships in a stable release, the docs should use the procedure that is actually available in the latest release.

Closes #5994

## Tests

Docs-only change. Verified the branch diff only changes the procedure name in the five affected docs files and preserves subsequent unrelated docs updates.