### PR TITLE
perf: Use an in-memory channel for self-loops in MPP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,8 +2091,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-distributed"
-version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-11-004258#aaf1a8129623ad7e1991173fe0fa5cb22a6d1656"
+version = "3.0.0"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-20-003844#4df003cbe51426af1650aa06a7d48ce922d8c027"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-YilptQU9A3DE3n949pY0nxL/qEFaDPu/zumr6LFVuaw=";
+  cargoHash = "sha256-B4RShh7F26o+VRub7IMz8aHNTg1wpGxqnW1Wv7m1VTs=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -95,7 +95,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "8d680db14a9134837bbd3d53497dd58c985c51a7", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-11-004258", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-20-003844", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -423,20 +423,6 @@ pub(crate) fn run_mpp_worker(
                         proc_for_task(n_workers, task)
                     }
                 };
-                let base = match worker_session
-                    .outbound_senders()
-                    .get(dest_proc as usize)
-                    .and_then(|s| s.as_ref())
-                {
-                    Some(s) => s,
-                    None => {
-                        return Err(datafusion::common::DataFusionError::Internal(format!(
-                            "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
-                             (self-loop or unattached); fragment stage_id={} task_idx={}",
-                            fragment.stage_id, fragment.task_idx,
-                        )));
-                    }
-                };
                 let q_u32 = u32::try_from(q).map_err(|_| {
                     datafusion::common::DataFusionError::Internal(format!(
                         "mpp worker dispatch: output partition {q} exceeds transport u32 \
@@ -444,25 +430,44 @@ pub(crate) fn run_mpp_worker(
                         fragment.stage_id, fragment.task_idx,
                     ))
                 })?;
+                let stream_key = MppDataStreamKey::new(fragment.stage_id, fragment.task_idx, q_u32);
                 crate::mpp_log!(
                     "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
                      task_idx={}) partition={q} → dest_proc={dest_proc}",
                     fragment.stage_id,
                     fragment.task_idx,
                 );
-                // Attach the worker mesh as the cooperative drain so a full outbound
-                // ring doesn't block the backend thread. The spin pulls every inbound
-                // drain while retrying the send, breaking the symmetric-send stall
-                // pattern where every peer is blocked sending to a full peer.
-                per_partition_sinks.push(Box::new(MppPartitionSink::new(
-                    base.clone_with_header(MppFrameHeader::batch(
-                        MppDataStreamKey::new(fragment.stage_id, fragment.task_idx, q_u32),
-                        mesh_for_block.this_proc,
-                    ))
-                    .with_cooperative_drain(
-                        Arc::clone(&mesh_for_block) as Arc<dyn CooperativeDrainSet>
-                    ),
-                )));
+                if dest_proc == mesh_for_block.this_proc {
+                    per_partition_sinks.push(mesh_for_block.open_local_partition_sink(stream_key));
+                } else {
+                    let base = match worker_session
+                        .outbound_senders()
+                        .get(dest_proc as usize)
+                        .and_then(|s| s.as_ref())
+                    {
+                        Some(s) => s,
+                        None => {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
+                                 (unattached); fragment stage_id={} task_idx={}",
+                                fragment.stage_id, fragment.task_idx,
+                            )));
+                        }
+                    };
+                    // Attach the worker mesh as the cooperative drain so a full outbound
+                    // ring doesn't block the backend thread. The spin pulls every inbound
+                    // drain while retrying the send, breaking the symmetric-send stall
+                    // pattern where every peer is blocked sending to a full peer.
+                    per_partition_sinks.push(Box::new(MppPartitionSink::new(
+                        base.clone_with_header(MppFrameHeader::batch(
+                            stream_key,
+                            mesh_for_block.this_proc,
+                        ))
+                        .with_cooperative_drain(
+                            Arc::clone(&mesh_for_block) as Arc<dyn CooperativeDrainSet>
+                        ),
+                    )));
+                }
             }
 
             // Build a TaskContext seeded with the right `DistributedTaskContext` so the boundary

--- a/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
+++ b/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
@@ -111,26 +111,32 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            : │   SortPreservingMergeExec: [id@1 DESC], fetch=10
-           : │     [Stage 3] => NetworkCoalesceExec: output_partitions=16, input_tasks=4
+           : │     [Stage 4] => NetworkCoalesceExec: output_partitions=16, input_tasks=4
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 3 ── tasks=4, partitions=4
+           :   ┌───── Stage 4 ── tasks=4, partitions=4
            :   │ SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
            :   │   VisibilityFilterExec: tables=[i]
            :   │     HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(id@1, company_id@0)]
-           :   │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=1
-           :   │       [Stage 2] => NetworkShuffleExec: output_partitions=4, input_tasks=4
+           :   │       [Stage 2] => NetworkShuffleExec: output_partitions=4, input_tasks=1
+           :   │       [Stage 3] => NetworkShuffleExec: output_partitions=4, input_tasks=4
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=16
+           :     ┌───── Stage 2 ── tasks=1, partitions=16
            :     │ RepartitionExec: partitioning=Hash([id@1], 16), input_partitions=4
            :     │   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@1, company_id@0)], null_aware
            :     │     CoalescePartitionsExec
-           :     │       DistributedLeafExec:
-           :     │         t0: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :     │       [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=4
            :     │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
            :     │       DistributedLeafExec:
            :     │         t0: PgSearchScan: segments=2, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
            :     └──────────────────────────────────────────────────
-           :     ┌───── Stage 2 ── tasks=4, partitions=16
+           :       ┌───── Stage 1 ── tasks=4, partitions=4
+           :       │ DistributedLeafExec:
+           :       │   t0: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       │   t1: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       │   t2: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       │   t3: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :       └──────────────────────────────────────────────────
+           :     ┌───── Stage 3 ── tasks=4, partitions=16
            :     │ RepartitionExec: partitioning=Hash([company_id@0], 16), input_partitions=1
            :     │   DistributedLeafExec:
            :     │     t0: PgSearchScan: segments=30, dynamic_filters=1, query="all"
@@ -138,7 +144,7 @@ LIMIT 10;
            :     │     t2: PgSearchScan: segments=30, dynamic_filters=1, query="all"
            :     │     t3: PgSearchScan: segments=30, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-(39 rows)
+(45 rows)
 
 SELECT i.id
 FROM js_rti_items i


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5332

## What

Incorporates a new tag of `datafusion-distributed` which picks up https://github.com/datafusion-contrib/datafusion-distributed/pull/656, and switches to using it for self-loops.

## Why

To avoid serialization costs when sending data in-process.

## Tests

Causes some benchmark movement on small datasets, but no change on larger datasets.