### PR TITLE
chore: update dependency and configuration guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,8 @@ Located in the `stressgres/` directory.
 
 Two scripts in `scripts/` wrap the install-and-start dance for a throwaway instance, for when you want a psql prompt or a test run against a freshly built extension:
 
-- `PGVER=18.0 ./scripts/pg_search_run.sh [--release] [psql arguments]` installs the extension, starts Postgres, creates a database, and connects to it.
-- `PGVER=18.0 ./scripts/pg_search_test.sh [--release] [--test test_name]` does the same, then runs the integration tests against it.
+- `PGVER=18.6 ./scripts/pg_search_run.sh [--release] [psql arguments]` installs the extension, starts Postgres, creates a database, and connects to it.
+- `PGVER=18.6 ./scripts/pg_search_test.sh [--release] [--test test_name]` does the same, then runs the integration tests against it.
 
 ## Legal Info
 

--- a/docker/Dockerfile.antithesis-18
+++ b/docker/Dockerfile.antithesis-18
@@ -36,7 +36,7 @@ RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        postgresql-18-pgvector=0.8.5-1.pgdg13+1 \
+        postgresql-18-pgvector=0.8.6-1.pgdg13+1 \
         postgresql-18-cron=1.6.7-3.pgdg13+1 \
         postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
         postgresql-18-postgis-$POSTGIS_VERSION_MAJOR=3.6.4+dfsg-2.pgdg13+1 \

--- a/docker/Dockerfile.official-15
+++ b/docker/Dockerfile.official-15
@@ -22,7 +22,7 @@ RUN set -eux; \
 RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends postgresql-15-pgvector=0.8.5-1.pgdg13+1; \
+    apt-get install -y --no-install-recommends postgresql-15-pgvector=0.8.6-1.pgdg13+1; \
     apt-get dist-clean
 
 RUN set -eux; \

--- a/docker/Dockerfile.official-16
+++ b/docker/Dockerfile.official-16
@@ -22,7 +22,7 @@ RUN set -eux; \
 RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends postgresql-16-pgvector=0.8.5-1.pgdg13+1; \
+    apt-get install -y --no-install-recommends postgresql-16-pgvector=0.8.6-1.pgdg13+1; \
     apt-get dist-clean
 
 RUN set -eux; \

--- a/docker/Dockerfile.official-17
+++ b/docker/Dockerfile.official-17
@@ -22,7 +22,7 @@ RUN set -eux; \
 RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends postgresql-17-pgvector=0.8.5-1.pgdg13+1; \
+    apt-get install -y --no-install-recommends postgresql-17-pgvector=0.8.6-1.pgdg13+1; \
     apt-get dist-clean
 
 RUN set -eux; \

--- a/docker/Dockerfile.official-18
+++ b/docker/Dockerfile.official-18
@@ -22,7 +22,7 @@ RUN set -eux; \
 RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends postgresql-18-pgvector=0.8.5-1.pgdg13+1; \
+    apt-get install -y --no-install-recommends postgresql-18-pgvector=0.8.6-1.pgdg13+1; \
     apt-get dist-clean
 
 RUN set -eux; \

--- a/docker/Dockerfile.paradedb-15
+++ b/docker/Dockerfile.paradedb-15
@@ -42,7 +42,7 @@ RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        postgresql-15-pgvector=0.8.5-1.pgdg13+1 \
+        postgresql-15-pgvector=0.8.6-1.pgdg13+1 \
         postgresql-15-cron=1.6.7-3.pgdg13+1 \
         postgresql-15-pg-ivm=1.13-1.pgdg13+1 \
         postgresql-15-postgis-$POSTGIS_VERSION_MAJOR=3.6.4+dfsg-2.pgdg13+1 \

--- a/docker/Dockerfile.paradedb-16
+++ b/docker/Dockerfile.paradedb-16
@@ -42,7 +42,7 @@ RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        postgresql-16-pgvector=0.8.5-1.pgdg13+1 \
+        postgresql-16-pgvector=0.8.6-1.pgdg13+1 \
         postgresql-16-cron=1.6.7-3.pgdg13+1 \
         postgresql-16-pg-ivm=1.13-1.pgdg13+1 \
         postgresql-16-postgis-$POSTGIS_VERSION_MAJOR=3.6.4+dfsg-2.pgdg13+1 \

