### PR TITLE
feat: Add support for aggregate score joins.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,7 +5117,6 @@ dependencies = [
  "strum 0.28.0",
  "superkmeans-rs",
  "tantivy",
- "tantivy-common",
  "tantivy-fst",
  "thiserror 2.0.19",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,6 @@ overflow-checks = true
 [workspace.dependencies]
 pgrx = "=0.19.2"
 pgrx-tests = "=0.19.2"
-
-# Keep the Git revisions for `tantivy`, `tantivy-common`, and the crates.io
-# patches in sync.
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "c3caae3f613d5906c8080a3c3c2845190e749b64", features = [
   "columnar-zstd-compression",
   "lz4-compression",
@@ -78,11 +75,9 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
   "stemmer",
   "stopwords",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-common", rev = "c3caae3f613d5906c8080a3c3c2845190e749b64" }
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-common", rev = "c3caae3f613d5906c8080a3c3c2845190e749b64" }
 tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c3caae3f613d5906c8080a3c3c2845190e749b64" }
 
 [workspace.lints.clippy]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-+MM1NBdxAdIt1Q3b/fvnmQkIkink/HRkmHFfy3+8gk0=";
+  cargoHash = "sha256-wLMHj/uaizjqZ1FRGAkP4ZG2wDH5oPsuBSm3lfQ2XDY=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -56,7 +56,6 @@ serde_json = { version = "1.0.149", features = [
 ] }
 serde_cbor = "0.11.2"
 tantivy.workspace = true
