### PR TITLE
feat: partitioned index build execution

### DIFF
--- a/pg_search/src/api/operator/keyset.rs
+++ b/pg_search/src/api/operator/keyset.rs
@@ -32,6 +32,7 @@
 
 use crate::api::HashSet;
 use crate::gucs::WorkMem;
+use crate::postgres::tuplesort::Sorter;
 use crate::postgres::types::TantivyValue;
 use pgrx::pg_sys;
 use std::os::raw::c_int;
@@ -123,88 +124,7 @@ impl KeySetBuilder {
     fn finish(self) -> KeySet {
         match self.sort {
             None => KeySet::InMemory(self.in_memory),
-            Some(sort) => KeySet::Spilled(sort.finish()),
-        }
-    }
-}
-
-/// Thin wrapper over a `bytea` `tuplesort` used to externally sort the serialized keys.
-struct Sorter {
-    state: *mut pg_sys::Tuplesortstate,
-}
-
-impl Sorter {
-    fn new(budget: usize) -> Self {
-        unsafe {
-            // `<` operator for bytea, so the sort orders by memcmp of the serialized keys.
-            let tcache =
-                pg_sys::lookup_type_cache(pg_sys::BYTEAOID, pg_sys::TYPECACHE_LT_OPR as c_int);
-            let lt_op = (*tcache).lt_opr;
-            let state = pg_sys::tuplesort_begin_datum(
-                pg_sys::BYTEAOID,
-                lt_op,
-                pg_sys::InvalidOid, // bytea has no collation
-                false,              // nullsFirstFlag (there are no nulls)
-                (budget / 1024).max(64) as c_int,
-                std::ptr::null_mut(), // not parallel
-                0,                    // sortopt: no random access
-            );
-            Sorter { state }
-        }
-    }
-
-    fn put(&mut self, bytes: &[u8]) {
-        unsafe {
-            let datum = bytea_datum(bytes);
-            pg_sys::tuplesort_putdatum(self.state, datum, false);
-            // `tuplesort_putdatum` copies the value, so free our transient bytea.
-            pg_sys::pfree(datum.cast_mut_ptr());
-        }
-    }
-
-    /// Drain the sorted keys into a `BufFile` + sparse index.
-    fn finish(self) -> Spilled {
-        unsafe {
-            pg_sys::tuplesort_performsort(self.state);
-
-            // The BufFile is probed on later scan rows, so both the file (via its resource owner)
-            // and the BufFile *struct* (via the current memory context) must outlive the current
-            // per-tuple ExprContext. Create it against the transaction's owner/context; `Spilled`'s
-            // Drop closes it when the function's cache is torn down at end of query.
-            let saved_owner = pg_sys::CurrentResourceOwner;
-            let saved_cxt = pg_sys::CurrentMemoryContext;
-            pg_sys::CurrentResourceOwner = pg_sys::CurTransactionResourceOwner;
-            pg_sys::CurrentMemoryContext = pg_sys::CurTransactionContext;
-            let file = pg_sys::BufFileCreateTemp(false);
-            pg_sys::CurrentResourceOwner = saved_owner;
-            pg_sys::CurrentMemoryContext = saved_cxt;
-            let mut index: Vec<IndexEntry> = Vec::new();
-            let mut count: usize = 0;
-
-            let mut val: pg_sys::Datum = pg_sys::Datum::from(0);
-            let mut is_null = false;
-            let mut abbrev: pg_sys::Datum = pg_sys::Datum::from(0);
-            while tuplesort_getdatum_forward(self.state, &mut val, &mut is_null, &mut abbrev) {
-                let bytes = datum_bytea(val);
-
-                if count.is_multiple_of(INDEX_STRIDE) {
-                    let (fileno, offset) = buffile_tell(file);
-                    index.push(IndexEntry {
-                        key: bytes.to_vec(),
-                        fileno,
-                        offset,
-                    });
-                }
-
-                let len = bytes.len() as u32;
-                buffile_write(file, &len.to_ne_bytes());
-                buffile_write(file, bytes);
-                count += 1;
-            }
-
-            pg_sys::tuplesort_end(self.state);
-
-            Spilled { file, index, count }
+            Some(sort) => KeySet::Spilled(Spilled::from_sorter(sort)),
         }
     }
 }