--- a/docker/Dockerfile.paradedb-17
+++ b/docker/Dockerfile.paradedb-17
@@ -42,7 +42,7 @@ RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        postgresql-17-pgvector=0.8.5-1.pgdg13+1 \
+        postgresql-17-pgvector=0.8.6-1.pgdg13+1 \
         postgresql-17-cron=1.6.7-3.pgdg13+1 \
         postgresql-17-pg-ivm=1.13-1.pgdg13+1 \
         postgresql-17-postgis-$POSTGIS_VERSION_MAJOR=3.6.4+dfsg-2.pgdg13+1 \

--- a/docker/Dockerfile.paradedb-18
+++ b/docker/Dockerfile.paradedb-18
@@ -42,7 +42,7 @@ RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        postgresql-18-pgvector=0.8.5-1.pgdg13+1 \
+        postgresql-18-pgvector=0.8.6-1.pgdg13+1 \
         postgresql-18-cron=1.6.7-3.pgdg13+1 \
         postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
         postgresql-18-postgis-$POSTGIS_VERSION_MAJOR=3.6.4+dfsg-2.pgdg13+1 \

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -57,7 +57,7 @@ RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.5-1.pgdg13+1 \
+        postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.6-1.pgdg13+1 \
         postgresql-@@PG_VERSION_MAJOR@@-cron=1.6.7-3.pgdg13+1 \
         postgresql-@@PG_VERSION_MAJOR@@-pg-ivm=1.13-1.pgdg13+1 \
         postgresql-@@PG_VERSION_MAJOR@@-postgis-$POSTGIS_VERSION_MAJOR=3.6.4+dfsg-2.pgdg13+1 \
@@ -86,7 +86,7 @@ COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 RUN set -eux; \
     echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.5-1.pgdg13+1; \
+    apt-get install -y --no-install-recommends postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.6-1.pgdg13+1; \
     apt-get dist-clean
 
 RUN set -eux; \

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -109,7 +109,7 @@ Next, add the extension(s) to `shared_preload_libraries` in `postgresql.conf`.
 shared_preload_libraries = 'pg_search'
 ```
 
-Reload the Postgres server for these changes to take effect.
+Restart the Postgres server for these changes to take effect.
 
 ## Load the Extension
 

--- a/docs/documentation/performance-tuning/writes.mdx
+++ b/docs/documentation/performance-tuning/writes.mdx
@@ -38,7 +38,7 @@ Setting `layer_sizes` to `0` disables foreground merging, and setting `backgroun
 A good starting point for `work_mem` is `(RAM - shared_buffers) / (3 * max_connections)`. If your typical update patterns are large, bulk updates (not single-row updates) a larger value may be better.
 
 ```sql
-SET work_mem = 64MB;
+SET work_mem = '64MB';
 ```
 
 Since many write operations can be running concurrently, this value should be raised more conservatively than `maintenance_work_mem`.

--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -65,8 +65,8 @@ ParadeDB accelerates standard SQL queries. That includes:
 
 ### One Index Behind Every Query
 
