### PR TITLE
chore: pointed datafusion-distributed at the unbounded self-loop branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,8 +2091,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-distributed"
-version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-11-004258#aaf1a8129623ad7e1991173fe0fa5cb22a6d1656"
+version = "3.0.0"
+source = "git+https://github.com/paradedb/datafusion-distributed?branch=moe%2Fselfloop-unbounded-channel#5b1fc3f5b0853716be1b3aebe406d7abd5776149"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-YilptQU9A3DE3n949pY0nxL/qEFaDPu/zumr6LFVuaw=";
+  cargoHash = "sha256-b6Vb7zZ9nv2ZKR9Vw4ArLboNGQs2Tqn4p42VWnxCm18=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -95,7 +95,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-11-004258", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", branch = "moe/selfloop-unbounded-channel", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
+++ b/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
@@ -111,26 +111,32 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            : │   SortPreservingMergeExec: [id@1 DESC], fetch=10
-           : │     [Stage 3] => NetworkCoalesceExec: output_partitions=16, input_tasks=4
+           : │     [Stage 4] => NetworkCoalesceExec: output_partitions=16, input_tasks=4
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 3 ── tasks=4, partitions=4
+           :   ┌───── Stage 4 ── tasks=4, partitions=4
            :   │ SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
            :   │   VisibilityFilterExec: tables=[i]
            :   │     HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(id@1, company_id@0)]
-           :   │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=1
-           :   │       [Stage 2] => NetworkShuffleExec: output_partitions=4, input_tasks=4
+           :   │       [Stage 2] => NetworkShuffleExec: output_partitions=4, input_tasks=1
+           :   │       [Stage 3] => NetworkShuffleExec: output_partitions=4, input_tasks=4
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=16
+           :     ┌───── Stage 2 ── tasks=1, partitions=16
            :     │ RepartitionExec: partitioning=Hash([id@1], 16), input_partitions=4
            :     │   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@1, company_id@0)], null_aware
            :     │     CoalescePartitionsExec
-           :     │       DistributedLeafExec:
-           :     │         t0: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :     │       [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=4
            :     │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
            :     │       DistributedLeafExec:
            :     │         t0: PgSearchScan: segments=2, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
            :     └──────────────────────────────────────────────────
-           :     ┌───── Stage 2 ── tasks=4, partitions=16
+           :       ┌───── Stage 1 ── tasks=4, partitions=4
+           :       │ DistributedLeafExec:
+           :       │   t0: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       │   t1: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       │   t2: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       │   t3: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       └──────────────────────────────────────────────────
+           :     ┌───── Stage 3 ── tasks=4, partitions=16
            :     │ RepartitionExec: partitioning=Hash([company_id@0], 16), input_partitions=1
            :     │   DistributedLeafExec:
            :     │     t0: PgSearchScan: segments=30, dynamic_filters=1, query="all"
@@ -138,7 +144,7 @@ LIMIT 10;
            :     │     t2: PgSearchScan: segments=30, dynamic_filters=1, query="all"
            :     │     t3: PgSearchScan: segments=30, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-(39 rows)
+(45 rows)
 
 SELECT i.id
 FROM js_rti_items i


### PR DESCRIPTION
## Ticket(s) Closed

- None.

## What

This PR points `datafusion-distributed` at `moe/selfloop-unbounded-channel` (paradedb/datafusion-distributed#84) to run the benchmarks against it.

Benchmark wiring only. Once #84 is promoted, the pin goes back to a snapshot tag and this PR closes.

## Why

MPP workers preallocated a 32 MiB self-loop channel on every query. That was about half of the MPP launch floor and the main cause of the ~2x anti-join regression a customer saw after upgrading from 0.24.3 to 0.25.3. Details and numbers are in the df-d PR.

## How

`pg_search/Cargo.toml` and `Cargo.lock` only. Please note that the df-d branch sits on the fork's rebased `main` (v3.0.0), which carries 24 upstream commits past the pinned `snapshot-main-2026-08-11-004258`. The benchmark measures rebase plus fix against `main`, not the fix alone.

## Tests

- `cargo check`, `mpp_joinscan`, `mpp_aggregate`, `mpp_worker_sizing` regress pass locally against this df-d branch.
- On the local anti-join repro, `worker_setup (attach)` went from 11 to 13 ms per worker to about 0.1 ms, and `first_frame` from 39 to 53 ms to 24 to 30 ms. MPP and serial results match.

## Benchmark results

The stackoverflow suite ran on `27313d3` (results are in the review comments below). The MPP variants of the join queries got a flat ~10 ms cheaper, which matches removing the per-worker channel allocation. Everything else is flat.

100k, the scale where the launch floor dominates. Thirteen MPP variants improved 15 to 27%:

| query | before | after | ratio |
|-|-|-|-|
| `join_foreign_filter_local_sort - alt 1` | 41.7 ms | 30.6 ms | 0.73 |
| `join_semi_filter - alt 1` | 40.9 ms | 30.4 ms | 0.74 |
| `join_aggregate_count - alt 1` | 42.0 ms | 33.6 ms | 0.80 |
| `join_aggregate_multi - alt 1` | 42.8 ms | 34.1 ms | 0.80 |
| `join_aggregate_groupby - alt 2` | 61.3 ms | 50.8 ms | 0.83 |
| `join_aggregate_topk_count - alt 1` | 80.1 ms | 66.9 ms | 0.83 |

At 1m the sub-100 ms MPP variants improved 7 to 22% (`join_semi_filter - alt 1` 0.78, `join_top_k-score-desc - alt 1` 0.82). At 20m the change is invisible, as expected: ~10 ms against multi-second queries.

Non-join queries: median ratio 1.00 at all three scales, so the change is isolated to the MPP path.

The 1m alert (`join_hierarchical_content-scores-large` +10 ms, `join_distinct_parent_sort - alt 1` 1.19) does not look related: the regressed base variant runs with `enable_join_custom_scan = off`, so df-d never executes, its CTE variant is flat, all four variants are 1.00 to 1.02 at 100k and 20m, and the `join_distinct_parent_sort` row has a ±900 ms spread on a 3 s mean.
