### PR TITLE
feat: One global centroid index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7130,7 +7130,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "bitpacking",
 ]
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7257,7 +7257,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=c0f401fb684eb55b1a459c833c43eeb8af5cb6a5#c0f401fb684eb55b1a459c833c43eeb8af5cb6a5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7130,7 +7130,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "bitpacking",
 ]
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7257,7 +7257,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7fc422a614b54fec99b10bb8734ff037e32fa266#7fc422a614b54fec99b10bb8734ff037e32fa266"
+source = "git+https://github.com/paradedb/tantivy.git?rev=084aec7972f1a7108b80698c133baab4997f9fca#084aec7972f1a7108b80698c133baab4997f9fca"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ overflow-checks = true
 [workspace.dependencies]
 pgrx = "=0.19.2"
 pgrx-tests = "=0.19.2"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "7fc422a614b54fec99b10bb8734ff037e32fa266", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "084aec7972f1a7108b80698c133baab4997f9fca", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -78,7 +78,7 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "7fc422a614b54fec99b10bb8734ff037e32fa266" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "084aec7972f1a7108b80698c133baab4997f9fca" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ overflow-checks = true
 [workspace.dependencies]
 pgrx = "=0.19.2"
 pgrx-tests = "=0.19.2"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "c0f401fb684eb55b1a459c833c43eeb8af5cb6a5", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "7fc422a614b54fec99b10bb8734ff037e32fa266", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -78,7 +78,7 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c0f401fb684eb55b1a459c833c43eeb8af5cb6a5" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "7fc422a614b54fec99b10bb8734ff037e32fa266" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-cRwQs6yU8jcuyBRySwp1io6setdOdtlWPn+DJnhEBGQ=";
