### PR TITLE
ci: only post the benchmarker summary comment on PRs

### DIFF
--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -311,9 +311,10 @@ jobs:
           user_email: "github-actions[bot]@users.noreply.github.com"
           commit_message: "benchmarker dashboards for ${{ steps.commit_info.outputs.short_commit }}"
 
-      # On a PR the links land as a PR comment; on a push to main, as a commit comment.
+      # Summary comment, PR-only by convention (see benchmark-queries): main
+      # runs are tracked on the gh-pages charts, alerts still comment anywhere.
       - name: Comment dashboard links
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -333,11 +334,7 @@ jobs:
             printf 'Over-time tracking (QPS + latency percentiles across commits): [%s](%s)\n\n' "$OVERTIME" "$OVERTIME"
             printf '_gh-pages may take ~a minute to deploy after this run._\n'
           } > _comment.md
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file _comment.md
-          else
-            gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/comments" -F 'body=@_comment.md'
-          fi
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file _comment.md
 
       # Publishes run continue-on-error, so gate here: fail loudly if k6 recorded
       # no samples (empty QPS) instead of a silently-masked green.

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -269,8 +269,7 @@ jobs:
           alert-threshold: "115%"
           comment-on-alert: true
           alert-comment-cc-users: "@${{ github.actor }}"
-          # No comment-always: the dashboard-links comment below carries the
-          # PR compare table, so only alerts comment from here.
+          comment-always: ${{ github.event_name == 'pull_request' }}
 
       # Each publish clones gh-pages into ./benchmark-data-repository, so clear
       # it again or the latency clone fails on a non-empty destination (and
@@ -294,8 +293,7 @@ jobs:
           alert-threshold: "115%"
           comment-on-alert: true
           alert-comment-cc-users: "@${{ github.actor }}"
-          # No comment-always: the dashboard-links comment below carries the
-          # PR compare table, so only alerts comment from here.
+          comment-always: ${{ github.event_name == 'pull_request' }}
 
       # ---- Publish per-run dashboards to gh-pages and link them -------------
       # The k6 html export is self-contained (data inlined as
@@ -335,46 +333,9 @@ jobs:
             nm="$(basename "$h" .html)"
             links="${links}- [${nm}](${BASE}/${nm}.html)"$'\n'
           done
