### PR TITLE
refactor: require Pod for ParallelState, replace unsafe as_bytes

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -598,7 +598,8 @@ pub fn execute_aggregate(
             if consumers == 0 {
                 return None;
             }
-            let segments: Vec<SegmentId> = segment_ids.iter().map(|entry| entry.segment_id()).collect();
+            let segments: Vec<SegmentId> =
+                segment_ids.iter().map(|entry| entry.segment_id()).collect();
             let handle = bitmap_exec.shared_source(consumers, &segments)?;
             if let Some(cell) = query.bitmap_cell()
                 && let Some(source) = bitmap_exec.source()

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -82,13 +82,13 @@ impl TryInto<Aggregations> for AggregateRequest {
 struct State {
     // these require the Spinlock mutex for atomic access (read and write)
     mutex: Spinlock,
-    _pad: [u8; 7],
+    _pad: [u8; 4],
     nlaunched: usize,
     remaining_segments: usize,
 }
 
 // SAFETY: State is #[repr(C)] with explicit padding. All fields are
-// integer types (Spinlock = u8 wrapper, usize). Every bit pattern is valid.
+// integer types (Spinlock = i32 wrapper, usize). Every bit pattern is valid.
 unsafe impl bytemuck::Zeroable for State {}
 unsafe impl bytemuck::Pod for State {}
 
@@ -165,6 +165,10 @@ impl ParallelStateType for State {}
 impl ParallelStateType for Config {}
 impl ParallelStateType for SegmentDeletedDocs {}
 
+const _: () = assert!(size_of::<State>() == 24);
+const _: () = assert!(size_of::<Config>() == 40);
+const _: () = assert!(size_of::<SegmentDeletedDocs>() == 20);
+
 impl ParallelProcess for ParallelAggregation {
     fn state_values(&self) -> Vec<&dyn ParallelState> {
         vec![
@@ -195,7 +199,7 @@ impl ParallelAggregation {
         Ok(Self {
             state: State {
                 mutex: Spinlock::new(),
-                _pad: [0; 7],
+                _pad: [0; 4],
                 nlaunched: 0,
                 remaining_segments: segment_ids.len(),
             },
@@ -689,7 +693,7 @@ pub fn execute_aggregate(
                 .collect::<Vec<_>>();
             let mut state = State {
                 mutex: Spinlock::default(),
-                _pad: [0; 7],
+                _pad: [0; 4],
                 nlaunched: 1,
                 remaining_segments: segment_ids.len(),
             };

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -82,19 +82,39 @@ impl TryInto<Aggregations> for AggregateRequest {
 struct State {
     // these require the Spinlock mutex for atomic access (read and write)
     mutex: Spinlock,
+    _pad: [u8; 7],
     nlaunched: usize,
     remaining_segments: usize,
 }
+
+// SAFETY: State is #[repr(C)] with explicit padding. All fields are
+// integer types (Spinlock = u8 wrapper, usize). Every bit pattern is valid.
+unsafe impl bytemuck::Zeroable for State {}
+unsafe impl bytemuck::Pod for State {}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 struct Config {
     indexrelid: pg_sys::Oid,
+    _pad1: [u8; 4],
     total_segments: usize,
-    solve_mvcc: bool,
-
+    solve_mvcc: u8,
+    _pad2: [u8; 7],
     memory_limit: u64,
     bucket_limit: u32,
+    _pad3: [u8; 4],
+}
+
+// SAFETY: Config is #[repr(C)] with explicit padding. All fields are
+// integer types (Oid = u32 wrapper, usize, u8, u64, u32). Every bit
+// pattern is valid.
+unsafe impl bytemuck::Zeroable for Config {}
+unsafe impl bytemuck::Pod for Config {}
+
+impl Config {
+    fn solve_mvcc(&self) -> bool {
+        self.solve_mvcc != 0
+    }
 }
 
 impl State {
@@ -154,15 +174,19 @@ impl ParallelAggregation {
         Ok(Self {
             state: State {
                 mutex: Spinlock::new(),
+                _pad: [0; 7],
                 nlaunched: 0,
                 remaining_segments: segment_ids.len(),
             },
             config: Config {
                 indexrelid,
+                _pad1: [0; 4],
                 total_segments: segment_ids.len(),
-                solve_mvcc,
+                solve_mvcc: solve_mvcc as u8,
+                _pad2: [0; 7],
                 memory_limit,
                 bucket_limit,
+                _pad3: [0; 4],
             },
             agg_req_bytes: serde_json::to_vec(&aggregation)?,
             query_bytes: serde_json::to_vec(query)?,
@@ -231,10 +255,13 @@ impl<'a> ParallelAggregationWorker<'a> {
             state,
             config: Config {
                 indexrelid,
+                _pad1: [0; 4],
                 total_segments: segment_ids.len(),
-                solve_mvcc,
+                solve_mvcc: solve_mvcc as u8,
+                _pad2: [0; 7],
                 memory_limit,
                 bucket_limit,
+                _pad3: [0; 4],
             },
             aggregation: Some(aggregation),
             query,
@@ -332,7 +359,7 @@ impl<'a> ParallelAggregationWorker<'a> {
             .heap_relation()
             .expect("index should belong to a heap relation");
         let (base_collector, vischeck) =
-            aggregations.plan(&reader, &heaprel, self.config.solve_mvcc, limits);
+            aggregations.plan(&reader, &heaprel, self.config.solve_mvcc(), limits);
 
         let start = std::time::Instant::now();
         let intermediate_results = if let Some(vischeck) = vischeck {
@@ -642,6 +669,7 @@ pub fn execute_aggregate(
                 .collect::<Vec<_>>();
             let mut state = State {
                 mutex: Spinlock::default(),
+                _pad: [0; 7],
                 nlaunched: 1,
                 remaining_segments: segment_ids.len(),
             };

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -112,12 +112,40 @@ unsafe impl bytemuck::Zeroable for Config {}
 unsafe impl bytemuck::Pod for Config {}
 
 impl Config {
+    fn new(
+        indexrelid: pg_sys::Oid,
+        total_segments: usize,
+        solve_mvcc: bool,
+        memory_limit: u64,
+        bucket_limit: u32,
+    ) -> Self {
+        Self {
+            indexrelid,
+            _pad1: [0; 4],
+            total_segments,
+            solve_mvcc: solve_mvcc as u8,
+            _pad2: [0; 7],
+            memory_limit,
+            bucket_limit,
+            _pad3: [0; 4],
+        }
+    }
+
     fn solve_mvcc(&self) -> bool {
         self.solve_mvcc != 0
     }
 }
 
 impl State {
+    fn new(nlaunched: usize, remaining_segments: usize) -> Self {
+        Self {
+            mutex: Spinlock::new(),
+            _pad: [0; 4],
+            nlaunched,
+            remaining_segments,
+        }
+    }
+
     fn set_launched_workers(&mut self, nlaunched: usize) {
         let _lock = self.mutex.acquire();
         self.nlaunched = nlaunched;
@@ -197,22 +225,8 @@ impl ParallelAggregation {
         bitmap_handle: Option<SharedBitmapHandle>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
-            state: State {
-                mutex: Spinlock::new(),
-                _pad: [0; 4],
-                nlaunched: 0,
-                remaining_segments: segment_ids.len(),
-            },
-            config: Config {
-                indexrelid,
-                _pad1: [0; 4],
-                total_segments: segment_ids.len(),
-                solve_mvcc: solve_mvcc as u8,
-                _pad2: [0; 7],
-                memory_limit,
-                bucket_limit,
-                _pad3: [0; 4],
-            },
+            state: State::new(0, segment_ids.len()),
+            config: Config::new(indexrelid, segment_ids.len(), solve_mvcc, memory_limit, bucket_limit),
             agg_req_bytes: serde_json::to_vec(&aggregation)?,
             query_bytes: serde_json::to_vec(query)?,
             bitmap_handle_bytes: postcard::to_allocvec(&bitmap_handle)?,
@@ -278,16 +292,7 @@ impl<'a> ParallelAggregationWorker<'a> {
     ) -> Self {
         Self {
             state,
-            config: Config {
-                indexrelid,
-                _pad1: [0; 4],
-                total_segments: segment_ids.len(),
-                solve_mvcc: solve_mvcc as u8,
-                _pad2: [0; 7],
-                memory_limit,
-                bucket_limit,
-                _pad3: [0; 4],
-            },
+            config: Config::new(indexrelid, segment_ids.len(), solve_mvcc, memory_limit, bucket_limit),
             aggregation: Some(aggregation),
             query,
             segment_ids,
@@ -691,12 +696,7 @@ pub fn execute_aggregate(
                 .iter()
                 .map(|r| SegmentDeletedDocs::new(r.segment_id(), r.num_deleted_docs()))
                 .collect::<Vec<_>>();
-            let mut state = State {
-                mutex: Spinlock::default(),
-                _pad: [0; 4],
-                nlaunched: 1,
-                remaining_segments: segment_ids.len(),
-            };
+            let mut state = State::new(1, segment_ids.len());
             let mut worker = ParallelAggregationWorker::new_local(
                 agg_req.clone(),
                 query,
@@ -1333,5 +1333,21 @@ mod tests {
         assert!(config.solve_mvcc());
         config.solve_mvcc = 2;
         assert!(config.solve_mvcc());
+    }
+
+    #[test]
+    fn config_new_zeroes_padding() {
+        let config = Config::new(pg_sys::Oid::INVALID, 10, true, 1024, 50);
+        let bytes = bytemuck::bytes_of(&config);
+        assert_eq!(bytes[4..8], [0; 4]);
+        assert_eq!(bytes[17..24], [0; 7]);
+        assert_eq!(bytes[36..40], [0; 4]);
+    }
+
+    #[test]
+    fn state_new_zeroes_padding() {
+        let state = State::new(0, 5);
+        let bytes = bytemuck::bytes_of(&state);
+        assert_eq!(bytes[4..8], [0; 4]);
     }
 }

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -1300,3 +1300,38 @@ pub mod mvcc_collector {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segment_deleted_docs_round_trips() {
+        let id = SegmentId::generate_random();
+        let entry = SegmentDeletedDocs::new(id, 42);
+
+        assert_eq!(entry.segment_id(), id);
+        assert_eq!(entry.deleted_docs, 42);
+    }
+
+    #[test]
+    fn segment_deleted_docs_bytes_match_fields() {
+        let entry = SegmentDeletedDocs {
+            segment_id_bytes: [1; 16],
+            deleted_docs: 99,
+        };
+        let bytes = bytemuck::bytes_of(&entry);
+        assert_eq!(bytes.len(), size_of::<SegmentDeletedDocs>());
+        assert_eq!(&bytes[..16], &[1u8; 16]);
+    }
+
+    #[test]
+    fn config_solve_mvcc_accessor() {
+        let mut config: Config = bytemuck::Zeroable::zeroed();
+        assert!(!config.solve_mvcc());
+        config.solve_mvcc = 1;
+        assert!(config.solve_mvcc());
+        config.solve_mvcc = 2;
+        assert!(config.solve_mvcc());
+    }
+}

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -598,7 +598,7 @@ pub fn execute_aggregate(
             if consumers == 0 {
                 return None;
             }
-            let segments: Vec<SegmentId> = segment_ids.iter().map(|(id, _)| *id).collect();
+            let segments: Vec<SegmentId> = segment_ids.iter().map(|entry| entry.segment_id()).collect();
             let handle = bitmap_exec.shared_source(consumers, &segments)?;
             if let Some(cell) = query.bitmap_cell()
                 && let Some(source) = bitmap_exec.source()
@@ -1348,18 +1348,20 @@ mod tests {
     }
 
     #[test]
-    fn config_new_zeroes_padding() {
-        let config = Config::new(pg_sys::Oid::INVALID, 10, true, 1024, 50);
+    fn config_zeroed_has_no_uninit_padding() {
+        let config: Config = bytemuck::Zeroable::zeroed();
         let bytes = bytemuck::bytes_of(&config);
         assert_eq!(bytes[4..8], [0; 4]);
         assert_eq!(bytes[17..24], [0; 7]);
         assert_eq!(bytes[36..40], [0; 4]);
+        assert_eq!(bytes.len(), 40);
     }
 
     #[test]
-    fn state_new_zeroes_padding() {
-        let state = State::new(0, 5);
+    fn state_zeroed_has_no_uninit_padding() {
+        let state: State = bytemuck::Zeroable::zeroed();
         let bytes = bytemuck::bytes_of(&state);
         assert_eq!(bytes[4..8], [0; 4]);
+        assert_eq!(bytes.len(), 24);
     }
 }

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -226,7 +226,13 @@ impl ParallelAggregation {
     ) -> anyhow::Result<Self> {
         Ok(Self {
             state: State::new(0, segment_ids.len()),
-            config: Config::new(indexrelid, segment_ids.len(), solve_mvcc, memory_limit, bucket_limit),
+            config: Config::new(
+                indexrelid,
+                segment_ids.len(),
+                solve_mvcc,
+                memory_limit,
+                bucket_limit,
+            ),
             agg_req_bytes: serde_json::to_vec(&aggregation)?,
             query_bytes: serde_json::to_vec(query)?,
             bitmap_handle_bytes: postcard::to_allocvec(&bitmap_handle)?,
@@ -292,7 +298,13 @@ impl<'a> ParallelAggregationWorker<'a> {
     ) -> Self {
         Self {
             state,
-            config: Config::new(indexrelid, segment_ids.len(), solve_mvcc, memory_limit, bucket_limit),
+            config: Config::new(
+                indexrelid,
+                segment_ids.len(),
+                solve_mvcc,
+                memory_limit,
+                bucket_limit,
+            ),
             aggregation: Some(aggregation),
             query,
             segment_ids,

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -130,19 +130,40 @@ impl State {
 }
 
 type NumDeletedDocs = u32;
+
+#[derive(Copy, Clone, Debug, bytemuck::Zeroable, bytemuck::Pod)]
+#[repr(C)]
+struct SegmentDeletedDocs {
+    segment_id_bytes: [u8; 16],
+    deleted_docs: u32,
+}
+
+impl SegmentDeletedDocs {
+    fn new(id: SegmentId, deleted: NumDeletedDocs) -> Self {
+        Self {
+            segment_id_bytes: *id.uuid_bytes(),
+            deleted_docs: deleted,
+        }
+    }
+
+    fn segment_id(&self) -> SegmentId {
+        SegmentId::from_bytes(self.segment_id_bytes)
+    }
+}
+
 struct ParallelAggregation {
     state: State,
     config: Config,
     query_bytes: Vec<u8>,
     agg_req_bytes: Vec<u8>,
     bitmap_handle_bytes: Vec<u8>,
-    segment_ids: Vec<(SegmentId, NumDeletedDocs)>,
+    segment_ids: Vec<SegmentDeletedDocs>,
     ambulkdelete_epoch: u32,
 }
 
 impl ParallelStateType for State {}
 impl ParallelStateType for Config {}
-impl ParallelStateType for (SegmentId, NumDeletedDocs) {}
+impl ParallelStateType for SegmentDeletedDocs {}
 
 impl ParallelProcess for ParallelAggregation {
     fn state_values(&self) -> Vec<&dyn ParallelState> {
@@ -167,7 +188,7 @@ impl ParallelAggregation {
         solve_mvcc: bool,
         memory_limit: u64,
         bucket_limit: u32,
-        segment_ids: Vec<(SegmentId, NumDeletedDocs)>,
+        segment_ids: Vec<SegmentDeletedDocs>,
         ambulkdelete_epoch: u32,
         bitmap_handle: Option<SharedBitmapHandle>,
     ) -> anyhow::Result<Self> {
@@ -202,7 +223,7 @@ struct ParallelAggregationWorker<'a> {
     config: Config,
     aggregation: Option<AggregateRequest>,
     query: SearchQueryInput,
-    segment_ids: Vec<(SegmentId, NumDeletedDocs)>,
+    segment_ids: Vec<SegmentDeletedDocs>,
     #[allow(dead_code)]
     ambulkdelete_epoch: u32,
     /// The owner's published claim table, attached lazily by bgworkers (the
@@ -243,7 +264,7 @@ impl<'a> ParallelAggregationWorker<'a> {
     fn new_local(
         aggregation: AggregateRequest,
         query: SearchQueryInput,
-        segment_ids: Vec<(SegmentId, NumDeletedDocs)>,
+        segment_ids: Vec<SegmentDeletedDocs>,
         ambulkdelete_epoch: u32,
         indexrelid: pg_sys::Oid,
         solve_mvcc: bool,
@@ -299,8 +320,7 @@ impl<'a> ParallelAggregationWorker<'a> {
         self.state.remaining_segments -= 1;
         self.segment_ids
             .get(self.state.remaining_segments)
-            .cloned()
-            .map(|(segment_id, _)| segment_id)
+            .map(|entry| entry.segment_id())
     }
 
     fn execute_aggregate(
@@ -396,7 +416,7 @@ impl ParallelWorker for ParallelAggregationWorker<'_> {
             .expect("wrong type for query_bytes")
             .expect("missing query_bytes value");
         let segment_ids = state_manager
-            .slice::<(SegmentId, NumDeletedDocs)>(4)
+            .slice::<SegmentDeletedDocs>(4)
             .expect("wrong type for segment_ids")
             .expect("missing segment_ids value");
         let ambulkdelete_epoch = state_manager
@@ -545,7 +565,7 @@ pub fn execute_aggregate(
         let segment_ids = reader
             .segment_readers()
             .iter()
-            .map(|r| (r.segment_id(), r.num_deleted_docs()))
+            .map(|r| SegmentDeletedDocs::new(r.segment_id(), r.num_deleted_docs()))
             .collect::<Vec<_>>();
         // Publish the bitmap claim table for the worker pool: rebuild the
         // leader's bitmap into this scan's own DSA area, prepare one iterator
@@ -665,7 +685,7 @@ pub fn execute_aggregate(
             let segment_ids = reader
                 .segment_readers()
                 .iter()
-                .map(|r| (r.segment_id(), r.num_deleted_docs()))
+                .map(|r| SegmentDeletedDocs::new(r.segment_id(), r.num_deleted_docs()))
                 .collect::<Vec<_>>();
             let mut state = State {
                 mutex: Spinlock::default(),

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -58,11 +58,13 @@ impl From<TocKeys> for u64 {
     }
 }
 
-/// Marker for plain-old-data types stored in DSM entries as raw bytes. An entry is written
-/// by copying a live value, and [`ParallelStateManager`] checks the recorded type name
-/// before handing it back, so a reader always sees a valid instance of the type it asked
-/// for.
-pub trait ParallelStateType: Copy {}
+/// Marker for plain-old-data types stored in DSM entries as raw bytes.
+///
+/// Requires [`bytemuck::Pod`], which guarantees: `#[repr(C)]` layout, no
+/// uninitialised padding bytes, and every bit pattern is a valid instance.
+/// These properties let `as_bytes()` and `object()`/`slice()` operate
+/// without undefined behaviour.
+pub trait ParallelStateType: bytemuck::Pod {}
 
 pub trait ParallelState {
     /// A binary representation of the header information necessary to store/retrieve [`ParallelState`]
@@ -162,12 +164,10 @@ impl ParallelStateType for i64 {}
 impl ParallelStateType for isize {}
 impl ParallelStateType for f32 {}
 impl ParallelStateType for f64 {}
-impl ParallelStateType for bool {}
-impl ParallelStateType for () {}
 
 impl<T: ParallelStateType> ParallelState for T {
     fn as_bytes(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const u8, self.size_of()) }
+        bytemuck::bytes_of(self)
     }
 }
 
@@ -182,7 +182,7 @@ impl<T: ParallelStateType> ParallelState for Vec<T> {
         self.len()
     }
     fn as_bytes(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.as_ptr() as *const u8, self.size_of()) }
+        bytemuck::cast_slice(self.as_slice())
     }
 }
 

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -482,8 +482,8 @@ impl ParallelStateManager {
 /// use pg_search::parallel_worker::mqueue::MessageQueueSender;
 ///
 /// // Define a ParallelState type
+/// #[derive(Copy, Clone, bytemuck::Zeroable, bytemuck::Pod)]
 /// #[repr(C)]
-/// #[derive(Copy, Clone)]
 /// struct MyState {
 ///     junk: u32
 /// }
@@ -687,8 +687,8 @@ mod tests {
 
     #[pg_test]
     fn test_parallel_workers() {
+        #[derive(Copy, Clone, bytemuck::Zeroable, bytemuck::Pod)]
         #[repr(C)]
-        #[derive(Copy, Clone)]
         struct MyState {
             junk: u32,
         }
@@ -803,6 +803,41 @@ mod tests {
         // Any other send error, including unknown future/Postgres-specific
         // codes, must still panic.
         finish_parallel_worker(Err(MessageQueueSendError::Unknown(42 as _).into()));
+    }
+
+    #[pg_test]
+    fn test_pod_struct_bytes_of_round_trip() {
+        #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Zeroable, bytemuck::Pod)]
+        #[repr(C)]
+        struct TestPod {
+            a: u32,
+            _pad: [u8; 4],
+            b: u64,
+        }
+
+        impl ParallelStateType for TestPod {}
+
+        let original = TestPod {
+            a: 42,
+            _pad: [0; 4],
+            b: 12345,
+        };
+        let bytes = <TestPod as ParallelState>::as_bytes(&original);
+        assert_eq!(bytes.len(), std::mem::size_of::<TestPod>());
+
+        let recovered: &TestPod = bytemuck::from_bytes(bytes);
+        assert_eq!(recovered.a, 42);
+        assert_eq!(recovered.b, 12345);
+    }
+
+    #[pg_test]
+    fn test_pod_vec_cast_slice_round_trip() {
+        let values: Vec<u32> = vec![1, 2, 3, 4, 5];
+        let bytes = <Vec<u32> as ParallelState>::as_bytes(&values);
+        assert_eq!(bytes.len(), 5 * std::mem::size_of::<u32>());
+
+        let recovered: &[u32] = bytemuck::cast_slice(bytes);
+        assert_eq!(recovered, &[1, 2, 3, 4, 5]);
     }
 }
 

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -314,42 +314,10 @@ impl ParallelStateManager {
         Ok(Some((len, type_name)))
     }
 
-    /// Retrieve a **mutable** reference to the object stored in the state at index `i`.
-    ///
-    /// Returns a [`ValueError`] if the type `T` doesn't match the type of the object at index `i`.
-    /// Returns `None` if `i` is out of bounds
-    pub fn object<T: ParallelStateType>(
+    unsafe fn lookup_entry<T: Copy + 'static>(
         &self,
         i: usize,
-    ) -> Result<Option<&'static mut T>, ValueError> {
-        if i >= self.len {
-            return Ok(None);
-        }
-
-        let i = i * 2;
-        unsafe {
-            let Some((_, _)) = self.decode_info::<T>(i)? else {
-                return Ok(None);
-            };
-
-            let idx: u64 = TocKeys::UserState.into();
-            let idx = idx + i as u64 + 1;
-            let ptr = pg_sys::shm_toc_lookup(self.toc.as_ptr(), idx, true);
-            if ptr.is_null() {
-                return Ok(None);
-            }
-            Ok(Some(&mut *ptr.cast()))
-        }
-    }
-
-    /// Retrieve a slice to the Vec of objects stored in the state at index `i`.
-    ///
-    /// Returns a [`ValueError`] if the type `T` doesn't match the type of the slice elements at index `i`.
-    /// Returns `None` if `i` is out of bounds
-    pub fn slice<T: ParallelStateType>(
-        &self,
-        i: usize,
-    ) -> Result<Option<&'static [T]>, ValueError> {
+    ) -> Result<Option<(usize, *mut T)>, ValueError> {
         if i >= self.len {
             return Ok(None);
         }
@@ -366,8 +334,32 @@ impl ParallelStateManager {
             if ptr.is_null() {
                 return Ok(None);
             }
-            let slice = std::slice::from_raw_parts(ptr.cast(), len);
-            Ok(Some(slice))
+            Ok(Some((len, ptr.cast())))
+        }
+    }
+
+    /// Retrieve a **mutable** reference to the object stored in the state at index `i`.
+    ///
+    /// Returns a [`ValueError`] if the type `T` doesn't match the type of the object at index `i`.
+    /// Returns `None` if `i` is out of bounds
+    pub fn object<T: ParallelStateType>(
+        &self,
+        i: usize,
+    ) -> Result<Option<&'static mut T>, ValueError> {
+        unsafe { self.lookup_entry::<T>(i).map(|opt| opt.map(|(_, p)| &mut *p)) }
+    }
+
+    /// Retrieve a slice to the Vec of objects stored in the state at index `i`.
+    ///
+    /// Returns a [`ValueError`] if the type `T` doesn't match the type of the slice elements at index `i`.
+    /// Returns `None` if `i` is out of bounds
+    pub fn slice<T: ParallelStateType>(
+        &self,
+        i: usize,
+    ) -> Result<Option<&'static [T]>, ValueError> {
+        unsafe {
+            self.lookup_entry::<T>(i)
+                .map(|opt| opt.map(|(len, p)| std::slice::from_raw_parts(p, len)))
         }
     }
 
@@ -379,24 +371,9 @@ impl ParallelStateManager {
         &self,
         i: usize,
     ) -> Result<Option<&'static mut [T]>, ValueError> {
-        if i >= self.len {
-            return Ok(None);
-        }
-
-        let i = i * 2;
         unsafe {
-            let Some((len, _)) = self.decode_info::<T>(i)? else {
-                return Ok(None);
-            };
-
-            let idx: u64 = TocKeys::UserState.into();
-            let idx = idx + i as u64 + 1;
-            let ptr = pg_sys::shm_toc_lookup(self.toc.as_ptr(), idx, true);
-            if ptr.is_null() {
-                return Ok(None);
-            }
-            let slice = std::slice::from_raw_parts_mut(ptr.cast(), len);
-            Ok(Some(slice))
+            self.lookup_entry::<T>(i)
+                .map(|opt| opt.map(|(len, p)| std::slice::from_raw_parts_mut(p, len)))
         }
     }
 
@@ -415,24 +392,7 @@ impl ParallelStateManager {
         &self,
         i: usize,
     ) -> Result<Option<*mut T>, ValueError> {
-        if i >= self.len {
-            return Ok(None);
-        }
-
-        let i = i * 2;
-        unsafe {
-            let Some((_, _)) = self.decode_info::<T>(i)? else {
-                return Ok(None);
-            };
-
-            let idx: u64 = TocKeys::UserState.into();
-            let idx = idx + i as u64 + 1;
-            let ptr = pg_sys::shm_toc_lookup(self.toc.as_ptr(), idx, true);
-            if ptr.is_null() {
-                return Ok(None);
-            }
-            Ok(Some(ptr.cast()))
-        }
+        unsafe { self.lookup_entry::<T>(i).map(|opt| opt.map(|(_, p)| p)) }
     }
 }
 

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -346,7 +346,10 @@ impl ParallelStateManager {
         &self,
         i: usize,
     ) -> Result<Option<&'static mut T>, ValueError> {
-        unsafe { self.lookup_entry::<T>(i).map(|opt| opt.map(|(_, p)| &mut *p)) }
+        unsafe {
+            self.lookup_entry::<T>(i)
+                .map(|opt| opt.map(|(_, p)| &mut *p))
+        }
     }
 
     /// Retrieve a slice to the Vec of objects stored in the state at index `i`.

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -284,7 +284,7 @@ impl ParallelStateManager {
         self.seg
     }
 
-    unsafe fn decode_info<T: ParallelStateType>(
+    unsafe fn decode_info<T: Copy + 'static>(
         &self,
         i: usize,
     ) -> Result<Option<(usize, &str)>, ValueError> {
@@ -397,6 +397,41 @@ impl ParallelStateManager {
             }
             let slice = std::slice::from_raw_parts_mut(ptr.cast(), len);
             Ok(Some(slice))
+        }
+    }
+
+    /// Retrieve a raw pointer to the object stored in the state at index `i`.
+    ///
+    /// Unlike [`Self::object`], this method does not require `T: ParallelStateType`.
+    /// Use it for foreign types that cannot implement `Pod` (e.g. bindgen-generated
+    /// Postgres structs). The type-name check still runs.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the DSM bytes at index `i` form a valid
+    /// instance of `T`. This is satisfied when the leader wrote a valid `T`
+    /// into this slot before workers were launched.
+    pub unsafe fn object_raw<T: Copy + 'static>(
+        &self,
+        i: usize,
+    ) -> Result<Option<*mut T>, ValueError> {
+        if i >= self.len {
+            return Ok(None);
+        }
+
+        let i = i * 2;
+        unsafe {
+            let Some((_, _)) = self.decode_info::<T>(i)? else {
+                return Ok(None);
+            };
+
+            let idx: u64 = TocKeys::UserState.into();
+            let idx = idx + i as u64 + 1;
+            let ptr = pg_sys::shm_toc_lookup(self.toc.as_ptr(), idx, true);
+            if ptr.is_null() {
+                return Ok(None);
+            }
+            Ok(Some(ptr.cast()))
         }
     }
 }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -98,7 +98,8 @@ impl ParallelStateType for WorkerConfig {}
 /// Type alias that holds a pointer to a [`pg_sys::ParallelTableScanDescData`] which is over-allocated,
 /// so the [`usize`] field tells us how big it really is, in bytes
 type ScanDesc = (usize, *mut pg_sys::ParallelTableScanDescData);
-impl ParallelStateType for pg_sys::ParallelTableScanDescData {}
+// ParallelTableScanDescData is a foreign bindgen type that cannot implement
+// Pod. It is accessed through object_raw() instead of the typed object() path.
 
 #[derive(Copy, Clone, Default)]
 #[repr(C)]
@@ -271,10 +272,14 @@ impl ParallelWorker for BuildWorker<'_> {
             .object::<WorkerConfig>(0)
             .expect("should be able to get ParallelBuildConfig from state manager")
             .expect("ParallelBuildConfig should not be NULL");
-        let scandesc = state_manager
-            .object::<pg_sys::ParallelTableScanDescData>(1)
-            .expect("should be able to get ParallelTableScanDesc")
-            .expect("ParallelTableScanDesc should not be NULL");
+        // SAFETY: the leader wrote a valid ParallelTableScanDescData into
+        // this slot via table_parallelscan_initialize before workers launched.
+        let scandesc = unsafe {
+            state_manager
+                .object_raw::<pg_sys::ParallelTableScanDescData>(1)
+                .expect("should be able to get ParallelTableScanDesc")
+                .expect("ParallelTableScanDesc should not be NULL")
+        };
         let coordination = state_manager
             .object::<WorkerCoordination>(2)
             .expect("should be able to get WorkerCoordination")

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -70,10 +70,28 @@ const TUPLES_DONE_BATCH_SIZE: usize = 5;
 struct WorkerConfig {
     heaprelid: pg_sys::Oid,
     indexrelid: pg_sys::Oid,
-    concurrent: bool,
+    concurrent: u8,
+    _pad1: [u8; 7],
     current_xid: pg_sys::FullTransactionId,
-    need_wal: bool,
+    need_wal: u8,
+    _pad2: [u8; 7],
     next_xid: pg_sys::FullTransactionId,
+}
+
+// SAFETY: WorkerConfig is #[repr(C)] with explicit padding. All fields
+// are integer types (Oid = u32 wrapper, u8, FullTransactionId = u64
+// wrapper). Every bit pattern is valid.
+unsafe impl bytemuck::Zeroable for WorkerConfig {}
+unsafe impl bytemuck::Pod for WorkerConfig {}
+
+impl WorkerConfig {
+    fn concurrent(&self) -> bool {
+        self.concurrent != 0
+    }
+
+    fn need_wal(&self) -> bool {
+        self.need_wal != 0
+    }
 }
 impl ParallelStateType for WorkerConfig {}
 
@@ -86,6 +104,7 @@ impl ParallelStateType for pg_sys::ParallelTableScanDescData {}
 #[repr(C)]
 struct WorkerCoordination {
     mutex: Spinlock,
+    _pad: [u8; 7],
     nstarted: usize,
     nlaunched: usize,
     ntuples_done: usize,
@@ -93,6 +112,12 @@ struct WorkerCoordination {
     /// Participants whose partitioned-build scan is over and whose spill files are closed.
     nspilled: usize,
 }
+
+// SAFETY: WorkerCoordination is #[repr(C)] with explicit padding. All
+// fields are integer types (Spinlock = u8 wrapper, usize). Every bit
+// pattern is valid.
+unsafe impl bytemuck::Zeroable for WorkerCoordination {}
+unsafe impl bytemuck::Pod for WorkerCoordination {}
 
 impl ParallelStateType for WorkerCoordination {}
 impl ParallelStateType for pg_sys::SharedFileSet {}
@@ -273,7 +298,7 @@ impl ParallelWorker for BuildWorker<'_> {
                 pg_sys::SharedFileSetAttach(fileset, state_manager.dsm_segment());
             }
 
-            let (heap_lock, index_lock) = if !config.concurrent {
+            let (heap_lock, index_lock) = if !config.concurrent() {
                 (pg_sys::ShareLock, pg_sys::AccessExclusiveLock)
             } else {
                 (pg_sys::ShareUpdateExclusiveLock, pg_sys::RowExclusiveLock)
@@ -286,7 +311,7 @@ impl ParallelWorker for BuildWorker<'_> {
             let table_scan_desc = pg_sys::table_beginscan_parallel(heaprel.as_ptr(), scandesc);
 
             indexrel.set_is_create_index();
-            indexrel.set_need_wal(config.need_wal);
+            indexrel.set_need_wal(config.need_wal());
 
             Self {
                 config: *config,
@@ -341,7 +366,7 @@ impl<'a> BuildWorker<'a> {
     fn do_build(&mut self, worker_number: i32, is_leader: bool) -> anyhow::Result<(f64, usize)> {
         unsafe {
             let index_info = self.indexrel.index_info();
-            (*index_info).ii_Concurrent = self.config.concurrent;
+            (*index_info).ii_Concurrent = self.config.concurrent();
             let nlaunched = self.coordination.nlaunched();
             let per_worker_memory_budget =
                 gucs::adjust_maintenance_work_mem(nlaunched).get() / nlaunched;
@@ -1370,14 +1395,14 @@ pub(super) fn build_index(
         }
     });
 
-    let config = WorkerConfig {
-        heaprelid: heaprel.oid(),
-        indexrelid: indexrel.oid(),
+    let config = WorkerConfig::new(
+        heaprel.oid(),
+        indexrel.oid(),
         concurrent,
-        current_xid: unsafe { pg_sys::GetCurrentFullTransactionId() },
-        need_wal: indexrel.need_wal(),
-        next_xid: unsafe { pg_sys::ReadNextFullTransactionId() },
-    };
+        unsafe { pg_sys::GetCurrentFullTransactionId() },
+        indexrel.need_wal(),
+        unsafe { pg_sys::ReadNextFullTransactionId() },
+    );
 
     // Boundaries are fixed before any worker starts, so every worker cuts on the same ones.
     // A concurrent build samples under its registered snapshot, and its drain re-fetches

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -105,7 +105,7 @@ type ScanDesc = (usize, *mut pg_sys::ParallelTableScanDescData);
 #[repr(C)]
 struct WorkerCoordination {
     mutex: Spinlock,
-    _pad: [u8; 7],
+    _pad: [u8; 4],
     nstarted: usize,
     nlaunched: usize,
     ntuples_done: usize,
@@ -115,13 +115,22 @@ struct WorkerCoordination {
 }
 
 // SAFETY: WorkerCoordination is #[repr(C)] with explicit padding. All
-// fields are integer types (Spinlock = u8 wrapper, usize). Every bit
+// fields are integer types (Spinlock = i32 wrapper, usize). Every bit
 // pattern is valid.
 unsafe impl bytemuck::Zeroable for WorkerCoordination {}
 unsafe impl bytemuck::Pod for WorkerCoordination {}
 
 impl ParallelStateType for WorkerCoordination {}
+
+// SAFETY: SharedFileSet is #[repr(C)]. All fields are integer types
+// (pid_t, uint32, c_int, slock_t, Oid array). Every bit pattern is valid.
+unsafe impl bytemuck::Zeroable for pg_sys::SharedFileSet {}
+unsafe impl bytemuck::Pod for pg_sys::SharedFileSet {}
 impl ParallelStateType for pg_sys::SharedFileSet {}
+
+const _: () = assert!(size_of::<WorkerConfig>() == 40);
+const _: () = assert!(size_of::<WorkerCoordination>() == 40);
+
 impl WorkerCoordination {
     fn inc_nstarted(&mut self) {
         let _lock = self.mutex.acquire();

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -142,14 +142,11 @@ unsafe impl bytemuck::Pod for WorkerCoordination {}
 
 impl ParallelStateType for WorkerCoordination {}
 
-// SAFETY: SharedFileSet is #[repr(C)]. All fields are integer types
-// (pid_t, uint32, c_int, slock_t, Oid array). Every bit pattern is valid.
-unsafe impl bytemuck::Zeroable for pg_sys::SharedFileSet {}
-unsafe impl bytemuck::Pod for pg_sys::SharedFileSet {}
-impl ParallelStateType for pg_sys::SharedFileSet {}
+// SharedFileSet is a foreign bindgen type that cannot implement Pod.
+// It is accessed through object_raw() instead of the typed object() path.
 
 const _: () = assert!(size_of::<WorkerConfig>() == 40);
-const _: () = assert!(size_of::<WorkerCoordination>() == 40);
+const _: () = assert!(size_of::<WorkerCoordination>() == 48);
 
 impl WorkerCoordination {
     fn inc_nstarted(&mut self) {
@@ -207,6 +204,14 @@ struct ParallelBuild {
     /// leader initializes it in place once the DSM is mapped, since its cleanup hooks onto the
     /// segment. Untouched without `partition_by`.
     fileset: pg_sys::SharedFileSet,
+}
+
+impl ParallelState for pg_sys::SharedFileSet {
+    fn as_bytes(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(self as *const _ as *const u8, size_of_val(self))
+        }
+    }
 }
 
 impl ParallelState for ScanDesc {
@@ -318,10 +323,14 @@ impl ParallelWorker for BuildWorker<'_> {
             .expect("should be able to get partitioning bytes")
             .expect("partitioning bytes should not be NULL");
         let partitioning = deserialize_partitioning(partitioning);
-        let fileset = state_manager
-            .object::<pg_sys::SharedFileSet>(FILESET_STATE_IDX)
-            .expect("should be able to get the spill fileset")
-            .expect("spill fileset should not be NULL");
+        // SAFETY: the leader wrote a valid SharedFileSet into this slot
+        // via SharedFileSetInit before workers launched.
+        let fileset = unsafe {
+            state_manager
+                .object_raw::<pg_sys::SharedFileSet>(FILESET_STATE_IDX)
+                .expect("should be able to get the spill fileset")
+                .expect("spill fileset should not be NULL")
+        };
 
         unsafe {
             // A worker attaches so that the last process out deletes the spill files. On an
@@ -431,7 +440,7 @@ impl<'a> BuildWorker<'a> {
             // descriptor on the parallel path, and from `build_index` on the serial one. The
             // scan ends before the drain runs and unregisters what it registered, so this
             // registration keeps the snapshot alive until the drain is done with it.
-            let build_snapshot = (partitioning.is_some() && self.config.concurrent)
+            let build_snapshot = (partitioning.is_some() && self.config.concurrent())
                 .then(|| {
                     self.table_scan_desc
                         .map(|scan| (*scan.as_ptr()).rs_snapshot)
@@ -1488,11 +1497,15 @@ pub(super) fn build_index(
             }
             // The spill fileset is initialized in the DSM itself: its cleanup is a detach
             // callback on the segment, keyed on this very address, so a copy would not do.
-            let fileset = launcher
-                .state_manager()
-                .object::<pg_sys::SharedFileSet>(FILESET_STATE_IDX)
-                .expect("should be able to get the spill fileset")
-                .expect("spill fileset should not be NULL");
+            // SAFETY: the leader initialises the SharedFileSet in this slot
+            // before any worker launches.
+            let fileset = unsafe {
+                launcher
+                    .state_manager()
+                    .object_raw::<pg_sys::SharedFileSet>(FILESET_STATE_IDX)
+                    .expect("should be able to get the spill fileset")
+                    .expect("spill fileset should not be NULL")
+            };
             unsafe { pg_sys::SharedFileSetInit(fileset, launcher.dsm_segment()) };
         }
     ) {

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -85,6 +85,26 @@ unsafe impl bytemuck::Zeroable for WorkerConfig {}
 unsafe impl bytemuck::Pod for WorkerConfig {}
 
 impl WorkerConfig {
+    fn new(
+        heaprelid: pg_sys::Oid,
+        indexrelid: pg_sys::Oid,
+        concurrent: bool,
+        current_xid: pg_sys::FullTransactionId,
+        need_wal: bool,
+        next_xid: pg_sys::FullTransactionId,
+    ) -> Self {
+        Self {
+            heaprelid,
+            indexrelid,
+            concurrent: concurrent as u8,
+            _pad1: [0; 7],
+            current_xid,
+            need_wal: need_wal as u8,
+            _pad2: [0; 7],
+            next_xid,
+        }
+    }
+
     fn concurrent(&self) -> bool {
         self.concurrent != 0
     }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -208,9 +208,7 @@ struct ParallelBuild {
 
 impl ParallelState for pg_sys::SharedFileSet {
     fn as_bytes(&self) -> &[u8] {
-        unsafe {
-            std::slice::from_raw_parts(self as *const _ as *const u8, size_of_val(self))
-        }
+        unsafe { std::slice::from_raw_parts(self as *const _ as *const u8, size_of_val(self)) }
     }
 }
 

--- a/pg_search/src/postgres/locks.rs
+++ b/pg_search/src/postgres/locks.rs
@@ -17,7 +17,7 @@
 use pgrx::{IntoDatum, direct_function_call, pg_sys};
 use std::ptr::addr_of_mut;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, bytemuck::Zeroable, bytemuck::Pod)]
 #[repr(transparent)]
 pub struct Spinlock(pg_sys::slock_t);
 


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #5552

## What

Replace `ParallelStateType: Copy` with `ParallelStateType: bytemuck::Pod`. Replace unsafe `as_bytes()` with safe `bytemuck::bytes_of()` and `bytemuck::cast_slice()`. Add `object_raw()` for foreign types that cannot implement `Pod`. Replace the `(SegmentId, u32)` tuple with a named `#[repr(C)]` struct.

## Why

The `parallel_worker` module stores Rust structs as raw bytes in Postgres shared memory. The current code has three soundness bugs:

1. `as_bytes()` creates a `&[u8]` over the full struct size, including uninitialized padding bytes. This is undefined behavior. `Config` has 15 bytes of padding; `WorkerConfig` has 14.
2. `bool` is in the `ParallelStateType` impl list. A `bool` must be `0` or `1`. Any other byte value is undefined behavior.
3. `(SegmentId, u32)` uses unspecified Rust tuple layout. The compiler may reorder or pad fields between versions.

Pod guarantees three properties: `#[repr(C)]` layout, no uninitialized padding, and every bit pattern is valid. These properties let `as_bytes()` and `object()`/`slice()` operate without undefined behaviour. This approach follows the existing `AggregatesPayloadHeader` pattern at `postgres/mod.rs:168`.

## How

- **Wrapper trait kept.** `ParallelStateType` stays as a one-line supertrait over Pod. No call sites change. The wrapper can be removed in a follow-up if preferred.
- **Type-name check left unchanged.** The string identity check in `decode_info` is not undefined behavior. It is a separate concern.
- **`unsafe impl Pod` on 4 structs.** `Oid` and `FullTransactionId` are foreign pgrx types that do not implement Pod. The derive macro cannot verify its fields. Each `unsafe impl` block includes a SAFETY comment.

## Tests

Updated the existing `test_parallel_workers` test to add `Pod` and `Zeroable` derives to `MyState` so it satisfies the new `ParallelStateType: Pod` bound.

Added the following tests:

**`pg_search/src/parallel_worker/mod.rs`** (`#[pg_test]`):
- `test_pod_struct_bytes_of_round_trip` — build a Pod struct with explicit padding, serialise it with `bytes_of`, recover it with `from_bytes`, and verify the field values match.
- `test_pod_vec_cast_slice_round_trip` — serialise a `Vec<u32>` with `cast_slice`, recover it, and verify the values match.

**`pg_search/src/aggregate/mod.rs`** (`#[test]}`, no Postgres required):
- `segment_deleted_docs_round_trips` — convert a random `SegmentId` to `SegmentDeletedDocs` and back. Verify the id and deleted count survive the `[u8; 16]` round-trip.
- `segment_deleted_docs_bytes_match_fields` — verify that `bytemuck::bytes_of` produces the expected byte layout for known field values.
- `config_solve_mvcc_accessor` — verify the `u8`-to-`bool` accessor returns correct values for inputs `0`, `1`, and `2`.
- `config_new_zeroes_padding` — verify that `Config::new()` zeroes all three padding regions.
- `state_new_zeroes_padding` — verify that `State::new()` zeroes the padding region.
