### PR TITLE
fix(mpp): Tear down workers after a leader-side failure following the launch

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -140,6 +140,9 @@ static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
 #[cfg(debug_assertions)]
 static MPP_TEST_PANIC_IN_WORKER: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+#[cfg(debug_assertions)]
+static MPP_TEST_FAIL_LEADER_EXECUTE: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// Dedicated diagnostic GUC for per-shuffle EOF row counts. These lines emit concurrently
 /// from every participant and can reorder between runs, so they're kept off `mpp_debug` to
 /// avoid flaking regress expected files. Turn this on in long-running benchmark queries to
@@ -649,6 +652,16 @@ pub fn init() {
         GucFlags::default(),
     );
 
+    #[cfg(debug_assertions)]
+    GucRegistry::define_bool_guc(
+        c"paradedb.mpp_test_fail_leader_execute",
+        c"Fail a PgSearchScan executed by the MPP leader with a DataFusion error",
+        c"Used for testing teardown after a leader-side failure that follows the MPP launch.",
+        &MPP_TEST_FAIL_LEADER_EXECUTE,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
     GucRegistry::define_bool_guc(
         c"paradedb.mpp_trace",
         c"Emit MPP setup timing at WARNING level",
@@ -898,6 +911,11 @@ pub fn mpp_debug() -> bool {
 #[cfg(debug_assertions)]
 pub fn mpp_test_panic_in_worker() -> bool {
     MPP_TEST_PANIC_IN_WORKER.get()
+}
+
+#[cfg(debug_assertions)]
+pub fn mpp_test_fail_leader_execute() -> bool {
+    MPP_TEST_FAIL_LEADER_EXECUTE.get()
 }
 
 pub fn mpp_trace() -> bool {

--- a/pg_search/src/parallel_worker/builder.rs
+++ b/pg_search/src/parallel_worker/builder.rs
@@ -302,6 +302,20 @@ impl ParallelProcessFinish {
             messages
         }
     }
+
+    /// Tear the parallel context down without waiting for the workers to finish on their own:
+    /// `DestroyParallelContext` terminates them, waits for them to exit, and detaches the DSM.
+    /// For a leader-side failure after launch, where a worker may be parked waiting for work
+    /// the leader will never send.
+    pub fn abort(self) {
+        unsafe {
+            let pcxt = self.launcher.pcxt.as_ptr();
+            drop(self.launcher);
+
+            pg_sys::DestroyParallelContext(pcxt);
+            pg_sys::ExitParallelMode();
+        }
+    }
 }
 
 pub struct ParallelProcessMessageQueue {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -416,6 +416,44 @@ impl GroupingShape {
     }
 }
 
+impl AggregateScan {
+    /// Join a launched MPP run: drop the stream, drain the workers' metrics, release the plan
+    /// and runtime, and wait for the workers. Leaves `mpp` at `Inactive`.
+    fn finish_mpp_execution(df_state: &mut scan_state::DataFusionAggState) {
+        df_state.stream = None;
+        if let Some(leader) = df_state.mpp.leader()
+            && let Some(plan) = df_state.physical_plan.as_ref()
+        {
+            crate::postgres::customscan::mpp::glue::drain_worker_metrics(
+                plan,
+                &leader.session.mesh,
+            );
+        }
+        let finish = match df_state.mpp.take_leader() {
+            Some(mut leader) => leader.finish.take(),
+            None => None,
+        };
+        df_state.physical_plan = None;
+        df_state.runtime = None;
+        if let Some(finish) = finish {
+            finish.wait_for_finish();
+        }
+    }
+
+    /// Tear a launched MPP run down after the leader failed mid-stream: drop everything holding
+    /// a mesh reference, then terminate and reap the workers before the error unwinds.
+    fn abort_mpp_execution(df_state: &mut scan_state::DataFusionAggState) {
+        df_state.stream = None;
+        df_state.current_batch = None;
+        let leader = df_state.mpp.take_leader();
+        df_state.physical_plan = None;
+        df_state.runtime = None;
+        if let Some(leader) = leader {
+            crate::postgres::customscan::mpp::launch::abort_launch(leader);
+        }
+    }
+}
+
 impl CustomScan for AggregateScan {
     const NAME: &'static CStr = c"ParadeDB Aggregate Scan";
     type Args = CreateUpperPathsHookArgs;
@@ -910,10 +948,19 @@ impl CustomScan for AggregateScan {
         // Reset DataFusion state so rescan rebuilds the plan and stream.
         // Drop stream before runtime to avoid tokio panics.
         if let Some(ref mut df_state) = state.custom_state_mut().datafusion_state {
-            df_state.stream = None;
+            // A launched run must be joined and the launch re-armed, or the next execution
+            // consumes `Launched` as "not pending", replans serially, and leaves the old
+            // leader (and its workers) retained until the scan ends. Mirrors JoinScan.
+            let relaunch_mpp = matches!(
+                df_state.mpp,
+                MppLifecycle::Pending | MppLifecycle::Launched(_)
+            );
+            Self::finish_mpp_execution(df_state);
             df_state.current_batch = None;
             df_state.batch_row_idx = 0;
-            df_state.runtime = None;
+            if relaunch_mpp {
+                df_state.mpp = MppLifecycle::Pending;
+            }
         }
     }
 
@@ -1859,6 +1906,9 @@ impl AggregateScan {
                 .datafusion_state
                 .as_mut()
                 .expect("DataFusion state must be initialized");
+            // A launched leader stays in this local until the stream exists: a failure in
+            // between tears the workers down here, before the error unwinds.
+            let mut launched: Option<crate::postgres::customscan::mpp::glue::MppLeaderState> = None;
             let (ctx, physical_plan) = if is_mpp {
                 match leader {
                     Some(leader) => {
@@ -1870,7 +1920,7 @@ impl AggregateScan {
                         let mut timing = leader.timing;
                         timing.plan_us = plan_us;
                         df_state.launch_timing = Some(timing);
-                        df_state.mpp = MppLifecycle::Launched(leader);
+                        launched = Some(leader);
                         (exec_ctx, physical_plan)
                     }
                     None => {
@@ -1915,11 +1965,22 @@ impl AggregateScan {
             };
             let stream = {
                 let _guard = runtime.enter();
-                match physical_plan.execute(0, task_ctx) {
-                    Ok(s) => s,
-                    Err(e) => pgrx::error!("Failed to execute DataFusion aggregate plan: {}", e),
+                physical_plan.execute(0, task_ctx)
+            };
+            let stream = match stream {
+                Ok(stream) => stream,
+                Err(e) => {
+                    drop(physical_plan);
+                    drop(ctx);
+                    if let Some(leader) = launched.take() {
+                        crate::postgres::customscan::mpp::launch::abort_launch(leader);
+                    }
+                    pgrx::error!("Failed to execute DataFusion aggregate plan: {e}");
                 }
             };
+            if let Some(leader) = launched.take() {
+                df_state.mpp = MppLifecycle::Launched(leader);
+            }
 
             df_state.runtime = Some(runtime);
             df_state.physical_plan = Some(physical_plan);
@@ -1971,6 +2032,7 @@ impl AggregateScan {
                     df_state.batch_row_idx = 0;
                 }
                 Some(Err(e)) => {
+                    Self::abort_mpp_execution(df_state);
                     pgrx::error!("DataFusion aggregate execution failed: {}", e);
                 }
                 None => {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -948,6 +948,20 @@ impl JoinScan {
     /// leader out (its mesh handle drops with it), then drops the stream/plan/runtime
     /// (all carry mesh references) before `wait_for_finish` destroys the DSM. Used at
     /// EndCustomScan and before a correlated rescan relaunches a fresh worker set.
+    /// Tear a launched MPP run down after the leader failed mid-stream: drop everything holding
+    /// a mesh reference, then terminate and reap the workers before the error unwinds.
+    fn abort_mpp_execution(state: &mut CustomScanStateWrapper<Self>) {
+        let cs = state.custom_state_mut();
+        cs.datafusion_stream = None;
+        cs.current_batch = None;
+        let leader = cs.mpp.take_leader();
+        cs.physical_plan = None;
+        cs.runtime = None;
+        if let Some(leader) = leader {
+            crate::postgres::customscan::mpp::launch::abort_launch(leader);
+        }
+    }
+
     fn finish_mpp_execution(state: &mut CustomScanStateWrapper<Self>) {
         state.custom_state_mut().datafusion_stream = None;
         if let Some(leader) = state.custom_state().mpp.leader()
@@ -1519,6 +1533,11 @@ impl CustomScan for JoinScan {
                 // On a launch fallback (nothing to distribute, or too few attached workers) no
                 // workers remain and the `DistributedExec` shape has no mesh to read from, so
                 // replan serially.
+                //
+                // A launched leader stays in this local until the stream exists: a failure in
+                // between tears the workers down here, before the error unwinds.
+                let mut launched: Option<crate::postgres::customscan::mpp::glue::MppLeaderState> =
+                    None;
                 let (ctx, plan) = if mpp_pending {
                     match Self::launch_mpp(state, &plan) {
                         Some(leader) => {
@@ -1532,7 +1551,7 @@ impl CustomScan for JoinScan {
                             launch_us.attach_us = leader.timing.attach_us;
                             launch_us.leader_setup_us = leader.timing.leader_setup_us;
                             launch_us.workers = leader.timing.workers;
-                            state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
+                            launched = Some(leader);
                             (exec_ctx, plan)
                         }
                         None => {
@@ -1588,8 +1607,21 @@ impl CustomScan for JoinScan {
                 let stream = {
                     let _guard = runtime.enter();
                     plan.execute(0, task_ctx)
-                        .expect("Failed to execute DataFusion plan")
                 };
+                let stream = match stream {
+                    Ok(stream) => stream,
+                    Err(e) => {
+                        drop(plan);
+                        drop(ctx);
+                        if let Some(leader) = launched.take() {
+                            crate::postgres::customscan::mpp::launch::abort_launch(leader);
+                        }
+                        pgrx::error!("Failed to execute DataFusion plan: {e}");
+                    }
+                };
+                if let Some(leader) = launched.take() {
+                    state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
+                }
                 launch_us.exec_us = t_exec.elapsed().as_micros() as u64;
 
                 // Retain the executed plan so EXPLAIN ANALYZE can extract metrics. Record the
@@ -1652,7 +1684,10 @@ impl CustomScan for JoinScan {
                         state.custom_state_mut().current_batch = Some(batch);
                         state.custom_state_mut().batch_index = 0;
                     }
-                    Some(Err(e)) => panic!("DataFusion execution failed: {}", e),
+                    Some(Err(e)) => {
+                        Self::abort_mpp_execution(state);
+                        pgrx::error!("DataFusion execution failed: {}", e);
+                    }
                     None => return std::ptr::null_mut(),
                 }
             }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -183,6 +183,9 @@ async fn take_set_plan_draining(
         if let std::task::Poll::Ready(result) = futures::poll!(take.as_mut()) {
             return result;
         }
+        // A leader that fails before dispatching this stage never sends the frame; its abort
+        // terminates us, and nothing else in this loop would notice the SIGTERM.
+        mesh.check_interrupt()?;
         mesh.try_drain_pass()?;
         tokio::task::yield_now().await;
     }

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -443,6 +443,23 @@ fn launch_mpp(
 }
 
 /// AggregateScan launch entry: aggregate worker symbol.
+/// Tear down a launched MPP run after the leader failed between launch and its first batch.
+///
+/// Call once every plan, stream, and session context holding a mesh reference has been dropped,
+/// and before raising the PostgreSQL error. The workers may be blocked on full rings or parked
+/// waiting for plan frames the leader never sent, so they are terminated and reaped rather than
+/// joined; raising the error first would leave PostgreSQL's abort path waiting on them instead.
+pub(crate) fn abort_launch(mut leader: MppLeaderState) {
+    let finish = leader.finish.take();
+    // Flip the liveness flag before the session's senders drop so they never touch ring memory
+    // the DSM detach below is about to unmap.
+    leader.session.mesh.mark_detached();
+    drop(leader);
+    if let Some(finish) = finish {
+        finish.abort();
+    }
+}
+
 pub fn launch_mpp_aggregate(
     physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
     args: ParallelScanArgs,

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -960,6 +960,15 @@ impl ExecutionPlan for PgSearchScanPlan {
         if crate::gucs::mpp_test_panic_in_worker() {
             pgrx::error!("artificial panic to test worker error propagation");
         }
+        #[cfg(debug_assertions)]
+        if crate::gucs::mpp_test_fail_leader_execute()
+            && unsafe { pg_sys::ParallelWorkerNumber } < 0
+        {
+            return Err(DataFusionError::Execution(
+                "artificial leader-side execute failure (paradedb.mpp_test_fail_leader_execute)"
+                    .into(),
+            ));
+        }
 
         let mut state_guard = self.state.lock().map_err(|e| {
             DataFusionError::Internal(format!("Failed to lock PgSearchScanPlan state: {e}"))

--- a/tests/tests/mpp_leader_failure_teardown.rs
+++ b/tests/tests/mpp_leader_failure_teardown.rs
@@ -43,15 +43,12 @@ CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 CREATE TABLE mlft_items (id bigint PRIMARY KEY, txt text NOT NULL);
 CREATE TABLE mlft_excl  (id bigint PRIMARY KEY, val bigint);
 CREATE TABLE mlft_small (id bigint PRIMARY KEY, val bigint NOT NULL, txt text NOT NULL);
-CREATE INDEX mlft_items_idx ON mlft_items USING paradedb (id, txt)
-  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0',
-        text_fields = '{"txt":{"fast":true}}');
+CREATE INDEX mlft_items_idx ON mlft_items USING paradedb (id, (txt::pdb.literal))
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
 CREATE INDEX mlft_excl_idx ON mlft_excl USING paradedb (id, val)
-  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0',
-        numeric_fields = '{"val":{"fast":true}}');
-CREATE INDEX mlft_small_idx ON mlft_small USING paradedb (id, val, txt)
-  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0',
-        numeric_fields = '{"val":{"fast":true}}', text_fields = '{"txt":{"fast":true}}');
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+CREATE INDEX mlft_small_idx ON mlft_small USING paradedb (id, val, (txt::pdb.literal))
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
 
 SET paradedb.global_mutable_segment_rows = 0;
 INSERT INTO mlft_items SELECT s, 'match' FROM generate_series(1, 2000) s;
@@ -77,16 +74,16 @@ SET parallel_tuple_cost TO 0;
 
 const JOINSCAN_QUERY: &str = r#"
 SELECT i.id FROM mlft_items i JOIN mlft_small s ON s.val = i.id
-WHERE i.txt @@@ 'match' AND s.txt @@@ 'small'
-  AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ paradedb.all())
+WHERE i.txt === 'match' AND s.txt === 'small'
+  AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ pdb.all())
 ORDER BY i.id LIMIT 5
 "#;
 
 const AGGREGATESCAN_QUERY: &str = r#"
 SELECT count(*) FROM (
   SELECT i.id FROM mlft_items i JOIN mlft_small s ON s.val = i.id
-  WHERE i.txt @@@ 'match' AND s.txt @@@ 'small'
-    AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ paradedb.all())) q
+  WHERE i.txt === 'match' AND s.txt === 'small'
+    AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ pdb.all())) q
 "#;
 
 /// Hard watchdog: a regression here wedges the backend and its workers, which would otherwise

--- a/tests/tests/mpp_leader_failure_teardown.rs
+++ b/tests/tests/mpp_leader_failure_teardown.rs
@@ -1,0 +1,233 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//! A leader-side failure between the MPP launch and the first batch must not wedge the backend.
+//!
+//! The shape: a NOT IN subquery on the probe side of a broadcast join. The distributed planner
+//! caps the null-aware anti join to one task and leaves it in the leader's stage, so the leader
+//! itself executes that leaf — before it has dispatched plan frames for the other stages. A
+//! failure there used to unwind into PostgreSQL's parallel-context teardown, which terminated
+//! the workers and waited for them; a worker parked for a plan frame never checked for
+//! interrupts, ignored the SIGTERM, and the backend sat in `BgworkerShutdown` until an immediate
+//! restart.
+//!
+//! Two fault paths: `paradedb.mpp_test_panic_in_worker` raises a PostgreSQL error from the
+//! leader's `execute()` (longjmp; PostgreSQL's abort path does the teardown), and
+//! `paradedb.mpp_test_fail_leader_execute` returns a DataFusion error (the scans' explicit
+//! abort does it before raising).
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use rstest::*;
+use sqlx::{AssertSqlSafe, Executor, PgConnection};
+use tests::fixtures::*;
+use tokio::time::{sleep, timeout};
+
+const SETUP_SQL: &str = r#"
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
+
+CREATE TABLE mlft_items (id bigint PRIMARY KEY, txt text NOT NULL);
+CREATE TABLE mlft_excl  (id bigint PRIMARY KEY, val bigint);
+CREATE TABLE mlft_small (id bigint PRIMARY KEY, val bigint NOT NULL, txt text NOT NULL);
+CREATE INDEX mlft_items_idx ON mlft_items USING paradedb (id, txt)
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0',
+        text_fields = '{"txt":{"fast":true}}');
+CREATE INDEX mlft_excl_idx ON mlft_excl USING paradedb (id, val)
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0',
+        numeric_fields = '{"val":{"fast":true}}');
+CREATE INDEX mlft_small_idx ON mlft_small USING paradedb (id, val, txt)
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0',
+        numeric_fields = '{"val":{"fast":true}}', text_fields = '{"txt":{"fast":true}}');
+
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mlft_items SELECT s, 'match' FROM generate_series(1, 2000) s;
+INSERT INTO mlft_items SELECT s, 'match' FROM generate_series(2001, 4000) s;
+INSERT INTO mlft_excl  SELECT s, s FROM generate_series(50, 300) s;
+INSERT INTO mlft_excl  SELECT s, s FROM generate_series(301, 600) s;
+INSERT INTO mlft_small SELECT s, s, 'small' FROM generate_series(1, 20) s;
+INSERT INTO mlft_small SELECT s, s, 'small' FROM generate_series(21, 40) s;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mlft_items; ANALYZE mlft_excl; ANALYZE mlft_small;
+"#;
+
+const MPP_GUCS: &str = r#"
+SET paradedb.enable_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+"#;
+
+const JOINSCAN_QUERY: &str = r#"
+SELECT i.id FROM mlft_items i JOIN mlft_small s ON s.val = i.id
+WHERE i.txt @@@ 'match' AND s.txt @@@ 'small'
+  AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ paradedb.all())
+ORDER BY i.id LIMIT 5
+"#;
+
+const AGGREGATESCAN_QUERY: &str = r#"
+SELECT count(*) FROM (
+  SELECT i.id FROM mlft_items i JOIN mlft_small s ON s.val = i.id
+  WHERE i.txt @@@ 'match' AND s.txt @@@ 'small'
+    AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ paradedb.all())) q
+"#;
+
+/// Hard watchdog: a regression here wedges the backend and its workers, which would otherwise
+/// hang the whole shared test cluster.
+const WATCHDOG: Duration = Duration::from_secs(30);
+
+async fn launched_worker_pids(conn: &mut PgConnection) -> Result<Vec<i32>> {
+    Ok(sqlx::query_scalar(
+        "SELECT pid FROM pg_stat_activity WHERE backend_type = 'parallel worker' ORDER BY pid",
+    )
+    .fetch_all(conn)
+    .await?)
+}
+
+async fn guc_present(conn: &mut PgConnection, name: &str) -> Result<bool> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT name FROM pg_settings WHERE name = $1")
+        .bind(name)
+        .fetch_optional(conn)
+        .await?;
+    Ok(row.is_some())
+}
+
+/// Run `query` with a leader-side fault armed; the error must come back promptly, the backend
+/// must answer again, and every launched worker must exit rather than stay parked.
+async fn run_faulted(
+    conn: &mut PgConnection,
+    observer: &mut PgConnection,
+    query: &str,
+    expected_error: &str,
+) -> Result<()> {
+    let result = timeout(WATCHDOG, conn.execute(AssertSqlSafe(query.to_string())))
+        .await
+        .context("leader-side failure did not return; backend wedged")?;
+    let err = match result {
+        Ok(_) => bail!("query succeeded although the leader-side fault was armed"),
+        Err(err) => err.to_string(),
+    };
+    assert!(err.contains(expected_error), "unexpected error: {err}");
+
+    let one: i32 = timeout(
+        WATCHDOG,
+        sqlx::query_scalar("SELECT 1").fetch_one(&mut *conn),
+    )
+    .await
+    .context("backend did not answer after the aborted MPP run")??;
+    assert_eq!(one, 1);
+
+    let deadline = Instant::now() + WATCHDOG;
+    loop {
+        let pids = launched_worker_pids(observer).await?;
+        if pids.is_empty() {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            bail!("parallel workers survived the aborted MPP run: {pids:?}");
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[rstest]
+#[tokio::test]
+async fn mpp_leader_failure_tears_down_workers(database: Db) -> Result<()> {
+    let mut conn = database.connection().await;
+    conn.execute(SETUP_SQL).await?;
+    if !guc_present(&mut conn, "paradedb.mpp_test_panic_in_worker").await? {
+        println!(
+            "Skipping mpp_leader_failure_tears_down_workers: the fault-injection GUCs are not \
+             present (non-debug build)"
+        );
+        return Ok(());
+    }
+    conn.execute(MPP_GUCS).await?;
+
+    // The shape must actually put a multi-segment leaf in the leader's box, or the faults fire
+    // in a worker instead: the leader's box is everything before the first stage separator.
+    let plan: Vec<(String,)> = sqlx::query_as(AssertSqlSafe(format!(
+        "EXPLAIN (VERBOSE, COSTS OFF) {JOINSCAN_QUERY}"
+    )))
+    .fetch_all(&mut conn)
+    .await?;
+    let plan = plan
+        .into_iter()
+        .map(|(l,)| l)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let leader_box_end = plan.find("└──").context("distributed plan expected")?;
+    let leaf = plan
+        .find("table=mlft_excl, segments=2")
+        .context("2-segment mlft_excl leaf expected")?;
+    assert!(
+        leaf < leader_box_end,
+        "mlft_excl leaf is not leader-hosted:\n{plan}"
+    );
+
+    let mut observer = database.connection().await;
+
+    // PostgreSQL error raised inside the leader's execute: teardown runs from the abort path.
+    conn.execute("SET paradedb.mpp_test_panic_in_worker TO on")
+        .await?;
+    run_faulted(&mut conn, &mut observer, JOINSCAN_QUERY, "artificial panic").await?;
+    run_faulted(
+        &mut conn,
+        &mut observer,
+        AGGREGATESCAN_QUERY,
+        "artificial panic",
+    )
+    .await?;
+    conn.execute("SET paradedb.mpp_test_panic_in_worker TO off")
+        .await?;
+
+    // DataFusion error returned from the leader's execute: the scans abort the launch first.
+    conn.execute("SET paradedb.mpp_test_fail_leader_execute TO on")
+        .await?;
+    run_faulted(
+        &mut conn,
+        &mut observer,
+        JOINSCAN_QUERY,
+        "artificial leader-side execute failure",
+    )
+    .await?;
+    run_faulted(
+        &mut conn,
+        &mut observer,
+        AGGREGATESCAN_QUERY,
+        "artificial leader-side execute failure",
+    )
+    .await?;
+    conn.execute("SET paradedb.mpp_test_fail_leader_execute TO off")
+        .await?;
+
+    // With the faults cleared the same connection runs the query to completion.
+    let ids: Vec<(i64,)> = timeout(
+        WATCHDOG,
+        sqlx::query_as(AssertSqlSafe(JOINSCAN_QUERY.to_string())).fetch_all(&mut conn),
+    )
+    .await
+    .context("query after the aborted runs did not return")??;
+    assert_eq!(
+        ids.into_iter().map(|(id,)| id).collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5]
+    );
+    Ok(())
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6031

## What

A leader-side error between the MPP launch and the first batch left the backend stuck in `BgworkerShutdown` with workers that ignored SIGTERM. Workers now exit, and the scans tear the launch down before raising.

- **Worker:** `take_set_plan_draining` checks interrupts on every spin (`exec_worker.rs`). This is the root-cause fix.
- **Leader:** `ParallelProcessFinish::abort` terminates and reaps the workers instead of waiting for them (`builder.rs`); `abort_launch` marks the mesh detached, drops the session, and calls it (`launch.rs`).
- **JoinScan / AggregateScan:** the launched leader stays in a local until `execute()` returns a stream. On `Err` (execute or first poll): drop plan and context, `abort_launch`, then `pgrx::error!`. `Launched` is installed only after the stream exists.
- **AggregateScan rescan:** joins the launched run and re-arms `Pending`, as JoinScan already does. Before, it left the old leader retained and silently replanned serially.
- **Test GUC** (debug builds): `paradedb.mpp_test_fail_leader_execute` makes a scan executed by the leader return a DataFusion error. Sibling of `mpp_test_panic_in_worker` (#5848).

## Why

On abort, `DestroyParallelContext` SIGTERMs the workers and waits for them to exit. A worker waiting for its plan frame spins in `MppMesh::try_drain_pass`, which never checks the interrupt hook, so it never sees `ProcDiePending`. Leader waits for workers; workers wait for frames that never come.

Reachable from SQL: a `NOT IN` on the probe side of a broadcast join is capped to one task in the leader's stage, so the leader executes that leaf itself before dispatching the other stages. Any error there hits the window.

## Tests

`tests/tests/mpp_leader_failure_teardown.rs`: a `NOT IN` shape that puts a 2-segment leaf in the leader's stage, with a fault injected in the leader's `execute` (PostgreSQL error via `mpp_test_panic_in_worker`, DataFusion error via `mpp_test_fail_leader_execute`), through JoinScan and AggregateScan. Asserts the error returns within a watchdog, the backend stays usable, and no `parallel worker` backends remain.

Fails on `main` (backend wedged, workers survive `pg_terminate_backend`); passes with this change.

Related: #6026 adds a leaf that opens its reader in the leader on this path. Independent of this PR.