-          # Compare against the newest gh-pages entry per series (the last main
-          # run). data.js is the github-action-benchmark store with a JS
-          # assignment prefix; strip it and it is plain JSON. The table mirrors
-          # github-action-benchmark's own comment layout (see the queries
-          # benchmarks): Ratio > 1 is a regression for QPS and latency alike.
-          rows=""
-          prev_commit=""
-          if curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/gh-pages/benchmarker/data.js" \
-              | sed 's/^window\.BENCHMARK_DATA = //' > _baseline.json; then
-            prev_commit="$(jq -r --arg qps "benchmarker hn-ci (QPS)" \
-              '(.entries[$qps] // []) | if length > 0 then last.commit.id[0:7] else "" end' _baseline.json)"
-            rows="$(jq -r \
-              --arg qps "benchmarker hn-ci (QPS)" \
-              --arg lat "benchmarker hn-ci (latency percentiles)" \
-              --slurpfile cur_q benchmarker/benchmarker_qps.json \
-              --slurpfile cur_l benchmarker/benchmarker_latency.json '
-              def r2: (. * 100 | round) / 100;
-              def basemap($c): ((.entries[$c] // []) | if length > 0 then last.benches else [] end)
-                | map({(.name): .value}) | add // {};
-              basemap($qps) as $bq | basemap($lat) as $bl
-              | (($cur_q[0] | map(. + {prev: $bq[.name]}))
-                 + ($cur_l[0] | map(. + {prev: $bl[.name], lat: true})))[]
-              | .name as $n | .value as $v | .unit as $u | .prev as $p
-              | if ($p != null and $p > 0 and $v > 0) then
-                  "| `\($n)` | `\($v | r2)` \($u) | `\($p | r2)` \($u) | `\((if .lat then $v / $p else $p / $v end) | r2)` |"
-                else
-                  "| `\($n)` | `\($v | r2)` \($u) | | |"
-                end
-            ' _baseline.json)"
-          fi
           {
-            printf '# benchmarker hn-ci\n\n'
-            if [ -n "$rows" ]; then
-              printf '<details>\n\n'
-              printf '| Benchmark suite | Current: %s | Previous: %s | Ratio |\n|-|-|-|-|\n' \
-                "${{ steps.commit_info.outputs.short_commit }}" "${prev_commit:-n/a}"
-              printf '%s\n' "$rows"
-              printf '\n</details>\n\n'
-            fi
-            printf '📊 Dashboards (latency timeline, throughput, per-container CPU / memory):\n\n'
+            printf '### 📊 Benchmarker dashboards: `%s`\n\n' "${{ steps.commit_info.outputs.short_commit }}"
+            printf 'Interactive per-script graphs (latency timeline, throughput, per-container **CPU %%** / **memory**):\n\n'
             printf '%s\n' "$links"
             printf 'Over-time tracking (QPS + latency percentiles across commits): [%s](%s)\n\n' "$OVERTIME" "$OVERTIME"
             printf '_gh-pages may take ~a minute to deploy after this run._\n'

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -331,11 +331,16 @@ jobs:
           done
           # Compare against the newest gh-pages entry per series (the last main
           # run). data.js is the github-action-benchmark store with a JS
-          # assignment prefix; strip it and it is plain JSON.
-          table=""
+          # assignment prefix; strip it and it is plain JSON. The table mirrors
+          # github-action-benchmark's own comment layout (see the queries
+          # benchmarks): Ratio > 1 is a regression for QPS and latency alike.
+          rows=""
+          prev_commit=""
           if curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/gh-pages/benchmarker/data.js" \
               | sed 's/^window\.BENCHMARK_DATA = //' > _baseline.json; then
-            table="$(jq -r \
+            prev_commit="$(jq -r --arg qps "benchmarker hn-ci (QPS)" \
+              '(.entries[$qps] // []) | if length > 0 then last.commit.id[0:7] else "" end' _baseline.json)"
+            rows="$(jq -r \
               --arg qps "benchmarker hn-ci (QPS)" \
               --arg lat "benchmarker hn-ci (latency percentiles)" \
               --slurpfile cur_q benchmarker/benchmarker_qps.json \
@@ -343,21 +348,28 @@ jobs:
               def r2: (. * 100 | round) / 100;
               def basemap($c): ((.entries[$c] // []) | if length > 0 then last.benches else [] end)
                 | map({(.name): .value}) | add // {};
-              (basemap($qps) + basemap($lat)) as $base
-              | ($cur_q[0] + $cur_l[0])[]
-              | .name as $n | .value as $v | .unit as $u | ($base[$n] // null) as $p
-              | "| \($n) | \($v | r2) \($u) | \(if $p then "\($p | r2) \($u)" else "-" end) | \(if $p then "\((($v - $p) / $p * 100) | r2)%" else "-" end) |"
+              basemap($qps) as $bq | basemap($lat) as $bl
+              | (($cur_q[0] | map(. + {prev: $bq[.name]}))
+                 + ($cur_l[0] | map(. + {prev: $bl[.name], lat: true})))[]
+              | .name as $n | .value as $v | .unit as $u | .prev as $p
+              | if ($p != null and $p > 0 and $v > 0) then
+                  "| `\($n)` | `\($v | r2)` \($u) | `\($p | r2)` \($u) | `\((if .lat then $v / $p else $p / $v end) | r2)` |"
+                else
+                  "| `\($n)` | `\($v | r2)` \($u) | | |"
+                end
             ' _baseline.json)"
           fi
           {
-            printf '### 📊 Benchmarker dashboards: `%s`\n\n' "${{ steps.commit_info.outputs.short_commit }}"
-            printf 'Interactive per-script graphs (latency timeline, throughput, per-container **CPU %%** / **memory**):\n\n'
-            printf '%s\n' "$links"
-            if [ -n "$table" ]; then
-              printf 'Compared to the last run on main (for QPS a positive Δ is better; for latency, worse):\n\n'
-              printf '| Benchmark | This run | main | Δ |\n|---|---|---|---|\n'
-              printf '%s\n\n' "$table"
+            printf '# benchmarker hn-ci\n\n'
+            if [ -n "$rows" ]; then
+              printf '<details>\n\n'
+              printf '| Benchmark suite | Current: %s | Previous: %s | Ratio |\n|-|-|-|-|\n' \
+                "${{ steps.commit_info.outputs.short_commit }}" "${prev_commit:-n/a}"
+              printf '%s\n' "$rows"
+              printf '\n</details>\n\n'
             fi
+            printf '📊 Dashboards (latency timeline, throughput, per-container CPU / memory):\n\n'
+            printf '%s\n' "$links"
             printf 'Over-time tracking (QPS + latency percentiles across commits): [%s](%s)\n\n' "$OVERTIME" "$OVERTIME"
             printf '_gh-pages may take ~a minute to deploy after this run._\n'
           } > _comment.md

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -2,7 +2,7 @@
 #
 # Runs the benchmarker suite (github.com/paradedb/benchmarker) on the hn-ci
 # dataset, against a pg_search compiled from this repo's source and overlaid
-# onto a released ParadeDB image. Dashboards and QPS/latency history are
+# onto a released ParadeDB image. Dashboards and latency history are
 # published to gh-pages.
 # https://www.paradedb.com/blog/benchmarker-iteration
 
@@ -219,74 +219,42 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          # Per-run QPS + p50/p90/p95/p99 from queries[].latencies (ms); QPS =
-          # sample count over the timestamp span. Run .name is the series name.
+          # Per-run mean + p50/p90/p95/p99 from queries[].latencies (ms), all
+          # smaller-is-better so everything fits one series (like the queries
+          # benchmarks). The scripts are closed-loop, so mean ms stands in for
+          # QPS: QPS = VUs / mean latency. Run .name is the series name.
           mkdir -p _metrics
           for j in results/*.json; do
             nm="$(basename "$j" .json)"
             jq '[ .runs | to_entries[] | .value as $r
-                  | ([$r.queries[]?.latencies[]?]) as $lat
-                  | ([$r.queries[]?.timestamps[]?]) as $ts
-                  | ($lat | length) as $n
-                  | select($n > 0)
-                  | { name:  ($r.name + " QPS"),
-                      unit:  "QPS",
-                      value: ($n / (((($ts|max) - ($ts|min)) | if . <= 0 then 1000 else . end) / 1000)) } ]' \
-              "$j" > "_metrics/${nm}.qps.json"
-            # (50,90,95,99) fans out to four rows per run (nearest-rank).
-            jq '[ .runs | to_entries[] | .value as $r
                   | ([$r.queries[]?.latencies[]?] | sort) as $sorted
                   | ($sorted | length) as $n
                   | select($n > 0)
-                  | (50, 90, 95, 99) as $p
-                  | { name:  ($r.name + " p" + ($p|tostring) + " latency"),
+                  | { name:  ($r.name + " mean latency"),
                       unit:  "ms",
-                      value: $sorted[ ((($n - 1) * $p / 100) | floor) ] } ]' \
-              "$j" > "_metrics/${nm}.lat.json"
+                      value: (($sorted | add) / $n) },
+                    ((50, 90, 95, 99) as $p
+                     | { name:  ($r.name + " p" + ($p|tostring) + " latency"),
+                         unit:  "ms",
+                         value: $sorted[ ((($n - 1) * $p / 100) | floor) ] }) ]' \
+              "$j" > "_metrics/${nm}.json"
           done
           # Merge per-script arrays; empty set -> [].
-          if compgen -G "_metrics/*.qps.json" > /dev/null; then jq -s 'add' _metrics/*.qps.json; else echo '[]'; fi > benchmarker_qps.json
-          if compgen -G "_metrics/*.lat.json" > /dev/null; then jq -s 'add' _metrics/*.lat.json; else echo '[]'; fi > benchmarker_latency.json
-          echo "== QPS =="; cat benchmarker_qps.json
-          echo "== latency percentiles =="; cat benchmarker_latency.json
+          if compgen -G "_metrics/*.json" > /dev/null; then jq -s 'add' _metrics/*.json; else echo '[]'; fi > benchmarker_metrics.json
+          cat benchmarker_metrics.json
 
       - name: Cleanup Previous Benchmark Publish Working Directory
         run: rm -rf ./benchmark-data-repository
 
-      - name: Publish Throughput (QPS)
+      - name: Publish Latency (mean + percentiles)
         continue-on-error: true # Don't let a publish hiccup block the dashboards/comment below.
         # paradedb fork: shallow-clones only the gh-pages branch on publish.
         uses: paradedb/github-action-benchmark@v1
         with:
-          name: "benchmarker hn-ci (QPS)"
-          ref: ${{ steps.determine-ref.outputs.ref }}
-          tool: customBiggerIsBetter
-          output-file-path: benchmarker/benchmarker_qps.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-repository: github.com/${{ github.repository }}
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: benchmarker
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
-          alert-threshold: "115%"
-          comment-on-alert: true
-          alert-comment-cc-users: "@${{ github.actor }}"
-          comment-always: ${{ github.event_name == 'pull_request' }}
-
-      # Each publish clones gh-pages into ./benchmark-data-repository, so clear
-      # it again or the latency clone fails on a non-empty destination (and
-      # continue-on-error hides it: no latency history ever lands on gh-pages).
-      - name: Cleanup Benchmark Publish Working Directory
-        run: rm -rf ./benchmark-data-repository
-
-      - name: Publish Latency (p50/p90/p95/p99)
-        continue-on-error: true
-        # paradedb fork: shallow-clones only the gh-pages branch on publish.
-        uses: paradedb/github-action-benchmark@v1
-        with:
-          name: "benchmarker hn-ci (latency percentiles)"
+          name: "benchmarker hn-ci (latency)"
           ref: ${{ steps.determine-ref.outputs.ref }}
           tool: customSmallerIsBetter
-          output-file-path: benchmarker/benchmarker_latency.json
+          output-file-path: benchmarker/benchmarker_metrics.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-repository: github.com/${{ github.repository }}
           gh-pages-branch: gh-pages
@@ -339,22 +307,22 @@ jobs:
             printf '### 📊 Benchmarker dashboards: `%s`\n\n' "${{ steps.commit_info.outputs.short_commit }}"
             printf 'Interactive per-script graphs (latency timeline, throughput, per-container **CPU %%** / **memory**):\n\n'
             printf '%s\n' "$links"
-            printf 'Over-time tracking (QPS + latency percentiles across commits): [%s](%s)\n\n' "$OVERTIME" "$OVERTIME"
+            printf 'Over-time tracking (mean + percentile latency across commits): [%s](%s)\n\n' "$OVERTIME" "$OVERTIME"
             printf '_gh-pages may take ~a minute to deploy after this run._\n'
           } > _comment.md
           gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file _comment.md
 
       # Publishes run continue-on-error, so gate here: fail loudly if k6 recorded
-      # no samples (empty QPS) instead of a silently-masked green.
+      # no samples (empty metrics) instead of a silently-masked green.
       - name: Fail if no metrics were extracted
         if: always()
         run: |
-          f=benchmarker/benchmarker_qps.json
+          f=benchmarker/benchmarker_metrics.json
           # No metrics file means an earlier stage already failed; don't pile on.
           [ -f "$f" ] || { echo "no metrics file (earlier stage failed); skipping guard"; exit 0; }
           n=$(jq 'length' "$f")
-          echo "extracted QPS series: ${n}"
+          echo "extracted metric rows: ${n}"
           if [ "${n:-0}" -eq 0 ]; then
-            echo "::error::No benchmark metrics extracted (empty QPS set): the k6 run produced no query samples. Check query execution / the dashboard export." >&2
+            echo "::error::No benchmark metrics extracted: the k6 run produced no query samples. Check query execution / the dashboard export." >&2
             exit 1
           fi

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -255,7 +255,8 @@ jobs:
 
       - name: Publish Throughput (QPS)
         continue-on-error: true # Don't let a publish hiccup block the dashboards/comment below.
-        uses: benchmark-action/github-action-benchmark@v1
+        # paradedb fork: shallow-clones only the gh-pages branch on publish.
+        uses: paradedb/github-action-benchmark@v1
         with:
           name: "benchmarker hn-ci (QPS)"
           ref: ${{ steps.determine-ref.outputs.ref }}
@@ -279,7 +280,8 @@ jobs:
 
       - name: Publish Latency (p50/p90/p95/p99)
         continue-on-error: true
-        uses: benchmark-action/github-action-benchmark@v1
+        # paradedb fork: shallow-clones only the gh-pages branch on publish.
+        uses: paradedb/github-action-benchmark@v1
         with:
           name: "benchmarker hn-ci (latency percentiles)"
           ref: ${{ steps.determine-ref.outputs.ref }}

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -272,6 +272,12 @@ jobs:
           # No comment-always: the dashboard-links comment below carries the
           # PR compare table, so only alerts comment from here.
 
+      # Each publish clones gh-pages into ./benchmark-data-repository, so clear
+      # it again or the latency clone fails on a non-empty destination (and
+      # continue-on-error hides it: no latency history ever lands on gh-pages).
+      - name: Cleanup Benchmark Publish Working Directory
+        run: rm -rf ./benchmark-data-repository
+
       - name: Publish Latency (p50/p90/p95/p99)
         continue-on-error: true
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -269,7 +269,8 @@ jobs:
           alert-threshold: "115%"
           comment-on-alert: true
           alert-comment-cc-users: "@${{ github.actor }}"
-          comment-always: ${{ github.event_name == 'pull_request' }}
+          # No comment-always: the dashboard-links comment below carries the
+          # PR compare table, so only alerts comment from here.
 
       - name: Publish Latency (p50/p90/p95/p99)
         continue-on-error: true
@@ -287,7 +288,8 @@ jobs:
           alert-threshold: "115%"
           comment-on-alert: true
           alert-comment-cc-users: "@${{ github.actor }}"
-          comment-always: ${{ github.event_name == 'pull_request' }}
+          # No comment-always: the dashboard-links comment below carries the
+          # PR compare table, so only alerts comment from here.
 
       # ---- Publish per-run dashboards to gh-pages and link them -------------
       # The k6 html export is self-contained (data inlined as
@@ -327,10 +329,35 @@ jobs:
             nm="$(basename "$h" .html)"
             links="${links}- [${nm}](${BASE}/${nm}.html)"$'\n'
           done
+          # Compare against the newest gh-pages entry per series (the last main
+          # run). data.js is the github-action-benchmark store with a JS
+          # assignment prefix; strip it and it is plain JSON.
+          table=""
+          if curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/gh-pages/benchmarker/data.js" \
+              | sed 's/^window\.BENCHMARK_DATA = //' > _baseline.json; then
+            table="$(jq -r \
+              --arg qps "benchmarker hn-ci (QPS)" \
+              --arg lat "benchmarker hn-ci (latency percentiles)" \
+              --slurpfile cur_q benchmarker/benchmarker_qps.json \
+              --slurpfile cur_l benchmarker/benchmarker_latency.json '
+              def r2: (. * 100 | round) / 100;
+              def basemap($c): ((.entries[$c] // []) | if length > 0 then last.benches else [] end)
+                | map({(.name): .value}) | add // {};
+              (basemap($qps) + basemap($lat)) as $base
+              | ($cur_q[0] + $cur_l[0])[]
+              | .name as $n | .value as $v | .unit as $u | ($base[$n] // null) as $p
+              | "| \($n) | \($v | r2) \($u) | \(if $p then "\($p | r2) \($u)" else "-" end) | \(if $p then "\((($v - $p) / $p * 100) | r2)%" else "-" end) |"
+            ' _baseline.json)"
+          fi
           {
             printf '### 📊 Benchmarker dashboards: `%s`\n\n' "${{ steps.commit_info.outputs.short_commit }}"
             printf 'Interactive per-script graphs (latency timeline, throughput, per-container **CPU %%** / **memory**):\n\n'
             printf '%s\n' "$links"
+            if [ -n "$table" ]; then
+              printf 'Compared to the last run on main (for QPS a positive Δ is better; for latency, worse):\n\n'
+              printf '| Benchmark | This run | main | Δ |\n|---|---|---|---|\n'
+              printf '%s\n\n' "$table"
+            fi
             printf 'Over-time tracking (QPS + latency percentiles across commits): [%s](%s)\n\n' "$OVERTIME" "$OVERTIME"
             printf '_gh-pages may take ~a minute to deploy after this run._\n'
           } > _comment.md


### PR DESCRIPTION
Follow-up to #5850, aligning the benchmarker with the benchmark-queries / benchmark-stressgres conventions.

- Summary comments are PR-only; nothing posts on pushes to main (main runs are tracked on the gh-pages charts). Compare tables come from github-action-benchmark's comment-always.
- One tracked series instead of two: per-run mean + p50/p90/p95/p99 latency under a single customSmallerIsBetter publish, like queries. The k6 scripts are closed-loop, so mean ms carries the QPS signal (QPS = VUs / mean latency); this halves the publish steps and PR comments.
- Switched to the paradedb github-action-benchmark fork used by the other benchmark workflows (shallow-clones only the gh-pages branch).
- Fixed a masked failure: with two publishes, the second one's gh-pages clone always failed on the non-empty ./benchmark-data-repository left by the first, and continue-on-error hid it, so no latency history ever reached gh-pages. Now moot with a single publish, and the cleanup still runs before it.