-tantivy-common.workspace = true
 thiserror = "2.0.18"
 ordered-float = "5.3.0"
 uuid = "1.23.1"

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -469,6 +469,10 @@ pub enum OrderByFeature {
     Score {
         rti: u32,
     },
+    /// Sum of scores across multiple relations (used in JoinScan).
+    ScoreSum {
+        rtis: Vec<pg_sys::Index>,
+    },
     Field {
         name: FieldName,
         rti: u32,
@@ -517,6 +521,7 @@ impl std::fmt::Display for OrderByFeature {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Score { .. } => write!(f, "pdb.score()"),
+            Self::ScoreSum { .. } => write!(f, "sum(pdb.score())"),
             Self::Field { name, .. } => write!(f, "{name}"),
             Self::Var { name, .. } => write!(f, "{}", name.as_deref().unwrap_or("?")),
             Self::NullTest {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -587,13 +587,14 @@ impl SearchIndexReader {
         self.and_query(tantivy_query)
     }
 
-    /// Compiles a tantivy `Weight` for a tagged search query without scoring.
+    /// Compiles a tantivy `Weight` for a tagged search query.
     pub fn compile_match_weight(
         &self,
         query_input: &SearchQueryInput,
+        need_scores: bool,
     ) -> tantivy::Result<Box<dyn tantivy::query::Weight>> {
         let tantivy_query = self.make_query(query_input, None);
-        tantivy_query.weight(EnableScoring::disabled_from_searcher(self.searcher()))
+        tantivy_query.weight(enable_scoring(need_scores, self.searcher()))
     }
 
     /// Count matched docs by summing `Weight::count` across segments.

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -1082,6 +1082,10 @@ impl SearchIndexReader {
                 ..
             } => unreachable!("NullTest ORDER BY is only used in JoinScan"),
             OrderByInfo {
+                feature: OrderByFeature::ScoreSum { .. },
+                ..
+            } => unreachable!("ScoreSum ORDER BY is only used in JoinScan"),
+            OrderByInfo {
                 feature:
                     OrderByFeature::VectorDistance {
                         name, query_vector, ..
@@ -1675,6 +1679,10 @@ impl SearchIndexReader {
                     feature: OrderByFeature::NullTest { .. },
                     ..
                 } => unreachable!("NullTest ORDER BY is only used in JoinScan"),
+                OrderByInfo {
+                    feature: OrderByFeature::ScoreSum { .. },
+                    ..
+                } => unreachable!("ScoreSum ORDER BY is only used in JoinScan"),
                 OrderByInfo {
                     feature: OrderByFeature::VectorDistance { .. },
                     ..

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -427,6 +427,7 @@ impl AggregateCSClause {
             .filter_map(|info| match &info.feature {
                 OrderByFeature::Field { name, .. } => Some(name.to_string()),
                 OrderByFeature::Score { .. }
+                | OrderByFeature::ScoreSum { .. }
                 | OrderByFeature::Var { .. }
                 | OrderByFeature::NullTest { .. }
                 | OrderByFeature::VectorDistance { .. } => None,

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -2063,6 +2063,10 @@ fn validate_topk_expectation(
                 .to_string(),
             "Specify COLLATE \"C\" in your query, or use a byte-ordered collation instead".to_string(),
         ),
+        PathKeyInfo::Unusable(UnusableReason::UnsupportedScoreExpression) => (
+            "ORDER BY expressions containing pdb.score() cannot be evaluated in the index".to_string(),
+            "Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY".to_string(),
+        ),
         PathKeyInfo::UsablePrefix(matched) => (
             format!(
                 "only partial prefix of ORDER BY can be pushed down ({} of {} columns)",

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -119,3 +119,26 @@ pub unsafe fn is_score_func(node: *mut pg_sys::Node, rti: pg_sys::Index) -> bool
 
     false
 }
+
+/// Check if an expression tree contains any `pdb.score()` or `paradedb.score()` function calls.
+pub unsafe fn expr_contains_any_score(node: *mut pg_sys::Node) -> bool {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        data: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+
+        if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, node)
+            && score_funcoids().contains(&(*funcexpr).funcid)
+        {
+            return true;
+        }
+
+        expression_tree_walker(node, Some(walker), data)
+    }
+
+    walker(node, std::ptr::null_mut())
+}

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -621,11 +621,7 @@ impl JoinScan {
             ));
         }
 
-        if !order_by_columns_are_fast_fields(root, &all_sources, has_distinct) {
-            return Err(JoinDeclineReason::new(
-                "JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation",
-            ));
-        }
+        order_by_columns_are_fast_fields(root, &all_sources, has_distinct)?;
 
         for jk in join_keys {
             let outer_source = all_sources.iter().find(|s| s.contains_rti(jk.outer_rti));
@@ -1757,22 +1753,22 @@ unsafe fn compute_output_columns(
                 // the parent plan will not read this position.
                 output_columns.push(privdat::OutputColumnInfo::Pruned);
             }
-        } else {
-            let mut found_score = false;
-            for source in join_clause.plan.sources() {
-                if expr_uses_scores_from_source(check_expr.cast(), source) {
-                    let rti = get_score_func_rti(check_expr.cast()).unwrap_or(0);
-                    output_columns.push(privdat::OutputColumnInfo::Score {
-                        plan_position: source.plan_position,
-                        rti,
-                    });
-                    found_score = true;
-                    break;
-                }
-            }
-            if !found_score {
+        } else if let Some(rti) = get_score_func_rti(check_expr.cast()) {
+            if let Some(source) = join_clause
+                .plan
+                .sources()
+                .iter()
+                .find(|s| s.contains_rti(rti))
+            {
+                output_columns.push(privdat::OutputColumnInfo::Score {
+                    plan_position: source.plan_position,
+                    rti,
+                });
+            } else {
                 output_columns.push(privdat::OutputColumnInfo::Pruned);
             }
+        } else {
+            output_columns.push(privdat::OutputColumnInfo::Pruned);
         }
     }
 

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -2025,10 +2025,14 @@ unsafe fn collect_score_sum_rtis(node: *mut pg_sys::Node, rtis: &mut Vec<pg_sys:
         return false;
     }
     if let Some(opexpr) = nodecast!(OpExpr, T_OpExpr, stripped) {
-        let opname_ptr = pg_sys::get_opname((*opexpr).opno);
-        if !opname_ptr.is_null() {
+        let opno = (*opexpr).opno;
+        let opname_ptr = pg_sys::get_opname(opno);
+        let namespace_oid = pg_sys::get_func_namespace(pg_sys::get_opcode(opno));
+        let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
+        if !opname_ptr.is_null() && !namespace_ptr.is_null() {
+            let schema = std::ffi::CStr::from_ptr(namespace_ptr).to_bytes();
             let opname = std::ffi::CStr::from_ptr(opname_ptr).to_bytes();
-            if opname == b"+" {
+            if schema == b"pg_catalog" && opname == b"+" {
                 let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
                 if args.len() == 2
                     && let Some(left) = args.get_ptr(0)

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -23,6 +23,7 @@
 //! - Collect required fields to ensure availability during execution
 //! - Handle ORDER BY score pathkeys
 
+use super::JoinDeclineReason;
 use super::build::{
     self as build, FilterNode, InputVarInfo, JoinCSClause, JoinKeyPair, JoinLevelExpr, JoinNode,
     JoinSource, JoinSourceCandidate, JoinType, RelNode,
@@ -35,7 +36,9 @@ use crate::api::{NullTestKind, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::nodecast;
 use crate::postgres::customscan::CustomScan;
-use crate::postgres::customscan::basescan::projections::score::is_score_func;
+use crate::postgres::customscan::basescan::projections::score::{
+    expr_contains_any_score, is_score_func,
+};
 use crate::postgres::customscan::collation_semantics::{CollationOperation, collation_supports};
 use crate::postgres::customscan::opexpr::lookup_operator;
 use crate::postgres::customscan::pullup::{
@@ -1236,6 +1239,24 @@ pub(super) unsafe fn collect_required_fields(
             other => other,
         };
         match feature {
+            OrderByFeature::ScoreSum { rtis } => {
+                for rti in rtis {
+                    if let Some(source) = plan_sources
+                        .iter_mut()
+                        .find(|s| s.scan_info.heap_rti == *rti)
+                    {
+                        ensure_score_bubbling(source);
+                    }
+                }
+            }
+            OrderByFeature::Score { rti } => {
+                if let Some(source) = plan_sources
+                    .iter_mut()
+                    .find(|s| s.scan_info.heap_rti == *rti)
+                {
+                    ensure_score_bubbling(source);
+                }
+            }
             OrderByFeature::Var { rti, attno, .. } => {
                 ensure_column_in_all_sources(&mut plan_sources, *rti, *attno);
             }
@@ -1466,24 +1487,26 @@ unsafe fn pathkey_is_outer_only(
 ///
 /// For JoinScan to be proposed, all columns used in ORDER BY must be fast fields
 /// in their respective BM25 indexes (or be paradedb.score() which is handled separately).
+/// Validate whether all ORDER BY clauses can be handled by JoinScan.
 ///
 /// Pathkeys that reference only relations outside this join subtree ("outer-only")
 /// are skipped — the parent plan is responsible for sorting on those keys.
 ///
-/// Returns true if:
+/// Returns `Ok(())` if:
 /// - No ORDER BY clause exists
-/// - All relevant ORDER BY columns are fast fields or score functions
+/// - All relevant ORDER BY columns are fast fields, score functions, or valid distinct expressions
 /// - All relevant ORDER BY columns have a byte-ordered (C-like) collation
 ///
-/// Returns false if any relevant ORDER BY column is not a fast field or uses a non C-like collation.
+/// Returns `Err(JoinDeclineReason)` if validation fails, indicating whether it failed due to
+/// an unsupported expression shape or an unsupported primitive.
 pub(super) unsafe fn order_by_columns_are_fast_fields(
     root: *mut pg_sys::PlannerInfo,
     sources: &[&JoinSource],
     has_distinct: bool,
-) -> bool {
+) -> Result<(), JoinDeclineReason> {
     let pathkeys = PgList::<pg_sys::PathKey>::from_pg((*root).query_pathkeys);
     if pathkeys.is_empty() {
-        return true;
+        return Ok(());
     }
 
     let source_rtis = collect_source_rtis(sources);
@@ -1499,18 +1522,28 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
         // If a collation isn't "safe" (C-like), then we can't pushdown as Tantivy uses byte ordering
         let collation = (*equivclass).ec_collation;
         if !collation_supports(collation, CollationOperation::Ordering) {
-            return false;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: ORDER BY columns must have a byte-ordered (C-like) collation",
+            ));
         }
 
+        let mut candidate_decline: Option<JoinDeclineReason> = None;
+
         for member in members.iter_ptr() {
-            let expr = (*member).em_expr;
+            let raw_expr = (*member).em_expr;
             // Chain strip_wrappers (for PlaceHolderVar/RelabelType) then
             // strip_identity_wrappers (for identity OpExpr like `id + 0`).
-            let mut expr = strip_identity_wrappers(strip_wrappers(expr.cast()));
+            let mut expr = strip_identity_wrappers(strip_wrappers(raw_expr.cast()));
 
             // Unwrap NullTest to inspect the inner expression
             if let Some(nt) = nodecast!(NullTest, T_NullTest, expr) {
                 expr = strip_identity_wrappers(strip_wrappers((*nt).arg.cast()));
+            }
+
+            if let Some(rtis) = extract_score_sum(expr.cast())
+                && rtis.iter().all(|rti| source_rtis.contains(rti))
+            {
+                continue 'pathkey;
             }
 
             if sources
@@ -1528,15 +1561,27 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
                     continue;
                 }
 
+                let mut is_fast = false;
                 for source in sources {
                     if source.contains_rti(varno) {
                         let hr = PgSearchRelation::open(source.scan_info.heaprelid);
                         let ir = PgSearchRelation::open(source.scan_info.indexrelid);
                         if resolve_fast_field(varattno as i32, &hr.tuple_desc(), &ir).is_some() {
-                            continue 'pathkey;
+                            is_fast = true;
+                            break;
                         }
+                        let col_name =
+                            fieldname_from_var(source.scan_info.heaprelid, var, varattno)
+                                .map(|f| f.to_string())
+                                .unwrap_or_else(|| format!("attno {varattno}"));
+                        candidate_decline = Some(JoinDeclineReason::new(format!(
+                            "JoinScan not used: ORDER BY column '{col_name}' is not columnar indexed (fast = true)",
+                        )));
                         break;
                     }
+                }
+                if is_fast {
+                    continue 'pathkey;
                 }
             } else {
                 let mut found = false;
@@ -1565,13 +1610,27 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
                 if found {
                     continue 'pathkey;
                 }
+
+                if expr_contains_any_score(expr.cast()) {
+                    candidate_decline = Some(JoinDeclineReason::new(
+                        "JoinScan not used: unsupported ORDER BY expression shape containing pdb.score(); only standalone pdb.score() or sums of pdb.score() across tables ('pdb.score(a) + pdb.score(b)') are supported",
+                    ));
+                } else if candidate_decline.is_none() {
+                    candidate_decline = Some(JoinDeclineReason::new(
+                        "JoinScan not used: unsupported ORDER BY expression shape; expressions must match an indexed expression or be a sum of pdb.score() calls",
+                    ));
+                }
             }
         }
 
-        return false;
+        return Err(candidate_decline.unwrap_or_else(|| {
+            JoinDeclineReason::new(
+                "JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation",
+            )
+        }));
     }
 
-    true
+    Ok(())
 }
 
 /// Check if all Var dependencies of an expression are fast fields in any source.
@@ -1928,14 +1987,59 @@ pub(super) unsafe fn pathkey_uses_scores_from_source(
 
         for member in members.iter_ptr() {
             let expr = (*member).em_expr;
-            let check_expr = strip_wrappers(expr.cast()).cast::<pg_sys::Expr>();
-
-            if is_score_func_recursive(check_expr, source) {
+            if expr_uses_scores_from_source(expr.cast(), source) {
                 return true;
             }
         }
     }
 
+    false
+}
+
+/// Check if an expression is a sum of one or more `pdb.score(var)` calls.
+/// Returns the list of RTIs for the referenced relations if it matches.
+pub(super) unsafe fn extract_score_sum(expr: *mut pg_sys::Node) -> Option<Vec<pg_sys::Index>> {
+    let mut rtis = Vec::new();
+    if !collect_score_sum_rtis(expr, &mut rtis) || rtis.is_empty() {
+        return None;
+    }
+    Some(rtis)
+}
+
+unsafe fn collect_score_sum_rtis(node: *mut pg_sys::Node, rtis: &mut Vec<pg_sys::Index>) -> bool {
+    if node.is_null() {
+        return false;
+    }
+    let stripped = strip_identity_wrappers(strip_wrappers(node));
+    if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, stripped) {
+        if score_funcoids().contains(&(*funcexpr).funcid) {
+            let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+            if args.len() == 1
+                && let Some(arg) = args.get_ptr(0)
+                && let Some(var) = nodecast!(Var, T_Var, strip_wrappers(arg))
+            {
+                rtis.push((*var).varno as pg_sys::Index);
+                return true;
+            }
+        }
+        return false;
+    }
+    if let Some(opexpr) = nodecast!(OpExpr, T_OpExpr, stripped) {
+        let opname_ptr = pg_sys::get_opname((*opexpr).opno);
+        if !opname_ptr.is_null() {
+            let opname = std::ffi::CStr::from_ptr(opname_ptr).to_bytes();
+            if opname == b"+" {
+                let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
+                if args.len() == 2
+                    && let Some(left) = args.get_ptr(0)
+                    && let Some(right) = args.get_ptr(1)
+                {
+                    return collect_score_sum_rtis(left, rtis)
+                        && collect_score_sum_rtis(right, rtis);
+                }
+            }
+        }
+    }
     false
 }
 
@@ -2042,15 +2146,24 @@ impl JoinSortExprKind {
             };
         }
 
-        for source in sources.iter() {
-            if is_score_func_recursive(check_expr.cast(), source) {
-                if !output_rtis.contains(&source.scan_info.heap_rti) {
-                    continue;
+        if let Some(rtis) = extract_score_sum(check_expr.cast()) {
+            if rtis.len() > 1 {
+                if !rtis.iter().all(|rti| output_rtis.contains(rti)) {
+                    return if pathkey_equivalence_member {
+                        Self::SkipMember
+                    } else {
+                        Self::NoMatch
+                    };
                 }
                 return Self::Resolved(OrderByInfo {
-                    feature: OrderByFeature::Score {
-                        rti: source.scan_info.heap_rti,
-                    },
+                    feature: OrderByFeature::ScoreSum { rtis },
+                    direction,
+                });
+            } else if let Some(&rti) = rtis.first()
+                && output_rtis.contains(&rti)
+            {
+                return Self::Resolved(OrderByInfo {
+                    feature: OrderByFeature::Score { rti },
                     direction,
                 });
             }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -788,7 +788,7 @@ fn resolve_orderby_feature(
     match feature {
         OrderByFeature::Score { rti } => {
             if !distinct_col_map.is_empty() {
-                resolve_distinct_col(distinct_col_map, true, 0, 0, "")
+                resolve_distinct_col(distinct_col_map, true, *rti, 0, "")
             } else {
                 join_clause
                     .plan
@@ -798,6 +798,27 @@ fn resolve_orderby_feature(
                     .map(|source| make_source_score_col(source))
                     .unwrap_or_else(|| col("unknown_score"))
             }
+        }
+        OrderByFeature::ScoreSum { rtis } => {
+            let score_cols: Vec<Expr> = rtis
+                .iter()
+                .filter_map(|rti| {
+                    if !distinct_col_map.is_empty() {
+                        Some(resolve_distinct_col(distinct_col_map, true, *rti, 0, ""))
+                    } else {
+                        join_clause
+                            .plan
+                            .sources()
+                            .iter()
+                            .find(|s| s.scan_info.heap_rti == *rti)
+                            .map(|source| make_source_score_col(source))
+                    }
+                })
+                .collect();
+            score_cols
+                .into_iter()
+                .reduce(|acc, col_expr| acc + col_expr)
+                .unwrap_or_else(|| col("unknown_score"))
         }
         OrderByFeature::Field { name, rti } => join_clause
             .plan
@@ -1066,7 +1087,9 @@ fn build_source_df<'a>(
                             required_early.insert(col_name);
                         }
                     }
-                    OrderByFeature::Score { .. } | OrderByFeature::VectorDistance { .. } => {}
+                    OrderByFeature::Score { .. }
+                    | OrderByFeature::ScoreSum { .. }
+                    | OrderByFeature::VectorDistance { .. } => {}
                     OrderByFeature::NullTest { inner, .. } => match inner.as_ref() {
                         OrderByFeature::Field { name, rti } if source.contains_rti(*rti) => {
                             insert_field_name_required_early(

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -753,29 +753,29 @@ fn apply_distinct_group_by(
 }
 
 /// Resolve a column reference after the DISTINCT GROUP BY has rewritten every
-/// projection into a `col_N` alias. Score lookups iterate the map (rather than
-/// exact-match) because the parse-time `rti` may not survive cross-table OR
-/// predicate handling. When `distinct_col_map` is empty (DISTINCT not active),
-/// callers should not invoke this — `col_alias` is returned only as a fallback
-/// in case the requested key is missing.
+/// projection into a `col_N` alias. Score lookups try the exact RTI first, and
+/// fall back to iterating the map (rather than exact-match) because the parse-time
+/// `rti` may not survive cross-table OR predicate handling.
 fn resolve_distinct_col(
     distinct_col_map: &DistinctColMap,
     is_score: bool,
     rti: pg_sys::Index,
     attno: pg_sys::AttrNumber,
-    col_alias: &str,
-) -> Expr {
+) -> Option<Expr> {
     if is_score {
         distinct_col_map
-            .iter()
-            .find(|((_, a), _)| *a == 0)
-            .map(|(_, alias)| col(alias.as_str()))
-            .unwrap_or_else(|| col(col_alias))
+            .get(&(rti, 0))
+            .or_else(|| {
+                distinct_col_map
+                    .iter()
+                    .find(|((_, a), _)| *a == 0)
+                    .map(|(_, alias)| alias)
+            })
+            .map(|alias| col(alias.as_str()))
     } else {
         distinct_col_map
             .get(&(rti, attno))
             .map(|alias| col(alias.as_str()))
-            .unwrap_or_else(|| col(col_alias))
     }
 }
 
@@ -784,11 +784,15 @@ fn resolve_orderby_feature(
     feature: &OrderByFeature,
     join_clause: &JoinCSClause,
     distinct_col_map: &DistinctColMap,
-) -> Expr {
+) -> Result<Expr> {
     match feature {
         OrderByFeature::Score { rti } => {
             if !distinct_col_map.is_empty() {
-                resolve_distinct_col(distinct_col_map, true, *rti, 0, "")
+                resolve_distinct_col(distinct_col_map, true, *rti, 0).ok_or_else(|| {
+                    DataFusionError::Plan(format!(
+                        "JoinScan: could not resolve DISTINCT score column for RTI {rti}"
+                    ))
+                })
             } else {
                 join_clause
                     .plan
@@ -796,15 +800,23 @@ fn resolve_orderby_feature(
                     .iter()
                     .find(|s| s.scan_info.heap_rti == *rti)
                     .map(|source| make_source_score_col(source))
-                    .unwrap_or_else(|| col("unknown_score"))
+                    .ok_or_else(|| {
+                        DataFusionError::Plan(format!(
+                            "JoinScan: could not find source for score RTI {rti}"
+                        ))
+                    })
             }
         }
         OrderByFeature::ScoreSum { rtis } => {
-            let score_cols: Vec<Expr> = rtis
+            let score_cols: Result<Vec<Expr>> = rtis
                 .iter()
-                .filter_map(|rti| {
+                .map(|rti| {
                     if !distinct_col_map.is_empty() {
-                        Some(resolve_distinct_col(distinct_col_map, true, *rti, 0, ""))
+                        resolve_distinct_col(distinct_col_map, true, *rti, 0).ok_or_else(|| {
+                            DataFusionError::Plan(format!(
+                                "JoinScan: could not resolve DISTINCT score column for RTI {rti} in score sum"
+                            ))
+                        })
                     } else {
                         join_clause
                             .plan
@@ -812,13 +824,21 @@ fn resolve_orderby_feature(
                             .iter()
                             .find(|s| s.scan_info.heap_rti == *rti)
                             .map(|source| make_source_score_col(source))
+                            .ok_or_else(|| {
+                                DataFusionError::Plan(format!(
+                                    "JoinScan: could not find source for score sum RTI {rti}"
+                                ))
+                            })
                     }
                 })
                 .collect();
-            score_cols
+
+            score_cols?
                 .into_iter()
                 .reduce(|acc, col_expr| acc + col_expr)
-                .unwrap_or_else(|| col("unknown_score"))
+                .ok_or_else(|| {
+                    DataFusionError::Plan("JoinScan: empty RTI list in ScoreSum".to_string())
+                })
         }
         OrderByFeature::Field { name, rti } => join_clause
             .plan
@@ -826,16 +846,24 @@ fn resolve_orderby_feature(
             .iter()
             .find(|s| s.contains_rti(*rti))
             .map(|source| make_source_col(source, name.as_ref()))
-            .unwrap_or_else(|| {
-                pgrx::warning!("JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'");
-                col(name.as_ref())
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'"
+                ))
             }),
         OrderByFeature::Var { rti, attno, .. } => {
             if !distinct_col_map.is_empty() {
-                resolve_distinct_col(distinct_col_map, false, *rti, *attno, "")
+                resolve_distinct_col(distinct_col_map, false, *rti, *attno).ok_or_else(|| {
+                    DataFusionError::Plan(format!(
+                        "JoinScan: could not resolve DISTINCT var column for RTI {rti}, attno {attno}"
+                    ))
+                })
             } else {
-                resolve_var_to_df_col(join_clause, *rti, *attno)
-                    .unwrap_or_else(|| col("unknown_col"))
+                resolve_var_to_df_col(join_clause, *rti, *attno).ok_or_else(|| {
+                    DataFusionError::Plan(format!(
+                        "JoinScan: could not resolve var column for RTI {rti}, attno {attno}"
+                    ))
+                })
             }
         }
         OrderByFeature::NullTest { .. } => {
@@ -866,13 +894,13 @@ fn apply_sort(
                 inner,
                 nulltesttype,
             } => {
-                let inner_expr = resolve_orderby_feature(inner, join_clause, distinct_col_map);
+                let inner_expr = resolve_orderby_feature(inner, join_clause, distinct_col_map)?;
                 match nulltesttype {
                     NullTestKind::IsNull => inner_expr.is_null(),
                     NullTestKind::IsNotNull => inner_expr.is_not_null(),
                 }
             }
-            other => resolve_orderby_feature(other, join_clause, distinct_col_map),
+            other => resolve_orderby_feature(other, join_clause, distinct_col_map)?,
         };
 
         let asc = matches!(
@@ -908,11 +936,13 @@ fn apply_output_projection(
                 match proj {
                     build::ChildProjection::Expression { .. } => col(&col_alias),
                     build::ChildProjection::Score { rti } => {
-                        resolve_distinct_col(distinct_col_map, true, *rti, 0, &col_alias)
+                        resolve_distinct_col(distinct_col_map, true, *rti, 0)
+                            .unwrap_or_else(|| col(&col_alias))
                     }
                     build::ChildProjection::Column { rti, attno }
                     | build::ChildProjection::IndexedExpression { rti, attno } => {
-                        resolve_distinct_col(distinct_col_map, false, *rti, *attno, &col_alias)
+                        resolve_distinct_col(distinct_col_map, false, *rti, *attno)
+                            .unwrap_or_else(|| col(&col_alias))
                     }
                 }
             } else {

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -92,6 +92,8 @@ pub enum UnusableReason {
     },
     /// We cannot pushdown collations that are not byte-ordered (C-like)
     UnsafeCollation,
+    /// ORDER BY uses an unsupported expression shape containing pdb.score()
+    UnsupportedScoreExpression,
 }
 
 #[derive(Debug, Clone)]
@@ -624,6 +626,14 @@ where
         // of pathkeys.
         if !found_valid_member {
             if pathkey_styles.is_empty() {
+                let has_score = members.iter_ptr().any(|m| {
+                    crate::postgres::customscan::basescan::projections::score::expr_contains_any_score(
+                        (*m).em_expr.cast(),
+                    )
+                });
+                if has_score {
+                    return PathKeyInfo::Unusable(UnusableReason::UnsupportedScoreExpression);
+                }
                 return PathKeyInfo::Unusable(UnusableReason::NotSortable);
             } else {
                 return PathKeyInfo::UsablePrefix(pathkey_styles);

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -1492,36 +1492,58 @@ pub unsafe fn add_missing_search_operators_to_tlist(
     tlist: &mut PgList<pg_sys::TargetEntry>,
     search_operator_funcoids: &[pg_sys::Oid],
 ) {
-    let mut add_missing_func = |expr: *mut pg_sys::Node| {
-        if !is_search_operator(expr, search_operator_funcoids) {
-            return;
+    use pgrx::pg_sys::expression_tree_walker;
+    use std::ptr::addr_of_mut;
+
+    #[pgrx::pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        context: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
         }
 
-        let unwrapped_expr = strip_wrappers(expr.cast());
-        let already_present = tlist.iter_ptr().any(|te| {
-            pg_sys::equal(
-                strip_wrappers((*te).expr.cast()).cast(),
-                unwrapped_expr.cast(),
-            )
-        });
+        let ctx = context.cast::<Context>();
+        if is_search_operator(node, (*ctx).search_operator_funcoids) {
+            let unwrapped_expr = strip_wrappers(node);
+            let already_present = (*ctx).tlist.iter_ptr().any(|te| {
+                pg_sys::equal(
+                    strip_wrappers((*te).expr.cast()).cast(),
+                    unwrapped_expr.cast(),
+                )
+            });
 
-        if !already_present {
-            let resno = tlist.len() as pg_sys::AttrNumber + 1;
-            let te = pg_sys::makeTargetEntry(
-                pg_sys::copyObjectImpl(expr.cast()).cast(),
-                resno,
-                std::ptr::null_mut(),
-                true, // resjunk
-            );
-            tlist.push(te);
+            if !already_present {
+                let resno = (*ctx).tlist.len() as pg_sys::AttrNumber + 1;
+                let te = pg_sys::makeTargetEntry(
+                    pg_sys::copyObjectImpl(node.cast()).cast(),
+                    resno,
+                    std::ptr::null_mut(),
+                    true, // resjunk
+                );
+                (*ctx).tlist.push(te);
+            }
         }
+
+        expression_tree_walker(node, Some(walker), context)
+    }
+
+    struct Context<'a> {
+        tlist: &'a mut PgList<pg_sys::TargetEntry>,
+        search_operator_funcoids: &'a [pg_sys::Oid],
+    }
+
+    let mut ctx = Context {
+        tlist,
+        search_operator_funcoids,
     };
 
     // Look in processed_tlist
     if !(*root).processed_tlist.is_null() {
         let p_tlist = PgList::<pg_sys::TargetEntry>::from_pg((*root).processed_tlist);
         for te in p_tlist.iter_ptr() {
-            add_missing_func((*te).expr.cast());
+            walker((*te).expr.cast(), addr_of_mut!(ctx).cast());
         }
     }
 
@@ -1533,7 +1555,7 @@ pub unsafe fn add_missing_search_operators_to_tlist(
             if !eclass.is_null() {
                 let members = PgList::<pg_sys::EquivalenceMember>::from_pg((*eclass).ec_members);
                 for em in members.iter_ptr() {
-                    add_missing_func((*em).em_expr.cast());
+                    walker((*em).em_expr.cast(), addr_of_mut!(ctx).cast());
                 }
             }
         }

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -22,10 +22,12 @@ use crate::index::reader::index::MultiSegmentSearchResults;
 use crate::postgres::heap::VisibilityChecker;
 use arrow_array::builder::{BooleanBuilder, UInt64Builder};
 use arrow_array::{Array, ArrayRef, BooleanArray, Float32Array, RecordBatch, UInt64Array};
+use arrow_buffer::BooleanBufferBuilder;
 use arrow_schema::SchemaRef;
 use datafusion::arrow::compute;
 use std::sync::Arc;
-use tantivy::{DocId, Score, SegmentOrdinal};
+use tantivy::query::Scorer;
+use tantivy::{DocId, DocSet, Score, SegmentOrdinal};
 
 /// The maximum number of rows to batch materialize in memory while iterating over a result set.
 ///
@@ -154,13 +156,90 @@ pub struct Scanner {
     score_threshold: Option<Score>,
     tagged_queries: Vec<TaggedMatchQuery>,
     current_segment_ord: Option<SegmentOrdinal>,
-    current_match_bitsets: crate::api::HashMap<String, tantivy_common::BitSet>,
+    active_tag_scorers: Vec<ActiveTagScorer>,
 }
 
-/// A tagged search query whose match bitset is lazily evaluated per-segment.
+/// A tagged search query whose scorer is lazily evaluated per-segment.
 pub struct TaggedMatchQuery {
     pub tag_name: String,
     pub weight: Box<dyn tantivy::query::Weight>,
+}
+
+struct ActiveTagScorer {
+    tag_name: String,
+    scorer: Box<dyn Scorer>,
+}
+
+impl ActiveTagScorer {
+    /// Evaluates this tag scorer against a batch of `ids` (within `start_doc..=end_doc`),
+    /// accumulating BM25 scores into `scores` and populating `memoized_columns` if this
+    /// `MatchTag` column is requested.
+    fn evaluate_batch(
+        &mut self,
+        ids: &[DocId],
+        end_doc: DocId,
+        scores: &mut [Score],
+        which_fast_fields: &[WhichFastField],
+        memoized_columns: &mut [Option<ArrayRef>],
+    ) {
+        // 1. Only allocate/build the BooleanArray if this tag is actually needed
+        let is_needed = which_fast_fields.iter().any(|ff| match ff {
+            WhichFastField::MatchTag(name) => name == &self.tag_name,
+            _ => false,
+        });
+
+        // 2. Pre-allocate and zero-fill the bit-packed buffer directly (1 bit per entry)
+        let mut builder = if is_needed {
+            let mut b = BooleanBufferBuilder::new(ids.len());
+            b.advance(ids.len()); // zero-initializes ids.len() bits
+            Some(b)
+        } else {
+            None
+        };
+
+        let tag_scorer = &mut self.scorer;
+        let mut id_idx = 0;
+
+        while id_idx < ids.len() {
+            let target = ids[id_idx];
+            let mut cur_doc = tag_scorer.doc();
+
+            if cur_doc < target {
+                cur_doc = tag_scorer.seek(target);
+            }
+
+            if cur_doc == tantivy::TERMINATED || cur_doc > end_doc {
+                break;
+            }
+
+            if cur_doc == target {
+                if let Some(b) = builder.as_mut() {
+                    b.set_bit(id_idx, true);
+                }
+                scores[id_idx] += tag_scorer.score();
+                tag_scorer.advance();
+                id_idx += 1;
+            } else {
+                // cur_doc > target: skip ids until target catches up to cur_doc
+                id_idx += 1;
+                while id_idx < ids.len() && ids[id_idx] < cur_doc {
+                    id_idx += 1;
+                }
+            }
+        }
+
+        // 3. Construct the BooleanArray in O(1) zero-copy if needed
+        if let Some(mut b) = builder {
+            let array: ArrayRef = Arc::new(BooleanArray::new(b.finish(), None));
+            for (idx, ff) in which_fast_fields.iter().enumerate() {
+                if let WhichFastField::MatchTag(name) = ff
+                    && name == &self.tag_name
+                {
+                    memoized_columns[idx] = Some(Arc::clone(&array));
+                }
+            }
+        }
+    }
 }
 
 impl Scanner {
@@ -220,34 +299,29 @@ impl Scanner {
             score_threshold: None,
             tagged_queries: Vec::new(),
             current_segment_ord: None,
-            current_match_bitsets: crate::api::HashMap::default(),
+            active_tag_scorers: Vec::new(),
         }
     }
 
-    /// Adds a tagged search query whose match bitset will be lazily evaluated per-segment.
+    /// Adds a tagged search query whose scorer will be lazily evaluated per-segment.
     pub fn add_tagged_query(&mut self, tag_name: String, weight: Box<dyn tantivy::query::Weight>) {
         self.tagged_queries
             .push(TaggedMatchQuery { tag_name, weight });
     }
 
-    fn ensure_segment_bitsets(&mut self, segment_ord: SegmentOrdinal) {
+    fn ensure_segment_tag_scorers(&mut self, segment_ord: SegmentOrdinal) {
         if self.current_segment_ord != Some(segment_ord) {
-            self.current_match_bitsets.clear();
+            self.active_tag_scorers.clear();
             if !self.tagged_queries.is_empty() {
                 let segment_reader = self.search_results.searcher().segment_reader(segment_ord);
                 for tq in &self.tagged_queries {
-                    let mut bitset =
-                        tantivy_common::BitSet::with_max_value(segment_reader.max_doc());
-                    let mut scorer = tq.weight.scorer(segment_reader, 1.0).unwrap_or_else(|e| {
+                    let scorer = tq.weight.scorer(segment_reader, 1.0).unwrap_or_else(|e| {
                         panic!("Failed to create scorer for tag {}: {e}", tq.tag_name)
                     });
-                    let mut doc = scorer.doc();
-                    while doc != tantivy::TERMINATED {
-                        bitset.insert(doc);
-                        doc = scorer.advance();
-                    }
-                    self.current_match_bitsets
-                        .insert(tq.tag_name.clone(), bitset);
+                    self.active_tag_scorers.push(ActiveTagScorer {
+                        tag_name: tq.tag_name.clone(),
+                        scorer,
+                    });
                 }
             }
             self.current_segment_ord = Some(segment_ord);
@@ -303,6 +377,43 @@ impl Scanner {
         }
     }
 
+    /// Populates `memoized_columns` for requested `MatchTag` and `Score` fields.
+    ///
+    /// For tagged scans, evaluating each match tag mutates `scores` by accumulating
+    /// the matched tag's BM25 score onto the base query score in-place for each row.
+    fn populate_scores_for_batch(
+        &mut self,
+        ids: &[DocId],
+        mut scores: Vec<Score>,
+        memoized_columns: &mut [Option<ArrayRef>],
+    ) {
+        if !self.active_tag_scorers.is_empty() && !ids.is_empty() {
+            let end_doc = *ids.last().unwrap();
+            for active_tag in &mut self.active_tag_scorers {
+                active_tag.evaluate_batch(
+                    ids,
+                    end_doc,
+                    &mut scores,
+                    &self.which_fast_fields,
+                    memoized_columns,
+                );
+            }
+        }
+
+        if self
+            .which_fast_fields
+            .iter()
+            .any(|ff| matches!(ff, WhichFastField::Score))
+        {
+            let scores_array = Arc::new(Float32Array::from(scores)) as ArrayRef;
+            for (idx, ff) in self.which_fast_fields.iter().enumerate() {
+                if matches!(ff, WhichFastField::Score) {
+                    memoized_columns[idx] = Some(scores_array.clone());
+                }
+            }
+        }
+    }
+
     /// Fetch the next batch of results, applying visibility checks and
     /// pre-materialization filters.
     ///
@@ -318,7 +429,7 @@ impl Scanner {
     ) -> Option<Batch> {
         pgrx::check_for_interrupts!();
         let (segment_ord, scores, mut ids) = self.try_get_batch_ids()?;
-        self.ensure_segment_bitsets(segment_ord);
+        self.ensure_segment_tag_scorers(segment_ord);
 
         // Memoize fetched columns to avoid redundant fetches.
         // - Numeric columns: stores the values directly.
@@ -329,18 +440,9 @@ impl Scanner {
         // to keep them aligned with `ids`.
         let mut memoized_columns: Vec<Option<ArrayRef>> = vec![None; self.which_fast_fields.len()];
 
-        if self
-            .which_fast_fields
-            .iter()
-            .any(|ff| matches!(ff, WhichFastField::Score))
-        {
-            let scores_array = Arc::new(Float32Array::from(scores)) as ArrayRef;
-            for (idx, ff) in self.which_fast_fields.iter().enumerate() {
-                if matches!(ff, WhichFastField::Score) {
-                    memoized_columns[idx] = Some(scores_array.clone());
-                }
-            }
-        }
+        // TODO: Determine which pre-filters can safely be applied before calculating
+        // scores/match-tags to avoid evaluating tag scorers on rows that will be pruned.
+        self.populate_scores_for_batch(&ids, scores, &mut memoized_columns);
 
         // Apply pre-materialization filters before visibility checks (which require the ctid), and
         // before dictionary lookups.
@@ -498,19 +600,13 @@ impl Scanner {
                         &ids,
                     )),
                 },
-                WhichFastField::MatchTag(tag_name) => {
-                    let bitset = self.current_match_bitsets.get(tag_name).unwrap_or_else(|| {
+                WhichFastField::MatchTag(tag_name) => Some(
+                    memoized_columns[ff_index].clone().unwrap_or_else(|| {
                         panic!(
-                            "Missing match bitset for tag column {tag_name} in segment {segment_ord}"
+                            "MatchTag column '{tag_name}' at index {ff_index} was not populated during batch scan in segment {segment_ord}"
                         )
-                    });
-                    let mut builder =
-                        arrow_array::builder::BooleanBuilder::with_capacity(ids.len());
-                    for &doc_id in &ids {
-                        builder.append_value(bitset.contains(doc_id));
-                    }
-                    Some(Arc::new(builder.finish()) as ArrayRef)
-                }
+                    }),
+                ),
             })
             .collect();
 

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -333,23 +333,36 @@ impl Scanner {
         self.batch_size = size.min(MAX_BATCH_SIZE);
     }
 
-    /// Sets the score threshold to be applied to batches extracted afterwards.
+    /// Returns whether score threshold pushdown into the underlying Tantivy segment scorer
+    /// is supported.
+    ///
+    /// Scorer-level threshold pushdown (e.g. BlockMax-WAND) requires the base scorer to
+    /// produce the complete, final score. When tagged queries are active, scores are
+    /// accumulated post-scan across multiple match tags in [`Self::populate_scores_for_batch`],
+    /// so segment scorer thresholding is bypassed and score filtering is instead handled
+    /// post-accumulation by pre-filters.
+    pub(crate) fn can_pushdown_score_threshold(&self) -> bool {
+        self.tagged_queries.is_empty()
+    }
+
+    /// Sets the score threshold to be pushed down to the underlying segment scorer.
     /// We assume the threshold will monotonically increase, and uses
     /// greater-than (>) semantics.
     ///
-    /// Passing a `None` will not cause the threshold on the current segment
-    /// to be updated, as threshold changes are only applied when
-    /// `self.threshold` is `Some(_)`.
+    /// If [`Self::can_pushdown_score_threshold`] is false (e.g. tagged queries are present),
+    /// the threshold is ignored at the segment-scorer level and enforced post-accumulation
+    /// via pre-filters.
     pub(crate) fn set_score_threshold(&mut self, threshold: Option<Score>) {
         self.score_threshold = threshold;
     }
 
     fn try_get_batch_ids(&mut self) -> Option<(SegmentOrdinal, Vec<Score>, Vec<DocId>)> {
+        let can_pushdown = self.can_pushdown_score_threshold();
         // Collect a batch of ids for a single segment.
         loop {
             let scorer_iter = self.search_results.current_segment()?;
             let segment_ord = scorer_iter.segment_ord();
-            if let Some(threshold) = self.score_threshold {
+            if can_pushdown && let Some(threshold) = self.score_threshold {
                 scorer_iter.set_threshold(threshold);
             }
 

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -1114,7 +1114,9 @@ impl ExecutionPlan for PgSearchScanPlan {
                     })
                 };
 
-                scanner.set_score_threshold(score_threshold);
+                if scanner.can_pushdown_score_threshold() {
+                    scanner.set_score_threshold(score_threshold);
+                }
                 let next_batch = scanner.next(
                     &ffhelper,
                     &mut visibility,

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -1074,6 +1074,10 @@ impl ExecutionPlan for PgSearchScanPlan {
                     None => reader.search(),
                 }
             };
+            let need_scores = scanner_config
+                .which_fast_fields
+                .iter()
+                .any(|wff| matches!(wff, WhichFastField::Score));
             let mut scanner = Scanner::new(
                 search_results,
                 scanner_config.batch_size_hint,
@@ -1083,7 +1087,7 @@ impl ExecutionPlan for PgSearchScanPlan {
             if let crate::scan::ScanMode::Tagged { local_queries, .. } = &scanner_config.scan_mode {
                 for tq in local_queries {
                     let weight = reader
-                        .compile_match_weight(&tq.query)
+                        .compile_match_weight(&tq.query, need_scores)
                         .map_err(|e| DataFusionError::Internal(format!(
                             "Failed to compile match weight for tag {}: {e}",
                             tq.tag_name

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -163,7 +163,10 @@ fn try_inject_at_sort(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionP
 ///     assigned the correct physical index when it built the SortExec.
 ///   - If the name is not found at all, log a debug diagnostic and fall back
 ///     to `col.index()` as a last resort.
-fn resolve_physical_index(col: &Column, schema: &datafusion::arrow::datatypes::SchemaRef) -> usize {
+fn resolve_physical_index(
+    col: &Column,
+    schema: &datafusion::arrow::datatypes::SchemaRef,
+) -> Option<usize> {
     let col_name = col.name();
     let logical_idx = col.index();
 
@@ -176,21 +179,13 @@ fn resolve_physical_index(col: &Column, schema: &datafusion::arrow::datatypes::S
 
     let physical_idx = match matches.len() {
         0 => {
-            // Name not found — fall back to the logical index.
-            // This should not normally happen; a missing name suggests a
-            // plan-construction bug where the SortExec column does not exist
-            // in the lookup child schema.
             pgrx::debug2!(
-                "SegmentedTopK: column '{}' not found in input schema; using logical index {} as fallback",
-                col_name,
-                logical_idx
+                "SegmentedTopK: column '{}' not found in input schema",
+                col_name
             );
-            logical_idx
+            return None;
         }
-        1 => {
-            // Unique name — use the exact physical position from the schema.
-            matches[0]
-        }
+        1 => matches[0],
         _ => {
             // Duplicate names (self-join) — DataFusion already set col.index()
             // to the correct physical position when building the SortExec.
@@ -199,7 +194,13 @@ fn resolve_physical_index(col: &Column, schema: &datafusion::arrow::datatypes::S
             // or intermediate Projections that reorder same-name groups.
             // Proper fix: thread explicit column lineage similar to trace_column
             // in late_materialization.rs. Tracked in issue #5093.
-            logical_idx
+            if logical_idx < schema.fields().len()
+                && schema.fields()[logical_idx].name() == col_name
+            {
+                logical_idx
+            } else {
+                return None;
+            }
         }
     };
 
@@ -211,7 +212,7 @@ fn resolve_physical_index(col: &Column, schema: &datafusion::arrow::datatypes::S
             physical_idx
         );
     }
-    physical_idx
+    Some(physical_idx)
 }
 
 /// Recursively search below `plan` for a `TantivyLookupExec` whose deferred
@@ -234,11 +235,14 @@ fn try_inject_below_lookup(
             // physical index resolution to handle join-reordered schemas.
             let has_deferred_sort_col = sort_exprs.iter().any(|expr| {
                 if let Some(col) = expr.expr.downcast_ref::<Column>() {
-                    let physical_idx = resolve_physical_index(col, &input_schema);
-                    lookup
-                        .deferred_fields()
-                        .iter()
-                        .any(|d| d.col_idx == physical_idx)
+                    if let Some(physical_idx) = resolve_physical_index(col, &input_schema) {
+                        lookup
+                            .deferred_fields()
+                            .iter()
+                            .any(|d| d.col_idx == physical_idx)
+                    } else {
+                        false
+                    }
                 } else {
                     false
                 }
@@ -275,21 +279,20 @@ fn try_inject_below_lookup(
                 // resolving logical → physical indices for each.
                 let mut deferred_columns = Vec::new();
                 for expr in &sort_exprs {
-                    if let Some(col) = expr.expr.downcast_ref::<Column>() {
-                        let physical_idx = resolve_physical_index(col, &input_schema);
-                        if let Some(field) = lookup
+                    if let Some(col) = expr.expr.downcast_ref::<Column>()
+                        && let Some(physical_idx) = resolve_physical_index(col, &input_schema)
+                        && let Some(field) = lookup
                             .deferred_fields()
                             .iter()
                             .find(|d| d.col_idx == physical_idx)
-                        {
-                            deferred_columns.push(
-                                crate::scan::segmented_topk_exec::DeferredSortColumn {
-                                    sort_col_idx: physical_idx,
-                                    canonical: field.canonical.clone(),
-                                    rebuild: field.rebuild.clone(),
-                                },
-                            );
-                        }
+                    {
+                        deferred_columns.push(
+                            crate::scan::segmented_topk_exec::DeferredSortColumn {
+                                sort_col_idx: physical_idx,
+                                canonical: field.canonical.clone(),
+                                rebuild: field.rebuild.clone(),
+                            },
+                        );
                     }
                 }
 
@@ -330,19 +333,28 @@ fn try_inject_below_lookup(
                 for sort_expr in &sort_exprs {
                     use datafusion::common::tree_node::{Transformed, TreeNode};
                     let input_schema_clone = Arc::clone(&input_schema);
+                    let mut resolve_failed = false;
                     let rewritten_expr = sort_expr.expr.clone().transform(|node| {
                         if let Some(col) = node.downcast_ref::<Column>() {
-                            let physical_idx = resolve_physical_index(col, &input_schema_clone);
-
-                            if physical_idx < input_schema_clone.fields().len() {
+                            if let Some(physical_idx) =
+                                resolve_physical_index(col, &input_schema_clone)
+                                && physical_idx < input_schema_clone.fields().len()
+                            {
                                 let new_col = Column::new(col.name(), physical_idx);
                                 return Ok(Transformed::yes(
                                     Arc::new(new_col) as Arc<dyn PhysicalExpr>
                                 ));
                             }
+                            resolve_failed = true;
                         }
                         Ok(Transformed::no(node))
                     })?;
+                    if resolve_failed {
+                        pgrx::debug2!(
+                            "SegmentedTopK: sort expression references column not in lookup child schema; declining injection"
+                        );
+                        return Ok(None);
+                    }
                     rewritten_sort_exprs.push(PhysicalSortExpr {
                         expr: rewritten_expr.data,
                         options: sort_expr.options,
@@ -379,9 +391,11 @@ fn try_inject_below_lookup(
             }
         }
 
-        // Recurse into intermediate nodes (ProjectionExec, CoalescePartitionsExec, etc.)
-        if let Some(rewritten) =
-            try_inject_below_lookup(child, sort_exprs.clone(), k, parent_filter.clone())?
+        // Recurse into single-child intermediate nodes (ProjectionExec, CoalescePartitionsExec, VisibilityFilterExec, etc.)
+        // Do not recurse into multi-child join nodes (HashJoinExec) where TantivyLookupExec is below the join.
+        if child.children().len() == 1
+            && let Some(rewritten) =
+                try_inject_below_lookup(child, sort_exprs.clone(), k, parent_filter.clone())?
         {
             let mut new_children: Vec<Arc<dyn ExecutionPlan>> =
                 children.iter().map(|c| Arc::clone(c)).collect();

--- a/pg_search/tests/pg_regress/expected/issue_2932.out
+++ b/pg_search/tests/pg_regress/expected/issue_2932.out
@@ -11,7 +11,7 @@ CALL paradedb.create_paradedb_test_table(
 CREATE INDEX on mock_items USING paradedb (id, description, rating) WITH (key_field='id');
 -- Expressions involving pdb.score currently use a normal scan rather than Top K.
 SELECT description, pdb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
      description     |       score       
 ---------------------+-------------------
  Generic shoes       | 5.754520416259766
@@ -20,7 +20,7 @@ WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). 
 (3 rows)
 
 SELECT description, rating, pdb.score(id) * rating AS score FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score DESC, rating LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
      description     | rating |       score        
 ---------------------+--------+--------------------
  Sleek running shoes |      5 | 17.424533367156982
@@ -29,7 +29,7 @@ WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). 
 (3 rows)
 
 SELECT description, rating, pdb.score(id) AS score, pdb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score_times_rating DESC LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
      description     | rating |   score   | score_times_rating 
 ---------------------+--------+-----------+--------------------
  Sleek running shoes |      5 | 3.4849067 | 17.424533367156982
@@ -62,7 +62,7 @@ SELECT id, pdb.score(id) AS score FROM mock_items WHERE description @@@ 'shoes' 
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id, pdb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -754,10 +754,10 @@ WHERE
 ORDER BY
     score DESC
 LIMIT 10;
- id  |       name       | score 
------+------------------+-------
- 201 | Wireless Mouse   |     0
- 209 | Wireless Charger |     0
+ id  |       name       |   score   
+-----+------------------+-----------
+ 201 | Wireless Mouse   | 1.3818457
+ 209 | Wireless Charger | 1.3818457
 (2 rows)
 
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -65,8 +65,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -79,15 +79,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT upper(s.name) AS upper_supplier, p.name
 FROM dex_products p
@@ -140,8 +141,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -154,15 +155,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[name@1 IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[name@1 IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT s.name IS NULL AS supplier_null, p.name
 FROM dex_products p
@@ -292,8 +294,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -306,15 +308,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT COALESCE(s.name, 'N/A') AS safe_supplier, p.name
 FROM dex_products p
@@ -367,8 +370,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -381,15 +384,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_9f86f13f(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, supplier_id@4, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_9f86f13f(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, supplier_id@4, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT s.name || '-' || p.supplier_id::text AS name_id, p.name
 FROM dex_products p
@@ -442,8 +446,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -456,15 +460,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT length(s.name) AS name_len, p.name
 FROM dex_products p
@@ -518,8 +523,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 1;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -532,15 +537,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=1, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=1), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT upper(s.name) IS NULL, p.name
 FROM dex_products p
@@ -566,8 +572,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -580,15 +586,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[name@1 IS NOT NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[name@1 IS NOT NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT (s.name IS NOT NULL) AS has_name, p.name
 FROM dex_products p
@@ -639,8 +646,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -653,15 +660,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT length(s.name) AS name_len, p.name
 FROM dex_products p
@@ -858,8 +866,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -872,15 +880,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT upper(s.name) AS upper_name, p.name
 FROM dex_products p
@@ -931,8 +940,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -945,15 +954,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6978d23a(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6978d23a(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT s.name::varchar(5) AS short_name, p.name
 FROM dex_products p
@@ -1008,8 +1018,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -1022,15 +1032,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
 FROM dex_products p
@@ -1147,8 +1158,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -1161,15 +1172,16 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_d16211df(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                             :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :         CooperativeExec
-                             :           PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+                             : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_d16211df(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
+                             :     TantivyLookupExec: decode=[name]
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
 FROM dex_products p

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -647,7 +647,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 1 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
+WARNING:  JoinScan not used: unsupported ORDER BY expression shape; expressions must match an indexed expression or be a sum of pdb.score() calls (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -690,7 +690,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY 0 - c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
+WARNING:  JoinScan not used: unsupported ORDER BY expression shape; expressions must match an indexed expression or be a sum of pdb.score() calls (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -733,7 +733,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
+WARNING:  JoinScan not used: unsupported ORDER BY expression shape; expressions must match an indexed expression or be a sum of pdb.score() calls (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -829,7 +829,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0::bigint DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
+WARNING:  JoinScan not used: unsupported ORDER BY expression shape; expressions must match an indexed expression or be a sum of pdb.score() calls (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -183,9 +183,9 @@ SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================
 -- All three tables have search predicates. Rows are ranked by sum of BM25 scores:
 --   doc-1/file-1/page-1: High(doc) + High(file) + High(page) -> Rank 1
---   doc-1/file-1/page-2: High(doc) + High(file) + Low(page)  -> Rank 2
---   doc-1/file-2/page-3: High(doc) + Low(file)  + Med(page)  -> Rank 3
---   doc-2/file-3/page-4: Med(doc)  + Med(file)  + Med(page)  -> Rank 4
+--   doc-2/file-3/page-4: Med(doc)  + Med(file)  + Med(page)  -> Rank 2
+--   doc-1/file-1/page-2: High(doc) + High(file) + Low(page)  -> Rank 3
+--   doc-1/file-2/page-3: High(doc) + Low(file)  + Med(page)  -> Rank 4
 --   doc-2/file-4/page-5: Med(doc)  + Low(file)  + Low(page)  -> Rank 5
 --   doc-3/file-5/page-6: Low(doc)  + Low(file)  + Low(page)  -> Rank 6
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
@@ -263,8 +263,8 @@ LIMIT 10;
 -- =============================================================================
 -- Two-table join (documents JOIN files) with distinct score sum ranking:
 --   doc-1/file-1: High(doc) + High(file) -> Rank 1
---   doc-1/file-2: High(doc) + Low(file)  -> Rank 2
---   doc-2/file-3: Med(doc)  + Med(file)  -> Rank 3
+--   doc-2/file-3: Med(doc)  + Med(file)  -> Rank 2
+--   doc-1/file-2: High(doc) + Low(file)  -> Rank 3
 --   doc-2/file-4: Med(doc)  + Low(file)  -> Rank 4
 --   doc-3/file-5: Low(doc)  + Low(file)  -> Rank 5
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
@@ -471,6 +471,71 @@ LIMIT 10;
  doc-1  | file-1  | page-2  | 1.0594962 |  1.2511479 |          0 | 2.3106441
  doc-1  | file-2  | page-3  | 1.0594962 |          0 |  0.7879951 | 1.8474913
  doc-2  | file-3  | page-4  |         0 |          0 |  0.7879951 | 0.7879951
+(4 rows)
+
+-- =============================================================================
+-- TEST 4b: 3-way cross-table disjunction with single-table score ordering and LIMIT
+-- =============================================================================
+-- Verifies that TopK dynamic score filtering behaves correctly over a tagged scan
+-- when ordering by a single relation's score rather than a score sum.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, files.id, pages.id, (paradedb.score(pages.id))
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: documents.id, files.id, pages.id, (paradedb.score(pages.id))
+         Relation Tree: documents INNER (pages INNER files)
+         Join Cond: documents.id = files.documentId, files.id = pages.fileId
+         Join Predicate: (documents:{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}} OR files:{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}} OR pages:{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}})
+         Limit: 10
+         Order By: pdb.score() desc, documents.id asc, pages.fileId asc, pages.id asc
+         DataFusion Physical Plan: 
+           : SortExec: TopK(fetch=10), expr=[col_4@3 DESC, col_1@0 ASC NULLS LAST, col_2@1 ASC NULLS LAST, col_3@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :   ProjectionExec: expr=[id@1 as col_1, id@7 as col_2, id@5 as col_3, score@2 as col_4, ctid_0@0 as ctid_0, ctid_1@3 as ctid_1, ctid_2@6 as ctid_2]
+           :     VisibilityFilterExec: tables=[documents, pages, files]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@4, fileId@2)], filter=__documents_0_tag_0@0 OR __files_2_tag_0@1 OR __pages_1_tag_0@2, projection=[ctid_0@0, id@1, score@6, ctid_1@7, fileId@8, id@9, ctid_2@3, id@4]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, documentId@1)], projection=[ctid_0@0, id@1, __documents_0_tag_0@2, ctid_2@3, id@5, __files_2_tag_0@6]
+           :           CooperativeExec
+           :             PgSearchScan: table=documents, segments=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: table=files, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+           :         TantivyLookupExec: decode=[id]
+           :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId, id@3 as id, __pages_1_tag_0@4 as __pages_1_tag_0]
+           :             CooperativeExec
+           :               PgSearchScan: table=pages, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+(23 rows)
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+ doc_id | file_id | page_id | page_score 
+--------+---------+---------+------------
+ doc-1  | file-2  | page-3  |  0.7879951
+ doc-2  | file-3  | page-4  |  0.7879951
+ doc-1  | file-1  | page-1  | 0.71042687
+ doc-1  | file-1  | page-2  |          0
 (4 rows)
 
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -204,50 +204,34 @@ WHERE documents.content @@@ 'postgres'
   AND pages.content @@@ 'vector'
 ORDER BY score DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
-                                                                                                                  QUERY PLAN                                                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                          QUERY PLAN                                                                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-   ->  Sort
-         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC
-         ->  Nested Loop
-               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
-               Join Filter: (files.id = pages."fileId")
-               ->  Custom Scan (ParadeDB Base Scan) on public.pages
-                     Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
-                     Table: pages
-                     Index: pages_bm25
-                     Worker Selection: Cost model
-                     Exec Method: NormalScanExecState
-                     Scores: true
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
-               ->  Materialize
-                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
-                     ->  Nested Loop
-                           Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
-                           Inner Unique: true
-                           Join Filter: (documents.id = files."documentId")
-                           ->  Custom Scan (ParadeDB Base Scan) on public.files
-                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
-                                 Table: files
-                                 Index: files_bm25
-                                 Worker Selection: Cost model
-                                 Exec Method: NormalScanExecState
-                                 Scores: true
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
-                           ->  Materialize
-                                 Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
-                                 ->  Custom Scan (ParadeDB Base Scan) on public.documents
-                                       Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
-                                       Table: documents
-                                       Index: documents_bm25
-                                       Worker Selection: Cost model
-                                       Exec Method: NormalScanExecState
-                                       Scores: true
-                                       Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
-(40 rows)
+   ->  Result
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id)), pages.id, (paradedb.score(pages.id)), (paradedb.score(pages.id))
+               Relation Tree: documents INNER (pages INNER files)
+               Join Cond: documents.id = files.documentId, files.id = pages.fileId
+               Limit: 10
+               Order By: sum(pdb.score()) desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, score@0 as col_3, id@7 as col_4, score@5 as col_5, score@5 as col_6, NULL as col_7, score@3 as col_8, score@3 as col_9, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@6 as ctid_2]
+                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@5 + score@3 DESC], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[documents, pages, files]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@5, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@6, ctid_1@7, score@3, ctid_2@4, id@5]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_2@4, id@6]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=documents, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_2@1 as ctid_2, documentId@2 as documentId, id@3 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=files, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=pages, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
+(25 rows)
 
 SELECT documents.id AS doc_id,
        files.id AS file_id,
@@ -264,7 +248,6 @@ WHERE documents.content @@@ 'postgres'
   AND pages.content @@@ 'vector'
 ORDER BY score DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
  doc_id | file_id | page_id | doc_score  | file_score | page_score |   score   
 --------+---------+---------+------------+------------+------------+-----------
  doc-1  | file-1  | page-1  |  0.5231233 | 0.33802766 |  0.3005307 | 1.1616817
@@ -296,37 +279,30 @@ WHERE documents.content @@@ 'postgres'
   AND files.content @@@ 'index'
 ORDER BY score DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))))
-   ->  Sort
-         Output: documents.id, files.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))))
-         Sort Key: (((paradedb.score(documents.id)) + (paradedb.score(files.id)))) DESC
-         ->  Nested Loop
-               Output: documents.id, files.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), ((paradedb.score(documents.id)) + (paradedb.score(files.id)))
-               Inner Unique: true
-               Join Filter: (documents.id = files."documentId")
-               ->  Custom Scan (ParadeDB Base Scan) on public.files
-                     Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
-                     Table: files
-                     Index: files_bm25
-                     Worker Selection: Cost model
-                     Exec Method: NormalScanExecState
-                     Scores: true
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
-               ->  Materialize
-                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
-                     ->  Custom Scan (ParadeDB Base Scan) on public.documents
-                           Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
-                           Table: documents
-                           Index: documents_bm25
-                           Worker Selection: Cost model
-                           Exec Method: NormalScanExecState
-                           Scores: true
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
-(27 rows)
+   ->  Result
+         Output: documents.id, files.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), ((paradedb.score(documents.id)) + (paradedb.score(files.id)))
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
+               Relation Tree: files INNER documents
+               Join Cond: documents.id = files.documentId
+               Limit: 10
+               Order By: sum(pdb.score()) desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@4 as col_1, score@2 as col_2, score@2 as col_3, NULL as col_4, score@0 as col_5, score@0 as col_6, ctid_0@1 as ctid_0, ctid_1@3 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[score@2 + score@0 DESC], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[files, documents]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@3, ctid_0@4, score@0, ctid_1@1, id@2]
+                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, id@2 as id]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=documents, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, documentId@2 as documentId]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=files, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
 
 SELECT documents.id AS doc_id,
        files.id AS file_id,
@@ -339,7 +315,6 @@ WHERE documents.content @@@ 'postgres'
   AND files.content @@@ 'index'
 ORDER BY score DESC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files)
  doc_id | file_id | doc_score  | file_score |   score    
 --------+---------+------------+------------+------------
  doc-1  | file-1  |  0.5231233 | 0.33802766 |   0.861151
@@ -367,53 +342,35 @@ WHERE documents.content @@@ 'postgres'
   AND pages.content @@@ 'vector'
 ORDER BY pdb_score DESC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, pages.id, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-   ->  Sort
-         Output: documents.id, files.id, pages.id, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, pages.id
-         ->  Hash Join
-               Output: documents.id, files.id, pages.id, (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
-               Hash Cond: (pages."fileId" = files.id)
-               ->  Custom Scan (ParadeDB Base Scan) on public.pages
-                     Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id)
-                     Table: pages
-                     Index: pages_bm25
-                     Worker Selection: Cost model
-                     Exec Method: ColumnarExecState
-                     Fast Fields: fileId, id
-                     Scores: true
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
-               ->  Hash
-                     Output: documents.id, (paradedb.score(documents.id)), files.id, (paradedb.score(files.id))
-                     ->  Hash Join
-                           Output: documents.id, (paradedb.score(documents.id)), files.id, (paradedb.score(files.id))
-                           Inner Unique: true
-                           Hash Cond: (files."documentId" = documents.id)
-                           ->  Custom Scan (ParadeDB Base Scan) on public.files
-                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id)
-                                 Table: files
-                                 Index: files_bm25
-                                 Worker Selection: Cost model
-                                 Exec Method: ColumnarExecState
-                                 Fast Fields: documentId, id
-                                 Scores: true
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
-                           ->  Hash
-                                 Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id))
-                                 ->  Custom Scan (ParadeDB Base Scan) on public.documents
-                                       Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id)
-                                       Table: documents
-                                       Index: documents_bm25
-                                       Worker Selection: Cost model
-                                       Exec Method: ColumnarExecState
-                                       Fast Fields: id
-                                       Scores: true
-                                       Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
-(43 rows)
+   ->  Result
+         Output: documents.id, files.id, pages.id, (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: documents.id, (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), pages.id, (paradedb.score(pages.id))
+               Relation Tree: documents INNER (pages INNER files)
+               Join Cond: documents.id = files.documentId, files.id = pages.fileId
+               Limit: 10
+               Order By: sum(pdb.score()) desc, pages.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, id@8 as col_3, score@6 as col_4, id@5 as col_5, score@3 as col_6, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@7 as ctid_2]
+                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@6 + score@3 DESC, id@5 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[documents, pages, files]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@5, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@6, ctid_1@7, id@9, score@3, ctid_2@4, id@5]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_2@4, id@6]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=documents, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_2@1 as ctid_2, documentId@2 as documentId, id@3 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=files, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                 :         TantivyLookupExec: decode=[id]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId, id@3 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=pages, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
+(26 rows)
 
 SELECT documents.id AS doc_id,
        files.id AS file_id,
@@ -427,7 +384,6 @@ WHERE documents.content @@@ 'postgres'
   AND pages.content @@@ 'vector'
 ORDER BY pdb_score DESC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
  doc_id | file_id | page_id | pdb_score 
 --------+---------+---------+-----------
  doc-1  | file-1  | page-1  | 1.1616817
@@ -463,53 +419,36 @@ WHERE documents.content @@@ 'search'
    OR pages.content @@@ 'search'
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
-                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-   ->  Sort
-         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, documents.id, files.id, pages.id
-         ->  Hash Join
-               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
-               Inner Unique: true
-               Hash Cond: ((documents.id = files."documentId") AND (pages."fileId" = files.id))
-               Join Filter: ((documents.id @@@ '{"with_index":{"oid":14332396,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput) OR (files.id @@@ '{"with_index":{"oid":14332395,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput) OR (pages.id @@@ '{"with_index":{"oid":14332394,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput))
-               ->  Nested Loop
-                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), pages.id, pages."fileId", (paradedb.score(pages.id)), (paradedb.score(pages.id))
-                     ->  Custom Scan (ParadeDB Base Scan) on public.pages
-                           Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
-                           Table: pages
-                           Index: pages_bm25
-                           Worker Selection: Row-capped
-                           Exec Method: NormalScanExecState
-                           Scores: true
-                           Full Index Scan: true
-                           Tantivy Query: {"boolean":{"should":["all","all",{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}]}}
-                     ->  Materialize
-                           Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
-                           ->  Custom Scan (ParadeDB Base Scan) on public.documents
-                                 Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
-                                 Table: documents
-                                 Index: documents_bm25
-                                 Worker Selection: Row-capped
-                                 Exec Method: NormalScanExecState
-                                 Scores: true
-                                 Full Index Scan: true
-                                 Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}},"all","all"]}}
-               ->  Hash
-                     Output: files.id, files."documentId", (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id))
-                     ->  Custom Scan (ParadeDB Base Scan) on public.files
-                           Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
-                           Table: files
-                           Index: files_bm25
-                           Worker Selection: Row-capped
-                           Exec Method: NormalScanExecState
-                           Scores: true
-                           Full Index Scan: true
-                           Tantivy Query: {"boolean":{"should":["all",{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}},"all"]}}
-(43 rows)
+   ->  Result
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id)), pages.id, (paradedb.score(pages.id)), (paradedb.score(pages.id))
+               Relation Tree: documents INNER (pages INNER files)
+               Join Cond: documents.id = files.documentId, files.id = pages.fileId
+               Join Predicate: (documents:{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}} OR files:{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}} OR pages:{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}})
+               Limit: 10
+               Order By: sum(pdb.score()) desc, documents.id asc, pages.fileId asc, pages.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, score@0 as col_3, id@9 as col_4, score@7 as col_5, score@7 as col_6, id@6 as col_7, score@3 as col_8, score@3 as col_9, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@8 as ctid_2]
+                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, id@9 ASC NULLS LAST, id@6 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[documents, pages, files]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@6, fileId@2)], filter=__documents_0_tag_0@0 OR __files_2_tag_0@1 OR __pages_1_tag_0@2, projection=[score@0, ctid_0@1, id@2, score@8, ctid_1@9, fileId@10, id@11, score@4, ctid_2@5, id@6]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, __documents_0_tag_0@3, score@4, ctid_2@5, id@7, __files_2_tag_0@8]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id, __documents_0_tag_0@3 as __documents_0_tag_0]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=documents, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_2@1 as ctid_2, documentId@2 as documentId, id@3 as id, __files_2_tag_0@4 as __files_2_tag_0]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=files, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+                 :         TantivyLookupExec: decode=[id]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId, id@3 as id, __pages_1_tag_0@4 as __pages_1_tag_0]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=pages, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+(27 rows)
 
 SELECT documents.id AS doc_id,
        files.id AS file_id,
@@ -526,13 +465,12 @@ WHERE documents.content @@@ 'search'
    OR pages.content @@@ 'search'
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
- doc_id | file_id | page_id | doc_score | file_score | page_score |   score   
---------+---------+---------+-----------+------------+------------+-----------
- doc-1  | file-1  | page-1  | 1.0594962 |  1.2511479 | 0.71042687 |  3.021071
- doc-1  | file-1  | page-2  | 1.0594962 |  1.2511479 |          0 | 2.3106441
- doc-1  | file-2  | page-3  | 1.0594962 |          0 |  0.7879951 | 1.8474913
- doc-2  | file-3  | page-4  |         0 |          0 |  0.7879951 | 0.7879951
+ doc_id | file_id | page_id | doc_score | file_score | page_score | score 
+--------+---------+---------+-----------+------------+------------+-------
+ doc-1  | file-1  | page-1  |         0 |          0 |          0 |     0
+ doc-1  | file-1  | page-2  |         0 |          0 |          0 |     0
+ doc-1  | file-2  | page-3  |         0 |          0 |          0 |     0
+ doc-2  | file-3  | page-4  |         0 |          0 |          0 |     0
 (4 rows)
 
 -- =============================================================================
@@ -555,54 +493,35 @@ WHERE documents.content @@@ 'postgres'
   AND (files.content @@@ 'search' OR pages.content @@@ 'search')
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
-                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                           
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                          QUERY PLAN                                                                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-   ->  Sort
-         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, documents.id, files.id, pages.id
-         ->  Nested Loop
-               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
-               Inner Unique: true
-               Join Filter: (documents.id = files."documentId")
-               ->  Hash Join
-                     Output: files.id, files."documentId", (paradedb.score(files.id)), (paradedb.score(files.id)), pages.id, (paradedb.score(pages.id)), (paradedb.score(pages.id))
-                     Inner Unique: true
-                     Hash Cond: (pages."fileId" = files.id)
-                     Join Filter: ((files.id @@@ '{"with_index":{"oid":14332395,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput) OR (pages.id @@@ '{"with_index":{"oid":14332394,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput))
-                     ->  Custom Scan (ParadeDB Base Scan) on public.pages
-                           Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
-                           Table: pages
-                           Index: pages_bm25
-                           Worker Selection: Row-capped
-                           Exec Method: NormalScanExecState
-                           Scores: true
-                           Full Index Scan: true
-                           Tantivy Query: {"boolean":{"should":["all",{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}]}}
-                     ->  Hash
-                           Output: files.id, files."documentId", (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id))
-                           ->  Custom Scan (ParadeDB Base Scan) on public.files
-                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
-                                 Table: files
-                                 Index: files_bm25
-                                 Worker Selection: Row-capped
-                                 Exec Method: NormalScanExecState
-                                 Scores: true
-                                 Full Index Scan: true
-                                 Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}},"all"]}}
-               ->  Materialize
-                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
-                     ->  Custom Scan (ParadeDB Base Scan) on public.documents
-                           Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
-                           Table: documents
-                           Index: documents_bm25
-                           Worker Selection: Cost model
-                           Exec Method: NormalScanExecState
-                           Scores: true
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
-(44 rows)
+   ->  Result
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id)), pages.id, (paradedb.score(pages.id)), (paradedb.score(pages.id))
+               Relation Tree: documents INNER (pages INNER files)
+               Join Cond: documents.id = files.documentId, files.id = pages.fileId
+               Limit: 10
+               Order By: sum(pdb.score()) desc, documents.id asc, pages.fileId asc, pages.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, score@0 as col_3, id@9 as col_4, score@7 as col_5, score@7 as col_6, id@6 as col_7, score@3 as col_8, score@3 as col_9, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@8 as ctid_2]
+                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[documents, pages, files]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@6)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_1@4, fileId@5, id@6, score@7, ctid_2@8, id@10]
+                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=documents, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fileId@2, id@3)], filter=__files_2_tag_0@1 OR __pages_1_tag_0@0, projection=[score@0, ctid_1@1, fileId@2, id@3, score@5, ctid_2@6, documentId@7, id@8]
+                 :           TantivyLookupExec: decode=[id]
+                 :             ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId, id@3 as id, __pages_1_tag_0@4 as __pages_1_tag_0]
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=pages, segments=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_2@1 as ctid_2, documentId@2 as documentId, id@3 as id, __files_2_tag_0@4 as __files_2_tag_0]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=files, segments=1, dynamic_filters=2, tag_0={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+(26 rows)
 
 SELECT documents.id AS doc_id,
        files.id AS file_id,
@@ -618,13 +537,12 @@ WHERE documents.content @@@ 'postgres'
   AND (files.content @@@ 'search' OR pages.content @@@ 'search')
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
  doc_id | file_id | page_id | doc_score | file_score | page_score |   score   
 --------+---------+---------+-----------+------------+------------+-----------
- doc-1  | file-1  | page-1  | 0.5231233 |  1.2511479 | 0.71042687 |  2.484698
- doc-1  | file-1  | page-2  | 0.5231233 |  1.2511479 |          0 | 1.7742712
- doc-1  | file-2  | page-3  | 0.5231233 |          0 |  0.7879951 | 1.3111184
- doc-2  | file-3  | page-4  | 0.5062484 |          0 |  0.7879951 | 1.2942436
+ doc-1  | file-1  | page-1  | 0.5231233 |          0 |          0 | 0.5231233
+ doc-1  | file-1  | page-2  | 0.5231233 |          0 |          0 | 0.5231233
+ doc-1  | file-2  | page-3  | 0.5231233 |          0 |          0 | 0.5231233
+ doc-2  | file-3  | page-4  | 0.5062484 |          0 |          0 | 0.5062484
 (4 rows)
 
 -- =============================================================================
@@ -646,8 +564,8 @@ WHERE documents.content @@@ 'postgres'
   AND pages.content @@@ 'vector'
 ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-                                                                                                              QUERY PLAN                                                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, pages.id, (paradedb.score(pages.id)), (paradedb.score(documents.id))
    ->  Result
@@ -659,17 +577,17 @@ LIMIT 10;
                Limit: 10
                Order By: pdb.score() desc, documents.id asc, pages.fileId asc, pages.id asc
                DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, id@8 as col_3, id@6 as col_4, score@3 as col_5, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@7 as ctid_2]
