### PR TITLE
ci(benchmarks): stop recall sweeps once the top target is reached

### DIFF
--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -67,7 +67,9 @@ pub struct SweepConfig {
     /// The name this sweep varies. The query file must reference it as `{{ param }}`; it is
     /// supplied by the sweep, so it needs no `[params]` entry.
     pub param: String,
-    /// Operating points to try. Each is a SQL scalar expression, like any other param value.
+    /// Operating points to try, ordered cheapest first: the sweep stops probing once a value
+    /// reaches the highest recall target. Each is a SQL scalar expression, like any other param
+    /// value.
     pub values: Vec<String>,
 }
 

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -878,7 +878,11 @@ fn select_points(points: &[SweepPoint]) -> Vec<SelectedPoint> {
         .collect()
 }
 
-/// Measure recall at every value of `sweep` for one query, reusing a single set of fixtures.
+/// Measure recall at each value of `sweep` for one query, reusing a single set of fixtures.
+///
+/// Values are ordered cheapest first, so the sweep stops after the first value that reaches the
+/// highest recall target: every target already has its cheapest qualifying point, and larger
+/// values only cost more.
 async fn sweep_query(
     conn: &mut PgConnection,
     args: &BenchmarkArgs,
@@ -928,6 +932,7 @@ async fn sweep_query(
     )
     .await?;
     let vars = HashMap::from([("dataset_size".to_owned(), dataset_rows(size)?.to_string())]);
+    let (_, top_target) = RECALL_TARGETS[RECALL_TARGETS.len() - 1];
 
     let mut points = Vec::new();
     for value in &sweep.values {
@@ -950,6 +955,10 @@ async fn sweep_query(
             recall,
             query,
         });
+        if recall >= top_target {
+            println!("  reached {top_target:.2} recall; skipping larger values");
+            break;
+        }
     }
     Ok(points)
 }


### PR DESCRIPTION
Recall sweeps measure every value in the ladder even after a point reaches r99, the highest recall target. Since values are ordered cheapest first and recall rises monotonically with these knobs, every target already has its cheapest qualifying point by then — probing the larger values only burns runner time.

This breaks out of the sweep loop after the first value that reaches the top target, and documents the cheapest-first ordering requirement on `SweepConfig.values`.