-Behind the SQL is a single custom index: the **ParadeDB index**, built on [Tantivy](https://github.com/quickwit-oss/tantivy), the Rust port of
-Lucene. It goes toe-to-toe with dedicated search engines on full-text performance, often coming out on top. [See how it's built →](/welcome/architecture)
+Behind the SQL is a single custom index: the **ParadeDB index**, built on [Tantivy](https://github.com/quickwit-oss/tantivy), a Rust search
+library inspired by Lucene. It goes toe-to-toe with dedicated search engines on full-text performance, often coming out on top. [See how it's built →](/welcome/architecture)
 
 ### As Reliable As Postgres
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -44,14 +44,14 @@ cargo pgrx init
 
 ### pgvector
 
-`pgvector` is needed for hybrid search integration tests. To build it against the pgrx-managed Postgres install (replace `18.3` with the version under `~/.pgrx/`):
+`pgvector` is needed for hybrid search integration tests. To build it against the pgrx-managed Postgres install (replace `18.6` with the version under `~/.pgrx/`):
 
 ```bash
 git clone --branch v0.8.6 https://github.com/pgvector/pgvector.git
 cd pgvector/
 
-PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make
-PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make install
+PG_CONFIG=~/.pgrx/18.6/pgrx-install/bin/pg_config make
+PG_CONFIG=~/.pgrx/18.6/pgrx-install/bin/pg_config make install
 ```
 
 ## Running the Extension

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -47,7 +47,7 @@ cargo pgrx init
 `pgvector` is needed for hybrid search integration tests. To build it against the pgrx-managed Postgres install (replace `18.3` with the version under `~/.pgrx/`):
 
 ```bash
-git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
+git clone --branch v0.8.6 https://github.com/pgvector/pgvector.git
 cd pgvector/
 
 PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make

--- a/scripts/pg_search_common.sh
+++ b/scripts/pg_search_common.sh
@@ -6,10 +6,10 @@
 # for the pg_search extension. It is meant to be sourced by other scripts.
 #
 # Possible PostgreSQL version values:
-#  - 15.15
-#  - 16.11
-#  - 17.7
-#  - 18.1 (default)
+#  - 15.19
+#  - 16.15
+#  - 17.11
+#  - 18.6 (default)
 #
 # After sourcing, the following are available:
 #  - BUILD_PARAMS: array of build flags (--release, --profile <value>)
@@ -53,12 +53,12 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # Change to pg_search directory
 cd "${SCRIPT_DIR}/../pg_search" || exit 1
 
-# Set PostgreSQL version or use default 18.1
-PGVER=${PGVER:-18.1}
+# Set PostgreSQL version or use default 18.6
+PGVER=${PGVER:-18.6}
 
 # Extract major version and set port and feature flag
 BASEVER=$(echo "${PGVER}" | cut -f1 -d.)
-PORT=288${BASEVER}  # Port 2880 + major version (e.g., 28818 for version 18.1)
+PORT=288${BASEVER}  # Port 2880 + major version (e.g., 28818 for version 18.6)
 FEATURE=pg${BASEVER}  # Feature flag (e.g., pg18)
 
 # Enable command echo for debugging the setup steps below. It is disabled again

--- a/scripts/pg_search_run.sh
+++ b/scripts/pg_search_run.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   PGVER=<version> ./pg_search_run.sh [--release] [psql arguments]
-#   Example: PGVER=17.4 ./pg_search_run.sh --release psql -c "SELECT 1"
+#   Example: PGVER=18.6 ./pg_search_run.sh --release psql -c "SELECT 1"
 
 CURRENT_DIR=$(pwd)
 

--- a/scripts/pg_search_test.sh
+++ b/scripts/pg_search_test.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   PGVER=<version> ./pg_search_test.sh [--release] [--test test_name]
-#   Example: PGVER=17.4 ./pg_search_test.sh --release --test sorting
+#   Example: PGVER=18.6 ./pg_search_test.sh --release --test sorting
 
 set -Eeuo pipefail
 

--- a/stressgres/runheadless.sh
+++ b/stressgres/runheadless.sh
@@ -2,7 +2,7 @@
 
 set -Eeuo pipefail
 
-PGVER=18.1
+PGVER=18.6
 EXTENSION=pg_search
 MANIFEST=~/_work/$1/Cargo.toml
 MANIFESTDIR=$(dirname "${MANIFEST}")

--- a/stressgres/runtui.sh
+++ b/stressgres/runtui.sh
@@ -2,7 +2,7 @@
 
 set -Eeuo pipefail
 
-PGVER=18.1
+PGVER=18.6
 EXTENSION=pg_search
 MANIFEST=~/_work/$1/Cargo.toml
 MANIFESTDIR=$(dirname "${MANIFEST}")

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,7 +31,7 @@ set -x
 export DATABASE_URL=postgresql://$(whoami)@localhost:28818/pg_search
 export RUST_BACKTRACE=1
 cargo pgrx stop --package pg_search
-cargo pgrx install --package pg_search --pg-config ~/.pgrx/18.1/pgrx-install/bin/pg_config
+cargo pgrx install --package pg_search --pg-config ~/.pgrx/18.6/pgrx-install/bin/pg_config
 cargo pgrx start --package pg_search
 
 cargo test --package tests


### PR DESCRIPTION
## Summary

- instruct users to restart Postgres after changing `shared_preload_libraries`
- quote the `64MB` value in the `SET work_mem` example
- describe Tantivy as a Rust search library inspired by Lucene, rather than a Lucene port
- update pgvector from 0.8.4/0.8.5 to 0.8.6 across development docs and all Docker image definitions
- update PostgreSQL development versions to 15.19, 16.15, 17.11, and 18.6 across docs, helper scripts, tests, and stressgres

## Validation

- changed-file pre-commit hooks (all passed except the Docker-backed ShellCheck hook because Docker is not running)
- native `shellcheck -x -P scripts` on all changed shell scripts
- `prettier --check` on changed Markdown/MDX files
- `git diff --check`
- repository audit found no remaining pgvector 0.8.4/0.8.5 references