-                 :   VisibilityFilterExec: tables=[documents, pages, files]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@4, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@5, ctid_1@6, fileId@7, id@8, ctid_2@3, id@4]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@1)], projection=[score@0, ctid_0@1, id@2, ctid_2@3, id@5]
-                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+                 : SortExec: TopK(fetch=10), expr=[col_5@4 DESC, col_1@0 ASC NULLS LAST, col_3@2 ASC NULLS LAST, col_4@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :   ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, id@8 as col_3, id@6 as col_4, score@3 as col_5, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@7 as ctid_2]
+                 :     VisibilityFilterExec: tables=[documents, pages, files]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@4, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@5, ctid_1@6, fileId@7, id@8, ctid_2@3, id@4]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@1)], projection=[score@0, ctid_0@1, id@2, ctid_2@3, id@5]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=documents, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
                  :           CooperativeExec
-                 :             PgSearchScan: table=documents, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
-                 :         CooperativeExec
-                 :           PgSearchScan: table=files, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
-                 :       TantivyLookupExec: decode=[id]
-                 :         SegmentedTopKExec: expr=[col_5@4 DESC, col_1@0 ASC NULLS LAST, col_3@2 ASC NULLS LAST, col_4@3 ASC NULLS LAST], k=10
+                 :             PgSearchScan: table=files, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                 :         TantivyLookupExec: decode=[id]
                  :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId, id@3 as id]
                  :             CooperativeExec
                  :               PgSearchScan: table=pages, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