+  cargoHash = "sha256-M41Q5Raxxdy7Wp9y62oYauv5rx3u3uUzU8FoPzMB2RI=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-M41Q5Raxxdy7Wp9y62oYauv5rx3u3uUzU8FoPzMB2RI=";
+  cargoHash = "sha256-VCVhtvdc3hGDcI7Np7Klm4yUBbe/XHEkCo6BB3eo4yk=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/unreleased/6027.vector_info.sql
+++ b/pg_search/sql/unreleased/6027.vector_info.sql
@@ -1,0 +1,5 @@
+-- Vector indexes use one index-level centroid index. Flushed segments cluster
+-- against it while mutable segments stay flat, so vector_info no longer
+-- reports the removed vector_format column.
+DROP FUNCTION IF EXISTS vector_info(index regclass, field text);
+CREATE OR REPLACE FUNCTION vector_info(index regclass, field text) RETURNS TABLE(segno text, vector_field text, vector_num_vectors pg_catalog."numeric", vector_num_centroids pg_catalog."numeric", vector_min_cluster_size pg_catalog."numeric", vector_max_cluster_size pg_catalog."numeric", vector_avg_cluster_size pg_catalog.float8, vector_empty_clusters pg_catalog."numeric", vector_total_memberships pg_catalog."numeric") AS 'MODULE_PATHNAME', 'vector_info_wrapper' LANGUAGE c STRICT;

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -389,9 +389,11 @@ fn index_info(
 /// explicitly rather than only the first one an index happens to carry. `segno`
 /// aligns with [`index_info`]'s so the two can be joined.
 ///
-/// The cluster columns are IVF-only (`NULL` for flat segments). `*_cluster_size`
-/// and `vector_total_memberships` count posting rows, so under replication their
-/// totals exceed `vector_num_vectors`, which counts distinct docs.
+/// Flushed segments cluster against the index-level centroid index; mutable
+/// segments store flat and report `vector_num_centroids = 0`.
+/// `*_cluster_size` and `vector_total_memberships` count posting rows, so
+/// under replication their totals exceed `vector_num_vectors`, which counts
+/// distinct docs.
 #[allow(clippy::type_complexity)]
 #[pg_extern]
 fn vector_info(
@@ -403,14 +405,13 @@ fn vector_info(
         (
             name!(segno, String),
             name!(vector_field, String),
-            name!(vector_format, String),
             name!(vector_num_vectors, AnyNumeric),
-            name!(vector_num_centroids, Option<AnyNumeric>),
-            name!(vector_min_cluster_size, Option<AnyNumeric>),
-            name!(vector_max_cluster_size, Option<AnyNumeric>),
-            name!(vector_avg_cluster_size, Option<f64>),
-            name!(vector_empty_clusters, Option<AnyNumeric>),
-            name!(vector_total_memberships, Option<AnyNumeric>),
+            name!(vector_num_centroids, AnyNumeric),
+            name!(vector_min_cluster_size, AnyNumeric),
+            name!(vector_max_cluster_size, AnyNumeric),
+            name!(vector_avg_cluster_size, f64),
+            name!(vector_empty_clusters, AnyNumeric),
+            name!(vector_total_memberships, AnyNumeric),
         ),
     >,
 > {
@@ -450,27 +451,23 @@ fn vector_info(
             let Some(info) = vector_index.info() else {
                 continue;
             };
-            let cluster_stats = info.cluster_stats.as_ref();
+            let cluster_stats = &info.cluster_stats;
             // Summed here rather than read off `cluster_stats`, which only
             // carries the average: this keeps the membership total exact.
             let total_memberships = vector_index
                 .cluster_sizes()
-                .map(|sizes| sizes.iter().map(|size| *size as u64).sum::<u64>());
+                .map(|sizes| sizes.iter().map(|size| *size as u64).sum::<u64>())
+                .unwrap_or(0);
             rows.push((
                 segment_reader.segment_id().short_uuid_string(),
                 field.clone(),
-                match info.format {
-                    tantivy::vector::VectorStorageFormat::Flat => "flat",
-                    tantivy::vector::VectorStorageFormat::Ivf => "ivf",
-                }
-                .to_string(),
                 info.num_vectors.into(),
-                info.num_centroids.map(Into::into),
-                cluster_stats.map(|stats| stats.min_cluster_size.into()),
-                cluster_stats.map(|stats| stats.max_cluster_size.into()),
-                cluster_stats.map(|stats| stats.avg_cluster_size),
-                cluster_stats.map(|stats| stats.empty_clusters.into()),
-                total_memberships.map(Into::into),
+                info.num_centroids.into(),
+                cluster_stats.min_cluster_size.into(),
+                cluster_stats.max_cluster_size.into(),
+                cluster_stats.avg_cluster_size,
+                cluster_stats.empty_clusters.into(),
+                total_memberships.into(),
             ));
         }
     }
@@ -535,7 +532,7 @@ fn vector_clusters(
             let sizes = vector_index
                 .cluster_sizes()
                 .map(|sizes| sizes.into_iter().map(i64::from).collect());
-            let radii = vector_index.index().map(|ivf| {
+            let radii = vector_index.clusters().map(|ivf| {
                 let bounds = ivf.bounds();
                 (0..ivf.num_clusters()).map(|c| bounds.ball_r(c)).collect()
             });

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -296,21 +296,14 @@ pub fn vector_router_recall() -> f32 {
     VECTOR_ROUTER_RECALL.get() as f32
 }
 
-/// Doc-count boundary at which a merged segment's vector storage switches
-/// from flat (exact scan) to IVF (clustered). Captured into the index's
-/// stored `IndexSettings` at CREATE INDEX time, so it applies to every merge
-/// of that index for its lifetime.
-///
-/// Default 500, overriding tantivy's 10,000: a single-segment flat-vs-IVF
-/// sweep (dim 768, default probe settings) put the latency crossover between
-/// 500 and 1,000 docs — IVF roughly ties flat at 500 docs, is 1.6x faster at
-/// 1,000, and 7x+ faster from 2,000 up, at recall@10 >= 0.99. 10,000 left
-/// mid-size segments (e.g. 100k rows split across CPU-count segments)
-/// brute-forcing their vectors.
-static VECTOR_CLUSTERING_THRESHOLD: GucSetting<i32> = GucSetting::<i32>::new(500);
+/// Minimum vector-bearing rows a table must hold for CREATE INDEX to train
+/// index-level centroids. Below the floor the build errors: too little data
+/// to train a meaningful clustering (or to warrant a vector index at all).
+/// Tests lower it to exercise small fixtures.
+static VECTOR_MIN_TRAINING_ROWS: GucSetting<i32> = GucSetting::<i32>::new(10_000);
 
-pub fn vector_clustering_threshold() -> usize {
-    VECTOR_CLUSTERING_THRESHOLD.get().max(1) as usize
+pub fn vector_min_training_rows() -> usize {
+    VECTOR_MIN_TRAINING_ROWS.get().max(1) as usize
 }
 
 pub fn init() {
@@ -581,10 +574,10 @@ pub fn init() {
     );
 
     GucRegistry::define_int_guc(
-        c"paradedb.vector_clustering_threshold",
-        c"Doc-count boundary at which merged segments switch from flat to IVF vector storage",
-        c"A merge whose target segment has at least this many docs writes clustered (IVF) vector storage; below it, flat. Captured into the index's stored settings at CREATE INDEX time.",
-        &VECTOR_CLUSTERING_THRESHOLD,
+        c"paradedb.vector_min_training_rows",
+        c"Minimum vector rows required to train a vector index",
+        c"CREATE INDEX errors when a vector field has fewer rows than this: too little data to train index-level centroids. Lower it only for testing.",
+        &VECTOR_MIN_TRAINING_ROWS,
         1,
         i32::MAX,
         GucContext::Userset,

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use super::utils::{load_metas, save_new_metas, save_schema, save_settings};
+use super::utils::{load_metas, save_centroid_index, save_new_metas, save_schema, save_settings};
 use crate::api::{HashMap, HashSet};
 use crate::index::reader::segment_component::SegmentComponentReader;
 use crate::index::writer::segment_component::SegmentComponentWriter;
@@ -375,6 +375,24 @@ impl MVCCDirectory {
     }
 
     fn file_entry(&self, path: &Path) -> tantivy::Result<Arc<dyn FileHandle>> {
+        // Index-level centroid index files (`centroids.<version>`) are not
+        // segment components: resolve them through the persisted registry.
+        if super::utils::is_centroid_index_path(path) {
+            let entries = super::utils::load_centroid_index(&self.indexrel)
+                .map_err(|e| TantivyError::InternalError(e.to_string()))?;
+            let Some(entry) = entries
+                .iter()
+                .find(|entry| Path::new(&entry.filename) == path)
+            else {
+                return Err(TantivyError::OpenDirectoryError(
+                    OpenDirectoryError::DoesNotExist(path.to_path_buf()),
+                ));
+            };
+            return Ok(Arc::new(unsafe {
+                SegmentComponentReader::new(&self.indexrel, entry.file_entry, None)
+            }));
+        }
+
         let file_name = path
             .file_name()
             .expect("path should have a filename")
@@ -676,6 +694,38 @@ impl Directory for MVCCDirectory {
 
         save_settings(&self.indexrel, &meta.index_settings)
             .map_err(|err| tantivy::TantivyError::InternalError(err.to_string()))?;
+
+        // Route index-level centroid index files OUT of the per-segment
+        // payload (their paths are not `<uuid>.<ext>`) and persist the
+        // registry, write-once, at index creation.
+        let centroid_paths: Vec<PathBuf> = payload
+            .keys()
+            .filter(|path| super::utils::is_centroid_index_path(path))
+            .cloned()
+            .collect();
+        // The registry is write-once at creation; later commits carry
+        // `centroid_index` forward in the meta but have no set file in
+        // their payload.
+        let registry_saved = MetaPage::open(&self.indexrel)
+            .centroid_index_bytes()
+            .map(|bytes| !bytes.is_empty())
+            .unwrap_or(false);
+        if let Some(filename) = meta.centroid_index.as_ref().filter(|_| !registry_saved) {
+            let file_entry = payload.get(Path::new(filename)).copied().ok_or_else(|| {
+                tantivy::TantivyError::InternalError(format!(
+                    "centroid index file {filename} was not written through this directory"
+                ))
+            })?;
+            let entries = [super::utils::CentroidIndexEntry {
+                filename: filename.clone(),
+                file_entry,
+            }];
+            save_centroid_index(&self.indexrel, &entries)
+                .map_err(|err| tantivy::TantivyError::InternalError(err.to_string()))?;
+        }
+        for path in centroid_paths {
+            payload.remove(&path);
+        }
 
         // If there were no new segments, skip the rest of the work
         if meta.segments.is_empty() {

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -33,6 +33,53 @@ use tantivy::{
     schema::Schema,
 };
 
+/// One index-level vector centroid index: tantivy's `(version, filename)`
+/// meta entry joined with the block-storage location of the file's bytes.
+/// Serialized as JSON into `MetaPage::centroid_index_bytes`, write-once at
+/// CREATE INDEX (re-publishing does not exist yet).
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct CentroidIndexEntry {
+    pub filename: String,
+    pub file_entry: FileEntry,
+}
+
+/// `true` for tantivy's index-level centroid index file
+/// ([`CENTROIDS_FILEPATH`](tantivy::vector::CENTROIDS_FILEPATH)), which is
+/// index-level, not a `<segment-uuid>.<ext>` component.
+pub fn is_centroid_index_path(path: &std::path::Path) -> bool {
+    path.file_name() == tantivy::vector::CENTROIDS_FILEPATH.file_name()
+}
+
+/// Persist the centroid index registry, write-once (mirrors `save_schema`).
+pub fn save_centroid_index(
+    indexrel: &PgSearchRelation,
+    entries: &[CentroidIndexEntry],
+) -> Result<()> {
+    let bytes_list = MetaPage::open(indexrel)
+        .centroid_index_bytes()
+        .expect("an index writing centroid index must have been created with a registry block");
+    if bytes_list.is_empty() {
+        let bytes = serde_json::to_vec(entries)?;
+        unsafe {
+            bytes_list.writer().write(&bytes)?;
+        }
+    }
+    Ok(())
+}
+
+/// The persisted centroid index registry; empty when the index has none
+/// (no vector fields, or created before the index-level format).
+pub fn load_centroid_index(indexrel: &PgSearchRelation) -> Result<Vec<CentroidIndexEntry>> {
+    let Some(bytes_list) = MetaPage::open(indexrel).centroid_index_bytes() else {
+        return Ok(Vec::new());
+    };
+    let bytes = unsafe { bytes_list.read_all() };
+    if bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
 pub fn save_schema(indexrel: &PgSearchRelation, tantivy_schema: &Schema) -> Result<()> {
     let schema = MetaPage::open(indexrel).schema_bytes();
     if schema.is_empty() {
@@ -478,6 +525,12 @@ pub unsafe fn load_metas(
     let settings = metapage.settings_bytes();
     let deserialized_settings = serde_json::from_slice(&settings.read_all())?;
 
+    let centroid_index = load_centroid_index(indexrel)
+        .map_err(|e| tantivy::TantivyError::InternalError(e.to_string()))?
+        .into_iter()
+        .next()
+        .map(|entry| entry.filename);
+
     Ok(LoadedMetas {
         entries: alive_entries,
         meta: IndexMeta {
@@ -489,6 +542,7 @@ pub unsafe fn load_metas(
             // Every index requires the stats plugin; a segment written before it existed just
             // has no `.stats` file, which readers treat as unknown.
             persisted_custom_extensions: vec![STATS_EXT.to_string()],
+            centroid_index,
         },
         pin_cushion,
         total_segments,

--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -56,7 +56,8 @@ pub fn index_settings(
         sort_by_field: SearchIndexSchema::build_sort_by_field(&options.sort_by(), schema),
         docstore_compress_dedicated_thread: false,
         codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
-        vector_clustering_threshold: crate::gucs::vector_clustering_threshold(),
+        vector_replicas: options.cluster_replication().max(1),
+        vector_bounds_scope: options.bounds_scope(),
         ..IndexSettings::default()
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -118,6 +118,10 @@ pub struct TopKSearchResults {
 pub struct TopKSearch {
     pub results: TopKSearchResults,
     pub segment_info: BTreeMap<SegmentId, serde_json::Value>,
+    /// Vector searches run ONE global probe loop across every segment, so
+    /// their instrumentation is a single JSON blob rather than a
+    /// per-segment map.
+    pub vector_search: Option<serde_json::Value>,
 }
 
 impl TopKSearch {
@@ -125,16 +129,19 @@ impl TopKSearch {
         Self {
             results,
             segment_info: BTreeMap::new(),
+            vector_search: None,
         }
     }
 
-    fn with_segment_info(
+    fn with_vector_search(
         results: TopKSearchResults,
         segment_info: BTreeMap<SegmentId, serde_json::Value>,
+        vector_search: serde_json::Value,
     ) -> Self {
         Self {
             results,
             segment_info,
+            vector_search: Some(vector_search),
         }
     }
 }
@@ -145,23 +152,9 @@ impl From<TopKSearchResults> for TopKSearch {
     }
 }
 
-fn probe_stats_to_segment_info(
-    segment_ids: &[SegmentId],
-    stats: &[ProbeStats],
-) -> BTreeMap<SegmentId, serde_json::Value> {
-    assert_eq!(
-        segment_ids.len(),
-        stats.len(),
-        "vector Fruit must yield one ProbeStats per collected segment"
-    );
-    segment_ids
-        .iter()
-        .zip(stats.iter())
-        .map(|(id, s)| {
-            let value = serde_json::to_value(s).expect("ProbeStats should serialize to JSON");
-            (*id, value)
-        })
-        .collect()
+/// The global probe loop's instrumentation, as the EXPLAIN-facing JSON.
+fn probe_stats_to_json(stats: &ProbeStats) -> serde_json::Value {
+    serde_json::to_value(stats).expect("ProbeStats should serialize to JSON")
 }
 
 impl TopKSearchResults {
@@ -1242,7 +1235,7 @@ impl SearchIndexReader {
                 tantivy::vector::set_fixed_probe_cost_rows(
                     crate::gucs::vector_fixed_probe_cost_rows(),
                 );
-                let collector = TopDocs::with_limit(n)
+                let vector_search = TopDocs::with_limit(n)
                     .and_offset(offset)
                     .order_by_similarity(tantivy_field, query_vector)
                     .with_adaptive_params(AdaptiveProbeParams {
@@ -1262,48 +1255,52 @@ impl SearchIndexReader {
                     tie_breaks.remove(i);
                 }
 
-                // Record SegmentIds as the (possibly lazy) iterator is consumed so
-                // we can zip them with per-segment ProbeStats from the Fruit.
-                let collected_ids = std::cell::RefCell::new(Vec::new());
-                let segment_ids = segment_ids.inspect(|id| collected_ids.borrow_mut().push(*id));
-                // Fruit is `VectorSimilarityFruit` — hits plus per-segment
+                // Vector search is ONE global probe loop across every
+                // segment of the searcher's snapshot, so it cannot ride
+                // the per-segment wrappers: window aggregates are rejected
+                // at plan time, and the parallel path never claims vector scans.
+                assert!(
+                    aux_collector.is_none(),
+                    "vector ORDER BY cannot run with an auxiliary aggregation collector; this \
+                     combination is rejected at plan time"
+                );
+                let consumed: Vec<SegmentId> = segment_ids.collect();
+                assert_eq!(
+                    consumed.len(),
+                    self.searcher.segment_readers().len(),
+                    "vector ORDER BY must run serially over the full segment snapshot"
+                );
+                // Fruit is `VectorSimilarityFruit` — hits plus ONE global
                 // ProbeStats — for every tie-break shape.
                 let tie_break_count = tie_breaks.len();
                 let mut tie_breaks = tie_breaks.into_iter();
                 let mut next = || tie_breaks.next().expect("tie-break feature should exist");
-                let (fruit, aggregation_results) = match tie_break_count {
-                    0 => self.collect_maybe_auxiliary(segment_ids, collector, aux_collector),
-                    1 => self.collect_maybe_auxiliary(
-                        segment_ids,
-                        collector.with_tie_break(next()),
-                        aux_collector,
-                    ),
-                    2 => self.collect_maybe_auxiliary(
-                        segment_ids,
-                        collector.with_tie_break((next(), next())),
-                        aux_collector,
-                    ),
-                    3 => self.collect_maybe_auxiliary(
-                        segment_ids,
-                        collector.with_tie_break((next(), next(), next())),
-                        aux_collector,
-                    ),
-                    4 => self.collect_maybe_auxiliary(
-                        segment_ids,
-                        collector.with_tie_break((next(), next(), next(), next())),
-                        aux_collector,
-                    ),
+                let fruit = match tie_break_count {
+                    0 => vector_search.search(&self.searcher, self.query()),
+                    1 => vector_search
+                        .with_tie_break(next())
+                        .search(&self.searcher, self.query()),
+                    2 => vector_search
+                        .with_tie_break((next(), next()))
+                        .search(&self.searcher, self.query()),
+                    3 => vector_search
+                        .with_tie_break((next(), next(), next()))
+                        .search(&self.searcher, self.query()),
+                    4 => vector_search
+                        .with_tie_break((next(), next(), next(), next()))
+                        .search(&self.searcher, self.query()),
                     x => panic!(
                         "Unsupported sort-field count: {}. At most {MAX_TOPK_FEATURES} are supported.",
                         x + 1
                     ),
-                };
-                let segment_ids = collected_ids.into_inner();
-                let mut segment_info = probe_stats_to_segment_info(&segment_ids, &fruit.stats);
+                }
+                .expect("vector search should not fail");
+                let mut segment_info = BTreeMap::new();
                 io_stats::attach(&mut segment_info);
-                TopKSearch::with_segment_info(
-                    TopKSearchResults::new_for_score(fruit.results, aggregation_results),
+                TopKSearch::with_vector_search(
+                    TopKSearchResults::new_for_score(fruit.results, None),
                     segment_info,
+                    probe_stats_to_json(&fruit.stats),
                 )
             }
         }

--- a/pg_search/src/index/stats/pruning.rs
+++ b/pg_search/src/index/stats/pruning.rs
@@ -25,6 +25,7 @@ use tantivy::index::{SegmentId, SegmentReader};
 
 use super::SegmentStats;
 use crate::index::mvcc::MvccSatisfies;
+use crate::index::open_index;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::rel::PgSearchRelation;
@@ -43,7 +44,7 @@ pub(crate) fn persisted_split_points(
         return Ok(None);
     }
     let directory = MvccSatisfies::Snapshot.directory(indexrel);
-    let index = crate::index::open_index(directory.clone())?;
+    let index = open_index(directory.clone())?;
     let Ok(field) = index.schema().get_field(partition_by) else {
         return Ok(None);
     };

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -31,10 +31,9 @@ use thiserror::Error;
 
 use crate::index::mvcc::{MVCCDirectory, MvccSatisfies};
 use crate::index::stats::{self, LogicalBoundsByField, StatsWriter};
-use crate::index::{index_settings, setup_tokenizers};
+use crate::index::{index_settings, open_index, setup_tokenizers};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{STATS_EXT, SegmentMetaEntry};
-use crate::vector::clusterer::set_ivf_clusterer;
 use crate::{postgres::types::TantivyValueError, schema::SearchIndexSchema};
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::{IntoDatum, PgLogLevel, PgSqlErrorCode, direct_function_call, function_name};
@@ -110,6 +109,10 @@ pub struct IndexWriterConfig {
     pub max_docs_per_segment: Option<u32>,
 }
 
+/// Legacy per-segment doc ceiling. The vector-specific cap it once
+/// enforced is gone — commit segments assign against the index-level
+/// centroid index at any size — so this survives only as a fixture size.
+#[cfg(any(test, feature = "pg_test"))]
 pub const DEFAULT_MAX_DOCS_PER_SEGMENT: u32 = 1000;
 
 impl IndexWriterConfig {
@@ -271,26 +274,6 @@ impl SerialIndexWriter {
         worker_number: i32,
     ) -> Result<Self> {
         let schema = index_relation.schema()?;
-        let has_vector_field = schema.has_vector_field();
-        // The IVF backend needs a doc-count ceiling, so vector indexes cap at
-        // `DEFAULT_MAX_DOCS_PER_SEGMENT`. Non-vector indexes honor the caller's
-        // value verbatim (the parallel-build planner sets it to hit
-        // `target_segment_count`).
-        let max_docs_per_segment = if has_vector_field {
-            Some(
-                config
-                    .max_docs_per_segment
-                    .map_or(DEFAULT_MAX_DOCS_PER_SEGMENT, |n| {
-                        n.min(DEFAULT_MAX_DOCS_PER_SEGMENT)
-                    }),
-            )
-        } else {
-            config.max_docs_per_segment
-        };
-        let config = IndexWriterConfig {
-            max_docs_per_segment,
-            ..config
-        };
 
         if unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) } {
             pgrx::debug1!(
@@ -302,11 +285,8 @@ impl SerialIndexWriter {
         }
 
         let directory = mvcc_satisfies.directory(index_relation);
-        let mut index = crate::index::open_index(directory)?;
+        let mut index = open_index(directory)?;
         stats::register(&mut index);
-        if has_vector_field {
-            set_ivf_clusterer(&mut index, index_relation.options());
-        }
         setup_tokenizers(index_relation, &mut index)?;
         let ctid_field = schema.ctid_field();
 
@@ -340,11 +320,11 @@ impl SerialIndexWriter {
         let settings = index_settings(index_relation.options(), &tantivy_schema);
         // No stats plugin here: the segment is a throwaway materialization that nothing
         // reads statistics from, and it is rebuilt per reader.
-        let mut index = Index::create(directory, tantivy_schema, settings)?;
-        crate::vector::clusterer::set_ivf_router(&mut index)?;
-        if schema.has_vector_field() {
-            set_ivf_clusterer(&mut index, index_relation.options());
-        }
+        // No centroid index: the staged mutable segment stores its vectors
+        // flat (doc-ordered) and is searched exhaustively; it clusters at
+        // its first merge inside the real index.
+        let builder = Index::builder().schema(tantivy_schema).settings(settings);
+        let mut index = builder.create(directory)?;
         setup_tokenizers(index_relation, &mut index)?;
         let ctid_field = schema.ctid_field();
         // We bound the input size instead: see the method doc.
@@ -536,12 +516,8 @@ impl SearchIndexMerger {
         mvcc_satisfies: MvccSatisfies,
     ) -> Result<SearchIndexMerger> {
         let directory = mvcc_satisfies.directory(indexrel);
-        let schema = indexrel.schema()?;
-        let mut index = crate::index::open_index(directory.clone())?;
+        let mut index = open_index(directory.clone())?;
         stats::register(&mut index);
-        if schema.has_vector_field() {
-            set_ivf_clusterer(&mut index, indexrel.options());
-        }
         Ok(Self {
             index,
             merged_segment_ids: Default::default(),
@@ -696,6 +672,7 @@ mod tests {
         Spi::run("SET client_min_messages = 'debug1';").unwrap();
         if with_vector {
             Spi::run("CREATE EXTENSION IF NOT EXISTS vector;").unwrap();
+            Spi::run("SET paradedb.vector_min_training_rows = 1;").unwrap();
             Spi::run("CREATE TABLE t_vec (id SERIAL, data TEXT, embedding vector(3));").unwrap();
             Spi::run("INSERT INTO t_vec (data, embedding) VALUES ('test', '[1,0,0]');").unwrap();
             Spi::run(

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -27,11 +27,14 @@ use crate::postgres::storage::custom_rmgr;
 use crate::postgres::storage::metadata::MetaPage;
 use crate::postgres::utils::{ExtractedFieldAttribute, extract_field_attributes};
 use crate::schema::{SearchFieldConfig, SearchFieldType};
+use crate::vector::clusterer::VectorSampler;
 use anyhow::Result;
 use pgrx::*;
 use std::ffi::CStr;
+use std::sync::Arc;
 use tantivy::Index;
 use tantivy::schema::Schema;
+use tantivy::vector::CentroidProducer;
 use tantivy::vector::VectorOptions;
 use tokenizers::SearchTokenizer;
 
@@ -56,7 +59,10 @@ pub extern "C-unwind" fn ambuild(
     }
 
     unsafe {
-        build_empty(&index_relation);
+        // Vector fields require centroids at index CREATION (tantivy's V3
+        // format trains once, index-wide), so `create_index` gets the heap
+        // to sample and train from.
+        build_empty(&index_relation, Some((&heap_relation, index_info)));
     }
 
     // ensure we only allow one ParadeDB index on this relation, accounting for a REINDEX
@@ -120,17 +126,69 @@ pub unsafe extern "C-unwind" fn ambuildempty(index_relation: pg_sys::Relation) {
     relation.set_fork_number(pg_sys::ForkNumber::INIT_FORKNUM);
     // INIT fork always needs WAL, even if the relation is unlogged
     relation.set_need_wal(true);
-    build_empty(&relation);
+    build_empty(&relation, None);
 }
 
-unsafe fn build_empty(index_relation: &PgSearchRelation) {
+unsafe fn build_empty(
+    index_relation: &PgSearchRelation,
+    heap_scan: Option<(&PgSearchRelation, *mut pg_sys::IndexInfo)>,
+) {
     unsafe {
         MetaPage::init(index_relation);
     }
 
     validate_index_config(index_relation);
 
-    create_index(index_relation).unwrap_or_else(|e| panic!("{e}"));
+    create_index(index_relation, heap_scan).unwrap_or_else(|e| panic!("{e}"));
+}
+
+/// Sample the heap (one `table_index_build_scan` pass feeding a reservoir
+/// per vector field), enforce the training floor, and train the
+/// index-level centroids.
+unsafe fn train_vector_centroids(
+    heap_relation: &PgSearchRelation,
+    index_relation: &PgSearchRelation,
+    index_info: *mut pg_sys::IndexInfo,
+    specs: Vec<crate::vector::clusterer::SampledFieldSpec>,
+) -> Result<Arc<dyn CentroidProducer>> {
+    let mut sampler = VectorSampler::from_specs(specs, index_relation.options());
+
+    unsafe extern "C-unwind" fn sample_callback(
+        _indexrel: pg_sys::Relation,
+        _ctid: pg_sys::ItemPointer,
+        values: *mut pg_sys::Datum,
+        isnull: *mut bool,
+        _tuple_is_alive: bool,
+        state: *mut std::os::raw::c_void,
+    ) {
+        check_for_interrupts!();
+        let sampler = &mut *state.cast::<VectorSampler>();
+        sampler.offer(values, isnull);
+    }
+
+    pg_sys::table_index_build_scan(
+        heap_relation.as_ptr(),
+        index_relation.as_ptr(),
+        index_info,
+        true,
+        true,
+        Some(sample_callback),
+        std::ptr::addr_of_mut!(sampler).cast(),
+        std::ptr::null_mut(),
+    );
+
+    let floor = crate::gucs::vector_min_training_rows();
+    for (field_name, seen) in sampler.rows_seen() {
+        if seen < floor {
+            pgrx::error!(
+                "vector field '{field_name}' has {seen} vectors, but at least {floor} are \
+                required to train a vector index (see paradedb.vector_min_training_rows); create \
+                the index after loading data"
+            );
+        }
+    }
+
+    Ok(Arc::new(sampler.train(index_relation.options())?))
 }
 
 unsafe fn validate_index_config(index_relation: &PgSearchRelation) {
@@ -341,24 +399,54 @@ fn am_handler_oid(amname: &CStr) -> Option<pg_sys::Oid> {
     }
 }
 
-fn create_index(index_relation: &PgSearchRelation) -> Result<()> {
-    let schema = planned_schema(index_relation);
+fn create_index(
+    index_relation: &PgSearchRelation,
+    heap_scan: Option<(&PgSearchRelation, *mut pg_sys::IndexInfo)>,
+) -> Result<()> {
+    let (schema, vector_fields) = plan_index_schema(index_relation);
+    let options = index_relation.options();
     let directory = MvccSatisfies::Snapshot.directory(index_relation);
 
-    let settings = index_settings(index_relation.options(), &schema);
-    let _ = Index::create(directory, schema, settings)?;
+    let settings = index_settings(options, &schema);
+    let centroid_producer: Option<Arc<dyn CentroidProducer>> = if vector_fields.is_empty() {
+        None
+    } else {
+        let Some((heap_relation, index_info)) = heap_scan else {
+            anyhow::bail!(
+                "a vector index requires data to train its centroids at CREATE INDEX time; \
+                 empty init forks (unlogged tables) are not supported for vector fields"
+            );
+        };
+        Some(unsafe {
+            train_vector_centroids(heap_relation, index_relation, index_info, vector_fields)?
+        })
+    };
+    let mut index_builder = Index::builder().schema(schema).settings(settings);
+    if let Some(centroid_producer) = centroid_producer {
+        index_builder = index_builder
+            .centroid_producer(centroid_producer)
+            .ivf_router(crate::vector::clusterer::IVF_ROUTER)?;
+    }
+    let _ = index_builder.create(directory)?;
     Ok(())
 }
 
-/// The tantivy schema this index will carry, from its reloptions and heap attributes. The
-/// stored copy exists only after [`create_index`], so validation reads the schema from here.
+/// Plan the schema before index creation so validation can inspect it.
 fn planned_schema(index_relation: &PgSearchRelation) -> Schema {
+    plan_index_schema(index_relation).0
+}
+
+fn plan_index_schema(
+    index_relation: &PgSearchRelation,
+) -> (Schema, Vec<crate::vector::clusterer::SampledFieldSpec>) {
     let options = index_relation.options();
     let mut builder = Schema::builder();
+    let mut vector_fields: Vec<crate::vector::clusterer::SampledFieldSpec> = Vec::new();
 
     for (
         name,
         ExtractedFieldAttribute {
+            attno,
             tantivy_type,
             normalizer,
             ..
@@ -396,7 +484,18 @@ fn planned_schema(index_relation: &PgSearchRelation) -> Schema {
                 builder.add_bytes_field(name.as_ref(), config.clone())
             }
             SearchFieldType::Vector(_, dims, metric) => {
-                builder.add_vector_field(name.as_ref(), VectorOptions::new(dims, metric.into()))
+                let field = builder
+                    .add_vector_field(name.as_ref(), VectorOptions::new(dims, metric.into()));
+                vector_fields.push(crate::vector::clusterer::SampledFieldSpec {
+                    // The build callback's `values` array is in index
+                    // attribute order.
+                    ordinal: attno,
+                    field,
+                    field_name: name.as_ref().to_string(),
+                    dim: dims,
+                    metric: metric.into(),
+                });
+                field
             }
         };
     }
@@ -415,7 +514,7 @@ fn planned_schema(index_relation: &PgSearchRelation) -> Schema {
         options.field_config_or_default(&FieldName::from("ctid")),
     );
 
-    builder.build()
+    (builder.build(), vector_fields)
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -1804,12 +1804,16 @@ mod tests {
         cleanup_parallel_build_large_table();
     }
 
-    /// A row count that is an exact multiple of the vector doc-count cap leaves the writer with
-    /// no pending segment at commit; the final merge must still run.
+    /// A row count that is an exact multiple of the per-segment doc target
+    /// leaves the writer with no pending segment at commit; the final merge
+    /// must still run. (The vector-specific doc cap is gone — commit
+    /// segments assign against the index-level set at any size — so the
+    /// old cap constant now only shapes this fixture's size.)
     #[pg_test]
     fn test_single_segment_build_exact_doc_cap_multiple() {
         let nrows = crate::index::writer::index::DEFAULT_MAX_DOCS_PER_SEGMENT * 5;
         Spi::run("CREATE EXTENSION IF NOT EXISTS vector;").unwrap();
+        Spi::run("SET paradedb.vector_min_training_rows = 1;").unwrap();
         Spi::run(&format!(
             r#"
             CREATE TABLE exact_cap_multiple (id SERIAL8, emb vector(8));

--- a/pg_search/src/postgres/customscan/basescan/cost.rs
+++ b/pg_search/src/postgres/customscan/basescan/cost.rs
@@ -76,6 +76,11 @@ pub(super) enum WorkerDecisionReason {
     /// The row-count heuristic (`compute_nworkers`): no ANALYZE stats, or an unsorted scan with no
     /// usable cost estimate. Caps workers so each gets at least `min_rows_per_worker` rows.
     RowHeuristic,
+    /// Vector-distance ORDER BY: the search is ONE global probe loop over
+    /// every segment with a shared kth threshold — splitting segments
+    /// across workers would re-create the per-partition waste the global
+    /// loop exists to remove, so it is always serial.
+    GlobalVectorSearch,
 }
 
 impl WorkerDecisionReason {
@@ -87,6 +92,7 @@ impl WorkerDecisionReason {
             Self::CostModelLimited => "Cost model (LIMIT)",
             Self::SortedPerSegment => "Per-segment",
             Self::RowHeuristic => "Row-capped",
+            Self::GlobalVectorSearch => "Global vector search",
         }
     }
 }
@@ -320,6 +326,10 @@ fn cost_test_limited(
 /// Inputs to [`decide_scan_parallelism`].
 pub(super) struct ScanParallelismInputs<'a> {
     pub(super) prunability: TopKPrunability,
+    /// `true` when the exec method's primary ORDER BY is a vector
+    /// distance: always serial (see
+    /// [`WorkerDecisionReason::GlobalVectorSearch`]).
+    pub(super) is_vector_orderby: bool,
     pub(super) query: &'a SearchQueryInput,
     /// The costable drive cost (see [`costable_drive_cost`]); `Some` marks the scan as costable and
     /// feeds both [`cost_test_limited`] and [`estimate_path_cost`].
@@ -349,6 +359,7 @@ pub(super) struct ScanParallelismInputs<'a> {
 pub(super) unsafe fn decide_scan_parallelism(inputs: ScanParallelismInputs) -> WorkerPathPolicy {
     let ScanParallelismInputs {
         prunability,
+        is_vector_orderby,
         query,
         drive_cost,
         row_estimate,
@@ -363,6 +374,16 @@ pub(super) unsafe fn decide_scan_parallelism(inputs: ScanParallelismInputs) -> W
         is_join_context,
         has_grouping,
     } = inputs;
+
+    // 0. Vector-distance ORDER BY -> serial only, unconditionally. The
+    //    cross-segment probe loop ranks the index-level centroid index once
+    //    and gathers each cluster across ALL segments into one heap;
+    //    per-worker segment partitions would undo exactly that.
+    if is_vector_orderby {
+        return WorkerPathPolicy::SerialOnly {
+            reason: WorkerDecisionReason::GlobalVectorSearch,
+        };
+    }
 
     // 1. Prunable short-circuit -> serial only. Block-WAND keeps primarily score-DESC ordered top-k sublinear
     //    (#4664), so workers would only add overhead. A hard gate: the cost model can't see

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -402,6 +402,7 @@ impl ExecMethod for TopKScanExecState {
             let TopKSearch {
                 results,
                 segment_info,
+                vector_search,
             } = self
                 .search_reader
                 .as_ref()
@@ -421,6 +422,11 @@ impl ExecMethod for TopKScanExecState {
             // DSM once at EndCustomScan; the leader merges at Shutdown.
             if !segment_info.is_empty() {
                 state.accumulate_segment_info(segment_info);
+            }
+            // The global vector probe loop reports one blob per query;
+            // vector scans are serial, so no DSM hop is needed.
+            if let Some(vector_search) = vector_search {
+                state.vector_search_info = Some(vector_search);
             }
             results
         } else {

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -41,6 +41,7 @@ use crate::api::{HashMap, HashSet, Varno};
 use crate::gucs;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::mvcc::MvccSatisfies;
+use crate::index::open_index;
 use crate::index::reader::index::{MAX_TOPK_FEATURES, SearchIndexReader};
 use crate::postgres::customscan::basescan::exec_methods::{
     ExecState, fast_fields, normal::NormalScanExecState,
@@ -780,8 +781,7 @@ impl CustomScan for BaseScan {
             let segment_count = {
                 let directory = MvccSatisfies::LargestSegment.directory(&bm25_index);
                 let segment_count = directory.total_segment_count(); // return value only valid after the index has been opened
-                crate::index::open_index(directory)
-                    .expect("custom_scan: should be able to open index");
+                open_index(directory).expect("custom_scan: should be able to open index");
                 segment_count.load(Ordering::Relaxed)
             };
             let schema = bm25_index
@@ -998,10 +998,20 @@ impl CustomScan for BaseScan {
                 let is_sorted = method.declares_sorted_output();
                 let consider_parallel_local = (*builder.args().rel).consider_parallel;
                 let prunability = topk_can_prune_for_method(&method, builder.args().root, &quals);
+                let is_vector_orderby = matches!(
+                    &method,
+                    ExecMethodType::TopK {
+                        orderby_info: Some(infos),
+                        ..
+                    } if infos
+                        .first()
+                        .is_some_and(|info| info.is_vector_distance())
+                );
 
                 // Decide the policy first: its reason gates the path cost below.
                 let policy = decide_scan_parallelism(ScanParallelismInputs {
                     prunability,
+                    is_vector_orderby,
                     query: &query,
                     drive_cost,
                     row_estimate,
@@ -1024,6 +1034,10 @@ impl CustomScan for BaseScan {
                 // applied to the cost.)
                 let path_drive_cost = match reason {
                     WorkerDecisionReason::BlockWandPrunable => None,
+                    // A vector top-k's cost is dominated by its probe
+                    // budget, not the filter drive; like the prunable
+                    // case, the full-docset drive cost would overstate it.
+                    WorkerDecisionReason::GlobalVectorSearch => None,
                     WorkerDecisionReason::CostModel
                     | WorkerDecisionReason::CostModelLimited
                     | WorkerDecisionReason::SortedPerSegment
@@ -1075,11 +1089,10 @@ impl CustomScan for BaseScan {
                         )
                         .set_force_path(forced);
 
-                        // Our BaseScan is always parallel-safe (can run in a worker), even when it's not
-                        // parallel-aware (splitting segments).
-                        if consider_parallel_local {
-                            path_builder = path_builder.set_parallel_safe(true);
-                        }
+                        path_builder = path_builder.set_parallel_safe(
+                            consider_parallel_local
+                                && !matches!(reason, WorkerDecisionReason::GlobalVectorSearch),
+                        );
                         if let Some(nworkers) = nworkers {
                             path_builder = path_builder.set_parallel(nworkers.get());
                         }
@@ -1108,6 +1121,11 @@ impl CustomScan for BaseScan {
                         method_private.set_worker_selection_reason(reason);
                         path_builder.build(method_private)
                     };
+
+                if is_vector_orderby {
+                    custom_paths.push(make_path(None, false, force));
+                    continue;
+                }
 
                 match policy {
                     WorkerPathPolicy::SerialOnly { .. } => {
@@ -1161,6 +1179,24 @@ impl CustomScan for BaseScan {
             let processed_tlist = (*builder.args().root).processed_tlist;
 
             let mut window_aggregates = deserialize_window_agg_placeholders(processed_tlist);
+
+            if !window_aggregates.is_empty()
+                && builder
+                    .custom_private()
+                    .maybe_orderby_info()
+                    .as_ref()
+                    .is_some_and(|infos| {
+                        infos.first().is_some_and(|info| info.is_vector_distance())
+                    })
+            {
+                // The global vector probe loop cannot ride the per-segment
+                // collector wrappers an in-scan aggregation needs; run the
+                // aggregate as its own query instead.
+                pgrx::error!(
+                    "window aggregates cannot be combined with a vector distance ORDER BY in the \
+                     same query; compute the aggregate in a separate query"
+                );
+            }
 
             if !window_aggregates.is_empty() {
                 // Convert PostgresExpression filters to SearchQueryInput now that we have root
@@ -1522,6 +1558,9 @@ impl CustomScan for BaseScan {
                 );
                 if let Some(explain_data) = state.custom_state().telemetry.parallel_explain() {
                     explainer.add_json("Parallel Workers", &explain_data.workers);
+                }
+                if let Some(vector_search) = &state.custom_state().vector_search_info {
+                    explainer.add_json("Vector Search", vector_search);
                 }
                 let segment_info = state.custom_state().segment_info_for_explain();
                 if !segment_info.is_empty() {

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -46,6 +46,11 @@ use tantivy::snippet::SnippetGenerator;
 
 #[derive(Default)]
 pub struct BaseScanState {
+    /// The global vector probe loop's instrumentation for this scan, one
+    /// JSON blob per query (vector scans are serial; no per-segment or
+    /// DSM breakdown exists). Surfaced in EXPLAIN as "Vector Search".
+    pub vector_search_info: Option<serde_json::Value>,
+
     /// Process-local EXPLAIN metrics (query counts, per-segment JSON, …).
     pub telemetry: ScanTelemetry,
     /// Set when this scan is parallel-aware (DSM attached).

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -49,6 +49,9 @@ unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
     if forced {
         (*rel).pathlist = std::ptr::null_mut();
         (*rel).partial_pathlist = std::ptr::null_mut();
+        if !path.path.parallel_safe {
+            (*rel).consider_parallel = false;
+        }
     }
 
     let custom_path = PgMemoryContexts::CurrentMemoryContext

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -17,6 +17,7 @@
 
 use crate::index::fast_fields_helper::FFType;
 use crate::index::mvcc::{MVCCDirectory, MvccSatisfies};
+use crate::index::open_index;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::locks::AdvisoryLock;
 use crate::postgres::rel::PgSearchRelation;
@@ -165,7 +166,7 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     let mut new_metas = Vec::new();
 
     let directory = MvccSatisfies::Vacuum.directory(&index_relation);
-    let index = crate::index::open_index(directory.clone()).unwrap();
+    let index = open_index(directory.clone()).unwrap();
     let searchable_segment_metas = index.searchable_segment_metas().unwrap();
     let mut did_delete = false;
 

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -188,18 +188,9 @@ extern "C-unwind" fn validate_search_tokenizer(value: *const std::os::raw::c_cha
         .unwrap_or_else(|| panic!("invalid search_tokenizer: '{s}'"));
 }
 
-/// The only legal `bounds_scope`: the merge folds centroid bounds over a
-/// cluster's NATIVE (primary-assignment) members. Kept as a CREATE INDEX
-/// option for compatibility; Tantivy no longer stores a bounds-scope setting.
-pub(crate) const BOUNDS_SCOPE_NATIVE: &str = "native";
+pub use tantivy::vector::BoundsScope;
 
-/// Local mirror of the former Tantivy `BoundsScope`. Native is the only
-/// supported value; bounds folding always covers primary-assignment members.
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
-pub enum BoundsScope {
-    #[default]
-    Native,
-}
+pub(crate) const BOUNDS_SCOPE_NATIVE: &str = "native";
 
 #[pg_guard]
 extern "C-unwind" fn validate_bounds_scope(value: *const std::os::raw::c_char) {

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -85,6 +85,13 @@ pub struct MetaPageData {
     created_by_version_patch: u16,
 
     created_at: pg_sys::TimestampTz,
+
+    /// Header block of the index-level vector centroid index registry (a
+    /// `LinkedBytesList` of JSON; see `directory::utils::save_centroid_index`).
+    /// Appended after `created_at`: zero on indexes created before the
+    /// index-level centroid format existed — those cannot hold vector
+    /// fields under the current format and must be reindexed.
+    centroid_index_start: pg_sys::BlockNumber,
 }
 
 /// Provides read access to the metadata page
@@ -122,6 +129,7 @@ impl MetaPage {
             metadata.settings_start = LinkedBytesList::create_without_fsm(indexrel);
             metadata.segment_metas_start =
                 LinkedItemList::<SegmentMetaEntry>::create_without_fsm(indexrel);
+            metadata.centroid_index_start = LinkedBytesList::create_without_fsm(indexrel);
 
             metadata.created_by_version_major =
                 const { parse_version_component(env!("CARGO_PKG_VERSION_MAJOR")) };
@@ -359,6 +367,18 @@ impl MetaPage {
             self.data.settings_start
         };
         LinkedBytesList::open(self.bman.buffer_access().rel(), blockno)
+    }
+
+    /// The index-level vector centroid index registry. `None` on indexes
+    /// created before the field existed — those predate the index-level
+    /// centroid format entirely (their vector segments require reindex).
+    pub fn centroid_index_bytes(&self) -> Option<LinkedBytesList> {
+        (self.data.centroid_index_start != 0).then(|| {
+            LinkedBytesList::open(
+                self.bman.buffer_access().rel(),
+                self.data.centroid_index_start,
+            )
+        })
     }
 
     pub fn segment_metas(&self) -> LinkedItemList<SegmentMetaEntry> {

--- a/pg_search/src/vector/clusterer.rs
+++ b/pg_search/src/vector/clusterer.rs
@@ -15,323 +15,273 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::{Arc, Mutex};
+//! CREATE INDEX-time centroid training.
+//!
+//! Centroids are an index-level artifact under tantivy's V3 vector format:
+//! trained ONCE, over a sample of the whole corpus, installed at index
+//! creation like the schema and settings, and never retrained — segments
+//! only assign against them (at commit and merge, inside tantivy). This
+//! module owns the training side: a reservoir sampler fed by the
+//! CREATE INDEX heap scan, the hierarchical-superkmeans run per vector
+//! field, and the [`CentroidProducer`] handed to
+//! `IndexBuilder::centroid_producer`.
 
+use crate::api::HashMap;
+use crate::postgres::options::BM25IndexOptions;
+use crate::vector::PgVector;
+use anyhow::{Result, bail};
+use pgrx::{FromDatum, pg_sys};
 use superkmeans::{HierarchicalSuperKMeans, HierarchicalSuperKMeansConfig};
+use tantivy::schema::Field;
 use tantivy::vector::{
-    IvfCentroids, IvfClusterer, IvfMatrix, IvfMergeSettings, IvfTrainingVectors, IvfVectors,
-    Metric, RouterKind, VectorOptions,
+    CentroidProducer, IvfCentroids, IvfMatrix, Metric, RouterKind, VectorOptions,
 };
 use tantivy::{Index, TantivyError};
 
-use crate::postgres::options::BM25IndexOptions;
-
-const DEFAULT_ASSIGN_BATCH_SIZE: usize = 40_960;
-
-/// The IVF centroid router every pg_search index builds and opens: a stacked
-/// IVF over the trained centroids. Tantivy persists the router kind in each
-/// segment's `.centroids` file and refuses to open a segment under a
-/// different kind, so this is a build-time constant, not a GUC.
 pub const IVF_ROUTER: RouterKind = RouterKind::Stacked;
 
-/// A `HierarchicalSuperKMeans` built for assignment, tagged with the
-/// `(dim, angular)` it was constructed for. `assign` never reads the clusterer's
-/// centroids, pruner, or cluster count — it derives everything from the vectors
-/// and centroids handed to it per call — so one instance is valid for every
-/// batch (and every merge) sharing the same `(dim, angular)`.
-struct AssignClusterer {
-    dim: usize,
-    angular: bool,
-    clusterer: Arc<HierarchicalSuperKMeans>,
-}
-
-#[derive(Clone)]
-pub struct SuperKMeansIvfClusterer {
-    config: HierarchicalSuperKMeansConfig,
-    centroid_ratio: f32,
-    training_sample_ratio: f32,
-    assign_batch_size: usize,
-    /// Lazily-built clusterer reused across `assign` batches.
-    assign_cache: Arc<Mutex<Option<AssignClusterer>>>,
-}
-
-impl std::fmt::Debug for SuperKMeansIvfClusterer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SuperKMeansIvfClusterer")
-            .field("config", &self.config)
-            .field("centroid_ratio", &self.centroid_ratio)
-            .field("training_sample_ratio", &self.training_sample_ratio)
-            .field("assign_batch_size", &self.assign_batch_size)
-            .finish_non_exhaustive()
-    }
-}
-
-impl Default for SuperKMeansIvfClusterer {
-    fn default() -> Self {
-        // Per-run knobs live on the nested `base` config in superkmeans-rs.
-        let mut config = HierarchicalSuperKMeansConfig::default();
-        config.base.suppress_warnings = true;
-        Self {
-            config,
-            centroid_ratio: 0.01,
-            training_sample_ratio: 0.32,
-            assign_batch_size: DEFAULT_ASSIGN_BATCH_SIZE,
-            assign_cache: Arc::new(Mutex::new(None)),
-        }
-    }
-}
-
-impl SuperKMeansIvfClusterer {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_centroid_ratio(mut self, centroid_ratio: f32) -> Self {
-        self.centroid_ratio = centroid_ratio;
-        self
-    }
-
-    pub fn with_training_sample_ratio(mut self, training_sample_ratio: f32) -> Self {
-        self.training_sample_ratio = training_sample_ratio;
-        self
-    }
-
-    /// Density-preserving leaf cap: a subsample of size
-    /// `training_sample_ratio * N` should still yield about
-    /// `centroid_ratio * N` leaves.
-    fn max_leaf_size(&self) -> usize {
-        let leaf = (self.training_sample_ratio / self.centroid_ratio).round() as usize;
-        leaf.max(1)
-    }
-}
-
-impl IvfClusterer for SuperKMeansIvfClusterer {
-    fn training_sample_ratio(&self) -> f32 {
-        self.training_sample_ratio
-    }
-
-    fn assign_batch_size(&self) -> usize {
-        self.assign_batch_size
-    }
-
-    fn merge_settings(&self, _total_target_docs: usize) -> tantivy::Result<IvfMergeSettings> {
-        let centroid_ratio = self.centroid_ratio;
-        let training_sample_ratio = self.training_sample_ratio;
-        let assign_batch_size = self.assign_batch_size;
-
-        assert!(
-            centroid_ratio > 0.0 && centroid_ratio <= 1.0,
-            "centroid_ratio must be in (0, 1], got {centroid_ratio}"
-        );
-        assert!(
-            training_sample_ratio > 0.0 && training_sample_ratio <= 1.0,
-            "training_sample_ratio must be in (0, 1], got {training_sample_ratio}"
-        );
-        assert!(assign_batch_size > 0, "assign_batch_size must be > 0");
-
-        Ok(IvfMergeSettings {
-            training_sample_ratio,
-            assign_batch_size,
-        })
-    }
-
-    fn train(
-        &self,
-        options: &VectorOptions,
-        vectors: IvfTrainingVectors,
-    ) -> tantivy::Result<IvfCentroids> {
-        let IvfTrainingVectors::F32(vectors) = vectors;
-        let dim = options.dim();
-        if vectors.matrix.dims != dim {
-            return Err(TantivyError::InvalidArgument(format!(
-                "vector dimensionality mismatch: expected {dim}, got {}",
-                vectors.matrix.dims
-            )));
-        }
-        if vectors.doc_ids.len() != vectors.matrix.rows {
-            return Err(TantivyError::InvalidArgument(format!(
-                "vector doc_id count mismatch: expected {}, got {}",
-                vectors.matrix.rows,
-                vectors.doc_ids.len()
-            )));
-        }
-        if vectors.matrix.values.len() != vectors.matrix.rows * dim {
-            return Err(TantivyError::InvalidArgument(format!(
-                "vector value count mismatch: expected {}, got {}",
-                vectors.matrix.rows * dim,
-                vectors.matrix.values.len()
-            )));
-        }
-
-        let mut config = self.config.clone();
-        config.max_leaf_size = self.max_leaf_size();
-        if matches!(options.metric(), Metric::Cosine | Metric::Dot) {
-            config.base.angular = true;
-        }
-        let mut clusterer = HierarchicalSuperKMeans::with_config(dim, config);
-        let rows = vectors.matrix.rows;
-        // Hand the buffer to superkmeans so it can rotate in place instead of
-        // keeping a second full-size copy alive through training. Callers
-        // (tantivy merge) are responsible for sampling before this call.
-        let centroids = clusterer.train_owned(vectors.matrix.values, rows);
-        if !centroids.len().is_multiple_of(dim) {
-            return Err(TantivyError::InternalError(format!(
-                "SuperKMeans returned {} centroid floats, not a multiple of dim {dim}",
-                centroids.len()
-            )));
-        }
-        let num_centroids = centroids.len() / dim;
-        if num_centroids == 0 {
-            return Err(TantivyError::InternalError(
-                "SuperKMeans returned zero centroids".to_string(),
-            ));
-        }
-        Ok(IvfCentroids::F32(IvfMatrix {
-            values: centroids,
-            rows: num_centroids,
-            dims: dim,
-        }))
-    }
-
-    fn assign(
-        &self,
-        options: &VectorOptions,
-        vectors: IvfVectors<'_>,
-        centroids: &IvfCentroids,
-    ) -> tantivy::Result<Vec<u32>> {
-        let IvfVectors::F32(vectors) = vectors;
-        let IvfCentroids::F32(centroids) = centroids;
-        let dim = options.dim();
-        let vector_matrix = vectors.matrix;
-        let centroid_matrix = centroids;
-        if vector_matrix.dims != dim {
-            return Err(TantivyError::InvalidArgument(format!(
-                "vector dimensionality mismatch: expected {dim}, got {}",
-                vector_matrix.dims
-            )));
-        }
-        if vectors.doc_ids.len() != vector_matrix.rows {
-            return Err(TantivyError::InvalidArgument(format!(
-                "vector doc_id count mismatch: expected {}, got {}",
-                vector_matrix.rows,
-                vectors.doc_ids.len()
-            )));
-        }
-        if vector_matrix.values.len() != vector_matrix.rows * dim {
-            return Err(TantivyError::InvalidArgument(format!(
-                "vector value count mismatch: expected {}, got {}",
-                vector_matrix.rows * dim,
-                vector_matrix.values.len()
-            )));
-        }
-        if centroid_matrix.rows == 0 {
-            return Err(TantivyError::InvalidArgument(
-                "cannot assign with zero centroids".to_string(),
-            ));
-        }
-        if centroid_matrix.dims != dim {
-            return Err(TantivyError::InvalidArgument(format!(
-                "centroid dimensionality mismatch: expected {dim}, got {}",
-                centroid_matrix.dims
-            )));
-        }
-        if centroid_matrix.values.len() != centroid_matrix.rows * dim {
-            return Err(TantivyError::InvalidArgument(format!(
-                "centroid value count mismatch: expected {}, got {}",
-                centroid_matrix.rows * dim,
-                centroid_matrix.values.len()
-            )));
-        }
-        if vector_matrix.rows == 0 {
-            return Ok(Vec::new());
-        }
-
-        let angular = matches!(options.metric(), Metric::Cosine | Metric::Dot);
-
-        // Build the clusterer once per `(dim, angular)` and reuse it across every batch.
-        let clusterer = {
-            let mut cache = self
-                .assign_cache
-                .lock()
-                .expect("assign clusterer cache mutex poisoned");
-            match cache.as_ref() {
-                Some(entry) if entry.dim == dim && entry.angular == angular => {
-                    entry.clusterer.clone()
-                }
-                _ => {
-                    let mut config = self.config.clone();
-                    config.base.angular = angular;
-                    let clusterer = Arc::new(HierarchicalSuperKMeans::with_config(dim, config));
-                    *cache = Some(AssignClusterer {
-                        dim,
-                        angular,
-                        clusterer: clusterer.clone(),
-                    });
-                    clusterer
-                }
-            }
-        };
-        // Primary (nearest-centroid) assignment via superkmeans, angular-aware
-        // for cosine/dot. One cluster per vector.
-        let primaries = clusterer.assign(
-            vector_matrix.values,
-            centroid_matrix.values.as_slice(),
-            vector_matrix.rows,
-        );
-        Ok(primaries)
-    }
-}
-
-/// Select the IVF router on an opened index. Every `Index::open` in pg_search
-/// goes through this: tantivy requires a configured router both to build IVF
-/// segments at merge time and to open existing ones for search.
 pub fn set_ivf_router(index: &mut Index) -> tantivy::Result<()> {
     index.set_ivf_router(IVF_ROUTER)
 }
 
-pub fn set_ivf_clusterer(index: &mut Index, options: &BM25IndexOptions) {
-    let clusterer = SuperKMeansIvfClusterer::new()
-        .with_centroid_ratio(options.centroid_ratio())
-        .with_training_sample_ratio(options.training_sample_ratio());
-    index.set_ivf_clusterer(Arc::new(clusterer));
+/// Floor on reservoir capacity, so a tiny table still trains on whatever
+/// it has rather than on a couple of rows.
+const MIN_RESERVOIR_ROWS: usize = 1024;
+
+/// The frozen training result for every vector field of the schema,
+/// pulled by tantivy exactly once at index creation.
+pub struct TrainedCentroidProducer {
+    fields: HashMap<Field, TrainedField>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+struct TrainedField {
+    values: Vec<f32>,
+    rows: usize,
+    dim: usize,
+}
 
-    #[test]
-    fn max_leaf_size_is_density_preserving() {
-        let clusterer = SuperKMeansIvfClusterer::new()
-            .with_centroid_ratio(0.01)
-            .with_training_sample_ratio(0.32);
-        assert_eq!(clusterer.max_leaf_size(), 32);
+impl CentroidProducer for TrainedCentroidProducer {
+    fn centroids(&self, field: Field, options: &VectorOptions) -> tantivy::Result<IvfCentroids> {
+        let Some(trained) = self.fields.get(&field) else {
+            return Err(TantivyError::InternalError(format!(
+                "no centroids were trained for vector field {field:?}"
+            )));
+        };
+        debug_assert_eq!(trained.dim, options.dim());
+        Ok(IvfCentroids::F32(IvfMatrix {
+            values: trained.values.clone(),
+            rows: trained.rows,
+            dims: trained.dim,
+        }))
+    }
+}
 
-        let full = SuperKMeansIvfClusterer::new()
-            .with_centroid_ratio(0.01)
-            .with_training_sample_ratio(1.0);
-        assert_eq!(full.max_leaf_size(), 100);
+/// One vector field of the index being built, as `create_index`'s schema
+/// loop discovered it: the tantivy [`Field`] it was assigned, and its
+/// position within the index's column order (the build callback's
+/// `values` array).
+pub struct SampledFieldSpec {
+    pub ordinal: usize,
+    pub field: Field,
+    pub field_name: String,
+    pub dim: usize,
+    pub metric: Metric,
+}
+
+/// One vector field's reservoir during the sampling heap scan.
+struct SampledField {
+    spec: SampledFieldSpec,
+    /// Reservoir capacity, in rows.
+    cap: usize,
+    /// Vector-bearing rows seen (not sampled) — the training-floor count
+    /// and the reservoir's algorithm-R denominator.
+    seen: usize,
+    /// The reservoir: `min(seen, cap)` rows, `dim`-strided.
+    rows: Vec<f32>,
+}
+
+/// Sampler over the CREATE INDEX heap scan, one reservoir per vector field.
+pub struct VectorSampler {
+    fields: Vec<SampledField>,
+    /// Fraction of the observed corpus retained for training.
+    sample_fraction: f64,
+    /// xorshift64* state; fixed seed, so a rebuild of the same data
+    /// samples the same rows.
+    rng: u64,
+}
+
+impl VectorSampler {
+    /// Allocate reservoirs for the vector fields discovered during schema planning.
+    pub fn from_specs(specs: Vec<SampledFieldSpec>, options: &BM25IndexOptions) -> Self {
+        assert!(!specs.is_empty(), "sampling requires vector fields");
+        let sample_fraction = f64::from(options.training_sample_ratio());
+        let fields = specs
+            .into_iter()
+            .map(|spec| SampledField {
+                spec,
+                cap: MIN_RESERVOIR_ROWS,
+                seen: 0,
+                rows: Vec::new(),
+            })
+            .collect();
+        VectorSampler {
+            fields,
+            sample_fraction,
+            rng: 0x9E37_79B9_7F4A_7C15,
+        }
     }
 
-    #[test]
-    fn merge_settings_use_training_sample_ratio() {
-        let settings = SuperKMeansIvfClusterer::new()
-            .with_training_sample_ratio(0.5)
-            .merge_settings(100_000)
-            .unwrap();
-        assert_eq!(settings.training_sample_ratio, 0.5);
-        assert_eq!(settings.assign_batch_size, DEFAULT_ASSIGN_BATCH_SIZE);
+    fn next_rng(&mut self) -> u64 {
+        let mut x = self.rng;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.rng = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
     }
 
-    /// The router is fixed per index: setting it twice with the same kind is
-    /// idempotent, so opening the same `Index` through several paths is safe.
-    #[test]
-    fn set_ivf_router_is_idempotent() {
-        use tantivy::schema::Schema;
+    /// Offer one heap row (the build callback's `values`/`isnull` arrays,
+    /// in index-column order) to every field's reservoir.
+    ///
+    /// # Safety
+    ///
+    /// `values` and `isnull` must be the arrays Postgres passes to an
+    /// `IndexBuildCallback`, valid for the index's column count.
+    pub unsafe fn offer(&mut self, values: *mut pg_sys::Datum, isnull: *mut bool) {
+        for i in 0..self.fields.len() {
+            let ordinal = self.fields[i].spec.ordinal;
+            if *isnull.add(ordinal) {
+                continue;
+            }
+            let datum = *values.add(ordinal);
+            let Some(vector) = PgVector::from_datum(datum, false) else {
+                continue;
+            };
+            let field = &self.fields[i];
+            if vector.0.len() != field.spec.dim {
+                panic!(
+                    "vector field '{}' expects {} dimensions, got {}",
+                    field.spec.field_name,
+                    field.spec.dim,
+                    vector.0.len()
+                );
+            }
+            // Capacity tracks the rows seen so far, so it converges on
+            // the requested training fraction without
+            // needing to know the row count up front. It only ever grows;
+            // the freed slots are filled by subsequent rows.
+            let dim = field.spec.dim;
+            let seen = field.seen;
+            let cap = (((seen + 1) as f64 * self.sample_fraction).ceil() as usize)
+                .max(MIN_RESERVOIR_ROWS);
+            // Occupied slots, which must stay DENSE: appending is the only
+            // way the reservoir grows, so a widened capacity is filled by
+            // subsequent rows instead of leaving zero-filled holes for
+            // k-means to train on.
+            let filled = field.rows.len() / dim;
+            let slot = if filled < cap {
+                Some(filled)
+            } else {
+                // Algorithm R: replace a random resident with probability
+                // cap / (seen + 1).
+                let j = (self.next_rng() % (seen as u64 + 1)) as usize;
+                (j < cap).then_some(j)
+            };
+            let field = &mut self.fields[i];
+            field.cap = cap;
+            if let Some(slot) = slot {
+                let start = slot * dim;
+                debug_assert!(start <= field.rows.len(), "reservoir must stay dense");
+                if field.rows.len() == start {
+                    field.rows.extend_from_slice(&vector.0);
+                } else {
+                    field.rows[start..start + dim].copy_from_slice(&vector.0);
+                }
+            }
+            field.seen += 1;
+        }
+    }
 
-        let mut index = Index::create_in_ram(Schema::builder().build());
-        set_ivf_router(&mut index).expect("first set");
-        set_ivf_router(&mut index).expect("same kind again");
-        assert!(index.set_ivf_router(RouterKind::Rng).is_err());
+    /// Vector-bearing rows seen per field, for the training floor.
+    pub fn rows_seen(&self) -> impl Iterator<Item = (&str, usize)> {
+        self.fields
+            .iter()
+            .map(|field| (field.spec.field_name.as_str(), field.seen))
+    }
+
+    /// Train each field's centroids over its reservoir. `centroid_ratio`
+    /// and the target centroid count are resolved against the TRUE row
+    /// count (`seen`), not the reservoir size.
+    pub fn train(self, options: &BM25IndexOptions) -> Result<TrainedCentroidProducer> {
+        let centroid_ratio = options.centroid_ratio();
+        let mut fields = HashMap::default();
+        for sampled in self.fields {
+            let spec = sampled.spec;
+            // The reservoir is dense, so its length IS the sample size.
+            let sampled_rows = sampled.rows.len() / spec.dim;
+            if sampled_rows == 0 {
+                bail!(
+                    "vector field '{}' has no vectors to train on",
+                    spec.field_name
+                );
+            }
+            let num_centroids = ((sampled.seen as f64) * f64::from(centroid_ratio))
+                .ceil()
+                .max(1.0) as usize;
+            let num_centroids = num_centroids.clamp(1, sampled_rows);
+
+            let mut values = sampled.rows;
+            debug_assert_eq!(values.len(), sampled_rows * spec.dim);
+            let angular = matches!(spec.metric, Metric::Cosine | Metric::Dot);
+            if spec.metric == Metric::Cosine {
+                // Mirror the stored-row contract: rows are unit-normalized
+                // at ingest, so train in the same space.
+                for row in values.chunks_exact_mut(spec.dim) {
+                    let norm = row
+                        .iter()
+                        .map(|x| f64::from(*x) * f64::from(*x))
+                        .sum::<f64>()
+                        .sqrt();
+                    if norm.is_finite() && norm > 0.0 {
+                        for x in row {
+                            *x = (f64::from(*x) / norm) as f32;
+                        }
+                    }
+                }
+            }
+
+            let mut config = HierarchicalSuperKMeansConfig::default();
+            config.base.suppress_warnings = true;
+            config.base.angular = angular;
+            config.max_leaf_size = (sampled_rows as f64 / num_centroids as f64)
+                .round()
+                .max(1.0) as usize;
+            let mut clusterer = HierarchicalSuperKMeans::with_config(spec.dim, config);
+            let centroids = clusterer.train_owned(values, sampled_rows);
+            if centroids.is_empty() || !centroids.len().is_multiple_of(spec.dim) {
+                bail!(
+                    "SuperKMeans returned {} centroid floats for field '{}' with dimension {}",
+                    centroids.len(),
+                    spec.field_name,
+                    spec.dim
+                );
+            }
+            let num_centroids = centroids.len() / spec.dim;
+            pgrx::debug1!(
+                "trained {num_centroids} centroids for vector field '{}' over {sampled_rows} \
+                 sampled rows ({} seen)",
+                spec.field_name,
+                sampled.seen,
+            );
+            fields.insert(
+                spec.field,
+                TrainedField {
+                    values: centroids,
+                    rows: num_centroids,
+                    dim: spec.dim,
+                },
+            );
+        }
+        Ok(TrainedCentroidProducer { fields })
     }
 }

--- a/pg_search/tests/pg_regress/expected/vector_delete_all_docs.out
+++ b/pg_search/tests/pg_regress/expected/vector_delete_all_docs.out
@@ -15,6 +15,8 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 DROP TABLE IF EXISTS delvec;
 CREATE TABLE delvec (
     id    int PRIMARY KEY,
@@ -28,6 +30,12 @@ CREATE TABLE delvec (
 -- cluster_replication = 1 pins primary-only assignment: the layer_sizes budget
 -- below is tuned to the on-disk vector footprint, which replica cells would
 -- inflate. This test exercises the empty-slots merge path, not replication.
+-- Centroids train at CREATE INDEX over existing rows, so seed a
+-- vector-bearing corpus first (deleted along with the rest below).
+INSERT INTO delvec
+SELECT g, md5(g::text),
+       ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(-999, 0) g;
 CREATE INDEX delvec_idx ON delvec
     USING paradedb (id, label, vec vector_l2_ops)
     WITH (
@@ -49,10 +57,10 @@ SELECT g,
             THEN ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
        END
 FROM generate_series(1, 24000) g;
-SELECT bool_or(vector_format = 'ivf') AS has_ivf
+SELECT bool_and(vector_num_centroids > 0) AS all_clustered
 FROM paradedb.vector_info('delvec_idx', 'vec');
- has_ivf 
----------
+ all_clustered 
+---------------
  t
 (1 row)
 
@@ -60,19 +68,24 @@ FROM paradedb.vector_info('delvec_idx', 'vec');
 -- merge sees those docs as dead.
 DELETE FROM delvec WHERE vec IS NOT NULL;
 VACUUM delvec;
--- Remerge with the (now vector-less) IVF segment as a source: ~880kb after
+-- Remerge with the (now vector-less) segment as a source: ~880kb after
 -- deletes, so an 1100kb layer admits it, and the surviving corpus plus the
 -- fresh vector-less rows overfill the extended layer. The merge target has
--- >= 10000 live docs, none carrying a vector — exactly the empty-slots path.
+-- >= 10000 live docs, none carrying a vector — the field writes NO slots
+-- and reads back as absent.
 ALTER INDEX delvec_idx SET (layer_sizes = '1100kb');
 INSERT INTO delvec
 SELECT g, md5(g::text), NULL
 FROM generate_series(24001, 30000) g;
--- An IVF segment now exists whose vector field is empty.
-SELECT bool_or(vector_format = 'ivf' AND vector_num_vectors = 0) AS ivf_with_empty_vector_field
-FROM paradedb.vector_info('delvec_idx', 'vec');
- ivf_with_empty_vector_field 
------------------------------
+-- The merge target carries only vector-less docs, so the field writes NO
+-- slots there and vector_info skips that segment entirely: it reports
+-- fewer segments than the index actually has. (Un-merged segments still
+-- hold their tombstoned vector rows, which is why this is not zero.)
+SELECT (SELECT count(*) FROM paradedb.vector_info('delvec_idx', 'vec'))
+       < (SELECT count(*) FROM paradedb.index_info('delvec_idx'))
+       AS emptied_segment_has_no_vector_slots;
+ emptied_segment_has_no_vector_slots 
+-------------------------------------
  t
 (1 row)
 
@@ -94,7 +107,8 @@ FROM (
 
 RESET paradedb.vector_cluster_max_probe;
 -- The index still serves non-vector queries over the surviving docs:
--- 12000 original vector-less rows plus 6000 fresh ones.
+-- 1000 seed rows + 12000 original vector-less rows + 6000 fresh ones,
+-- minus every vector-bearing row deleted above.
 SELECT count(*) AS live_docs
 FROM delvec
 WHERE id @@@ pdb.all();

--- a/pg_search/tests/pg_regress/expected/vector_ingest.out
+++ b/pg_search/tests/pg_regress/expected/vector_ingest.out
@@ -8,10 +8,16 @@
 -- vectors still ingest and are searchable.
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 CREATE TABLE nonfinite_vec (
     id  int PRIMARY KEY,
     vec vector(3)
 );
+-- Centroids are trained at CREATE INDEX over the existing rows, so the
+-- (finite) control corpus is loaded BEFORE the index exists — an index on
+-- an empty table is an error under the index-level centroid format.
+INSERT INTO nonfinite_vec VALUES (3, '[1, 0, 0]'), (4, '[0.5, 0.5, 0]');
 CREATE INDEX nonfinite_vec_idx ON nonfinite_vec
     USING paradedb (id, vec vector_cosine_ops)
     WITH (key_field = id);
@@ -22,10 +28,9 @@ ERROR:  NaN not allowed in vector at character 38
 -- expression-index shape over float arrays cannot smuggle one in either.
 INSERT INTO nonfinite_vec VALUES (2, ARRAY['Infinity'::float4, 0, 0]::vector);
 ERROR:  infinite value not allowed in vector
--- Control: finite vectors ingest into the cosine index and are searchable,
--- proving the rejections above happened before pg_search rather than inside a
--- broken index.
-INSERT INTO nonfinite_vec VALUES (3, '[1, 0, 0]'), (4, '[0.5, 0.5, 0]');
+-- Control: the pre-loaded finite vectors are searchable, proving the
+-- rejections above happened before pg_search rather than inside a broken
+-- index.
 SELECT id FROM nonfinite_vec WHERE id @@@ pdb.all() ORDER BY vec <=> '[1, 0, 0]' LIMIT 2;
  id 
 ----

--- a/pg_search/tests/pg_regress/expected/vector_merge.out
+++ b/pg_search/tests/pg_regress/expected/vector_merge.out
@@ -1,13 +1,9 @@
--- Merging an IVF segment into a larger one (tantivy c4582807: IVF count()
--- returns distinct docs, not posting rows). At the prior rev, a segment's
--- posting-row total was read where a doc count was meant, tripping
--- debug-build accounting asserts in tantivy's IVF plugin when such a segment
--- became a merge SOURCE. pgrx regress builds are debug builds, so this test
--- exercises those asserts for real.
---
--- cluster_replication is accepted for compatibility but assignment is
--- primary-only: every vector lands in exactly one cell, so per-cluster
--- memberships sum to the distinct-doc count.
+-- Merging an already-replicated IVF segment into a larger one (tantivy
+-- c4582807: IVF count() returns distinct docs, not posting rows). At the
+-- prior rev, a replicated segment's posting-row total was read where a doc
+-- count was meant, tripping debug-build accounting asserts in tantivy's IVF
+-- plugin when such a segment became a merge SOURCE. pgrx regress builds are
+-- debug builds, so this test exercises those asserts for real.
 --
 -- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
 -- NOTICE with nondeterministic millisecond values — keep it out of the
@@ -20,6 +16,8 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 DROP TABLE IF EXISTS remerge;
 CREATE TABLE remerge (
     id  int PRIMARY KEY,
@@ -29,10 +27,14 @@ CREATE TABLE remerge (
 -- (foreground merges only fire on an insert-cleanup that created a segment);
 -- target_segment_count = 1 keeps the merge policy engaged (merging is
 -- disabled while segment_count <= target); background_layer_sizes = '0'
--- keeps every merge in the foreground, deterministic. Inserts flush ~1000-doc
--- segments of ~70kb, and a 600kb layer closes its first candidate at
--- >= 10000 docs — at or above tantivy's vector_clustering_threshold, so the
--- merge target is written IVF (clustered) under the stacked centroid router.
+-- keeps every merge in the foreground, deterministic. Every segment —
+-- commit or merged — is clustered against the index-level centroid index,
+-- with every vector in 3 cells (cluster_replication = 3).
+-- Centroids train at CREATE INDEX over existing rows, so seed a corpus
+-- first; the waves below still drive the segment/merge behavior.
+INSERT INTO remerge
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(-999, 0) g;
 CREATE INDEX remerge_idx ON remerge
     USING paradedb (id, vec vector_l2_ops)
     WITH (
@@ -48,53 +50,51 @@ CREATE INDEX remerge_idx ON remerge
 INSERT INTO remerge
 SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
 FROM generate_series(1, 15000) g;
--- The merge produced a clustered segment...
-SELECT bool_or(vector_format = 'ivf') AS has_ivf
+-- Every segment is clustered against the index-level centroid index...
+SELECT bool_and(vector_num_centroids > 0) AS all_clustered
 FROM paradedb.vector_info('remerge_idx', 'vec');
- has_ivf 
----------
+ all_clustered 
+---------------
  t
 (1 row)
 
--- ...whose reported vector count is distinct docs (= its doc count)...
+-- ...whose reported vector count is distinct docs (= its doc count), not the
+-- 3x posting-row total that replication writes...
 SELECT bool_and(v.vector_num_vectors = i.num_docs) AS num_vectors_is_distinct_docs
 FROM paradedb.vector_info('remerge_idx', 'vec') v
-JOIN paradedb.index_info('remerge_idx') i USING (segno)
-WHERE v.vector_format = 'ivf';
+JOIN paradedb.index_info('remerge_idx') i USING (segno);
  num_vectors_is_distinct_docs 
 ------------------------------
  t
 (1 row)
 
--- ...and the per-cluster sizes are memberships, which under primary-only
--- assignment total exactly the distinct-doc count.
-SELECT sum(vector_total_memberships) = sum(vector_num_vectors)
+-- ...while the per-cluster sizes deliberately stay memberships: their total
+-- strictly exceeds the distinct-doc count under replication.
+SELECT sum(vector_total_memberships) > sum(vector_num_vectors)
          AS cluster_sizes_are_memberships
-FROM paradedb.vector_info('remerge_idx', 'vec')
-WHERE vector_format = 'ivf';
+FROM paradedb.vector_info('remerge_idx', 'vec');
  cluster_sizes_are_memberships 
 -------------------------------
  t
 (1 row)
 
--- Wave 2: make the IVF segment a merge SOURCE. The layer must
+-- Wave 2: make the replicated IVF segment a merge SOURCE. The layer must
 -- admit it (it is ~2.5-3.1mb; 3500kb leaves headroom) and the total corpus
 -- must overfill the extended layer, which the extra 35000 rows guarantee.
 ALTER INDEX remerge_idx SET (layer_sizes = '3500kb');
 INSERT INTO remerge
 SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
 FROM generate_series(15001, 50000) g;
-SELECT bool_or(vector_format = 'ivf') AS still_has_ivf
+SELECT bool_and(vector_num_centroids > 0) AS still_all_clustered
 FROM paradedb.vector_info('remerge_idx', 'vec');
- still_has_ivf 
----------------
+ still_all_clustered 
+---------------------
  t
 (1 row)
 
 SELECT bool_and(v.vector_num_vectors = i.num_docs) AS num_vectors_is_distinct_docs
 FROM paradedb.vector_info('remerge_idx', 'vec') v
-JOIN paradedb.index_info('remerge_idx') i USING (segno)
-WHERE v.vector_format = 'ivf';
+JOIN paradedb.index_info('remerge_idx') i USING (segno);
  num_vectors_is_distinct_docs 
 ------------------------------
  t
@@ -102,8 +102,9 @@ WHERE v.vector_format = 'ivf';
 
 -- Exhaustive probing: the ceiling clamps to each segment's cluster count,
 -- and LIMIT 60000 widens the candidate floor (4 x top_n) past the corpus so
--- the distance gate cannot stop early. The twice-merged index must return
--- every distinct row exactly once — nothing lost, nothing doubled.
+-- the distance gate cannot stop early. The twice-merged replicated index
+-- must return every distinct row exactly once — replicas deduped, nothing
+-- lost, nothing doubled.
 SET paradedb.vector_cluster_max_probe = 1.0;
 SELECT count(*) AS returned, count(DISTINCT id) AS distinct_ids
 FROM (
@@ -115,7 +116,7 @@ FROM (
 ) q;
  returned | distinct_ids 
 ----------+--------------
-    50000 |        50000
+    51000 |        51000
 (1 row)
 
 RESET paradedb.vector_cluster_max_probe;

--- a/pg_search/tests/pg_regress/expected/vector_mutable_segment.out
+++ b/pg_search/tests/pg_regress/expected/vector_mutable_segment.out
@@ -5,12 +5,19 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 DROP TABLE IF EXISTS mv;
 CREATE TABLE mv (
     id    int PRIMARY KEY,
     label text,
     vec   vector(3)
 );
+-- Centroids train at CREATE INDEX over existing rows, so seed a corpus
+-- first; the rows inserted AFTER the index exercise the mutable segment.
+INSERT INTO mv VALUES
+    (1, 'east',  '[1.0,  0.0, 0.0]'),
+    (2, 'east2', '[0.9,  0.0, 0.1]');
 CREATE INDEX mv_idx ON mv
     USING paradedb (id, label, vec vector_l2_ops)
     WITH (
@@ -20,8 +27,6 @@ CREATE INDEX mv_idx ON mv
         layer_sizes = '100mb'
     );
 INSERT INTO mv VALUES
-    (1, 'east',  '[1.0,  0.0, 0.0]'),
-    (2, 'east2', '[0.9,  0.0, 0.1]'),
     (3, 'north', '[0.0,  1.0, 0.0]'),
     (4, 'up',    '[0.0,  0.0, 1.0]'),
     (5, 'mid',   '[0.7,  0.7, 0.0]');
@@ -30,8 +35,9 @@ FROM paradedb.index_info('mv_idx')
 ORDER BY mutable DESC, num_docs DESC;
  mutable | num_docs 
 ---------+----------
- t       |        5
-(1 row)
+ t       |        3
+ f       |        2
+(2 rows)
 
 SELECT id, label
 FROM mv

--- a/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
@@ -13,6 +13,8 @@
 -- the K=2 ordering is unambiguous under all three metrics.
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 CREATE TABLE vsp (
     id    int PRIMARY KEY,
     label text,
@@ -53,6 +55,26 @@ SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
   2
 (2 rows)
 
+-- The shared router and recall GUC must survive index creation and reopen.
+SET paradedb.vector_router_recall = 0.5;
+DO $$
+DECLARE
+    plan jsonb;
+    routing jsonb;
+BEGIN
+    EXECUTE $query$
+        EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON, COSTS OFF, TIMING OFF)
+        SELECT id FROM vsp WHERE id @@@ pdb.all()
+        ORDER BY vec <-> '[1,0,0]' LIMIT 2
+    $query$ INTO plan;
+    routing := (jsonb_path_query_first(plan, '$.**."Vector Search"') #>> '{}')::jsonb->'routing';
+    IF routing->>'kind' IS DISTINCT FROM 'stacked'
+       OR (routing->>'recall_target')::real IS DISTINCT FROM 0.5::real THEN
+        RAISE EXCEPTION 'unexpected global router: %', routing;
+    END IF;
+END;
+$$;
+RESET paradedb.vector_router_recall;
 -- mismatch: <=> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;

--- a/pg_search/tests/pg_regress/expected/vector_unsupported_types.out
+++ b/pg_search/tests/pg_regress/expected/vector_unsupported_types.out
@@ -6,6 +6,8 @@
 -- index over halfvec / sparsevec / bit is rejected at CREATE INDEX.
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 CREATE TABLE unsupported_vec_types (
     id int PRIMARY KEY,
     hv halfvec(3),

--- a/pg_search/tests/pg_regress/sql/vector_delete_all_docs.sql
+++ b/pg_search/tests/pg_regress/sql/vector_delete_all_docs.sql
@@ -10,6 +10,8 @@
 SET client_min_messages = WARNING;
 CREATE EXTENSION IF NOT EXISTS vector;
 \i common/common_setup.sql
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 
 DROP TABLE IF EXISTS delvec;
 CREATE TABLE delvec (
@@ -25,6 +27,13 @@ CREATE TABLE delvec (
 -- cluster_replication = 1 pins primary-only assignment: the layer_sizes budget
 -- below is tuned to the on-disk vector footprint, which replica cells would
 -- inflate. This test exercises the empty-slots merge path, not replication.
+-- Centroids train at CREATE INDEX over existing rows, so seed a
+-- vector-bearing corpus first (deleted along with the rest below).
+INSERT INTO delvec
+SELECT g, md5(g::text),
+       ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(-999, 0) g;
+
 CREATE INDEX delvec_idx ON delvec
     USING paradedb (id, label, vec vector_l2_ops)
     WITH (
@@ -48,7 +57,7 @@ SELECT g,
        END
 FROM generate_series(1, 24000) g;
 
-SELECT bool_or(vector_format = 'ivf') AS has_ivf
+SELECT bool_and(vector_num_centroids > 0) AS all_clustered
 FROM paradedb.vector_info('delvec_idx', 'vec');
 
 -- Kill every vector-bearing doc. VACUUM records the deletes so the next
@@ -56,18 +65,23 @@ FROM paradedb.vector_info('delvec_idx', 'vec');
 DELETE FROM delvec WHERE vec IS NOT NULL;
 VACUUM delvec;
 
--- Remerge with the (now vector-less) IVF segment as a source: ~880kb after
+-- Remerge with the (now vector-less) segment as a source: ~880kb after
 -- deletes, so an 1100kb layer admits it, and the surviving corpus plus the
 -- fresh vector-less rows overfill the extended layer. The merge target has
--- >= 10000 live docs, none carrying a vector — exactly the empty-slots path.
+-- >= 10000 live docs, none carrying a vector — the field writes NO slots
+-- and reads back as absent.
 ALTER INDEX delvec_idx SET (layer_sizes = '1100kb');
 INSERT INTO delvec
 SELECT g, md5(g::text), NULL
 FROM generate_series(24001, 30000) g;
 
--- An IVF segment now exists whose vector field is empty.
-SELECT bool_or(vector_format = 'ivf' AND vector_num_vectors = 0) AS ivf_with_empty_vector_field
-FROM paradedb.vector_info('delvec_idx', 'vec');
+-- The merge target carries only vector-less docs, so the field writes NO
+-- slots there and vector_info skips that segment entirely: it reports
+-- fewer segments than the index actually has. (Un-merged segments still
+-- hold their tombstoned vector rows, which is why this is not zero.)
+SELECT (SELECT count(*) FROM paradedb.vector_info('delvec_idx', 'vec'))
+       < (SELECT count(*) FROM paradedb.index_info('delvec_idx'))
+       AS emptied_segment_has_no_vector_slots;
 
 -- Vector ORDER BY on the emptied field: no error, zero results. Exhaustive
 -- probing, so the empty result cannot be an artifact of probe pruning.
@@ -83,7 +97,8 @@ FROM (
 RESET paradedb.vector_cluster_max_probe;
 
 -- The index still serves non-vector queries over the surviving docs:
--- 12000 original vector-less rows plus 6000 fresh ones.
+-- 1000 seed rows + 12000 original vector-less rows + 6000 fresh ones,
+-- minus every vector-bearing row deleted above.
 SELECT count(*) AS live_docs
 FROM delvec
 WHERE id @@@ pdb.all();

--- a/pg_search/tests/pg_regress/sql/vector_ingest.sql
+++ b/pg_search/tests/pg_regress/sql/vector_ingest.sql
@@ -8,11 +8,17 @@
 -- vectors still ingest and are searchable.
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 
 CREATE TABLE nonfinite_vec (
     id  int PRIMARY KEY,
     vec vector(3)
 );
+-- Centroids are trained at CREATE INDEX over the existing rows, so the
+-- (finite) control corpus is loaded BEFORE the index exists — an index on
+-- an empty table is an error under the index-level centroid format.
+INSERT INTO nonfinite_vec VALUES (3, '[1, 0, 0]'), (4, '[0.5, 0.5, 0]');
 CREATE INDEX nonfinite_vec_idx ON nonfinite_vec
     USING paradedb (id, vec vector_cosine_ops)
     WITH (key_field = id);
@@ -24,10 +30,9 @@ INSERT INTO nonfinite_vec VALUES (1, '[NaN, 0, 0]');
 -- expression-index shape over float arrays cannot smuggle one in either.
 INSERT INTO nonfinite_vec VALUES (2, ARRAY['Infinity'::float4, 0, 0]::vector);
 
--- Control: finite vectors ingest into the cosine index and are searchable,
--- proving the rejections above happened before pg_search rather than inside a
--- broken index.
-INSERT INTO nonfinite_vec VALUES (3, '[1, 0, 0]'), (4, '[0.5, 0.5, 0]');
+-- Control: the pre-loaded finite vectors are searchable, proving the
+-- rejections above happened before pg_search rather than inside a broken
+-- index.
 SELECT id FROM nonfinite_vec WHERE id @@@ pdb.all() ORDER BY vec <=> '[1, 0, 0]' LIMIT 2;
 
 DROP TABLE nonfinite_vec;

--- a/pg_search/tests/pg_regress/sql/vector_merge.sql
+++ b/pg_search/tests/pg_regress/sql/vector_merge.sql
@@ -1,13 +1,9 @@
--- Merging an IVF segment into a larger one (tantivy c4582807: IVF count()
--- returns distinct docs, not posting rows). At the prior rev, a segment's
--- posting-row total was read where a doc count was meant, tripping
--- debug-build accounting asserts in tantivy's IVF plugin when such a segment
--- became a merge SOURCE. pgrx regress builds are debug builds, so this test
--- exercises those asserts for real.
---
--- cluster_replication is accepted for compatibility but assignment is
--- primary-only: every vector lands in exactly one cell, so per-cluster
--- memberships sum to the distinct-doc count.
+-- Merging an already-replicated IVF segment into a larger one (tantivy
+-- c4582807: IVF count() returns distinct docs, not posting rows). At the
+-- prior rev, a replicated segment's posting-row total was read where a doc
+-- count was meant, tripping debug-build accounting asserts in tantivy's IVF
+-- plugin when such a segment became a merge SOURCE. pgrx regress builds are
+-- debug builds, so this test exercises those asserts for real.
 --
 -- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
 -- NOTICE with nondeterministic millisecond values — keep it out of the
@@ -15,6 +11,8 @@
 SET client_min_messages = WARNING;
 CREATE EXTENSION IF NOT EXISTS vector;
 \i common/common_setup.sql
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 
 DROP TABLE IF EXISTS remerge;
 CREATE TABLE remerge (
@@ -26,10 +24,15 @@ CREATE TABLE remerge (
 -- (foreground merges only fire on an insert-cleanup that created a segment);
 -- target_segment_count = 1 keeps the merge policy engaged (merging is
 -- disabled while segment_count <= target); background_layer_sizes = '0'
--- keeps every merge in the foreground, deterministic. Inserts flush ~1000-doc
--- segments of ~70kb, and a 600kb layer closes its first candidate at
--- >= 10000 docs — at or above tantivy's vector_clustering_threshold, so the
--- merge target is written IVF (clustered) under the stacked centroid router.
+-- keeps every merge in the foreground, deterministic. Every segment —
+-- commit or merged — is clustered against the index-level centroid index,
+-- with every vector in 3 cells (cluster_replication = 3).
+-- Centroids train at CREATE INDEX over existing rows, so seed a corpus
+-- first; the waves below still drive the segment/merge behavior.
+INSERT INTO remerge
+SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
+FROM generate_series(-999, 0) g;
+
 CREATE INDEX remerge_idx ON remerge
     USING paradedb (id, vec vector_l2_ops)
     WITH (
@@ -47,24 +50,23 @@ INSERT INTO remerge
 SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
 FROM generate_series(1, 15000) g;
 
--- The merge produced a clustered segment...
-SELECT bool_or(vector_format = 'ivf') AS has_ivf
+-- Every segment is clustered against the index-level centroid index...
+SELECT bool_and(vector_num_centroids > 0) AS all_clustered
 FROM paradedb.vector_info('remerge_idx', 'vec');
 
--- ...whose reported vector count is distinct docs (= its doc count)...
+-- ...whose reported vector count is distinct docs (= its doc count), not the
+-- 3x posting-row total that replication writes...
 SELECT bool_and(v.vector_num_vectors = i.num_docs) AS num_vectors_is_distinct_docs
 FROM paradedb.vector_info('remerge_idx', 'vec') v
-JOIN paradedb.index_info('remerge_idx') i USING (segno)
-WHERE v.vector_format = 'ivf';
+JOIN paradedb.index_info('remerge_idx') i USING (segno);
 
--- ...and the per-cluster sizes are memberships, which under primary-only
--- assignment total exactly the distinct-doc count.
-SELECT sum(vector_total_memberships) = sum(vector_num_vectors)
+-- ...while the per-cluster sizes deliberately stay memberships: their total
+-- strictly exceeds the distinct-doc count under replication.
+SELECT sum(vector_total_memberships) > sum(vector_num_vectors)
          AS cluster_sizes_are_memberships
-FROM paradedb.vector_info('remerge_idx', 'vec')
-WHERE vector_format = 'ivf';
+FROM paradedb.vector_info('remerge_idx', 'vec');
 
--- Wave 2: make the IVF segment a merge SOURCE. The layer must
+-- Wave 2: make the replicated IVF segment a merge SOURCE. The layer must
 -- admit it (it is ~2.5-3.1mb; 3500kb leaves headroom) and the total corpus
 -- must overfill the extended layer, which the extra 35000 rows guarantee.
 ALTER INDEX remerge_idx SET (layer_sizes = '3500kb');
@@ -72,18 +74,18 @@ INSERT INTO remerge
 SELECT g, ('[' || repeat((g % 89)::text || ',', 15) || (g % 89)::text || ']')::vector
 FROM generate_series(15001, 50000) g;
 
-SELECT bool_or(vector_format = 'ivf') AS still_has_ivf
+SELECT bool_and(vector_num_centroids > 0) AS still_all_clustered
 FROM paradedb.vector_info('remerge_idx', 'vec');
 
 SELECT bool_and(v.vector_num_vectors = i.num_docs) AS num_vectors_is_distinct_docs
 FROM paradedb.vector_info('remerge_idx', 'vec') v
-JOIN paradedb.index_info('remerge_idx') i USING (segno)
-WHERE v.vector_format = 'ivf';
+JOIN paradedb.index_info('remerge_idx') i USING (segno);
 
 -- Exhaustive probing: the ceiling clamps to each segment's cluster count,
 -- and LIMIT 60000 widens the candidate floor (4 x top_n) past the corpus so
--- the distance gate cannot stop early. The twice-merged index must return
--- every distinct row exactly once — nothing lost, nothing doubled.
+-- the distance gate cannot stop early. The twice-merged replicated index
+-- must return every distinct row exactly once — replicas deduped, nothing
+-- lost, nothing doubled.
 SET paradedb.vector_cluster_max_probe = 1.0;
 SELECT count(*) AS returned, count(DISTINCT id) AS distinct_ids
 FROM (

--- a/pg_search/tests/pg_regress/sql/vector_mutable_segment.sql
+++ b/pg_search/tests/pg_regress/sql/vector_mutable_segment.sql
@@ -1,5 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS vector;
 \i common/common_setup.sql
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 
 DROP TABLE IF EXISTS mv;
 CREATE TABLE mv (
@@ -7,6 +9,12 @@ CREATE TABLE mv (
     label text,
     vec   vector(3)
 );
+
+-- Centroids train at CREATE INDEX over existing rows, so seed a corpus
+-- first; the rows inserted AFTER the index exercise the mutable segment.
+INSERT INTO mv VALUES
+    (1, 'east',  '[1.0,  0.0, 0.0]'),
+    (2, 'east2', '[0.9,  0.0, 0.1]');
 
 CREATE INDEX mv_idx ON mv
     USING paradedb (id, label, vec vector_l2_ops)
@@ -18,8 +26,6 @@ CREATE INDEX mv_idx ON mv
     );
 
 INSERT INTO mv VALUES
-    (1, 'east',  '[1.0,  0.0, 0.0]'),
-    (2, 'east2', '[0.9,  0.0, 0.1]'),
     (3, 'north', '[0.0,  1.0, 0.0]'),
     (4, 'up',    '[0.0,  0.0, 1.0]'),
     (5, 'mid',   '[0.7,  0.7, 0.0]');

--- a/pg_search/tests/pg_regress/sql/vector_search_pushdown.sql
+++ b/pg_search/tests/pg_regress/sql/vector_search_pushdown.sql
@@ -14,6 +14,8 @@
 
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 
 CREATE TABLE vsp (
     id    int PRIMARY KEY,
@@ -40,6 +42,27 @@ CREATE INDEX vsp_idx ON vsp
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+
+-- The shared router and recall GUC must survive index creation and reopen.
+SET paradedb.vector_router_recall = 0.5;
+DO $$
+DECLARE
+    plan jsonb;
+    routing jsonb;
+BEGIN
+    EXECUTE $query$
+        EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON, COSTS OFF, TIMING OFF)
+        SELECT id FROM vsp WHERE id @@@ pdb.all()
+        ORDER BY vec <-> '[1,0,0]' LIMIT 2
+    $query$ INTO plan;
+    routing := (jsonb_path_query_first(plan, '$.**."Vector Search"') #>> '{}')::jsonb->'routing';
+    IF routing->>'kind' IS DISTINCT FROM 'stacked'
+       OR (routing->>'recall_target')::real IS DISTINCT FROM 0.5::real THEN
+        RAISE EXCEPTION 'unexpected global router: %', routing;
+    END IF;
+END;
+$$;
+RESET paradedb.vector_router_recall;
 
 -- mismatch: <=> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/sql/vector_unsupported_types.sql
+++ b/pg_search/tests/pg_regress/sql/vector_unsupported_types.sql
@@ -6,6 +6,8 @@
 -- index over halfvec / sparsevec / bit is rejected at CREATE INDEX.
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Tiny fixtures: lower the centroid-training floor.
+SET paradedb.vector_min_training_rows = 1;
 
 CREATE TABLE unsupported_vec_types (
     id int PRIMARY KEY,


### PR DESCRIPTION
Vector indexes now train one shared centroid set at CREATE INDEX and use stacked IVF as the global router. Every clustered segment assigns against that immutable set, and each query ranks it once before probing all segments with one result heap and work budget.

Based on #6291 and paradedb/tantivy#205. Both Tantivy dependencies pin `084aec7972f1a7108b80698c133baab4997f9fca`, which includes Walter's latest stacked-router work from paradedb/tantivy#230: adaptive partition scanning, candidate and leaf-expansion limits, the empty-list fix, and 200-member router leaves. pg_search selects `RouterKind::Stacked` for creation and reopen; it does not configure an RNG router.

Build-time assignment uses batched SGEMM against the materialized shared centroid matrix, with a reusable score tile capped at 1 MiB. This applies to commit writes and flat-source merges, including primary and replica selection for L2, cosine, and raw inner product. Stacked IVF remains the query router.

Training stays at index creation and uses the current SuperKMeans API: `training_sample_ratio`, ownership transfer with `train_owned`, and a leaf-size target derived from the sampled rows and desired centroid density. Centroid metadata is persisted in the index, merges preserve existing assignments, and mutable staging vectors are scanned exactly until they join the clustered index. Vector searches use a serial global search path. The existing global-centroid training floor remains in place, and newer schema validation from the base branch is preserved.

Validation:
- All six PG18 vector SQL regressions pass against the updated dependency in an isolated Postgres installation: ingestion, deletes, merges, mutable segments, pushdown, and unsupported types.
- Workspace formatting and Clippy for all targets with warnings denied pass; pg_search builds against the updated Tantivy revision.
- Nix `cargoHash` recalculated and the `pg_search-pg18.cargoDeps` build verified.
- Tantivy: 1,502 library tests pass (16 ignored), and all 173 vector tests pass with the Accelerate backend.
- A synthetic release assignment benchmark (2,048 rows, 10,000 centroids, 1,024 dimensions) improved from 2.18–2.41 s to 46–50 ms, with identical assignments. This compares in-memory assignment paths, not total pg_search index-build time.