@@ -227,6 +147,47 @@ struct IndexEntry {
 }
 
 impl Spilled {
+    /// Drain the sorted keys into a `BufFile` + sparse index.
+    fn from_sorter(mut sorter: Sorter) -> Self {
+        unsafe {
+            sorter.performsort();
+
+            // The BufFile is probed on later scan rows, so both the file (via its resource owner)
+            // and the BufFile *struct* (via the current memory context) must outlive the current
+            // per-tuple ExprContext. Create it against the transaction's owner/context; `Spilled`'s
+            // Drop closes it when the function's cache is torn down at end of query.
+            let saved_owner = pg_sys::CurrentResourceOwner;
+            let saved_cxt = pg_sys::CurrentMemoryContext;
+            pg_sys::CurrentResourceOwner = pg_sys::CurTransactionResourceOwner;
+            pg_sys::CurrentMemoryContext = pg_sys::CurTransactionContext;
+            let file = pg_sys::BufFileCreateTemp(false);
+            pg_sys::CurrentResourceOwner = saved_owner;
+            pg_sys::CurrentMemoryContext = saved_cxt;
+
+            let mut index: Vec<IndexEntry> = Vec::new();
+            let mut count: usize = 0;
+            while let Some(bytes) = sorter.next_sorted() {
+                if count.is_multiple_of(INDEX_STRIDE) {
+                    let (fileno, offset) = buffile_tell(file);
+                    index.push(IndexEntry {
+                        key: bytes.to_vec(),
+                        fileno,
+                        offset,
+                    });
+                }
+
+                let len = bytes.len() as u32;
+                buffile_write(file, &len.to_ne_bytes());
+                buffile_write(file, bytes);
+                count += 1;
+            }
+
+            sorter.end();
+
+            Spilled { file, index, count }
+        }
+    }
+
     fn contains(&self, value: &TantivyValue) -> bool {
         if self.count == 0 {
             return false;
@@ -283,21 +244,6 @@ impl Drop for Spilled {
     }
 }
 
-/// Build a transient `bytea` Datum from `bytes` (palloc'd in the current context).
-unsafe fn bytea_datum(bytes: &[u8]) -> pg_sys::Datum {
-    use pgrx::IntoDatum;
-    bytes
-        .to_vec()
-        .into_datum()
-        .expect("byte slice should convert to a bytea datum")
-}
-
-/// View a `bytea` Datum's payload as bytes (valid until the datum is freed/overwritten).
-unsafe fn datum_bytea<'a>(datum: pg_sys::Datum) -> &'a [u8] {
-    let varlena = datum.cast_mut_ptr::<pg_sys::varlena>();
-    pgrx::varlena_to_byte_slice(varlena)
-}
-
 unsafe fn buffile_tell(file: *mut pg_sys::BufFile) -> (c_int, pg_sys::off_t) {
     let mut fileno: c_int = 0;
     let mut offset: pg_sys::off_t = 0;
@@ -306,24 +252,6 @@ unsafe fn buffile_tell(file: *mut pg_sys::BufFile) -> (c_int, pg_sys::off_t) {
 }
 
 // The following wrap Postgres APIs whose signatures differ across supported versions.
-
-/// `tuplesort_getdatum`, always reading forward. `copy: false` -- the returned datum is valid until
-/// the next call, which is all we need. (PG16 added the `copy` parameter.)
-unsafe fn tuplesort_getdatum_forward(
-    state: *mut pg_sys::Tuplesortstate,
-    val: *mut pg_sys::Datum,
-    is_null: *mut bool,
-    abbrev: *mut pg_sys::Datum,
-) -> bool {
-    #[cfg(feature = "pg15")]
-    {
-        pg_sys::tuplesort_getdatum(state, true, val, is_null, abbrev)
-    }
-    #[cfg(not(feature = "pg15"))]
-    {
-        pg_sys::tuplesort_getdatum(state, true, false, val, is_null, abbrev)
-    }
-}
 
 /// Write `data` to `file`. (PG15's `BufFileWrite` takes `*mut`; PG16+ takes `*const`.)
 unsafe fn buffile_write(file: *mut pg_sys::BufFile, data: &[u8]) {

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -19,7 +19,6 @@ use super::utils::{load_metas, save_new_metas, save_schema, save_settings};
 use crate::api::{HashMap, HashSet};
 use crate::index::reader::segment_component::SegmentComponentReader;
 use crate::index::writer::segment_component::SegmentComponentWriter;
-use crate::postgres::composite::CompositeSlotValues;
 use crate::postgres::heap::{ExpressionState, HeapFetchState};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::MAX_BUFFERS_TO_EXTEND_BY;
@@ -27,9 +26,8 @@ use crate::postgres::storage::block::{
     FileEntry, MVCCEntry, SegmentMetaEntry, SegmentMetaEntryContent, SegmentMetaEntryImmutable,
     SegmentMetaEntryMutable, bm25_max_free_space,
 };
-use crate::postgres::storage::buffer::{BorrowedBuffer, BufferManager, PinnedBuffer};
+use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};
 use crate::postgres::storage::metadata::MetaPage;
-use crate::schema::FieldSource;
 use parking_lot::Mutex;
 use pgrx::pg_sys;
 use std::any::Any;
@@ -679,16 +677,8 @@ pub fn index_memory_segment(
     mvcc_style: &MvccSatisfies,
 ) -> anyhow::Result<RamDirectory> {
     use crate::index::writer::index::SerialIndexWriter;
-    use crate::postgres::utils::{
-        resolve_field_value, row_to_search_document, u64_to_item_pointer,
-    };
-    use pgrx::{
-        PgTupleDesc,
-        pg_sys::{
-            GetOldestNonRemovableTransactionId, HTSV_Result, HeapTupleSatisfiesVacuum,
-            heap_deform_tuple,
-        },
-    };
+    use crate::postgres::heap::HeapDocFetcher;
+    use pgrx::PgTupleDesc;
 
     /// RAII guard that guarantees an active snapshot for the duration of the heap reads and
     /// detoasting performed while materializing a mutable segment.
@@ -748,25 +738,13 @@ pub fn index_memory_segment(
     let search_schema = indexrel.schema()?;
     let categorized_fields = search_schema.categorized_fields();
     let created_by_version = indexrel.created_by_version();
-    let oldest_xmin = unsafe { GetOldestNonRemovableTransactionId(heaprel.as_ptr()) };
-
-    let mut values = vec![pg_sys::Datum::null(); heaptupdesc.len()];
-    let mut isnull = vec![false; heaptupdesc.len()];
 
     // Query-visible materialization (Snapshot / ParallelWorker / LargestSegment) fetches each ctid
-    // with the active MVCC snapshot so that detoasting is safe: that registered snapshot holds back
-    // the global xmin horizon, preventing a concurrent VACUUM from reclaiming the external TOAST
-    // chunks we read. Fetching such rows with SnapshotAny could instead select DEAD /
-    // RECENTLY_DEAD versions whose TOAST has already been (or is being) freed, raising spurious
-    // "missing/unexpected chunk number ... in pg_toast_*" errors. Because materialization happens
-    // lazily inside query planning or execution, the active snapshot here is the snapshot that
-    // defines query-visible heap rows, so indexing an invisible ctid as empty cannot change a
-    // query result or estimate.
-    //
-    // Maintenance materialization (e.g. Mergeable) must index every live ctid regardless of any
-    // single snapshot, since the resulting segment may serve future snapshots, so it keeps using
-    // SnapshotAny and filters dead tuples with HeapTupleSatisfiesVacuum.
-    // See: https://github.com/paradedb/paradedb/issues/5365
+    // with the active MVCC snapshot; maintenance materialization (e.g. Mergeable) must index every
+    // live ctid regardless of any single snapshot. See the `HeapDocFetcher` docs for the full
+    // reasoning. Because query-visible materialization happens lazily inside query planning or
+    // execution, the active snapshot here is the snapshot that defines query-visible heap rows,
+    // so indexing an invisible ctid as empty cannot change a query result or estimate.
     let query_visible = match mvcc_style {
         MvccSatisfies::Snapshot
         | MvccSatisfies::ParallelWorker(_)
@@ -774,209 +752,23 @@ pub fn index_memory_segment(
         MvccSatisfies::Vacuum | MvccSatisfies::Mergeable => false,
     };
 
-    'next_ctid: for ctid in ctids {
-        // Guard against stale ctids referencing heap blocks truncated by VACUUM.
-        if !unsafe {
-            crate::postgres::utils::ctid_satisfies_nblocks(
-                ctid,
-                heaprel.as_ptr(),
-                heaprel.fork_number(),
-            )
-        } {
-            writer.insert(tantivy::TantivyDocument::new(), ctid, || {
-                unreachable!("No limits configured: should not finalize.")
-            })?;
-            continue 'next_ctid;
-        }
+    let mut fetcher = HeapDocFetcher::new(
+        heap_fetch_state,
+        expression_state,
+        &heaprel,
+        &heaptupdesc,
+        categorized_fields.as_slice(),
+        created_by_version,
+        query_visible,
+    );
 
-        let mut ipd = pg_sys::ItemPointerData::default();
-        u64_to_item_pointer(ctid, &mut ipd);
-
-        unsafe {
-            // See `query_visible` above for why these two styles fetch with different snapshots.
-            let fetch_snapshot = if query_visible {
-                pg_sys::GetActiveSnapshot()
-            } else {
-                &raw mut pg_sys::SnapshotAnyData
-            };
-            let mut call_again = false;
-            'next_hot_chain: loop {
-                let fetched = pg_sys::table_index_fetch_tuple(
-                    heap_fetch_state.scan,
-                    &mut ipd,
-                    fetch_snapshot,
-                    heap_fetch_state.slot(),
-                    // call_again: This parameter will be set to true if this `ctid` points to multiple
-                    // tuples as part of a HOT chain. We must attempt to find one live version of the
-                    // tuple, and it may not be the first one in the chain.
-                    &mut call_again,
-                    // all_dead: Can hypothetically signal that a `ctid` is dead in all
-                    // transactions: in practice, never actually seems to be anything but false
-                    // when used with `SnapshotAnyData`.
-                    &mut false,
-                );
-
-                if !fetched {
-                    // Either the tuple is not visible to `fetch_snapshot` (query-visible mode) or
-                    // heap page pruning removed it (SnapshotAny mode). In both cases there is no
-                    // content to index for this ctid, so insert an empty document.
-                    writer.insert(tantivy::TantivyDocument::new(), ctid, || {
-                        unreachable!("No limits configured: should not finalize.")
-                    })?;
-                    continue 'next_ctid;
-                }
-
-                if query_visible {
-                    // Visible to the snapshot: skip the SnapshotAny dead-tuple filtering below and
-                    // index it.
-                    break;
-                }
-
-                let mut htsv_result = {
-                    let buffer = (*heap_fetch_state.buffer_heap_slot()).buffer;
-                    let _lock = BorrowedBuffer::from_pg(buffer);
-                    HeapTupleSatisfiesVacuum(
-                        (*heap_fetch_state.buffer_heap_slot()).base.tuple,
-                        oldest_xmin,
-                        buffer,
-                    )
-                };
-
-                if htsv_result == HTSV_Result::HEAPTUPLE_RECENTLY_DEAD {
-                    // Our `oldest_xmin` might be stale compared to a concurrent VACUUM.
-                    // If VACUUM saw this tuple as DEAD and deleted its TOAST chunks, we
-                    // must also see it as DEAD, otherwise we'll crash trying to read them.
-                    //
-                    // A single re-check is sufficient (no loop needed) because
-                    // `GetOldestNonRemovableTransactionId` returns the current global
-                    // XID horizon. If the tuple is still RECENTLY_DEAD under this fresh
-                    // horizon, then no concurrent VACUUM could have considered it DEAD
-                    // (VACUUM uses the same or an older horizon), so its TOAST data is
-                    // guaranteed to still exist.
-                    let fresh_oldest_xmin =
-                        pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr());
-                    if fresh_oldest_xmin != oldest_xmin {
-                        let buffer = (*heap_fetch_state.buffer_heap_slot()).buffer;
-                        let _lock = BorrowedBuffer::from_pg(buffer);
-                        htsv_result = HeapTupleSatisfiesVacuum(
-                            (*heap_fetch_state.buffer_heap_slot()).base.tuple,
-                            fresh_oldest_xmin,
-                            buffer,
-                        );
-                    }
-                }
-
-                if htsv_result == HTSV_Result::HEAPTUPLE_DEAD {
-                    // table_index_fetch_tuple stored this dead tuple in a buffer-backed slot. Since
-                    // this branch skips the tuple, clear the slot before any HOT-chain retry or ctid
-                    // skip so the slot releases its buffer pin.
-                    pg_sys::ExecClearTuple(heap_fetch_state.slot());
-
-                    // This copy of the tuple is no longer visible to any transaction. Are there
-                    // more in the HOT chain?
-                    if call_again {
-                        // There are more entries in the hot chain: find the first one that is
-                        // visible.
-                        continue 'next_hot_chain;
-                    } else {
-                        // There are no more entries in the HOT chain, so no copy of the tuple is
-                        // visible in any transaction.
-                        writer.insert(tantivy::TantivyDocument::new(), ctid, || {
-                            unreachable!("No limits configured: should not finalize.")
-                        })?;
-                        continue 'next_ctid;
-                    }
-                }
-
-                // We successfully fetched a tuple. Break out to fetch and deform it.
-                break;
-            }
-
-            // We have a completely valid tuple to index: fetch and deform it.
-            //
-            // NOTE: We intentionally pass `false` (don't materialize) to keep the
-            // buffer pin held by the BufferHeapTupleTableSlot. This pin blocks
-            // VACUUM's LockBufferForCleanup, which prevents it from removing the
-            // heap tuple and deleting its TOAST chunks while we read them below.
-            // See: https://github.com/paradedb/paradedb/issues/5076
-            let htup = pg_sys::ExecFetchSlotHeapTuple(
-                heap_fetch_state.slot(),
-                false,
-                std::ptr::null_mut(),
-            );
-
-            heap_deform_tuple(
-                htup,
-                heaptupdesc.as_ptr(),
-                values.as_mut_ptr(),
-                isnull.as_mut_ptr(),
-            );
-
-            // Eagerly detoast all variable-length (varlena) datums while the
-            // buffer pin is still held. Without this, the lazy detoasting in
-            // row_to_search_document can race with VACUUM deleting TOAST chunks
-            // after we release the pin (the "missing chunk number 0" crash).
-            // pg_detoast_datum is a no-op for already-inline / non-TOASTed data.
-            for i in 0..heaptupdesc.len() {
-                if !isnull[i] {
-                    let att = heaptupdesc.get(i).expect("valid attribute");
-                    if att.attlen == -1 {
-                        values[i] =
-                            pg_sys::Datum::from(pg_sys::pg_detoast_datum(values[i].cast_mut_ptr()));
-                    }
-                }
-            }
-
-            let expr_results = expression_state.evaluate(heap_fetch_state.slot());
-
-            let mut doc = tantivy::TantivyDocument::new();
-
-            // Unpack all composites upfront from expr_results
-            let unpacked_composites = CompositeSlotValues::from_composites(
-                categorized_fields.iter().filter_map(|(_, cat)| {
-                    if let FieldSource::CompositeField {
-                        expression_idx,
-                        composite_type_oid,
-                        ..
-                    } = cat.source
-                    {
-                        let (datum, is_null) = expr_results[expression_idx];
-                        Some((expression_idx, datum, is_null, composite_type_oid))
-                    } else {
-                        None
-                    }
-                }),
-            );
-
-            row_to_search_document(
-                categorized_fields.iter().map(|(field, categorized)| {
-                    let (datum, is_null) = resolve_field_value(
-                        &categorized.source,
-                        &values,
-                        &isnull,
-                        &expr_results,
-                        &unpacked_composites,
-                    );
-                    (datum, is_null, field, categorized)
-                }),
-                &mut doc,
-                created_by_version,
-            )
-            .unwrap_or_else(|e| {
-                panic!("Failed to create document from row: {e}");
-            });
-
-            writer.insert(doc, ctid, || {
-                unreachable!("No limits configured: should not finalize.")
-            })?;
-
-            // Eagerly release the buffer pin now that all datum values have
-            // been detoasted into palloc'd memory. Without this, the pin would
-            // stay held until the next table_index_fetch_tuple call (which
-            // replaces the slot contents) or until HeapFetchState is dropped at
-            // end-of-query, unnecessarily blocking VACUUM on this buffer.
-            pg_sys::ExecClearTuple(heap_fetch_state.slot());
-        }
+    for ctid in ctids {
+        // A ctid with nothing to index becomes an empty document: the segment must contain
+        // every ctid in the mutable snapshot.
+        let doc = unsafe { fetcher.fetch_doc(ctid) }.unwrap_or_else(tantivy::TantivyDocument::new);
+        writer.insert(doc, ctid, || {
+            unreachable!("No limits configured: should not finalize.")
+        })?;
     }
 
     writer.finalize_nocommit()?.expect(

--- a/pg_search/src/index/kdtree.rs
+++ b/pg_search/src/index/kdtree.rs
@@ -121,10 +121,7 @@ impl KdTree {
         }
     }
 
-    // `dims`, `route`, and `to_range_partitioning` are the routing API the partitioned scan and
-    // merge paths will call. They stay unused here until those land.
     /// The `partition_by` fields, in the order [`Point`]s must be laid out.
-    #[allow(dead_code)]
     pub fn dims(&self) -> &[FieldName] {
         &self.dims
     }
@@ -134,7 +131,6 @@ impl KdTree {
     }
 
     /// The partition a row belongs to. `values` must be laid out like [`Self::dims`].
-    #[allow(dead_code)]
     pub fn route(&self, values: &[PdbOwnedValue]) -> usize {
         debug_assert_eq!(values.len(), self.dims.len());
         let mut node = &self.root;

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -475,8 +475,10 @@ struct WorkerBuildState<'a> {
     unmerged_metas: Vec<SegmentMeta>,
     local_tuple_done_count: usize, // worker-local number of tuples done - used to updated the shared `ntuples_done` in `coordination`
     is_leader: bool,
-    // whether the first flushed segment's on-disk size has been reported to the disk guard
-    recorded_segment_bytes: bool,
+    // the first flushed segment's on-disk size, once observed. Segments are memory-budget
+    // bound, so one sample is representative; the partitioned drain re-applies it to each
+    // per-cell writer's fresh disk guard.
+    sampled_segment_bytes: Option<u64>,
     // For a partitioned build: phase-1 routing and spill state. `None` on the regular path.
     partitioning: Option<PartitionSpill>,
     // The writer config, kept to reopen the per-cell writers on the partitioned drain.
@@ -552,7 +554,7 @@ impl<'a> WorkerBuildState<'a> {
             unmerged_metas: Default::default(),
             local_tuple_done_count: 0,
             is_leader,
-            recorded_segment_bytes: false,
+            sampled_segment_bytes: None,
             partitioning,
             writer_config: config,
             worker_number,
@@ -568,7 +570,7 @@ impl<'a> WorkerBuildState<'a> {
         let remaining = self.target_segment_count.saturating_sub(written);
 
         let mut segment_bytes = None;
-        if !self.recorded_segment_bytes {
+        if self.sampled_segment_bytes.is_none() {
             unsafe {
                 MetaPage::open(&self.indexrel)
                     .segment_metas()
@@ -578,7 +580,7 @@ impl<'a> WorkerBuildState<'a> {
                         }
                     });
             }
-            self.recorded_segment_bytes = segment_bytes.is_some();
+            self.sampled_segment_bytes = segment_bytes;
         }
 
         let Some(writer) = self.writer.as_mut() else {
@@ -876,14 +878,18 @@ impl<'a> WorkerBuildState<'a> {
             .indexrel
             .is_create_index()
             .then(|| DiskSpaceGuard::new(&self.indexrel));
-        self.writer = Some(
-            SerialIndexWriter::open(
-                &self.indexrel,
-                self.writer_config.clone(),
-                self.worker_number,
-            )?
-            .with_disk_guard(disk_guard),
-        );
+        let mut writer = SerialIndexWriter::open(
+            &self.indexrel,
+            self.writer_config.clone(),
+            self.worker_number,
+        )?
+        .with_disk_guard(disk_guard);
+        // The segment size is sampled once per build, so this writer's fresh guard has not
+        // seen it; without it the guard never projects and its check is a no-op.
+        if let Some(bytes) = self.sampled_segment_bytes {
+            writer.set_segment_byte_size(bytes);
+        }
+        self.writer = Some(writer);
         Ok(())
     }
 }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -370,6 +370,14 @@ fn decode_sort_record(bytes: &[u8]) -> (u32, u64) {
     (pid, ctid)
 }
 
+/// Upper bound on how many segments one cell merge takes as input. `SearchIndexMerger` holds
+/// every input segment open for the whole merge, and an overfull cell can hold many segments
+/// (a vector schema's per-segment doc cap makes hundreds plausible), so [`finish_cell`] merges
+/// in passes of at most this many rather than handing the merger the whole cell at once.
+///
+/// [`finish_cell`]: WorkerBuildState::finish_cell
+const CELL_MERGE_FANIN: usize = 32;
+
 /// Phase-1 state for a partitioned build: rows are not indexed during the scan. Each row is
 /// routed to a partition cell by the leader's kd-tree (`#5991`) and its `(pid, ctid)` assignment
 /// spills to a worker-local sort, which the phase-2 drain reads back in `(pid, ctid)` order.
@@ -508,7 +516,7 @@ impl<'a> WorkerBuildState<'a> {
         // Partitioned builds cut segments at cell boundaries instead, so their writers stay
         // memory-driven at their half of the worker budget. (A vector schema's doc cap in
         // `SerialIndexWriter::open` still applies; an overfull cell then flushes in capped
-        // segments that `finish_cell` merges, as `try_merge` does on the regular path.)
+        // segments that `finish_cell` merges back down in bounded passes.)
         let max_docs_per_segment = if partitioning.is_none() && worker_segment_target > 1 {
             Some(
                 plan::estimate_heap_reltuples(heaprel) as u32
@@ -681,13 +689,18 @@ impl<'a> WorkerBuildState<'a> {
         };
 
         pgrx::debug1!("try_merge: last merge {is_last_merge}");
-        self.merge_now(&segment_ids_to_merge)
+        self.merge_now(&segment_ids_to_merge)?;
+        Ok(())
     }
 
     /// Merge the given segments into a single segment and garbage collect the index, returning
     /// the reclaimed space to the fsm. Split out of [`Self::try_merge`] so the partitioned
-    /// build can merge a cell's segments without the chunk accounting.
-    fn merge_now(&mut self, segment_ids_to_merge: &[SegmentId]) -> anyhow::Result<()> {
+    /// build can merge a cell's segments without the chunk accounting. Returns the merged
+    /// segment's meta, if the merge produced one.
+    fn merge_now(
+        &mut self,
+        segment_ids_to_merge: &[SegmentId],
+    ) -> anyhow::Result<Option<SegmentMeta>> {
         pgrx::debug1!(
             "do_merge: about to merge {} segments: {:?}",
             segment_ids_to_merge.len(),
@@ -695,7 +708,7 @@ impl<'a> WorkerBuildState<'a> {
         );
         let mut merger = SearchIndexMerger::open(&self.indexrel, MvccSatisfies::Mergeable)?;
         unsafe { set_ps_display_suffix(MERGING.as_ptr()) };
-        merger.merge_segments(segment_ids_to_merge)?;
+        let merged = merger.merge_segments(segment_ids_to_merge)?;
 
         // garbage collect the index, returning to the fsm
         pgrx::debug1!("do_merge: garbage collecting");
@@ -706,7 +719,7 @@ impl<'a> WorkerBuildState<'a> {
 
         self.nmerges += 1;
 
-        Ok(())
+        Ok(merged)
     }
 
     /// Estimates how many segments this worker will make if no merging happens.
@@ -863,7 +876,10 @@ impl<'a> WorkerBuildState<'a> {
 
     /// Finalize the current cell: commit the writer's pending segment and, if the cell's rows
     /// exceeded the writer budget and flushed multiple segments, merge them down to one.
-    /// Merges stay scoped to a single cell within a single worker; never across workers.
+    /// Merges stay scoped to a single cell within a single worker; never across workers. Each
+    /// pass merges at most [`CELL_MERGE_FANIN`] segments and feeds the merged segment into the
+    /// next pass, so the merger's open-segment footprint stays bounded however overfull the
+    /// cell was.
     fn finish_cell(&mut self, cell_metas: &mut Vec<SegmentMeta>) -> anyhow::Result<()> {
         let writer = self
             .writer
@@ -874,9 +890,18 @@ impl<'a> WorkerBuildState<'a> {
             cell_metas.push(segment_meta);
         }
 
-        if cell_metas.len() > 1 {
-            let segment_ids = cell_metas.iter().map(|meta| meta.id()).collect::<Vec<_>>();
-            self.merge_now(&segment_ids)?;
+        while cell_metas.len() > 1 {
+            let mut next_pass = Vec::with_capacity(cell_metas.len().div_ceil(CELL_MERGE_FANIN));
+            for chunk in cell_metas.chunks(CELL_MERGE_FANIN) {
+                match chunk {
+                    [lone] => next_pass.push(lone.clone()),
+                    _ => {
+                        let ids = chunk.iter().map(|meta| meta.id()).collect::<Vec<_>>();
+                        next_pass.extend(self.merge_now(&ids)?);
+                    }
+                }
+            }
+            *cell_metas = next_pass;
         }
         cell_metas.clear();
         Ok(())

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -303,14 +303,9 @@ impl<'a> BuildWorker<'a> {
                 "build_worker {worker_number}: target_segment_count: {target_segment_count}, nlaunched: {nlaunched}, worker_segment_target: {worker_segment_target}"
             );
 
-            // Partitioned builds cover only non-concurrent CREATE INDEX for now: a concurrent
-            // build's deferred re-fetch could index row versions newer than its registered
-            // snapshot. CONCURRENTLY falls back to the regular per-row build path.
-            let partitioning = if self.config.concurrent {
-                None
-            } else {
-                self.partitioning.take()
-            };
+            // `build_index` plans boundaries only for a non-concurrent build, so this is `None`
+            // under CONCURRENTLY and the worker takes the regular per-row path.
+            let partitioning = self.partitioning.take();
             if let Some(partitioning) = &partitioning {
                 pgrx::debug1!("build_worker {worker_number}: partition boundaries: {partitioning}");
             }
@@ -1000,14 +995,22 @@ pub(super) fn build_index(
     };
 
     // Boundaries are fixed before any worker starts, so every worker cuts on the same ones.
+    // Partitioned builds cover only non-concurrent CREATE INDEX for now: a concurrent build's
+    // deferred re-fetch could index row versions newer than its registered snapshot, so under
+    // CONCURRENTLY skip the planning entirely: no heap sample, and no tree in the DSM for
+    // workers to deserialize and drop.
     // TODO(M3): the target segment count doubles as the partition count for now; rename the
     // reloption to `partition_count` once partitioned storage lands.
-    let partitioning = plan_partition_boundaries(
-        &heaprel,
-        &indexrel,
-        snapshot.0,
-        plan::adjusted_target_segment_count(&heaprel, &indexrel),
-    )?;
+    let partitioning = if concurrent {
+        None
+    } else {
+        plan_partition_boundaries(
+            &heaprel,
+            &indexrel,
+            snapshot.0,
+            plan::adjusted_target_segment_count(&heaprel, &indexrel),
+        )?
+    };
     if let Some(partitioning) = &partitioning {
         pgrx::debug1!(
             "build_index: {} partition boundaries:\n{}",

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -379,7 +379,7 @@ fn decode_sort_record(bytes: &[u8]) -> (u32, u64) {
 const CELL_MERGE_FANIN: usize = 32;
 
 /// Phase-1 state for a partitioned build: rows are not indexed during the scan. Each row is
-/// routed to a partition cell by the leader's kd-tree (`#5991`) and its `(pid, ctid)` assignment
+/// routed to a partition cell by the leader's kd-tree boundaries and its `(pid, ctid)` assignment
 /// spills to a worker-local sort, which the phase-2 drain reads back in `(pid, ctid)` order.
 struct PartitionSpill {
     tree: KdTree,
@@ -1473,7 +1473,7 @@ mod tests {
         assert_eq!(count, 1, "expected a single segment, got {count}");
     }
 
-    /// An index with `partition_by` routes each row to a kd-tree cell (#5991) and builds one
+    /// An index with `partition_by` routes each row to a kd-tree cell and builds one
     /// segment per cell per worker. Verify doc-count parity and the segment layout: a serial
     /// build makes exactly one segment per cell, and a parallel build keeps doc and search
     /// parity. `tenant_id` is scattered across the heap so a worker's arbitrary slice still

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -403,9 +403,8 @@ impl PartitionSpill {
         Ok(Self {
             tree,
             dim_fields,
-            // The sort spills on the worker's own budget. Its read buffers stay resident through
-            // the phase-2 drain while the writer runs at the full worker budget, so the transient
-            // overlap is bounded by one extra worker budget.
+            // The caller hands the sort its half of the worker budget: its buffers stay
+            // resident through the phase-2 drain while the cell writer runs on the other half.
             sorter: Sorter::new(budget.get()),
         })
     }
@@ -507,7 +506,7 @@ impl<'a> WorkerBuildState<'a> {
         // Any vector-specific doc cap is applied in `SerialIndexWriter::open`.
         //
         // Partitioned builds cut segments at cell boundaries instead, so their writers stay
-        // memory-driven at the full worker budget. (A vector schema's doc cap in
+        // memory-driven at their half of the worker budget. (A vector schema's doc cap in
         // `SerialIndexWriter::open` still applies; an overfull cell then flushes in capped
         // segments that `finish_cell` merges, as `try_merge` does on the regular path.)
         let max_docs_per_segment = if partitioning.is_none() && worker_segment_target > 1 {
@@ -519,8 +518,19 @@ impl<'a> WorkerBuildState<'a> {
         } else {
             None
         };
+        // A partitioned build has the spill sort's buffers and a cell writer's arena resident
+        // together during the phase-2 drain, so they split the worker budget evenly: the
+        // worker's peak stays at the share of `maintenance_work_mem` that
+        // `adjust_maintenance_work_mem` sized. The sort spills to disk sooner, and an overfull
+        // cell flushes more segments for `finish_cell` to merge down.
+        let per_writer_budget = if partitioning.is_some() {
+            NonZeroUsize::new((per_worker_memory_budget.get() / 2).max(1))
+                .expect("halved worker budget should be non-zero")
+        } else {
+            per_worker_memory_budget
+        };
         let config = IndexWriterConfig {
-            memory_budget: per_worker_memory_budget,
+            memory_budget: per_writer_budget,
             max_docs_per_segment,
         };
         // Abort the build early if it is projected not to fit on the tablespace volume.
@@ -534,7 +544,7 @@ impl<'a> WorkerBuildState<'a> {
         let created_by_version = indexrel.created_by_version();
 
         let partitioning = partitioning
-            .map(|tree| PartitionSpill::new(tree, &categorized_fields, per_worker_memory_budget))
+            .map(|tree| PartitionSpill::new(tree, &categorized_fields, per_writer_budget))
             .transpose()?;
 
         Ok(Self {
@@ -773,7 +783,7 @@ impl<'a> WorkerBuildState<'a> {
     /// Phase 2 of a partitioned build. The scan spilled one `(pid, ctid)` record per row; sorted,
     /// they cluster each cell's rows together, in heap order within the cell, so re-fetching
     /// revisits heap blocks under a reused buffer pin. Rows are re-fetched and indexed cell by
-    /// cell: only one writer is alive at a time, at the full worker budget, and each cell
+    /// cell: only one writer is alive at a time, on its half of the worker budget, and each cell
     /// boundary finalizes the current segment.
     fn drain_partitioned(&mut self) -> anyhow::Result<()> {
         let PartitionSpill { mut sorter, .. } = self
@@ -872,7 +882,7 @@ impl<'a> WorkerBuildState<'a> {
         Ok(())
     }
 
-    /// Open a fresh writer for the next cell, at the full worker budget.
+    /// Open a fresh writer for the next cell.
     fn open_cell_writer(&mut self) -> anyhow::Result<()> {
         let disk_guard = self
             .indexrel

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -542,16 +542,22 @@ impl<'a> WorkerBuildState<'a> {
                 .collect::<Vec<_>>()
         };
 
-        // do the merge
+        pgrx::debug1!("try_merge: last merge {is_last_merge}");
+        self.merge_now(&segment_ids_to_merge)
+    }
+
+    /// Merge the given segments into a single segment and garbage collect the index, returning
+    /// the reclaimed space to the fsm. Split out of [`Self::try_merge`] so the partitioned
+    /// build can merge a cell's segments without the chunk accounting.
+    fn merge_now(&mut self, segment_ids_to_merge: &[SegmentId]) -> anyhow::Result<()> {
         pgrx::debug1!(
-            "do_merge: last merge {}, about to merge {} segments: {:?}",
-            is_last_merge,
+            "do_merge: about to merge {} segments: {:?}",
             segment_ids_to_merge.len(),
             segment_ids_to_merge
         );
         let mut merger = SearchIndexMerger::open(&self.indexrel, MvccSatisfies::Mergeable)?;
         unsafe { set_ps_display_suffix(MERGING.as_ptr()) };
-        merger.merge_segments(&segment_ids_to_merge)?;
+        merger.merge_segments(segment_ids_to_merge)?;
 
         // garbage collect the index, returning to the fsm
         pgrx::debug1!("do_merge: garbage collecting");

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -30,8 +30,10 @@ use crate::parallel_worker::{
 };
 use crate::postgres::build_partitioning::plan_partition_boundaries;
 use crate::postgres::composite::CompositeSlotValues;
+use crate::postgres::heap::{ExpressionState, HeapDocFetcher, HeapFetchState};
 use crate::postgres::locks::Spinlock;
 use crate::postgres::merge::garbage_collect_index;
+use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::ps_status::{
     COMMITTING, FINALIZING, GARBAGE_COLLECTING, INDEXING, MERGING, set_ps_display_remove_suffix,
     set_ps_display_suffix,
@@ -39,14 +41,16 @@ use crate::postgres::ps_status::{
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::buffer::BufferManager;
 use crate::postgres::storage::metadata::MetaPage;
+use crate::postgres::tuplesort::Sorter;
 use crate::postgres::utils::{
     collect_composites_for_unpacking, get_field_value, row_to_search_document,
+    scalar_datum_to_tantivy_value, unwrap_alias_datum,
 };
 use crate::schema::{CategorizedFieldData, SearchField};
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::{
-    PgLogLevel, PgMemoryContexts, PgSqlErrorCode, check_for_interrupts, function_name, pg_guard,
-    pg_sys,
+    PgLogLevel, PgMemoryContexts, PgSqlErrorCode, PgTupleDesc, check_for_interrupts, function_name,
+    pg_guard, pg_sys,
 };
 use std::num::NonZeroUsize;
 use std::ptr::{NonNull, addr_of_mut};
@@ -298,7 +302,16 @@ impl<'a> BuildWorker<'a> {
             pgrx::debug1!(
                 "build_worker {worker_number}: target_segment_count: {target_segment_count}, nlaunched: {nlaunched}, worker_segment_target: {worker_segment_target}"
             );
-            if let Some(partitioning) = &self.partitioning {
+
+            // Partitioned builds cover only non-concurrent CREATE INDEX for now: a concurrent
+            // build's deferred re-fetch could index row versions newer than its registered
+            // snapshot. CONCURRENTLY falls back to the regular per-row build path.
+            let partitioning = if self.config.concurrent {
+                None
+            } else {
+                self.partitioning.take()
+            };
+            if let Some(partitioning) = &partitioning {
                 pgrx::debug1!("build_worker {worker_number}: partition boundaries: {partitioning}");
             }
 
@@ -314,6 +327,7 @@ impl<'a> BuildWorker<'a> {
                 self.coordination,
                 worker_number,
                 is_leader,
+                partitioning,
             )?;
 
             set_ps_display_suffix(INDEXING.as_ptr());
@@ -331,9 +345,107 @@ impl<'a> BuildWorker<'a> {
                     .unwrap_or(std::ptr::null_mut()),
             );
 
-            build_state.commit()?;
+            if build_state.partitioning.is_some() {
+                build_state.drain_partitioned()?;
+            } else {
+                build_state.commit()?;
+            }
             Ok((reltuples as f64, build_state.nmerges))
         }
+    }
+}
+
+/// Fixed length of an encoded `(pid, ctid)` sort record: a big-endian `u32` then `u64`, so the
+/// `bytea` memcmp the sort orders by is exactly `(pid, ctid)` order.
+const SORT_RECORD_LEN: usize = 12;
+
+/// Encode one `(pid, ctid)` assignment for the spill sort.
+fn encode_sort_record(pid: u32, ctid: u64) -> [u8; SORT_RECORD_LEN] {
+    let mut record = [0u8; SORT_RECORD_LEN];
+    record[..4].copy_from_slice(&pid.to_be_bytes());
+    record[4..].copy_from_slice(&ctid.to_be_bytes());
+    record
+}
+
+/// Decode a record produced by [`encode_sort_record`].
+fn decode_sort_record(bytes: &[u8]) -> (u32, u64) {
+    debug_assert_eq!(bytes.len(), SORT_RECORD_LEN);
+    let pid = u32::from_be_bytes(bytes[..4].try_into().expect("record should hold a pid"));
+    let ctid = u64::from_be_bytes(bytes[4..].try_into().expect("record should hold a ctid"));
+    (pid, ctid)
+}
+
+/// Phase-1 state for a partitioned build: rows are not indexed during the scan. Each row is
+/// routed to a partition cell by the leader's kd-tree (`#5991`) and its `(pid, ctid)` assignment
+/// spills to a worker-local sort, which the phase-2 drain reads back in `(pid, ctid)` order.
+struct PartitionSpill {
+    tree: KdTree,
+    /// The `partition_by` fields in `tree.dims()` order, resolved to the index's categorized
+    /// fields so the callback can project each scanned row onto them.
+    dim_fields: Vec<(SearchField, CategorizedFieldData)>,
+    sorter: Sorter,
+}
+
+impl PartitionSpill {
+    fn new(
+        tree: KdTree,
+        categorized_fields: &[(SearchField, CategorizedFieldData)],
+        budget: NonZeroUsize,
+    ) -> anyhow::Result<Self> {
+        let dim_fields = tree
+            .dims()
+            .iter()
+            .map(|dim| {
+                categorized_fields
+                    .iter()
+                    .find(|(field, _)| field.field_name() == dim)
+                    .cloned()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("partition_by field `{dim}` is not an indexed field")
+                    })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(Self {
+            tree,
+            dim_fields,
+            // The sort spills on the worker's own budget. Its read buffers stay resident through
+            // the phase-2 drain while the writer runs at the full worker budget, so the transient
+            // overlap is bounded by one extra worker budget.
+            sorter: Sorter::new(budget.get()),
+        })
+    }
+
+    /// Route one scanned row to its cell by projecting it onto the `partition_by` dimensions and
+    /// consulting the kd-tree. `unpacked_composites` must be built over the full field set so a
+    /// composite `partition_by` field resolves the same way the document build would.
+    unsafe fn route(
+        &self,
+        values: *mut pg_sys::Datum,
+        isnull: *mut bool,
+        unpacked_composites: &CompositeSlotValues,
+    ) -> anyhow::Result<usize> {
+        let point = self
+            .dim_fields
+            .iter()
+            .map(|(field, categorized)| {
+                let (datum, is_null) = get_field_value(
+                    &categorized.source,
+                    categorized.attno,
+                    values,
+                    isnull,
+                    unpacked_composites,
+                );
+                if is_null {
+                    return Ok(PdbOwnedValue::Null);
+                }
+                let datum = unwrap_alias_datum(datum, categorized.pg_type);
+                Ok(
+                    scalar_datum_to_tantivy_value(datum, field.field_type(), categorized.base_oid)?
+                        .0,
+                )
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(self.tree.route(&point))
     }
 }
 
@@ -370,6 +482,11 @@ struct WorkerBuildState<'a> {
     is_leader: bool,
     // whether the first flushed segment's on-disk size has been reported to the disk guard
     recorded_segment_bytes: bool,
+    // For a partitioned build: phase-1 routing and spill state. `None` on the regular path.
+    partitioning: Option<PartitionSpill>,
+    // The writer config, kept to reopen the per-cell writers on the partitioned drain.
+    writer_config: IndexWriterConfig,
+    worker_number: i32,
 }
 
 impl<'a> WorkerBuildState<'a> {
@@ -385,12 +502,18 @@ impl<'a> WorkerBuildState<'a> {
         coordination: &'a mut WorkerCoordination,
         worker_number: i32,
         is_leader: bool,
+        partitioning: Option<KdTree>,
     ) -> anyhow::Result<Self> {
         // If we're making more than one segment, do an early cutoff based on doc
         // count in case the memory budget is so high that all the docs fit into one
         // segment. For a single-segment target, leave it unbounded (memory-driven).
         // Any vector-specific doc cap is applied in `SerialIndexWriter::open`.
-        let max_docs_per_segment = if worker_segment_target > 1 {
+        //
+        // Partitioned builds cut segments at cell boundaries instead, so their writers stay
+        // memory-driven at the full worker budget. (A vector schema's doc cap in
+        // `SerialIndexWriter::open` still applies; an overfull cell then flushes in capped
+        // segments that `finish_cell` merges, as `try_merge` does on the regular path.)
+        let max_docs_per_segment = if partitioning.is_none() && worker_segment_target > 1 {
             Some(
                 plan::estimate_heap_reltuples(heaprel) as u32
                     / coordination.nlaunched as u32
@@ -407,11 +530,16 @@ impl<'a> WorkerBuildState<'a> {
         let disk_guard = indexrel
             .is_create_index()
             .then(|| DiskSpaceGuard::new(indexrel));
-        let writer =
-            SerialIndexWriter::open(indexrel, config, worker_number)?.with_disk_guard(disk_guard);
+        let writer = SerialIndexWriter::open(indexrel, config.clone(), worker_number)?
+            .with_disk_guard(disk_guard);
         let schema = writer.schema();
         let categorized_fields = schema.categorized_fields().clone();
         let created_by_version = indexrel.created_by_version();
+
+        let partitioning = partitioning
+            .map(|tree| PartitionSpill::new(tree, &categorized_fields, per_worker_memory_budget))
+            .transpose()?;
+
         Ok(Self {
             writer: Some(writer),
             categorized_fields,
@@ -430,6 +558,9 @@ impl<'a> WorkerBuildState<'a> {
             local_tuple_done_count: 0,
             is_leader,
             recorded_segment_bytes: false,
+            partitioning,
+            writer_config: config,
+            worker_number,
         })
     }
 
@@ -583,6 +714,174 @@ impl<'a> WorkerBuildState<'a> {
             nsegments
         })
     }
+
+    /// Phase-1 handling for a partitioned build: route the scanned row to its cell and spill the
+    /// `(pid, ctid)` assignment to the worker-local sort. Composites are unpacked over the full
+    /// field set so a composite `partition_by` field resolves the same way the document build
+    /// would.
+    unsafe fn route_and_spill(
+        &mut self,
+        values: *mut pg_sys::Datum,
+        isnull: *mut bool,
+        ctid: u64,
+    ) -> anyhow::Result<()> {
+        let unpacked_composites =
+            CompositeSlotValues::from_composites(collect_composites_for_unpacking(
+                self.categorized_fields.iter().map(|(_, cat)| cat),
+                values,
+                isnull,
+            ));
+        let partitioning = self
+            .partitioning
+            .as_mut()
+            .expect("route_and_spill: partitioning should be set");
+        let pid = partitioning.route(values, isnull, &unpacked_composites)?;
+        partitioning
+            .sorter
+            .put(&encode_sort_record(pid as u32, ctid));
+        Ok(())
+    }
+
+    /// Bump the worker-local tuple count and periodically fold it into the shared progress
+    /// counter (`pg_stat_progress_create_index.tuples_done`).
+    fn count_tuple_done(&mut self) {
+        self.local_tuple_done_count += 1;
+
+        if self
+            .local_tuple_done_count
+            .is_multiple_of(TUPLES_DONE_BATCH_SIZE)
+        {
+            self.coordination.add_tuples_done(TUPLES_DONE_BATCH_SIZE);
+
+            if self.is_leader {
+                unsafe {
+                    pg_sys::pgstat_progress_update_param(
+                        pg_sys::PROGRESS_CREATEIDX_TUPLES_DONE as i32,
+                        self.coordination.tuples_done() as i64,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Phase 2 of a partitioned build. The scan spilled one `(pid, ctid)` record per row; sorted,
+    /// they cluster each cell's rows together, in heap order within the cell, so re-fetching
+    /// revisits heap blocks under a reused buffer pin. Rows are re-fetched and indexed cell by
+    /// cell: only one writer is alive at a time, at the full worker budget, and each cell
+    /// boundary finalizes the current segment.
+    fn drain_partitioned(&mut self) -> anyhow::Result<()> {
+        let PartitionSpill { mut sorter, .. } = self
+            .partitioning
+            .take()
+            .expect("drain_partitioned: partitioning state should be set");
+        sorter.performsort();
+
+        let heaprel = self.heaprel.clone();
+        let indexrel = self.indexrel.clone();
+        let heap_fetch_state = HeapFetchState::new(&heaprel);
+        let expression_state = ExpressionState::new(&indexrel);
+        let heaptupdesc = unsafe { PgTupleDesc::from_pg_unchecked(heaprel.rd_att) };
+        let categorized_fields = self.categorized_fields.clone();
+        let mut fetcher = HeapDocFetcher::new(
+            &heap_fetch_state,
+            &expression_state,
+            &heaprel,
+            &heaptupdesc,
+            &categorized_fields,
+            self.index_created_by_version,
+            // Like any CREATE INDEX, the build must index every live row so that the
+            // segments can serve future snapshots: fetch with maintenance semantics.
+            false,
+        )
+        // The scan callback spilled HOT chain root ctids; index each chain's live tail,
+        // as the inline callback would have.
+        .with_root_ctids();
+
+        let mut current_pid: Option<u32> = None;
+        let mut cell_metas: Vec<SegmentMeta> = Vec::new();
+        while let Some(record) = sorter.next_sorted() {
+            check_for_interrupts!();
+            let (pid, ctid) = decode_sort_record(record);
+
+            if current_pid != Some(pid) {
+                if current_pid.is_some() {
+                    self.finish_cell(&mut cell_metas)?;
+                }
+                if self.writer.is_none() {
+                    self.open_cell_writer()?;
+                }
+                current_pid = Some(pid);
+            }
+
+            // The doc's palloc traffic (detoast copies, expression evaluation) lands in the
+            // per-row context; the insert runs outside the closure because both the writer and
+            // the context live on `self`, and the doc's values are Rust-owned by then anyway.
+            let doc = unsafe { self.per_row_context.switch_to(|_| fetcher.fetch_doc(ctid)) };
+            if let Some(doc) = doc {
+                let segment_meta = self
+                    .writer
+                    .as_mut()
+                    .expect("drain_partitioned: writer should be set")
+                    .insert(doc, ctid, || unsafe {
+                        set_ps_display_suffix(COMMITTING.as_ptr())
+                    })?;
+                if let Some(segment_meta) = segment_meta {
+                    self.on_segment_flushed(segment_meta.id());
+                    cell_metas.push(segment_meta);
+                    unsafe { set_ps_display_suffix(INDEXING.as_ptr()) };
+                }
+            }
+            unsafe { self.per_row_context.reset() };
+            self.count_tuple_done();
+        }
+        // The sort's read side is done; release its memory before the final cell's commit and
+        // merge stack on top of it.
+        sorter.end();
+        if current_pid.is_some() {
+            self.finish_cell(&mut cell_metas)?;
+        }
+
+        unsafe { set_ps_display_remove_suffix() };
+        Ok(())
+    }
+
+    /// Finalize the current cell: commit the writer's pending segment and, if the cell's rows
+    /// exceeded the writer budget and flushed multiple segments, merge them down to one.
+    /// Merges stay scoped to a single cell within a single worker; never across workers.
+    fn finish_cell(&mut self, cell_metas: &mut Vec<SegmentMeta>) -> anyhow::Result<()> {
+        let writer = self
+            .writer
+            .take()
+            .expect("finish_cell: writer should be set");
+        if let Some((segment_meta, _)) = writer.commit()? {
+            self.on_segment_flushed(segment_meta.id());
+            cell_metas.push(segment_meta);
+        }
+
+        if cell_metas.len() > 1 {
+            let segment_ids = cell_metas.iter().map(|meta| meta.id()).collect::<Vec<_>>();
+            self.merge_now(&segment_ids)?;
+        }
+        cell_metas.clear();
+        Ok(())
+    }
+
+    /// Open a fresh writer for the next cell, at the full worker budget.
+    fn open_cell_writer(&mut self) -> anyhow::Result<()> {
+        let disk_guard = self
+            .indexrel
+            .is_create_index()
+            .then(|| DiskSpaceGuard::new(&self.indexrel));
+        self.writer = Some(
+            SerialIndexWriter::open(
+                &self.indexrel,
+                self.writer_config.clone(),
+                self.worker_number,
+            )?
+            .with_disk_guard(disk_guard),
+        );
+        Ok(())
+    }
 }
 
 #[pg_guard]
@@ -598,6 +897,17 @@ unsafe extern "C-unwind" fn build_callback(
 
     let build_state = &mut *state.cast::<WorkerBuildState>();
     let ctid_u64 = crate::postgres::utils::item_pointer_to_u64(*ctid);
+
+    // Partitioned build, phase 1: rows are not indexed during the scan. Route the row to its
+    // cell and spill the (pid, ctid) assignment to the worker-local sort; the phase-2 drain
+    // re-fetches and indexes rows cell by cell. tuples_done is reported from that drain, which
+    // does this row's actual indexing work; scan progress is visible through blocks_done.
+    if build_state.partitioning.is_some() {
+        build_state
+            .route_and_spill(values, isnull, ctid_u64)
+            .unwrap_or_else(|e| panic!("could not route row for partitioned build: {e}"));
+        return;
+    }
 
     let segment_meta = build_state.per_row_context.switch_to(|_| {
         let mut doc = TantivyDocument::new();
@@ -638,20 +948,7 @@ unsafe extern "C-unwind" fn build_callback(
     });
     build_state.per_row_context.reset();
 
-    build_state.local_tuple_done_count += 1;
-
-    if build_state.local_tuple_done_count % TUPLES_DONE_BATCH_SIZE == 0 {
-        build_state
-            .coordination
-            .add_tuples_done(TUPLES_DONE_BATCH_SIZE);
-
-        if build_state.is_leader {
-            pg_sys::pgstat_progress_update_param(
-                pg_sys::PROGRESS_CREATEIDX_TUPLES_DONE as i32,
-                build_state.coordination.tuples_done() as i64,
-            );
-        }
-    }
+    build_state.count_tuple_done();
 
     if let Some(segment_meta) = segment_meta {
         build_state.on_segment_flushed(segment_meta.id());

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -720,21 +720,30 @@ impl<'a> WorkerBuildState<'a> {
         isnull: *mut bool,
         ctid: u64,
     ) -> anyhow::Result<()> {
-        let unpacked_composites =
-            CompositeSlotValues::from_composites(collect_composites_for_unpacking(
-                self.categorized_fields.iter().map(|(_, cat)| cat),
-                values,
-                isnull,
-            ));
+        let categorized_fields = &self.categorized_fields;
         let partitioning = self
             .partitioning
             .as_mut()
             .expect("route_and_spill: partitioning should be set");
-        let pid = partitioning.route(values, isnull, &unpacked_composites)?;
-        partitioning
-            .sorter
-            .put(&encode_sort_record(pid as u32, ctid));
-        Ok(())
+        // Routing pallocs per row (composite unpacking, detoast, numeric conversion) and the
+        // callback's context lives for the whole scan, so run it in the per-row context and
+        // reset after, like the document branch. `Sorter::put` copies the record into the
+        // sort's own context, so it survives the reset.
+        let result = self.per_row_context.switch_to(|_| {
+            let unpacked_composites =
+                CompositeSlotValues::from_composites(collect_composites_for_unpacking(
+                    categorized_fields.iter().map(|(_, cat)| cat),
+                    values,
+                    isnull,
+                ));
+            let pid = partitioning.route(values, isnull, &unpacked_composites)?;
+            partitioning
+                .sorter
+                .put(&encode_sort_record(pid as u32, ctid));
+            Ok(())
+        });
+        self.per_row_context.reset();
+        result
     }
 
     /// Bump the worker-local tuple count and periodically fold it into the shared progress

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -1419,4 +1419,182 @@ mod tests {
         .unwrap();
         assert_eq!(count, 1, "expected a single segment, got {count}");
     }
+
+    /// An index with `partition_by` routes each row to a kd-tree cell (#5991) and builds one
+    /// segment per cell per worker. Verify doc-count parity and the segment layout: a serial
+    /// build makes exactly one segment per cell, and a parallel build keeps doc and search
+    /// parity. `tenant_id` is scattered across the heap so a worker's arbitrary slice still
+    /// covers every cell.
+    #[pg_test]
+    fn test_partitioned_build_segments_and_docs() {
+        // The heap must exceed the 15MB floor in `adjusted_target_segment_count`, or the target
+        // collapses to a single cell. A ~900-byte name over 20k rows clears it while staying
+        // under the TOAST threshold. `tenant_id` is scattered across the heap.
+        Spi::run(
+            r#"
+            CREATE TABLE partitioned_build (id BIGSERIAL PRIMARY KEY, tenant_id BIGINT, name TEXT);
+            INSERT INTO partitioned_build (tenant_id, name)
+            SELECT (i * 7919) % 100, 'lorem ipsum ' || i || ' ' || repeat('padding word here ', 50)
+            FROM generate_series(1, 20000) i;
+            "#,
+        )
+        .unwrap();
+
+        // Serial build: a single worker sees every cell, so it emits exactly one segment per
+        // cell (the kd-tree's partition count).
+        Spi::run("SET max_parallel_maintenance_workers = 0;").unwrap();
+        Spi::run(
+            "CREATE INDEX partitioned_build_idx ON partitioned_build USING paradedb (id, tenant_id, name) WITH (key_field = 'id', partition_by = 'tenant_id', target_segment_count = 8);",
+        )
+        .unwrap();
+
+        let count: i64 = Spi::get_one(
+            "SELECT COUNT(*)::bigint FROM paradedb.index_info('partitioned_build_idx');",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(count, 8, "serial partitioned build: one segment per cell");
+
+        let num_docs: i64 = Spi::get_one(
+            "SELECT COALESCE(SUM(num_docs), 0)::bigint FROM paradedb.index_info('partitioned_build_idx');",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            num_docs, 20000,
+            "serial partitioned build indexes every row"
+        );
+
+        let matches: i64 = Spi::get_one(
+            "SELECT COUNT(*)::bigint FROM partitioned_build WHERE partitioned_build @@@ 'name:lorem';",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            matches, 20000,
+            "search through the serial partitioned index"
+        );
+
+        // Parallel build: 2 workers, each covering every cell, so the layout is between the cell
+        // count and cells x workers. Doc and search parity must hold regardless.
+        Spi::run("DROP INDEX partitioned_build_idx;").unwrap();
+        Spi::run("SET max_parallel_workers = 8;").unwrap();
+        Spi::run("SET max_parallel_maintenance_workers = 2;").unwrap();
+        Spi::run("SET parallel_leader_participation = false;").unwrap();
+        Spi::run("SET maintenance_work_mem = '128MB';").unwrap();
+        Spi::run(
+            "CREATE INDEX partitioned_build_idx ON partitioned_build USING paradedb (id, tenant_id, name) WITH (key_field = 'id', partition_by = 'tenant_id', target_segment_count = 8);",
+        )
+        .unwrap();
+
+        let count: i64 = Spi::get_one(
+            "SELECT COUNT(*)::bigint FROM paradedb.index_info('partitioned_build_idx');",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(
+            (8..=16).contains(&count),
+            "parallel partitioned build: 8 to 16 segments, got {count}"
+        );
+
+        let num_docs: i64 = Spi::get_one(
+            "SELECT COALESCE(SUM(num_docs), 0)::bigint FROM paradedb.index_info('partitioned_build_idx');",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            num_docs, 20000,
+            "parallel partitioned build indexes every row"
+        );
+
+        let matches: i64 = Spi::get_one(
+            "SELECT COUNT(*)::bigint FROM partitioned_build WHERE partitioned_build @@@ 'name:lorem';",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            matches, 20000,
+            "search through the parallel partitioned index"
+        );
+
+        Spi::run("DROP TABLE partitioned_build;").unwrap();
+    }
+
+    /// A HOT update superseding a row in the same transaction as CREATE INDEX leaves the chain
+    /// root DELETE_IN_PROGRESS at drain time. The partitioned drain re-fetches by root ctid and
+    /// must walk the chain to the live tail, indexing the value the inline build callback
+    /// delivered, not the superseded version's. The whole test runs in one transaction (pgrx
+    /// wraps each test in one), which is exactly the same-transaction scenario; a low fillfactor
+    /// keeps the update on-page (HOT).
+    #[pg_test]
+    fn test_partitioned_build_indexes_live_hot_member() {
+        Spi::run(
+            r#"
+            CREATE TABLE partitioned_hot (id BIGSERIAL PRIMARY KEY, tenant_id BIGINT, name TEXT)
+                WITH (fillfactor = 20);
+            INSERT INTO partitioned_hot (tenant_id, name)
+            SELECT (i * 7919) % 8, 'filler ' || i FROM generate_series(1, 200) i;
+            INSERT INTO partitioned_hot (tenant_id, name) VALUES (3, 'stalemarker');
+            UPDATE partitioned_hot SET name = 'freshmarker' WHERE name = 'stalemarker';
+            CREATE INDEX partitioned_hot_idx ON partitioned_hot USING paradedb (id, tenant_id, name) WITH (key_field = 'id', partition_by = 'tenant_id', target_segment_count = 2);
+            "#,
+        )
+        .unwrap();
+
+        let fresh: i64 = Spi::get_one(
+            "SELECT COUNT(*)::bigint FROM partitioned_hot WHERE partitioned_hot @@@ 'name:freshmarker';",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(fresh, 1, "the live row version must be indexed");
+
+        let stale: i64 = Spi::get_one(
+            "SELECT COUNT(*)::bigint FROM partitioned_hot WHERE partitioned_hot @@@ 'name:stalemarker';",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(stale, 0, "the superseded row version must not be indexed");
+    }
+
+    /// A cell whose rows outgrow the writer budget flushes multiple segments mid-cell;
+    /// finish_cell must merge them back down so the layout stays one segment per cell.
+    #[pg_test]
+    fn test_partitioned_build_merges_overfull_cells() {
+        // High-entropy text (every md5 distinct) so the writer's arena genuinely outgrows the
+        // small budget within each cell. Values stay under the TOAST threshold so the heap keeps
+        // its bytes in the main fork.
+        Spi::run(
+            r#"
+            CREATE TABLE partitioned_overfull (id BIGSERIAL PRIMARY KEY, tenant_id BIGINT, name TEXT);
+            INSERT INTO partitioned_overfull (tenant_id, name)
+            SELECT (i * 7919) % 4,
+                   (SELECT string_agg(md5((i * 32 + j)::text), ' ') FROM generate_series(1, 32) j)
+            FROM generate_series(1, 24000) i;
+            "#,
+        )
+        .unwrap();
+        Spi::run("SET max_parallel_maintenance_workers = 0;").unwrap();
+        Spi::run("SET maintenance_work_mem = '16MB';").unwrap();
+        Spi::run(
+            "CREATE INDEX partitioned_overfull_idx ON partitioned_overfull USING paradedb (id, tenant_id, name) WITH (key_field = 'id', partition_by = 'tenant_id', target_segment_count = 2);",
+        )
+        .unwrap();
+
+        let count: i64 = Spi::get_one(
+            "SELECT COUNT(*)::bigint FROM paradedb.index_info('partitioned_overfull_idx');",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            count, 2,
+            "overfull cells must merge down to one segment each"
+        );
+
+        let num_docs: i64 = Spi::get_one(
+            "SELECT COALESCE(SUM(num_docs), 0)::bigint FROM paradedb.index_info('partitioned_overfull_idx');",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(num_docs, 24000, "merged cells must keep every row");
+    }
 }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -1650,4 +1650,84 @@ mod tests {
         .unwrap();
         assert_eq!(num_docs, 24000, "merged cells must keep every row");
     }
+
+    /// The partitioned build must return the same rows a non-partitioned build would, serial
+    /// and parallel: the other tests check totals, which would not catch a row misrouted or
+    /// dropped inside a cell. `partition_by` spans two fields, one of them text, so the
+    /// multi-dimensional projection and a detoastable dimension go through the routing spill.
+    /// `tenant_id` is scattered across the heap so each worker's slice spans every cell.
+    #[pg_test]
+    fn test_partitioned_build_result_parity() {
+        // ~950-byte rows over 20k rows clear the 15MB floor in `adjusted_target_segment_count`
+        // so the target of 8 yields real cells, while staying under the TOAST threshold.
+        Spi::run(
+            r#"
+            CREATE TABLE partitioned_parity (id BIGSERIAL PRIMARY KEY, tenant_id BIGINT, message TEXT);
+            INSERT INTO partitioned_parity (tenant_id, message)
+            SELECT (i * 7919) % 16,
+                   'doc ' || i || ' ' || (ARRAY['alpha', 'beta', 'gamma'])[1 + i % 3]
+                       || ' ' || repeat('padding word here ', 50)
+            FROM generate_series(1, 20000) i;
+            "#,
+        )
+        .unwrap();
+
+        let ids_for = |query: &str| -> String {
+            Spi::get_one::<String>(&format!(
+                "SELECT COALESCE(string_agg(id::text, ',' ORDER BY id), '') \
+                 FROM partitioned_parity WHERE partitioned_parity @@@ '{query}';"
+            ))
+            .unwrap()
+            .unwrap()
+        };
+
+        // Ground truth: a non-partitioned index over the same rows.
+        Spi::run("SET max_parallel_maintenance_workers = 0;").unwrap();
+        Spi::run(
+            "CREATE INDEX partitioned_parity_plain ON partitioned_parity USING paradedb (id, tenant_id, message) WITH (key_field = 'id');",
+        )
+        .unwrap();
+        let expected_alpha = ids_for("message:alpha");
+        let expected_beta = ids_for("message:beta");
+        let expected_all = ids_for("message:doc");
+        assert!(
+            !expected_alpha.is_empty(),
+            "baseline should match some rows"
+        );
+        Spi::run("DROP INDEX partitioned_parity_plain;").unwrap();
+
+        let assert_parity = |label: &str| {
+            assert_eq!(
+                ids_for("message:alpha"),
+                expected_alpha,
+                "{label}: alpha rows differ"
+            );
+            assert_eq!(
+                ids_for("message:beta"),
+                expected_beta,
+                "{label}: beta rows differ"
+            );
+            assert_eq!(
+                ids_for("message:doc"),
+                expected_all,
+                "{label}: full set differs"
+            );
+        };
+        let create_partitioned = "CREATE INDEX partitioned_parity_idx ON partitioned_parity USING paradedb (id, tenant_id, message) WITH (key_field = 'id', partition_by = 'tenant_id, message', target_segment_count = 8);";
+
+        // Serial build.
+        Spi::run(create_partitioned).unwrap();
+        assert_parity("serial");
+        Spi::run("DROP INDEX partitioned_parity_idx;").unwrap();
+
+        // Parallel build over the same rows: the result set must not change.
+        Spi::run("SET max_parallel_workers = 8;").unwrap();
+        Spi::run("SET max_parallel_maintenance_workers = 4;").unwrap();
+        Spi::run("SET parallel_leader_participation = false;").unwrap();
+        Spi::run("SET maintenance_work_mem = '128MB';").unwrap();
+        Spi::run(create_partitioned).unwrap();
+        assert_parity("parallel");
+
+        Spi::run("DROP TABLE partitioned_parity;").unwrap();
+    }
 }

--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -585,6 +585,7 @@ pub struct HeapDocFetcher<'a> {
     created_by_version: Option<Version>,
     oldest_xmin: pg_sys::TransactionId,
     query_visible: bool,
+    root_ctids: bool,
     values: Vec<pg_sys::Datum>,
     isnull: Vec<bool>,
 }
@@ -609,9 +610,25 @@ impl<'a> HeapDocFetcher<'a> {
             created_by_version,
             oldest_xmin,
             query_visible,
+            root_ctids: false,
             values: vec![pg_sys::Datum::null(); heaptupdesc.len()],
             isnull: vec![false; heaptupdesc.len()],
         }
+    }
+
+    /// The ctids this fetcher will receive are HOT chain roots from a table scan (what an index
+    /// build callback hands over), not exact member ctids. In maintenance mode the fetch must
+    /// then walk past superseded chain members to the live tail: the member whose values the
+    /// inline build callback delivered for the root. Without this, a chain whose root is still
+    /// RECENTLY_DEAD, or DELETE_IN_PROGRESS in this transaction, would have the superseded
+    /// version's values indexed under the root ctid.
+    ///
+    /// Exact-ctid callers (rebuilding docs for ctids that an index entry points at) must NOT
+    /// set this: with the index in place, HOT guarantees the chain members agree on indexed
+    /// columns, and the first surviving member is the version the entry was made for.
+    pub fn with_root_ctids(mut self) -> Self {
+        self.root_ctids = true;
+        self
     }
 
     /// Fetch `ctid` and build the document the index would hold for it, or `None` when there is
@@ -719,6 +736,21 @@ impl<'a> HeapDocFetcher<'a> {
                         // visible in any transaction.
                         return None;
                     }
+                }
+
+                if self.root_ctids
+                    && call_again
+                    && (htsv_result == pg_sys::HTSV_Result::HEAPTUPLE_RECENTLY_DEAD
+                        || htsv_result == pg_sys::HTSV_Result::HEAPTUPLE_DELETE_IN_PROGRESS)
+                {
+                    // This member survives for old snapshots, but the chain continues: a newer
+                    // member carries the values the build callback delivered for this root.
+                    // Skip forward so the segment holds the live version, matching what
+                    // heapam_index_build_range_scan indexes for a broken HOT chain. (A LIVE
+                    // member whose updater aborted also reports call_again; it correctly
+                    // breaks below, since its successor is dead.)
+                    pg_sys::ExecClearTuple(self.fetch_state.slot());
+                    continue 'next_hot_chain;
                 }
 
                 // We successfully fetched a tuple. Break out to fetch and deform it.

--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -17,11 +17,15 @@
 
 use std::ops::Deref;
 
+use crate::api::version::Version;
+use crate::postgres::composite::CompositeSlotValues;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::buffer::{BorrowedBuffer, BufferManager, PinnedBuffer};
 use crate::postgres::utils;
-use pgrx::PgList;
+use crate::schema::{CategorizedFieldData, FieldSource, SearchField};
 use pgrx::pg_sys;
+use pgrx::{PgList, PgTupleDesc};
+use tantivy::TantivyDocument;
 
 /// A pinned heap buffer that releases its pin on drop. It stays off the index block tracker
 /// that `PinnedBuffer` feeds. That tracker keys blocks by number with no relation, so a heap
@@ -552,6 +556,259 @@ impl ExpressionState {
             }
         }
         expr_results
+    }
+}
+
+/// Rebuilds the index document for individual ctids by re-fetching their rows from the heap.
+///
+/// Bundles the per-relation state needed to turn one ctid into the `TantivyDocument` the index
+/// holds for it. Fetches reuse the [`HeapFetchState`]'s buffer pins, so feeding ctids in heap
+/// order keeps same-block fetches on a pinned buffer.
+///
+/// Query-visible mode (`query_visible: true`) fetches each ctid with the active MVCC snapshot
+/// so that detoasting is safe: that registered snapshot holds back the global xmin horizon,
+/// preventing a concurrent VACUUM from reclaiming the external TOAST chunks we read. Fetching
+/// such rows with `SnapshotAny` could instead select DEAD / RECENTLY_DEAD versions whose TOAST
+/// has already been (or is being) freed, raising spurious "missing/unexpected chunk number ...
+/// in pg_toast_*" errors.
+///
+/// Maintenance mode (`query_visible: false`) must index every live ctid regardless of any
+/// single snapshot, since the resulting segment may serve future snapshots, so it fetches with
+/// `SnapshotAny` and filters dead tuples with `HeapTupleSatisfiesVacuum`, walking HOT chains
+/// for a live member. See: <https://github.com/paradedb/paradedb/issues/5365>
+pub struct HeapDocFetcher<'a> {
+    fetch_state: &'a HeapFetchState,
+    expression_state: &'a ExpressionState,
+    heaprel: &'a PgSearchRelation,
+    heaptupdesc: &'a PgTupleDesc<'a>,
+    categorized_fields: &'a [(SearchField, CategorizedFieldData)],
+    created_by_version: Option<Version>,
+    oldest_xmin: pg_sys::TransactionId,
+    query_visible: bool,
+    values: Vec<pg_sys::Datum>,
+    isnull: Vec<bool>,
+}
+
+impl<'a> HeapDocFetcher<'a> {
+    pub fn new(
+        fetch_state: &'a HeapFetchState,
+        expression_state: &'a ExpressionState,
+        heaprel: &'a PgSearchRelation,
+        heaptupdesc: &'a PgTupleDesc<'a>,
+        categorized_fields: &'a [(SearchField, CategorizedFieldData)],
+        created_by_version: Option<Version>,
+        query_visible: bool,
+    ) -> Self {
+        let oldest_xmin = unsafe { pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr()) };
+        Self {
+            fetch_state,
+            expression_state,
+            heaprel,
+            heaptupdesc,
+            categorized_fields,
+            created_by_version,
+            oldest_xmin,
+            query_visible,
+            values: vec![pg_sys::Datum::null(); heaptupdesc.len()],
+            isnull: vec![false; heaptupdesc.len()],
+        }
+    }
+
+    /// Fetch `ctid` and build the document the index would hold for it, or `None` when there is
+    /// nothing to index at `ctid`: its block was truncated by a previous VACUUM, the tuple is
+    /// not visible to the active snapshot (query-visible mode), or every version in its HOT
+    /// chain is dead (maintenance mode).
+    pub unsafe fn fetch_doc(&mut self, ctid: u64) -> Option<TantivyDocument> {
+        unsafe {
+            // Guard against stale ctids referencing heap blocks truncated by VACUUM.
+            if !utils::ctid_satisfies_nblocks(
+                ctid,
+                self.heaprel.as_ptr(),
+                self.heaprel.fork_number(),
+            ) {
+                return None;
+            }
+
+            let mut ipd = pg_sys::ItemPointerData::default();
+            utils::u64_to_item_pointer(ctid, &mut ipd);
+
+            // See the struct docs for why the two modes fetch with different snapshots.
+            let fetch_snapshot = if self.query_visible {
+                pg_sys::GetActiveSnapshot()
+            } else {
+                &raw mut pg_sys::SnapshotAnyData
+            };
+            let mut call_again = false;
+            'next_hot_chain: loop {
+                let fetched = pg_sys::table_index_fetch_tuple(
+                    self.fetch_state.scan,
+                    &mut ipd,
+                    fetch_snapshot,
+                    self.fetch_state.slot(),
+                    // call_again: This parameter will be set to true if this `ctid` points to multiple
+                    // tuples as part of a HOT chain. We must attempt to find one live version of the
+                    // tuple, and it may not be the first one in the chain.
+                    &mut call_again,
+                    // all_dead: Can hypothetically signal that a `ctid` is dead in all
+                    // transactions: in practice, never actually seems to be anything but false
+                    // when used with `SnapshotAnyData`.
+                    &mut false,
+                );
+
+                if !fetched {
+                    // Either the tuple is not visible to `fetch_snapshot` (query-visible mode) or
+                    // heap page pruning removed it (SnapshotAny mode). In both cases there is no
+                    // content to index for this ctid.
+                    return None;
+                }
+
+                if self.query_visible {
+                    // Visible to the snapshot: skip the SnapshotAny dead-tuple filtering below and
+                    // index it.
+                    break;
+                }
+
+                let mut htsv_result = {
+                    let buffer = (*self.fetch_state.buffer_heap_slot()).buffer;
+                    let _lock = BorrowedBuffer::from_pg(buffer);
+                    pg_sys::HeapTupleSatisfiesVacuum(
+                        (*self.fetch_state.buffer_heap_slot()).base.tuple,
+                        self.oldest_xmin,
+                        buffer,
+                    )
+                };
+
+                if htsv_result == pg_sys::HTSV_Result::HEAPTUPLE_RECENTLY_DEAD {
+                    // Our `oldest_xmin` might be stale compared to a concurrent VACUUM.
+                    // If VACUUM saw this tuple as DEAD and deleted its TOAST chunks, we
+                    // must also see it as DEAD, otherwise we'll crash trying to read them.
+                    //
+                    // A single re-check is sufficient (no loop needed) because
+                    // `GetOldestNonRemovableTransactionId` returns the current global
+                    // XID horizon. If the tuple is still RECENTLY_DEAD under this fresh
+                    // horizon, then no concurrent VACUUM could have considered it DEAD
+                    // (VACUUM uses the same or an older horizon), so its TOAST data is
+                    // guaranteed to still exist.
+                    let fresh_oldest_xmin =
+                        pg_sys::GetOldestNonRemovableTransactionId(self.heaprel.as_ptr());
+                    if fresh_oldest_xmin != self.oldest_xmin {
+                        let buffer = (*self.fetch_state.buffer_heap_slot()).buffer;
+                        let _lock = BorrowedBuffer::from_pg(buffer);
+                        htsv_result = pg_sys::HeapTupleSatisfiesVacuum(
+                            (*self.fetch_state.buffer_heap_slot()).base.tuple,
+                            fresh_oldest_xmin,
+                            buffer,
+                        );
+                    }
+                }
+
+                if htsv_result == pg_sys::HTSV_Result::HEAPTUPLE_DEAD {
+                    // table_index_fetch_tuple stored this dead tuple in a buffer-backed slot. Since
+                    // this branch skips the tuple, clear the slot before any HOT-chain retry or ctid
+                    // skip so the slot releases its buffer pin.
+                    pg_sys::ExecClearTuple(self.fetch_state.slot());
+
+                    // This copy of the tuple is no longer visible to any transaction. Are there
+                    // more in the HOT chain?
+                    if call_again {
+                        // There are more entries in the hot chain: find the first one that is
+                        // visible.
+                        continue 'next_hot_chain;
+                    } else {
+                        // There are no more entries in the HOT chain, so no copy of the tuple is
+                        // visible in any transaction.
+                        return None;
+                    }
+                }
+
+                // We successfully fetched a tuple. Break out to fetch and deform it.
+                break;
+            }
+
+            // We have a completely valid tuple to index: fetch and deform it.
+            //
+            // NOTE: We intentionally pass `false` (don't materialize) to keep the
+            // buffer pin held by the BufferHeapTupleTableSlot. This pin blocks
+            // VACUUM's LockBufferForCleanup, which prevents it from removing the
+            // heap tuple and deleting its TOAST chunks while we read them below.
+            // See: https://github.com/paradedb/paradedb/issues/5076
+            let htup = pg_sys::ExecFetchSlotHeapTuple(
+                self.fetch_state.slot(),
+                false,
+                std::ptr::null_mut(),
+            );
+
+            pg_sys::heap_deform_tuple(
+                htup,
+                self.heaptupdesc.as_ptr(),
+                self.values.as_mut_ptr(),
+                self.isnull.as_mut_ptr(),
+            );
+
+            // Eagerly detoast all variable-length (varlena) datums while the
+            // buffer pin is still held. Without this, the lazy detoasting in
+            // row_to_search_document can race with VACUUM deleting TOAST chunks
+            // after we release the pin (the "missing chunk number 0" crash).
+            // pg_detoast_datum is a no-op for already-inline / non-TOASTed data.
+            for i in 0..self.heaptupdesc.len() {
+                if !self.isnull[i] {
+                    let att = self.heaptupdesc.get(i).expect("valid attribute");
+                    if att.attlen == -1 {
+                        self.values[i] = pg_sys::Datum::from(pg_sys::pg_detoast_datum(
+                            self.values[i].cast_mut_ptr(),
+                        ));
+                    }
+                }
+            }
+
+            let expr_results = self.expression_state.evaluate(self.fetch_state.slot());
+
+            let mut doc = TantivyDocument::new();
+
+            // Unpack all composites upfront from expr_results
+            let unpacked_composites = CompositeSlotValues::from_composites(
+                self.categorized_fields.iter().filter_map(|(_, cat)| {
+                    if let FieldSource::CompositeField {
+                        expression_idx,
+                        composite_type_oid,
+                        ..
+                    } = cat.source
+                    {
+                        let (datum, is_null) = expr_results[expression_idx];
+                        Some((expression_idx, datum, is_null, composite_type_oid))
+                    } else {
+                        None
+                    }
+                }),
+            );
+
+            utils::row_to_search_document(
+                self.categorized_fields.iter().map(|(field, categorized)| {
+                    let (datum, is_null) = utils::resolve_field_value(
+                        &categorized.source,
+                        &self.values,
+                        &self.isnull,
+                        &expr_results,
+                        &unpacked_composites,
+                    );
+                    (datum, is_null, field, categorized)
+                }),
+                &mut doc,
+                self.created_by_version,
+            )
+            .unwrap_or_else(|e| {
+                panic!("Failed to create document from row: {e}");
+            });
+
+            // Eagerly release the buffer pin now that all datum values have
+            // been detoasted into palloc'd memory. Without this, the pin would
+            // stay held until the next table_index_fetch_tuple call (which
+            // replaces the slot contents) or until HeapFetchState is dropped at
+            // end-of-query, unnecessarily blocking VACUUM on this buffer.
+            pg_sys::ExecClearTuple(self.fetch_state.slot());
+
+            Some(doc)
+        }
     }
 }
 

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -67,6 +67,7 @@ pub mod pdb_owned_value;
 pub mod planner_warnings;
 pub mod rel;
 pub mod storage;
+pub mod tuplesort;
 pub mod types;
 pub mod types_arrow;
 pub mod utils;

--- a/pg_search/src/postgres/tuplesort.rs
+++ b/pg_search/src/postgres/tuplesort.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! A thin wrapper over a Postgres `bytea` datum `tuplesort`.
+//!
+//! Records are ordered by `memcmp` of their bytes (the `bytea` `<` operator), so callers that
+//! need a semantic order must encode it into the bytes (big-endian integers, or a serialization
+//! that is consistent between the sort side and the probe side). The sort is bounded by the
+//! caller's budget and spills to temporary files past it, like any other Postgres tuplesort.
+
+use pgrx::pg_sys;
+use std::os::raw::c_int;
+
+/// Wraps a `Tuplesortstate` over `bytea` datums: `memcmp` order, caller-provided memory budget.
+pub struct Sorter {
+    state: *mut pg_sys::Tuplesortstate,
+    /// PG15's `tuplesort_getdatum` has no `copy` flag and always hands back a copy palloc'd in
+    /// the caller's context, which the caller owns. Held here so [`Self::next_sorted`] can free
+    /// the previous record instead of leaking one allocation per record into a context that may
+    /// live for the whole sort read (a CREATE INDEX, for the build path).
+    #[cfg(feature = "pg15")]
+    last_returned: Option<pg_sys::Datum>,
+}
+
+impl Sorter {
+    /// `budget` is in bytes; the sort spills to temporary files beyond it.
+    pub fn new(budget: usize) -> Self {
+        unsafe {
+            // `<` operator for bytea, so the sort orders by memcmp of the serialized keys.
+            let tcache =
+                pg_sys::lookup_type_cache(pg_sys::BYTEAOID, pg_sys::TYPECACHE_LT_OPR as c_int);
+            let lt_op = (*tcache).lt_opr;
+            let state = pg_sys::tuplesort_begin_datum(
+                pg_sys::BYTEAOID,
+                lt_op,
+                pg_sys::InvalidOid, // bytea has no collation
+                false,              // nullsFirstFlag (there are no nulls)
+                (budget / 1024).max(64) as c_int,
+                std::ptr::null_mut(), // not parallel
+                0,                    // sortopt: no random access
+            );
+            Sorter {
+                state,
+                #[cfg(feature = "pg15")]
+                last_returned: None,
+            }
+        }
+    }
+
+    pub fn put(&mut self, bytes: &[u8]) {
+        unsafe {
+            let datum = bytea_datum(bytes);
+            pg_sys::tuplesort_putdatum(self.state, datum, false);
+            // `tuplesort_putdatum` copies the value, so free our transient bytea.
+            pg_sys::pfree(datum.cast_mut_ptr());
+        }
+    }
+
+    /// Finish loading and sort. Call once, before the first [`Self::next_sorted`].
+    pub fn performsort(&mut self) {
+        unsafe { pg_sys::tuplesort_performsort(self.state) }
+    }
+
+    /// The next record in sorted order, or `None` once the sort is exhausted. The returned
+    /// bytes are only valid until the next call.
+    pub fn next_sorted(&mut self) -> Option<&[u8]> {
+        unsafe {
+            self.free_last_returned();
+            let mut val: pg_sys::Datum = pg_sys::Datum::from(0);
+            let mut is_null = false;
+            let mut abbrev: pg_sys::Datum = pg_sys::Datum::from(0);
+            if tuplesort_getdatum_forward(self.state, &mut val, &mut is_null, &mut abbrev) {
+                #[cfg(feature = "pg15")]
+                {
+                    self.last_returned = Some(val);
+                }
+                Some(datum_bytea(val))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Release the sort's memory and temporary files.
+    pub fn end(mut self) {
+        unsafe {
+            self.free_last_returned();
+            pg_sys::tuplesort_end(self.state)
+        }
+    }
+
+    /// Free the copy PG15's `tuplesort_getdatum` handed us for the previous record. A no-op on
+    /// PG16+, where `copy: false` leaves ownership with the sort and the datum is simply valid
+    /// until the next call.
+    #[cfg_attr(not(feature = "pg15"), allow(clippy::unused_self))]
+    unsafe fn free_last_returned(&mut self) {
+        #[cfg(feature = "pg15")]
+        if let Some(previous) = self.last_returned.take() {
+            unsafe { pg_sys::pfree(previous.cast_mut_ptr()) };
+        }
+    }
+}
+
+/// Build a transient `bytea` Datum from `bytes` (palloc'd in the current context).
+unsafe fn bytea_datum(bytes: &[u8]) -> pg_sys::Datum {
+    use pgrx::IntoDatum;
+    bytes
+        .into_datum()
+        .expect("byte slice should convert to a bytea datum")
+}
+
+/// View a `bytea` Datum's payload as bytes (valid until the datum is freed/overwritten).
+unsafe fn datum_bytea<'a>(datum: pg_sys::Datum) -> &'a [u8] {
+    let varlena = datum.cast_mut_ptr::<pg_sys::varlena>();
+    pgrx::varlena_to_byte_slice(varlena)
+}
+
+/// `tuplesort_getdatum`, always reading forward. On PG16+, `copy: false` borrows the datum from
+/// the sort, valid until the next call. PG15 predates the `copy` parameter and always returns a
+/// palloc'd copy owned by the caller; [`Sorter`] tracks and frees it.
+unsafe fn tuplesort_getdatum_forward(
+    state: *mut pg_sys::Tuplesortstate,
+    val: *mut pg_sys::Datum,
+    is_null: *mut bool,
+    abbrev: *mut pg_sys::Datum,
+) -> bool {
+    #[cfg(feature = "pg15")]
+    {
+        pg_sys::tuplesort_getdatum(state, true, val, is_null, abbrev)
+    }
+    #[cfg(not(feature = "pg15"))]
+    {
+        pg_sys::tuplesort_getdatum(state, true, false, val, is_null, abbrev)
+    }
+}


### PR DESCRIPTION
## What

Partitioned `CREATE INDEX` execution for an index that declares `partition_by`. Each worker routes its scanned rows onto the leader's kd-tree boundaries (#5991) and builds one segment per cell, so a fresh index's segments do not overlap in `partition_by` space, with no merges across workers.

## How

Phase 1: each scanned row is routed by the shared `KdTree` and its `(pid, ctid)` spills to a worker-local `bytea` tuplesort, no index content. Sorting by the `ctid` too keeps within-cell re-fetch in sparse heap order. Phase 2: the sorted records re-fetch rows through `HeapDocFetcher` under a reused buffer pin and index them cell by cell, one `SerialIndexWriter` alive at a time at the full worker budget. Each cell boundary finalizes a segment; a cell that overran the budget merges its own segments (`merge_now`), never across workers. The drain re-fetches HOT chain roots to the live tail so it indexes what the inline callback would have. `CONCURRENTLY` falls back to the regular path.

Three preparatory refactors land first: extract the `bytea` tuplesort wrapper from `keyset.rs`, extract `HeapDocFetcher` from `index_memory_segment`, and split `merge_now` out of `try_merge`.

## Testing

`cargo pgrx test pg18`: serial one segment per cell, parallel doc and search parity, a same-transaction HOT update indexed at its live value, and overfull-cell merge. Full `cargo pgrx regress pg18` green.

Persisting each cell's `partition_bounds` into segment stats is a follow-up, paired with the query-side segment pruning that will read it.