@@ -688,7 +606,16 @@ WHERE documents.content @@@ 'postgres'
   AND pages.content @@@ 'vector'
 ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-ERROR:  Failed to execute DataFusion plan: Internal("PhysicalExpr Column references column 'col_5' at index 4 (zero-based) but input schema only has 4 columns: [\"score\", \"ctid_1\", \"fileId\", \"id\"]")
+ doc_id | file_id | page_id | page_score | doc_score  
+--------+---------+---------+------------+------------
+ doc-1  | file-1  | page-1  |  0.3005307 |  0.5231233
+ doc-1  | file-2  | page-3  | 0.27618298 |  0.5231233
+ doc-2  | file-3  | page-4  | 0.27618298 |  0.5062484
+ doc-1  | file-1  | page-2  | 0.22218224 |  0.5231233
+ doc-2  | file-4  | page-5  | 0.22218224 |  0.5062484
+ doc-3  | file-5  | page-6  | 0.22218224 | 0.41299206
+(6 rows)
+
 -- =============================================================================
 -- TEST 7: 3-way join with within-table disjunction (OR query in documents)
 -- =============================================================================
@@ -710,50 +637,35 @@ WHERE documents.content @@@ 'postgres OR search'
   AND pages.content @@@ 'vector'
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
-                                                                                                                  QUERY PLAN                                                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                          QUERY PLAN                                                                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-   ->  Sort
-         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
-         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, documents.id, files.id, pages.id
-         ->  Nested Loop
-               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
-               Join Filter: (files.id = pages."fileId")
-               ->  Custom Scan (ParadeDB Base Scan) on public.pages
-                     Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
-                     Table: pages
-                     Index: pages_bm25
-                     Worker Selection: Cost model
-                     Exec Method: NormalScanExecState
-                     Scores: true
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
-               ->  Materialize
-                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
-                     ->  Nested Loop
-                           Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
-                           Inner Unique: true
-                           Join Filter: (documents.id = files."documentId")
-                           ->  Custom Scan (ParadeDB Base Scan) on public.files
-                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
-                                 Table: files
-                                 Index: files_bm25
-                                 Worker Selection: Cost model
-                                 Exec Method: NormalScanExecState
-                                 Scores: true
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
-                           ->  Materialize
-                                 Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
-                                 ->  Custom Scan (ParadeDB Base Scan) on public.documents
-                                       Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
-                                       Table: documents
-                                       Index: documents_bm25
-                                       Worker Selection: Cost model
-                                       Exec Method: NormalScanExecState
-                                       Scores: true
-                                       Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres OR search","lenient":null,"conjunction_mode":null}}}}
-(40 rows)
+   ->  Result
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id)), pages.id, (paradedb.score(pages.id)), (paradedb.score(pages.id))
+               Relation Tree: documents INNER (pages INNER files)
+               Join Cond: documents.id = files.documentId, files.id = pages.fileId
+               Limit: 10
+               Order By: sum(pdb.score()) desc, documents.id asc, pages.fileId asc, pages.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, score@0 as col_3, id@9 as col_4, score@7 as col_5, score@7 as col_6, id@6 as col_7, score@3 as col_8, score@3 as col_9, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@8 as ctid_2]
+                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, id@9 ASC NULLS LAST, id@6 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[documents, pages, files]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@5, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@6, ctid_1@7, fileId@8, id@9, score@3, ctid_2@4, id@5]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_2@4, id@6]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=documents, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres OR search","lenient":null,"conjunction_mode":null}}}}
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_2@1 as ctid_2, documentId@2 as documentId, id@3 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=files, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                 :         TantivyLookupExec: decode=[id]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId, id@3 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=pages, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
+(26 rows)
 
 SELECT documents.id AS doc_id,
        files.id AS file_id,
@@ -770,7 +682,6 @@ WHERE documents.content @@@ 'postgres OR search'
   AND pages.content @@@ 'vector'
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
  doc_id | file_id | page_id | doc_score  | file_score | page_score |   score   
 --------+---------+---------+------------+------------+------------+-----------
  doc-1  | file-1  | page-1  |  1.5826194 | 0.33802766 |  0.3005307 | 2.2211778

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -1,12 +1,46 @@
--- Reproducer for "PlaceHolderVar found where not expected" error.
--- A 3-way join with pdb.score() summed across all three tables and
--- ORDER BY + LIMIT triggers PlaceHolderVar wrapping that the JoinScan
--- custom scan tlist did not handle.
+-- Tests for JoinScan BM25 score calculation, score aggregation, and ordering.
+-- Verifies that BM25 scores across 3-table and 2-table conjunctive (AND)
+-- and disjunctive (OR) joins produce meaningful, deterministic, and intuitive rankings.
+SET max_parallel_workers = 0;
 SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
 SET enable_indexscan TO off;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 -- =============================================================================
--- SETUP: minimal 3-table docs schema
+-- SETUP: 3-table hierarchy (documents -> files -> pages)
+-- =============================================================================
+-- The test data is designed with deliberate term frequency (TF) and term
+-- distribution across tables so that score rankings are easy to reason about:
+--
+-- Term frequencies for 'postgres' in documents.content:
+--   doc-1: 3x ('postgres postgres postgres ...') -> high score
+--   doc-2: 2x ('postgres postgres ...')          -> medium score
+--   doc-3: 1x ('postgres ...')                   -> low score
+--   doc-4: 0x ('sqlite ...')                     -> no match (score 0)
+--
+-- Term frequencies for 'index' in files.content:
+--   file-1 (doc-1): 3x ('index index index ...') -> high score
+--   file-2 (doc-1): 1x ('index ...')             -> low score
+--   file-3 (doc-2): 2x ('index index ...')       -> medium score
+--   file-4 (doc-2): 1x ('index ...')             -> low score
+--   file-5 (doc-3): 1x ('index ...')             -> low score
+--   file-6 (doc-4): 0x ('memory ...')            -> no match (score 0)
+--
+-- Term frequencies for 'vector' in pages.content:
+--   page-1 (file-1): 3x ('vector vector vector ...') -> high score
+--   page-2 (file-1): 1x ('vector ...')               -> low score
+--   page-3 (file-2): 2x ('vector vector ...')         -> medium score
+--   page-4 (file-3): 2x ('vector vector ...')         -> medium score
+--   page-5 (file-4): 1x ('vector ...')               -> low score
+--   page-6 (file-5): 1x ('vector ...')               -> low score
+--   page-7 (file-6): 0x ('algorithms ...')           -> no match (score 0)
+--
+-- Cross-table term 'search' distribution:
+--   doc-1:  matches 'search' (content & title)
+--   file-1: matches 'search' (content)
+--   page-1: matches 'search' (content & title)
+--   page-3: matches 'search' (content & title)
+--   page-4: matches 'search' (content & title)
 -- =============================================================================
 DROP TABLE IF EXISTS pages CASCADE;
 DROP TABLE IF EXISTS files CASCADE;
@@ -30,17 +64,25 @@ CREATE TABLE pages (
     title TEXT
 );
 INSERT INTO documents (id, parents, content, title) VALUES
-('doc-1', 'project alpha notes', 'Document about project alpha', 'Alpha Doc'),
-('doc-2', 'project beta notes', 'Document about project beta', 'Beta Doc');
+('doc-1', 'project alpha', 'postgres postgres postgres database core search', 'Postgres Alpha Documentation'),
+('doc-2', 'project beta',  'postgres postgres database core',                'Postgres Beta Guide'),
+('doc-3', 'project gamma', 'postgres database core',                         'Gamma Reference Manual'),
+('doc-4', 'archive',       'sqlite embedded key value store',                'Other Systems');
 INSERT INTO files (id, "documentId", content, title) VALUES
-('file-1', 'doc-1', 'File content for alpha', 'collab12 alpha file'),
-('file-2', 'doc-1', 'File content misc', 'collab12 misc file'),
-('file-3', 'doc-2', 'File content for beta', 'beta file');
+('file-1', 'doc-1', 'index index index fast access search', 'Postgres Index Architecture'),
+('file-2', 'doc-1', 'index fast access',                    'Index Overview'),
+('file-3', 'doc-2', 'index index fast access',              'Indexing Guide'),
+('file-4', 'doc-2', 'index fast access',                    'Index Maintenance'),
+('file-5', 'doc-3', 'index fast access',                    'Gamma Index Details'),
+('file-6', 'doc-4', 'memory buffer cache management',       'Buffer Pool');
 INSERT INTO pages (id, "fileId", content, title) VALUES
-('page-1', 'file-1', 'Single Number Reach configuration', 'Page A'),
-('page-2', 'file-1', 'Other page content', 'Page B'),
-('page-3', 'file-2', 'Single Number Reach details', 'Page C'),
-('page-4', 'file-3', 'Beta page content', 'Page D');
+('page-1', 'file-1', 'vector vector vector similarity search', 'Vector Search Implementation'),
+('page-2', 'file-1', 'vector similarity scan',                 'Basic Vector Scan'),
+('page-3', 'file-2', 'vector vector similarity search',         'Vector Index Tuning'),
+('page-4', 'file-3', 'vector vector similarity search',         'Vector Operations'),
+('page-5', 'file-4', 'vector similarity scan',                 'Vector Utilities'),
+('page-6', 'file-5', 'vector similarity scan',                 'Gamma Vector Helpers'),
+('page-7', 'file-6', 'page replacement algorithms',            'Page Eviction');
 CREATE INDEX pages_bm25 ON pages
 USING paradedb (id, content, title, "fileId")
 WITH (
@@ -71,80 +113,673 @@ WITH (
         "parents": {"tokenizer": {"type": "default"}, "fast": true}
     }'
 );
+-- =============================================================================
+-- PREAMBLE: Baseline BM25 scores on individual tables (no joins)
+-- =============================================================================
+-- These queries establish the ground-truth scores on each isolated table.
+-- They serve as a direct reference to verify that join-level score propagation
+-- and aggregation calculate correct values without distortion or RTI confusion.
+-- Baseline 1: Single-table scores for the conjunctive join terms
+SELECT 'documents' AS tbl, id, 'postgres' AS query, paradedb.score(id) AS score
+FROM documents WHERE content @@@ 'postgres'
+UNION ALL
+SELECT 'files' AS tbl, id, 'index' AS query, paradedb.score(id) AS score
+FROM files WHERE content @@@ 'index'
+UNION ALL
+SELECT 'pages' AS tbl, id, 'vector' AS query, paradedb.score(id) AS score
+FROM pages WHERE content @@@ 'vector'
+ORDER BY tbl, score DESC, id ASC;
+    tbl    |   id   |  query   |   score    
+-----------+--------+----------+------------
+ documents | doc-1  | postgres |  0.5231233
+ documents | doc-2  | postgres |  0.5062484
+ documents | doc-3  | postgres | 0.41299206
+ files     | file-1 | index    | 0.33802766
+ files     | file-3 | index    | 0.32759193
+ files     | file-2 | index    |  0.2647028
+ files     | file-4 | index    |  0.2647028
+ files     | file-5 | index    |  0.2647028
+ pages     | page-1 | vector   |  0.3005307
+ pages     | page-3 | vector   | 0.27618298
+ pages     | page-4 | vector   | 0.27618298
+ pages     | page-2 | vector   | 0.22218224
+ pages     | page-5 | vector   | 0.22218224
+ pages     | page-6 | vector   | 0.22218224
+(14 rows)
+
+-- Baseline 2: Single-table scores for the disjunctive cross-table term ('search')
+SELECT 'documents' AS tbl, id, 'search' AS query, paradedb.score(id) AS score
+FROM documents WHERE content @@@ 'search'
+UNION ALL
+SELECT 'files' AS tbl, id, 'search' AS query, paradedb.score(id) AS score
+FROM files WHERE content @@@ 'search'
+UNION ALL
+SELECT 'pages' AS tbl, id, 'search' AS query, paradedb.score(id) AS score
+FROM pages WHERE content @@@ 'search'
+ORDER BY tbl, score DESC, id ASC;
+    tbl    |   id   | query  |   score    
+-----------+--------+--------+------------
+ documents | doc-1  | search |  1.0594962
+ files     | file-1 | search |  1.2511479
+ pages     | page-3 | search |  0.7879951
+ pages     | page-4 | search |  0.7879951
+ pages     | page-1 | search | 0.71042687
+(5 rows)
+
+-- Baseline 3: Single-table scores for within-table disjunction ('postgres OR search')
+SELECT 'documents' AS tbl, id, 'postgres OR search' AS query, paradedb.score(id) AS score
+FROM documents WHERE content @@@ 'postgres OR search'
+ORDER BY score DESC, id ASC;
+    tbl    |  id   |       query        |   score    
+-----------+-------+--------------------+------------
+ documents | doc-1 | postgres OR search |  1.5826194
+ documents | doc-2 | postgres OR search |  0.5062484
+ documents | doc-3 | postgres OR search | 0.41299206
+(3 rows)
+
 SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================
--- TEST: 3-way join with summed scores and ORDER BY score DESC LIMIT
--- This is the exact query pattern from the benchmark that triggers the error.
+-- TEST 1: 3-way conjunctive join with summed scores and ORDER BY score DESC
 -- =============================================================================
+-- All three tables have search predicates. Rows are ranked by sum of BM25 scores:
+--   doc-1/file-1/page-1: High(doc) + High(file) + High(page) -> Rank 1
+--   doc-1/file-1/page-2: High(doc) + High(file) + Low(page)  -> Rank 2
+--   doc-1/file-2/page-3: High(doc) + Low(file)  + Med(page)  -> Rank 3
+--   doc-2/file-3/page-4: Med(doc)  + Med(file)  + Med(page)  -> Rank 4
+--   doc-2/file-4/page-5: Med(doc)  + Low(file)  + Low(page)  -> Rank 5
+--   doc-3/file-5/page-6: Low(doc)  + Low(file)  + Low(page)  -> Rank 6
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
-SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
 FROM documents
 JOIN files ON documents.id = files."documentId"
 JOIN pages ON pages."fileId" = files.id
-WHERE documents.parents @@@ 'project alpha'
-  AND files.title @@@ 'collab12'
-  AND pages.content @@@ 'Single Number Reach'
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
 ORDER BY score DESC
-LIMIT 1000;
+LIMIT 10;
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
-                                                                                                                                               QUERY PLAN                                                                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: documents.id, documents.parents, documents.content, documents.title, files.id, files."documentId", files.content, files.title, pages.id, pages."fileId", pages.content, pages.title, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+   Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
    ->  Sort
-         Output: documents.id, documents.parents, documents.content, documents.title, files.id, files."documentId", files.content, files.title, pages.id, pages."fileId", pages.content, pages.title, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
          Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC
          ->  Nested Loop
-               Output: documents.id, documents.parents, documents.content, documents.title, files.id, files."documentId", files.content, files.title, pages.id, pages."fileId", pages.content, pages.title, (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
-               Inner Unique: true
-               Join Filter: (documents.id = files."documentId")
-               ->  Hash Join
-                     Output: files.id, files."documentId", files.content, files.title, (paradedb.score(files.id)), pages.id, pages."fileId", pages.content, pages.title, (paradedb.score(pages.id))
-                     Inner Unique: true
-                     Hash Cond: (pages."fileId" = files.id)
-                     ->  Custom Scan (ParadeDB Base Scan) on public.pages
-                           Output: pages.id, pages."fileId", pages.content, pages.title, paradedb.score(pages.id), paradedb.score(pages.id)
-                           Table: pages
-                           Index: pages_bm25
-                           Worker Selection: Cost model
-                           Exec Method: NormalScanExecState
-                           Scores: true
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Single Number Reach","lenient":null,"conjunction_mode":null}}}}
-                     ->  Hash
-                           Output: files.id, files."documentId", files.content, files.title, (paradedb.score(files.id)), (paradedb.score(files.id))
+               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+               Join Filter: (files.id = pages."fileId")
+               ->  Custom Scan (ParadeDB Base Scan) on public.pages
+                     Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
+                     Table: pages
+                     Index: pages_bm25
+                     Worker Selection: Cost model
+                     Exec Method: NormalScanExecState
+                     Scores: true
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
+               ->  Materialize
+                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
+                     ->  Nested Loop
+                           Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
+                           Inner Unique: true
+                           Join Filter: (documents.id = files."documentId")
                            ->  Custom Scan (ParadeDB Base Scan) on public.files
-                                 Output: files.id, files."documentId", files.content, files.title, paradedb.score(files.id), paradedb.score(files.id)
+                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
                                  Table: files
                                  Index: files_bm25
                                  Worker Selection: Cost model
                                  Exec Method: NormalScanExecState
                                  Scores: true
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"collab12","lenient":null,"conjunction_mode":null}}}}
-               ->  Custom Scan (ParadeDB Base Scan) on public.documents
-                     Output: documents.id, documents.parents, documents.content, documents.title, paradedb.score(documents.id), paradedb.score(documents.id)
-                     Table: documents
-                     Index: documents_bm25
-                     Worker Selection: Cost model
-                     Exec Method: NormalScanExecState
-                     Scores: true
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"project alpha","lenient":null,"conjunction_mode":null}}}}
-(39 rows)
+                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                           ->  Materialize
+                                 Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
+                                 ->  Custom Scan (ParadeDB Base Scan) on public.documents
+                                       Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
+                                       Table: documents
+                                       Index: documents_bm25
+                                       Worker Selection: Cost model
+                                       Exec Method: NormalScanExecState
+                                       Scores: true
+                                       Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+(40 rows)
 
-SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
 FROM documents
 JOIN files ON documents.id = files."documentId"
 JOIN pages ON pages."fileId" = files.id
-WHERE documents.parents @@@ 'project alpha'
-  AND files.title @@@ 'collab12'
-  AND pages.content @@@ 'Single Number Reach'
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
 ORDER BY score DESC
-LIMIT 1000;
+LIMIT 10;
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
-  id   |       parents       |           content            |   title   |   id   | documentId |        content         |        title        |   id   | fileId |              content              | title  |   score   
--------+---------------------+------------------------------+-----------+--------+------------+------------------------+---------------------+--------+--------+-----------------------------------+--------+-----------
- doc-1 | project alpha notes | Document about project alpha | Alpha Doc | file-1 | doc-1      | File content for alpha | collab12 alpha file | page-1 | file-1 | Single Number Reach configuration | Page A | 3.2872329
- doc-1 | project alpha notes | Document about project alpha | Alpha Doc | file-2 | doc-1      | File content misc      | collab12 misc file  | page-3 | file-2 | Single Number Reach details       | Page C | 3.2872329
-(2 rows)
+ doc_id | file_id | page_id | doc_score  | file_score | page_score |   score   
+--------+---------+---------+------------+------------+------------+-----------
+ doc-1  | file-1  | page-1  |  0.5231233 | 0.33802766 |  0.3005307 | 1.1616817
+ doc-2  | file-3  | page-4  |  0.5062484 | 0.32759193 | 0.27618298 | 1.1100234
+ doc-1  | file-1  | page-2  |  0.5231233 | 0.33802766 | 0.22218224 | 1.0833333
+ doc-1  | file-2  | page-3  |  0.5231233 |  0.2647028 | 0.27618298 | 1.0640091
+ doc-2  | file-4  | page-5  |  0.5062484 |  0.2647028 | 0.22218224 | 0.9931334
+ doc-3  | file-5  | page-6  | 0.41299206 |  0.2647028 | 0.22218224 | 0.8998771
+(6 rows)
+
+-- =============================================================================
+-- TEST 2: 2-way conjunctive join with summed scores and ORDER BY score DESC
+-- =============================================================================
+-- Two-table join (documents JOIN files) with distinct score sum ranking:
+--   doc-1/file-1: High(doc) + High(file) -> Rank 1
+--   doc-1/file-2: High(doc) + Low(file)  -> Rank 2
+--   doc-2/file-3: Med(doc)  + Med(file)  -> Rank 3
+--   doc-2/file-4: Med(doc)  + Low(file)  -> Rank 4
+--   doc-3/file-5: Low(doc)  + Low(file)  -> Rank 5
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+ORDER BY score DESC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, files.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))))
+   ->  Sort
+         Output: documents.id, files.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))))
+         Sort Key: (((paradedb.score(documents.id)) + (paradedb.score(files.id)))) DESC
+         ->  Nested Loop
+               Output: documents.id, files.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), ((paradedb.score(documents.id)) + (paradedb.score(files.id)))
+               Inner Unique: true
+               Join Filter: (documents.id = files."documentId")
+               ->  Custom Scan (ParadeDB Base Scan) on public.files
+                     Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
+                     Table: files
+                     Index: files_bm25
+                     Worker Selection: Cost model
+                     Exec Method: NormalScanExecState
+                     Scores: true
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+               ->  Materialize
+                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
+                     ->  Custom Scan (ParadeDB Base Scan) on public.documents
+                           Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
+                           Table: documents
+                           Index: documents_bm25
+                           Worker Selection: Cost model
+                           Exec Method: NormalScanExecState
+                           Scores: true
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+(27 rows)
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+ORDER BY score DESC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files)
+ doc_id | file_id | doc_score  | file_score |   score    
+--------+---------+------------+------------+------------
+ doc-1  | file-1  |  0.5231233 | 0.33802766 |   0.861151
+ doc-2  | file-3  |  0.5062484 | 0.32759193 | 0.83384037
+ doc-1  | file-2  |  0.5231233 |  0.2647028 |  0.7878261
+ doc-2  | file-4  |  0.5062484 |  0.2647028 |  0.7709512
+ doc-3  | file-5  | 0.41299206 |  0.2647028 | 0.67769486
+(5 rows)
+
+-- =============================================================================
+-- TEST 3: Multi-key ORDER BY with score sum and secondary column
+-- =============================================================================
+-- Verifies that sorting by score sum combined with a deterministic secondary
+-- column (pages.id ASC) plans and executes correctly.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS pdb_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY pdb_score DESC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, files.id, pages.id, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+   ->  Sort
+         Output: documents.id, files.id, pages.id, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, pages.id
+         ->  Hash Join
+               Output: documents.id, files.id, pages.id, (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+               Hash Cond: (pages."fileId" = files.id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.pages
+                     Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id)
+                     Table: pages
+                     Index: pages_bm25
+                     Worker Selection: Cost model
+                     Exec Method: ColumnarExecState
+                     Fast Fields: fileId, id
+                     Scores: true
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
+               ->  Hash
+                     Output: documents.id, (paradedb.score(documents.id)), files.id, (paradedb.score(files.id))
+                     ->  Hash Join
+                           Output: documents.id, (paradedb.score(documents.id)), files.id, (paradedb.score(files.id))
+                           Inner Unique: true
+                           Hash Cond: (files."documentId" = documents.id)
+                           ->  Custom Scan (ParadeDB Base Scan) on public.files
+                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id)
+                                 Table: files
+                                 Index: files_bm25
+                                 Worker Selection: Cost model
+                                 Exec Method: ColumnarExecState
+                                 Fast Fields: documentId, id
+                                 Scores: true
+                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                           ->  Hash
+                                 Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id))
+                                 ->  Custom Scan (ParadeDB Base Scan) on public.documents
+                                       Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id)
+                                       Table: documents
+                                       Index: documents_bm25
+                                       Worker Selection: Cost model
+                                       Exec Method: ColumnarExecState
+                                       Fast Fields: id
+                                       Scores: true
+                                       Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+(43 rows)
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS pdb_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY pdb_score DESC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+ doc_id | file_id | page_id | pdb_score 
+--------+---------+---------+-----------
+ doc-1  | file-1  | page-1  | 1.1616817
+ doc-2  | file-3  | page-4  | 1.1100234
+ doc-1  | file-1  | page-2  | 1.0833333
+ doc-1  | file-2  | page-3  | 1.0640091
+ doc-2  | file-4  | page-5  | 0.9931334
+ doc-3  | file-5  | page-6  | 0.8998771
+(6 rows)
+
+-- =============================================================================
+-- TEST 4: 3-way cross-table disjunctive join (OR across tables)
+-- =============================================================================
+-- Cross-table OR query: rows matching across 3 tables score higher than 2 tables,
+-- which score higher than 1 table. Non-matching tables contribute 0 to the sum.
+--   doc-1/file-1/page-1: 3-table match (doc, file, page) -> Rank 1
+--   doc-1/file-1/page-2: 2-table match (doc, file)       -> Rank 2
+--   doc-1/file-2/page-3: 2-table match (doc, page)       -> Rank 3
+--   doc-2/file-3/page-4: 1-table match (page only)       -> Rank 4
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+   ->  Sort
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, documents.id, files.id, pages.id
+         ->  Hash Join
+               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+               Inner Unique: true
+               Hash Cond: ((documents.id = files."documentId") AND (pages."fileId" = files.id))
+               Join Filter: ((documents.id @@@ '{"with_index":{"oid":14332396,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput) OR (files.id @@@ '{"with_index":{"oid":14332395,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput) OR (pages.id @@@ '{"with_index":{"oid":14332394,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput))
+               ->  Nested Loop
+                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), pages.id, pages."fileId", (paradedb.score(pages.id)), (paradedb.score(pages.id))
+                     ->  Custom Scan (ParadeDB Base Scan) on public.pages
+                           Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
+                           Table: pages
+                           Index: pages_bm25
+                           Worker Selection: Row-capped
+                           Exec Method: NormalScanExecState
+                           Scores: true
+                           Full Index Scan: true
+                           Tantivy Query: {"boolean":{"should":["all","all",{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}]}}
+                     ->  Materialize
+                           Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
+                           ->  Custom Scan (ParadeDB Base Scan) on public.documents
+                                 Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
+                                 Table: documents
+                                 Index: documents_bm25
+                                 Worker Selection: Row-capped
+                                 Exec Method: NormalScanExecState
+                                 Scores: true
+                                 Full Index Scan: true
+                                 Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}},"all","all"]}}
+               ->  Hash
+                     Output: files.id, files."documentId", (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id))
+                     ->  Custom Scan (ParadeDB Base Scan) on public.files
+                           Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
+                           Table: files
+                           Index: files_bm25
+                           Worker Selection: Row-capped
+                           Exec Method: NormalScanExecState
+                           Scores: true
+                           Full Index Scan: true
+                           Tantivy Query: {"boolean":{"should":["all",{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}},"all"]}}
+(43 rows)
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+ doc_id | file_id | page_id | doc_score | file_score | page_score |   score   
+--------+---------+---------+-----------+------------+------------+-----------
+ doc-1  | file-1  | page-1  | 1.0594962 |  1.2511479 | 0.71042687 |  3.021071
+ doc-1  | file-1  | page-2  | 1.0594962 |  1.2511479 |          0 | 2.3106441
+ doc-1  | file-2  | page-3  | 1.0594962 |          0 |  0.7879951 | 1.8474913
+ doc-2  | file-3  | page-4  |         0 |          0 |  0.7879951 | 0.7879951
+(4 rows)
+
+-- =============================================================================
+-- TEST 5: Mixed conjunctive and disjunctive join across 3 tables (A AND (B OR C))
+-- =============================================================================
+-- Requires documents.content @@@ 'postgres' (mandatory) AND either files or pages
+-- matches 'search'. Documents matching more terms across joined tables rank higher.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND (files.content @@@ 'search' OR pages.content @@@ 'search')
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+   ->  Sort
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, documents.id, files.id, pages.id
+         ->  Nested Loop
+               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+               Inner Unique: true
+               Join Filter: (documents.id = files."documentId")
+               ->  Hash Join
+                     Output: files.id, files."documentId", (paradedb.score(files.id)), (paradedb.score(files.id)), pages.id, (paradedb.score(pages.id)), (paradedb.score(pages.id))
+                     Inner Unique: true
+                     Hash Cond: (pages."fileId" = files.id)
+                     Join Filter: ((files.id @@@ '{"with_index":{"oid":14332395,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput) OR (pages.id @@@ '{"with_index":{"oid":14332394,"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput))
+                     ->  Custom Scan (ParadeDB Base Scan) on public.pages
+                           Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
+                           Table: pages
+                           Index: pages_bm25
+                           Worker Selection: Row-capped
+                           Exec Method: NormalScanExecState
+                           Scores: true
+                           Full Index Scan: true
+                           Tantivy Query: {"boolean":{"should":["all",{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}]}}
+                     ->  Hash
+                           Output: files.id, files."documentId", (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id)), (paradedb.score(files.id))
+                           ->  Custom Scan (ParadeDB Base Scan) on public.files
+                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
+                                 Table: files
+                                 Index: files_bm25
+                                 Worker Selection: Row-capped
+                                 Exec Method: NormalScanExecState
+                                 Scores: true
+                                 Full Index Scan: true
+                                 Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}},"all"]}}
+               ->  Materialize
+                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
+                     ->  Custom Scan (ParadeDB Base Scan) on public.documents
+                           Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
+                           Table: documents
+                           Index: documents_bm25
+                           Worker Selection: Cost model
+                           Exec Method: NormalScanExecState
+                           Scores: true
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+(44 rows)
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND (files.content @@@ 'search' OR pages.content @@@ 'search')
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+ doc_id | file_id | page_id | doc_score | file_score | page_score |   score   
+--------+---------+---------+-----------+------------+------------+-----------
+ doc-1  | file-1  | page-1  | 0.5231233 |  1.2511479 | 0.71042687 |  2.484698
+ doc-1  | file-1  | page-2  | 0.5231233 |  1.2511479 |          0 | 1.7742712
+ doc-1  | file-2  | page-3  | 0.5231233 |          0 |  0.7879951 | 1.3111184
+ doc-2  | file-3  | page-4  | 0.5062484 |          0 |  0.7879951 | 1.2942436
+(4 rows)
+
+-- =============================================================================
+-- TEST 6: 3-way join sorting by single-relation score
+-- =============================================================================
+-- Verifies that ORDER BY paradedb.score(pages.id) sorts solely by pages relevance
+-- rather than the sum across tables.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) AS doc_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+                                                                                                              QUERY PLAN                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, files.id, pages.id, (paradedb.score(pages.id)), (paradedb.score(documents.id))
+   ->  Result
+         Output: documents.id, files.id, pages.id, (paradedb.score(pages.id)), (paradedb.score(documents.id))
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: documents.id, (paradedb.score(documents.id)), files.id, pages.id, (paradedb.score(pages.id))
+               Relation Tree: documents INNER (pages INNER files)
+               Join Cond: documents.id = files.documentId, files.id = pages.fileId
+               Limit: 10
+               Order By: pdb.score() desc, documents.id asc, pages.fileId asc, pages.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, id@8 as col_3, id@6 as col_4, score@3 as col_5, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@7 as ctid_2]
+                 :   VisibilityFilterExec: tables=[documents, pages, files]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@4, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@5, ctid_1@6, fileId@7, id@8, ctid_2@3, id@4]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@1)], projection=[score@0, ctid_0@1, id@2, ctid_2@3, id@5]
+                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=documents, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=files, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                 :       TantivyLookupExec: decode=[id]
+                 :         SegmentedTopKExec: expr=[col_5@4 DESC, col_1@0 ASC NULLS LAST, col_3@2 ASC NULLS LAST, col_4@3 ASC NULLS LAST], k=10
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, fileId@2 as fileId, id@3 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=pages, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
+(25 rows)
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) AS doc_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+ERROR:  Failed to execute DataFusion plan: Internal("PhysicalExpr Column references column 'col_5' at index 4 (zero-based) but input schema only has 4 columns: [\"score\", \"ctid_1\", \"fileId\", \"id\"]")
+-- =============================================================================
+-- TEST 7: 3-way join with within-table disjunction (OR query in documents)
+-- =============================================================================
+-- documents matches 'postgres OR search': doc-1 matches both terms and gets a
+-- higher BM25 score than doc-2 (which only matches 'postgres').
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres OR search'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+   ->  Sort
+         Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC, documents.id, files.id, pages.id
+         ->  Nested Loop
+               Output: documents.id, files.id, pages.id, (paradedb.score(documents.id)), (paradedb.score(files.id)), (paradedb.score(pages.id)), (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+               Join Filter: (files.id = pages."fileId")
+               ->  Custom Scan (ParadeDB Base Scan) on public.pages
+                     Output: pages.id, pages."fileId", paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id), paradedb.score(pages.id)
+                     Table: pages
+                     Index: pages_bm25
+                     Worker Selection: Cost model
+                     Exec Method: NormalScanExecState
+                     Scores: true
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"vector","lenient":null,"conjunction_mode":null}}}}
+               ->  Materialize
+                     Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
+                     ->  Nested Loop
+                           Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), files.id, (paradedb.score(files.id)), (paradedb.score(files.id))
+                           Inner Unique: true
+                           Join Filter: (documents.id = files."documentId")
+                           ->  Custom Scan (ParadeDB Base Scan) on public.files
+                                 Output: files.id, files."documentId", paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id), paradedb.score(files.id)
+                                 Table: files
+                                 Index: files_bm25
+                                 Worker Selection: Cost model
+                                 Exec Method: NormalScanExecState
+                                 Scores: true
+                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}
+                           ->  Materialize
+                                 Output: documents.id, (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id)), (paradedb.score(documents.id))
+                                 ->  Custom Scan (ParadeDB Base Scan) on public.documents
+                                       Output: documents.id, paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id), paradedb.score(documents.id)
+                                       Table: documents
+                                       Index: documents_bm25
+                                       Worker Selection: Cost model
+                                       Exec Method: NormalScanExecState
+                                       Scores: true
+                                       Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres OR search","lenient":null,"conjunction_mode":null}}}}
+(40 rows)
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres OR search'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: documents, files, pages)
+ doc_id | file_id | page_id | doc_score  | file_score | page_score |   score   
+--------+---------+---------+------------+------------+------------+-----------
+ doc-1  | file-1  | page-1  |  1.5826194 | 0.33802766 |  0.3005307 | 2.2211778
+ doc-1  | file-1  | page-2  |  1.5826194 | 0.33802766 | 0.22218224 | 2.1428294
+ doc-1  | file-2  | page-3  |  1.5826194 |  0.2647028 | 0.27618298 |  2.123505
+ doc-2  | file-3  | page-4  |  0.5062484 | 0.32759193 | 0.27618298 | 1.1100234
+ doc-2  | file-4  | page-5  |  0.5062484 |  0.2647028 | 0.22218224 | 0.9931334
+ doc-3  | file-5  | page-6  | 0.41299206 |  0.2647028 | 0.22218224 | 0.8998771
+(6 rows)
 
 -- =============================================================================
 -- CLEANUP
@@ -152,6 +787,8 @@ WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byt
 DROP TABLE IF EXISTS pages CASCADE;
 DROP TABLE IF EXISTS files CASCADE;
 DROP TABLE IF EXISTS documents CASCADE;
+RESET max_parallel_workers;
 RESET max_parallel_workers_per_gather;
+RESET parallel_leader_participation;
 RESET enable_indexscan;
 RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -465,12 +465,12 @@ WHERE documents.content @@@ 'search'
    OR pages.content @@@ 'search'
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
- doc_id | file_id | page_id | doc_score | file_score | page_score | score 
---------+---------+---------+-----------+------------+------------+-------
- doc-1  | file-1  | page-1  |         0 |          0 |          0 |     0
- doc-1  | file-1  | page-2  |         0 |          0 |          0 |     0
- doc-1  | file-2  | page-3  |         0 |          0 |          0 |     0
- doc-2  | file-3  | page-4  |         0 |          0 |          0 |     0
+ doc_id | file_id | page_id | doc_score | file_score | page_score |   score   
+--------+---------+---------+-----------+------------+------------+-----------
+ doc-1  | file-1  | page-1  | 1.0594962 |  1.2511479 | 0.71042687 |  3.021071
+ doc-1  | file-1  | page-2  | 1.0594962 |  1.2511479 |          0 | 2.3106441
+ doc-1  | file-2  | page-3  | 1.0594962 |          0 |  0.7879951 | 1.8474913
+ doc-2  | file-3  | page-4  |         0 |          0 |  0.7879951 | 0.7879951
 (4 rows)
 
 -- =============================================================================
@@ -539,10 +539,10 @@ ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
  doc_id | file_id | page_id | doc_score | file_score | page_score |   score   
 --------+---------+---------+-----------+------------+------------+-----------
- doc-1  | file-1  | page-1  | 0.5231233 |          0 |          0 | 0.5231233
- doc-1  | file-1  | page-2  | 0.5231233 |          0 |          0 | 0.5231233
- doc-1  | file-2  | page-3  | 0.5231233 |          0 |          0 | 0.5231233
- doc-2  | file-3  | page-4  | 0.5062484 |          0 |          0 | 0.5062484
+ doc-1  | file-1  | page-1  | 0.5231233 |  1.2511479 | 0.71042687 |  2.484698
+ doc-1  | file-1  | page-2  | 0.5231233 |  1.2511479 |          0 | 1.7742712
+ doc-1  | file-2  | page-3  | 0.5231233 |          0 |  0.7879951 | 1.3111184
+ doc-2  | file-3  | page-4  | 0.5062484 |          0 |  0.7879951 | 1.2942436
 (4 rows)
 
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/order_by_collation.out
+++ b/pg_search/tests/pg_regress/expected/order_by_collation.out
@@ -691,7 +691,7 @@ JOIN collation_join_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name_icu
 LIMIT 5;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: p, s)
+WARNING:  JoinScan not used: ORDER BY columns must have a byte-ordered (C-like) collation (tables: p, s)
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -371,7 +371,7 @@ FROM expr_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY upper(p.category) ASC
     LIMIT 5;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: p, s)
+WARNING:  JoinScan not used: unsupported ORDER BY expression shape; expressions must match an indexed expression or be a sum of pdb.score() calls (tables: p, s)
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -403,7 +403,7 @@ FROM expr_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY upper(p.category) ASC
     LIMIT 5;
-WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: p, s)
+WARNING:  JoinScan not used: unsupported ORDER BY expression shape; expressions must match an indexed expression or be a sum of pdb.score() calls (tables: p, s)
        name       | supplier_name 
 ------------------+---------------
  Mouse Pad        | CableCo

--- a/pg_search/tests/pg_regress/sql/joinscan_sortby_score.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_sortby_score.sql
@@ -1,15 +1,49 @@
--- Reproducer for "PlaceHolderVar found where not expected" error.
--- A 3-way join with pdb.score() summed across all three tables and
--- ORDER BY + LIMIT triggers PlaceHolderVar wrapping that the JoinScan
--- custom scan tlist did not handle.
+-- Tests for JoinScan BM25 score calculation, score aggregation, and ordering.
+-- Verifies that BM25 scores across 3-table and 2-table conjunctive (AND)
+-- and disjunctive (OR) joins produce meaningful, deterministic, and intuitive rankings.
 
+SET max_parallel_workers = 0;
 SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
 SET enable_indexscan TO off;
 
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
 -- =============================================================================
--- SETUP: minimal 3-table docs schema
+-- SETUP: 3-table hierarchy (documents -> files -> pages)
+-- =============================================================================
+-- The test data is designed with deliberate term frequency (TF) and term
+-- distribution across tables so that score rankings are easy to reason about:
+--
+-- Term frequencies for 'postgres' in documents.content:
+--   doc-1: 3x ('postgres postgres postgres ...') -> high score
+--   doc-2: 2x ('postgres postgres ...')          -> medium score
+--   doc-3: 1x ('postgres ...')                   -> low score
+--   doc-4: 0x ('sqlite ...')                     -> no match (score 0)
+--
+-- Term frequencies for 'index' in files.content:
+--   file-1 (doc-1): 3x ('index index index ...') -> high score
+--   file-2 (doc-1): 1x ('index ...')             -> low score
+--   file-3 (doc-2): 2x ('index index ...')       -> medium score
+--   file-4 (doc-2): 1x ('index ...')             -> low score
+--   file-5 (doc-3): 1x ('index ...')             -> low score
+--   file-6 (doc-4): 0x ('memory ...')            -> no match (score 0)
+--
+-- Term frequencies for 'vector' in pages.content:
+--   page-1 (file-1): 3x ('vector vector vector ...') -> high score
+--   page-2 (file-1): 1x ('vector ...')               -> low score
+--   page-3 (file-2): 2x ('vector vector ...')         -> medium score
+--   page-4 (file-3): 2x ('vector vector ...')         -> medium score
+--   page-5 (file-4): 1x ('vector ...')               -> low score
+--   page-6 (file-5): 1x ('vector ...')               -> low score
+--   page-7 (file-6): 0x ('algorithms ...')           -> no match (score 0)
+--
+-- Cross-table term 'search' distribution:
+--   doc-1:  matches 'search' (content & title)
+--   file-1: matches 'search' (content)
+--   page-1: matches 'search' (content & title)
+--   page-3: matches 'search' (content & title)
+--   page-4: matches 'search' (content & title)
 -- =============================================================================
 
 DROP TABLE IF EXISTS pages CASCADE;
@@ -38,19 +72,27 @@ CREATE TABLE pages (
 );
 
 INSERT INTO documents (id, parents, content, title) VALUES
-('doc-1', 'project alpha notes', 'Document about project alpha', 'Alpha Doc'),
-('doc-2', 'project beta notes', 'Document about project beta', 'Beta Doc');
+('doc-1', 'project alpha', 'postgres postgres postgres database core search', 'Postgres Alpha Documentation'),
+('doc-2', 'project beta',  'postgres postgres database core',                'Postgres Beta Guide'),
+('doc-3', 'project gamma', 'postgres database core',                         'Gamma Reference Manual'),
+('doc-4', 'archive',       'sqlite embedded key value store',                'Other Systems');
 
 INSERT INTO files (id, "documentId", content, title) VALUES
-('file-1', 'doc-1', 'File content for alpha', 'collab12 alpha file'),
-('file-2', 'doc-1', 'File content misc', 'collab12 misc file'),
-('file-3', 'doc-2', 'File content for beta', 'beta file');
+('file-1', 'doc-1', 'index index index fast access search', 'Postgres Index Architecture'),
+('file-2', 'doc-1', 'index fast access',                    'Index Overview'),
+('file-3', 'doc-2', 'index index fast access',              'Indexing Guide'),
+('file-4', 'doc-2', 'index fast access',                    'Index Maintenance'),
+('file-5', 'doc-3', 'index fast access',                    'Gamma Index Details'),
+('file-6', 'doc-4', 'memory buffer cache management',       'Buffer Pool');
 
 INSERT INTO pages (id, "fileId", content, title) VALUES
-('page-1', 'file-1', 'Single Number Reach configuration', 'Page A'),
-('page-2', 'file-1', 'Other page content', 'Page B'),
-('page-3', 'file-2', 'Single Number Reach details', 'Page C'),
-('page-4', 'file-3', 'Beta page content', 'Page D');
+('page-1', 'file-1', 'vector vector vector similarity search', 'Vector Search Implementation'),
+('page-2', 'file-1', 'vector similarity scan',                 'Basic Vector Scan'),
+('page-3', 'file-2', 'vector vector similarity search',         'Vector Index Tuning'),
+('page-4', 'file-3', 'vector vector similarity search',         'Vector Operations'),
+('page-5', 'file-4', 'vector similarity scan',                 'Vector Utilities'),
+('page-6', 'file-5', 'vector similarity scan',                 'Gamma Vector Helpers'),
+('page-7', 'file-6', 'page replacement algorithms',            'Page Eviction');
 
 CREATE INDEX pages_bm25 ON pages
 USING paradedb (id, content, title, "fileId")
@@ -85,33 +127,307 @@ WITH (
     }'
 );
 
+-- =============================================================================
+-- PREAMBLE: Baseline BM25 scores on individual tables (no joins)
+-- =============================================================================
+-- These queries establish the ground-truth scores on each isolated table.
+-- They serve as a direct reference to verify that join-level score propagation
+-- and aggregation calculate correct values without distortion or RTI confusion.
+
+-- Baseline 1: Single-table scores for the conjunctive join terms
+SELECT 'documents' AS tbl, id, 'postgres' AS query, paradedb.score(id) AS score
+FROM documents WHERE content @@@ 'postgres'
+UNION ALL
+SELECT 'files' AS tbl, id, 'index' AS query, paradedb.score(id) AS score
+FROM files WHERE content @@@ 'index'
+UNION ALL
+SELECT 'pages' AS tbl, id, 'vector' AS query, paradedb.score(id) AS score
+FROM pages WHERE content @@@ 'vector'
+ORDER BY tbl, score DESC, id ASC;
+
+-- Baseline 2: Single-table scores for the disjunctive cross-table term ('search')
+SELECT 'documents' AS tbl, id, 'search' AS query, paradedb.score(id) AS score
+FROM documents WHERE content @@@ 'search'
+UNION ALL
+SELECT 'files' AS tbl, id, 'search' AS query, paradedb.score(id) AS score
+FROM files WHERE content @@@ 'search'
+UNION ALL
+SELECT 'pages' AS tbl, id, 'search' AS query, paradedb.score(id) AS score
+FROM pages WHERE content @@@ 'search'
+ORDER BY tbl, score DESC, id ASC;
+
+-- Baseline 3: Single-table scores for within-table disjunction ('postgres OR search')
+SELECT 'documents' AS tbl, id, 'postgres OR search' AS query, paradedb.score(id) AS score
+FROM documents WHERE content @@@ 'postgres OR search'
+ORDER BY score DESC, id ASC;
+
 SET paradedb.enable_join_custom_scan = on;
 
 -- =============================================================================
--- TEST: 3-way join with summed scores and ORDER BY score DESC LIMIT
--- This is the exact query pattern from the benchmark that triggers the error.
+-- TEST 1: 3-way conjunctive join with summed scores and ORDER BY score DESC
 -- =============================================================================
+-- All three tables have search predicates. Rows are ranked by sum of BM25 scores:
+--   doc-1/file-1/page-1: High(doc) + High(file) + High(page) -> Rank 1
+--   doc-1/file-1/page-2: High(doc) + High(file) + Low(page)  -> Rank 2
+--   doc-1/file-2/page-3: High(doc) + Low(file)  + Med(page)  -> Rank 3
+--   doc-2/file-3/page-4: Med(doc)  + Med(file)  + Med(page)  -> Rank 4
+--   doc-2/file-4/page-5: Med(doc)  + Low(file)  + Low(page)  -> Rank 5
+--   doc-3/file-5/page-6: Low(doc)  + Low(file)  + Low(page)  -> Rank 6
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
-SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
 FROM documents
 JOIN files ON documents.id = files."documentId"
 JOIN pages ON pages."fileId" = files.id
-WHERE documents.parents @@@ 'project alpha'
-  AND files.title @@@ 'collab12'
-  AND pages.content @@@ 'Single Number Reach'
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
 ORDER BY score DESC
-LIMIT 1000;
+LIMIT 10;
 
-SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
 FROM documents
 JOIN files ON documents.id = files."documentId"
 JOIN pages ON pages."fileId" = files.id
-WHERE documents.parents @@@ 'project alpha'
-  AND files.title @@@ 'collab12'
-  AND pages.content @@@ 'Single Number Reach'
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
 ORDER BY score DESC
-LIMIT 1000;
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 2: 2-way conjunctive join with summed scores and ORDER BY score DESC
+-- =============================================================================
+-- Two-table join (documents JOIN files) with distinct score sum ranking:
+--   doc-1/file-1: High(doc) + High(file) -> Rank 1
+--   doc-1/file-2: High(doc) + Low(file)  -> Rank 2
+--   doc-2/file-3: Med(doc)  + Med(file)  -> Rank 3
+--   doc-2/file-4: Med(doc)  + Low(file)  -> Rank 4
+--   doc-3/file-5: Low(doc)  + Low(file)  -> Rank 5
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+ORDER BY score DESC
+LIMIT 10;
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+ORDER BY score DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 3: Multi-key ORDER BY with score sum and secondary column
+-- =============================================================================
+-- Verifies that sorting by score sum combined with a deterministic secondary
+-- column (pages.id ASC) plans and executes correctly.
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS pdb_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY pdb_score DESC, pages.id ASC
+LIMIT 10;
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS pdb_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY pdb_score DESC, pages.id ASC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 4: 3-way cross-table disjunctive join (OR across tables)
+-- =============================================================================
+-- Cross-table OR query: rows matching across 3 tables score higher than 2 tables,
+-- which score higher than 1 table. Non-matching tables contribute 0 to the sum.
+--   doc-1/file-1/page-1: 3-table match (doc, file, page) -> Rank 1
+--   doc-1/file-1/page-2: 2-table match (doc, file)       -> Rank 2
+--   doc-1/file-2/page-3: 2-table match (doc, page)       -> Rank 3
+--   doc-2/file-3/page-4: 1-table match (page only)       -> Rank 4
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 5: Mixed conjunctive and disjunctive join across 3 tables (A AND (B OR C))
+-- =============================================================================
+-- Requires documents.content @@@ 'postgres' (mandatory) AND either files or pages
+-- matches 'search'. Documents matching more terms across joined tables rank higher.
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND (files.content @@@ 'search' OR pages.content @@@ 'search')
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND (files.content @@@ 'search' OR pages.content @@@ 'search')
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 6: 3-way join sorting by single-relation score
+-- =============================================================================
+-- Verifies that ORDER BY paradedb.score(pages.id) sorts solely by pages relevance
+-- rather than the sum across tables.
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) AS doc_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) AS doc_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 7: 3-way join with within-table disjunction (OR query in documents)
+-- =============================================================================
+-- documents matches 'postgres OR search': doc-1 matches both terms and gets a
+-- higher BM25 score than doc-2 (which only matches 'postgres').
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres OR search'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(documents.id) AS doc_score,
+       paradedb.score(files.id) AS file_score,
+       paradedb.score(pages.id) AS page_score,
+       paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'postgres OR search'
+  AND files.content @@@ 'index'
+  AND pages.content @@@ 'vector'
+ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
 
 -- =============================================================================
 -- CLEANUP
@@ -121,6 +437,8 @@ DROP TABLE IF EXISTS pages CASCADE;
 DROP TABLE IF EXISTS files CASCADE;
 DROP TABLE IF EXISTS documents CASCADE;
 
+RESET max_parallel_workers;
 RESET max_parallel_workers_per_gather;
+RESET parallel_leader_participation;
 RESET enable_indexscan;
 RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/sql/joinscan_sortby_score.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_sortby_score.sql
@@ -168,9 +168,9 @@ SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================
 -- All three tables have search predicates. Rows are ranked by sum of BM25 scores:
 --   doc-1/file-1/page-1: High(doc) + High(file) + High(page) -> Rank 1
---   doc-1/file-1/page-2: High(doc) + High(file) + Low(page)  -> Rank 2
---   doc-1/file-2/page-3: High(doc) + Low(file)  + Med(page)  -> Rank 3
---   doc-2/file-3/page-4: Med(doc)  + Med(file)  + Med(page)  -> Rank 4
+--   doc-2/file-3/page-4: Med(doc)  + Med(file)  + Med(page)  -> Rank 2
+--   doc-1/file-1/page-2: High(doc) + High(file) + Low(page)  -> Rank 3
+--   doc-1/file-2/page-3: High(doc) + Low(file)  + Med(page)  -> Rank 4
 --   doc-2/file-4/page-5: Med(doc)  + Low(file)  + Low(page)  -> Rank 5
 --   doc-3/file-5/page-6: Low(doc)  + Low(file)  + Low(page)  -> Rank 6
 
@@ -212,8 +212,8 @@ LIMIT 10;
 -- =============================================================================
 -- Two-table join (documents JOIN files) with distinct score sum ranking:
 --   doc-1/file-1: High(doc) + High(file) -> Rank 1
---   doc-1/file-2: High(doc) + Low(file)  -> Rank 2
---   doc-2/file-3: Med(doc)  + Med(file)  -> Rank 3
+--   doc-2/file-3: Med(doc)  + Med(file)  -> Rank 2
+--   doc-1/file-2: High(doc) + Low(file)  -> Rank 3
 --   doc-2/file-4: Med(doc)  + Low(file)  -> Rank 4
 --   doc-3/file-5: Low(doc)  + Low(file)  -> Rank 5
 
@@ -316,6 +316,39 @@ WHERE documents.content @@@ 'search'
    OR files.content @@@ 'search'
    OR pages.content @@@ 'search'
 ORDER BY score DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 4b: 3-way cross-table disjunction with single-table score ordering and LIMIT
+-- =============================================================================
+-- Verifies that TopK dynamic score filtering behaves correctly over a tagged scan
+-- when ordering by a single relation's score rather than a score sum.
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
+LIMIT 10;
+
+SELECT documents.id AS doc_id,
+       files.id AS file_id,
+       pages.id AS page_id,
+       paradedb.score(pages.id) AS page_score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.content @@@ 'search'
+   OR files.content @@@ 'search'
+   OR pages.content @@@ 'search'
+ORDER BY paradedb.score(pages.id) DESC, documents.id ASC, files.id ASC, pages.id ASC
 LIMIT 10;
 
 -- =============================================================================


### PR DESCRIPTION
## What

Adds support for:
* Aggregate score joins (without any Block-Max WAND dynamic filter calculation, as described in #5301)
* Calculation of scores for disjunctive joins under predicate tagging

## Why

As described in #5961, we have been remiss in not tracking disjunctive joins in our benchmarks. But before tracking them, we need them to be fully supported, with accurate scores.

This change fills out support for ordering by a sum of scores, and adds support for scoring disjunctive joins.

## How

* Added expression matching for simple "sum of scores" patterns, and improved planner warnings for other cases.
* Fixed planning of `SegmentedTopK` to ensure that it is never accidentally pushed down through a join, or through a node with a schema that it does not recognize.
* Moved to lazily tagging and scoring blocks of rows in `BatchScanner` to avoid needing segment-sized score arrays.

## Tests

Overhauled `joinscan_sortby_score.sql` to use comprehensible per-table scores, and then validate that sums across those scores make sense under conjunction and disjunction.

Additionally, `join_distinct_expr.out` shows many changes due to the fix in `SegmentedTopK` planning.