### PR TITLE
docs: refresh repository guidance and fix copy

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -320,7 +320,10 @@ jobs:
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: Postgres for Search and Analytics' >> $CONTROL_FILE
+          echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
+          echo ' pg_search adds Elastic-quality full-text search, vector retrieval, and' >> $CONTROL_FILE
+          echo ' aggregations to Postgres. Your application data and your search engine' >> $CONTROL_FILE
+          echo ' live in one database, with no second system to deploy and nothing to sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the
           # CloudNativePG postgres-extensions-containers Dockerfiles, which

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -331,9 +331,9 @@ jobs:
           Requires:       openblas
 
           %description
-          pg_search is a Postgres extension that brings full-text search, vector
-          retrieval, and aggregations to PostgreSQL tables. It is built on top of
-          Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.
+          pg_search adds Elastic-quality full-text search, vector retrieval, and
+          aggregations to Postgres. Your application data and your search engine
+          live in one database, with no second system to deploy and nothing to sync.
 
           %install
           %{__rm} -rf %{buildroot}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -316,7 +316,10 @@ jobs:
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: Postgres for Search and Analytics' >> $CONTROL_FILE
+          echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
+          echo ' pg_search adds Elastic-quality full-text search, vector retrieval, and' >> $CONTROL_FILE
+          echo ' aggregations to Postgres. Your application data and your search engine' >> $CONTROL_FILE
+          echo ' live in one database, with no second system to deploy and nothing to sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the
           # CloudNativePG postgres-extensions-containers Dockerfiles, which

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ ParadeDB has four main test categories. For a full overview of how and when to u
 Located in `pg_search/tests/pg_regress`.
 
 - **Purpose:** These are for output / golden testing, and are useful when the output is small enough that you can inspect it visually to determine correctness.
-- **Running:** Run them with `cargo pgrx regress -p pg_search --auto -- pg18 one_file_name`. There is no need to manually install the extension: it is handled automatically.
+- **Running:** From `pg_search/`, run them with `cargo pgrx regress --auto`. To run a specific test, pass its name, for example `cargo pgrx regress --auto pg18 PREFIX_your_test`. There is no need to manually install the extension: it is handled automatically.
 - **Details:** See [`pg_search/tests/pg_regress/README.md`](pg_search/tests/pg_regress/README.md) for more details.
 
 #### 2. Integration tests
@@ -86,7 +86,7 @@ Located in the `pg_search/src` directory.
 Located in the `stressgres/` directory.
 
 - **Purpose:** Replicate representative customer workloads against ParadeDB (or vanilla Postgres) to surface concurrency, correctness, and performance regressions that don't show up in shorter-lived tests.
-- **Running:** Run a suite interactively with `cargo run -- ui suites/vanilla-postgres.toml`, or headlessly with `cargo run -- headless suites/vanilla-postgres.toml --runtime=300000`.
+- **Running:** Run a suite interactively with `cargo run -p stressgres -- ui stressgres/suites/vanilla-postgres.toml`, or headlessly with `cargo run -p stressgres -- headless stressgres/suites/vanilla-postgres.toml --runtime=300000`.
 - **Details:** See [`stressgres/README.md`](stressgres/README.md) for more details.
 
 #### Helper scripts

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,13 +7,13 @@ This is a basic, single-query latency, benchmarking suite for ParadeDB. It execu
 The benchmarking scripts require a Postgres database with [`pg_search`](/pg_search) installed. If you are building `pg_search` with
 `cargo pgrx`, make sure to build in `--release` mode. It also requires AWS credentials to be available in order to load the data.
 
-### pg_stat_staements
+### pg_stat_statements
 
-Query timing is done via `pg_stat_statements`, so you'll need to configure it. The import bits are:
+Query timing is done via `pg_stat_statements`, so you'll need to configure it. The important settings are:
 
 - `pg_stat_statements` must be in `shared_preload_libraries`.
   - `ALTER SYSTEM SET shared_preload_libraries = pg_search,pg_stat_statements;`
-- Then after a postgres restart, configure it:
+- After restarting Postgres, configure it:
 
   ```sql
   CREATE EXTENSION pg_stat_statements;

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ There are three flavors of files generated:
 
 - `paradedb`: The default ParadeDB Docker image, published to `paradedb/paradedb`. Includes Barman Cloud which is used in our CNPG deployments.
 - `official`: The image for Docker Official Images which will be published to `paradedb` once approved by Docker. Includes only `pg_search` and its required `pgvector` dependency, initialized in `template1`, `paradedb`, and `POSTGRES_DB`.
-- `antithesis`: The image used by Antithesis test runs. Its `pg_search` is built with Antithesis coverage instrumentation (see `docs/reference/sdk/rust/instrumentation`); `libvoidstar` is injected at runtime rather than baked into the image.
+- `antithesis`: The image used by Antithesis test runs. Its `pg_search` is built with [Antithesis coverage instrumentation](https://antithesis.com/docs/reference/sdk/rust/instrumentation); `libvoidstar` is injected at runtime rather than baked into the image.
 
 `paradedb` and `official` both install Debian artifacts published to GitHub Releases. `antithesis` installs a locally built `.deb` so that it can be run on a per-commit basis.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,7 +25,7 @@ postgresql:
   extensions:
     - name: pg_search
       image:
-        reference: paradedb/paradedb-extension:0.25.0-18-trixie
+        reference: paradedb/paradedb-extension:0.25.3-18-trixie
       ld_library_path:
         - system
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,20 @@
 # ParadeDB Documentation
 
-ParadeDB [documentation](https://docs.paradedb.com) is built using [Mintlify](https://mintlify.com/docs/quickstart).
+ParadeDB [documentation](https://docs.paradedb.com) is built using [Mintlify](https://www.mintlify.com/docs/quickstart).
 
 ## 👩‍💻 Development
 
-Install the [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview
-the documentation changes locally. To install, use the following command:
+Install the [Mintlify CLI](https://www.mintlify.com/docs/cli/install) to preview
+documentation changes locally. The CLI requires Node.js 20.17 or later.
 
 ```bash
-npm i -g mintlify
+npm i -g mint
 ```
 
-Run the following command at the root of your documentation (where `docs.json` is)
+Run the following command from `docs/`, where `docs.json` is located:
 
 ```bash
-mintlify dev
+mint dev
 ```
 
 ## 😎 Publishing Changes
@@ -26,5 +26,5 @@ You can also preview changes using PRs, which generates a preview link of the do
 
 ## Troubleshooting
 
-- Mintlify dev isn't running - Run `mintlify install` it'll re-install dependencies.
-- Page loads as a 404 - Make sure you are running in a folder with `docs.json`
+- Local preview is out of sync with the deployed documentation - Run `mint update`.
+- Page loads as a 404 - Make sure you are running in the `docs/` folder that contains `docs.json`.

--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: GitHub Actions
-description: How to run ParadeDB in Github Actions CI
+description: How to run ParadeDB in GitHub Actions CI
 canonical: https://docs.paradedb.com/deploy/ci/github-actions
 ---
 

--- a/docs/deploy/cloud-platforms/dokku.mdx
+++ b/docs/deploy/cloud-platforms/dokku.mdx
@@ -62,7 +62,7 @@ Point Dokku at the official ParadeDB image and rebuild the app:
 dokku git:from-image paradedb paradedb/paradedb:latest
 ```
 
-See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags. Pin a tag (for example `paradedb/paradedb:0.25.0-pg18`) instead of `latest` for reproducible deploys.
+See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags. Pin a tag (for example `paradedb/paradedb:0.25.3-pg18`) instead of `latest` for reproducible deploys.
 
 ## Connect to ParadeDB
 

--- a/docs/deploy/cloud-platforms/fly.mdx
+++ b/docs/deploy/cloud-platforms/fly.mdx
@@ -29,7 +29,7 @@ fly launch \
   --no-deploy
 ```
 
-`fly launch` prompts for an app name and a primary region, then writes a `fly.toml` in the current directory. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available `paradedb/paradedb` tags — pin one (for example `paradedb/paradedb:0.25.0-pg18`) instead of `latest` for reproducible deploys.
+`fly launch` prompts for an app name and a primary region, then writes a `fly.toml` in the current directory. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available `paradedb/paradedb` tags — pin one (for example `paradedb/paradedb:0.25.3-pg18`) instead of `latest` for reproducible deploys.
 
 ## Create a Persistent Volume
 

--- a/docs/deploy/self-hosted/high-availability.mdx
+++ b/docs/deploy/self-hosted/high-availability.mdx
@@ -43,7 +43,7 @@ Without these settings, ParadeDB physical replicas will see much more frequent q
 
 ## Asynchronous vs. Synchronous Replication
 
-By default, ParadeDB ships with asynchronuous replication, meaning transactions on the primary **do not** wait for confirmation from
+By default, ParadeDB ships with asynchronous replication, meaning transactions on the primary **do not** wait for confirmation from
 the standby instances before committing.
 
 **Quorum-based synchronous replication** ensures that a transaction is successfully written to standbys before it completes.

--- a/docs/deploy/self-hosted/kubernetes.mdx
+++ b/docs/deploy/self-hosted/kubernetes.mdx
@@ -137,7 +137,7 @@ spec:
     extensions:
       - name: pg_search
         image:
-          reference: docker.io/paradedb/paradedb-extension:0.25.0-18-trixie
+          reference: docker.io/paradedb/paradedb-extension:0.25.3-18-trixie
         extension_control_path:
           - /share
         dynamic_library_path:
@@ -158,11 +158,11 @@ spec:
     name: paradedb
   extensions:
     - name: pg_search
-      version: "0.25.0"
+      version: "0.25.3"
 ```
 
 The extension image tag format is `<paradedb-version>-<postgres-major>-trixie`.
-For example, use `0.25.0-18-trixie` for ParadeDB `0.25.0` on Postgres 18.
+For example, use `0.25.3-18-trixie` for ParadeDB `0.25.3` on Postgres 18.
 
 ## Connect to the Cluster
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -580,7 +580,7 @@
       "rating": "general",
       "revisit-after": "7 days",
       "language": "en",
-      "copyright": "ParadeDB, Inc. 2025",
+      "copyright": "ParadeDB, Inc. 2026",
       "reply-to": "support@paradedb.com",
       "distribution": "global",
       "coverage": "Worldwide",

--- a/docs/documentation/joins/overview.mdx
+++ b/docs/documentation/joins/overview.mdx
@@ -370,4 +370,4 @@ To verify join pushdown, run `EXPLAIN` on the query and look for a `ParadeDB Joi
 
 ## Performance
 
-If your join query isn't as fast as you'd like, we invite you to [open a Github issue](https://github.com/paradedb/paradedb/issues).
+If your join query isn't as fast as you'd like, we invite you to [open a GitHub issue](https://github.com/paradedb/paradedb/issues).

--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -17,8 +17,8 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 ### Ecosystem Integrations
 
 - **ORMs**. Official support for more ORMs, like Prisma and others, is coming. [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Django](https://github.com/paradedb/django-paradedb), [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) are already available.
-- **AI Frameworks**. Official support for LangChain, LLamaIndex, CrewAI, and others are coming.
-- **PaaS Providers**. Official tutorials for hosting ParadeDB on more platform-as-a-service providers like Porter.run and others is coming. [Railway](/deploy/cloud-platforms/railway), [Render](/deploy/cloud-platforms/render), and [DigitalOcean](/deploy/cloud-platforms/digitalocean) are already available.
+- **AI Frameworks**. Official support for LangChain, LlamaIndex, CrewAI, and others is coming.
+- **PaaS Providers**. Official tutorials for hosting ParadeDB on more platform-as-a-service providers like Porter.run and others are coming. [Railway](/deploy/cloud-platforms/railway), [Render](/deploy/cloud-platforms/render), and [DigitalOcean](/deploy/cloud-platforms/digitalocean) are already available.
 
 ## Long Term
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -3,7 +3,7 @@
 <br>
 </h1>
 
-This README covers development of the `pg_search` extension. For installation, deployment, and usage, see the [top-level ParadeDB README](../README.md) or the [ParadeDB documentation](https://docs.paradedb.com).
+This README covers development of the `pg_search` extension. For installation, deployment, and usage, see the [ParadeDB documentation](https://docs.paradedb.com).
 
 `pg_search` is supported on official PostgreSQL Global Development Group Postgres versions, starting at PostgreSQL 15.
 
@@ -44,7 +44,7 @@ cargo pgrx init
 
 ### pgvector
 
-`pgvector` is needed for hybrid search integration tests. To build it against the pgrx-managed Postgres install (replace `18.6` with the version under `~/.pgrx/`):
+`pg_search` uses `pgvector`'s types to index vector fields alongside text and other fields in ParadeDB indexes, so `pgvector` must be available before `pg_search` can be created. To build it against the pgrx-managed Postgres install (replace `18.6` with the version under `~/.pgrx/`):
 
 ```bash
 git clone --branch v0.8.6 https://github.com/pgvector/pgvector.git

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -47,7 +47,7 @@ When MPP is eligible, `DistributedPlanner` builds an MPP execution tree (`Distri
 
 ### 4. Deferred Columns
 
-String columns are emitted as a [2-way `UnionArray`](../../scan/deferred_encode.rs) (doc_address | term_ordinal) so intermediate nodes work with cheap integer ordinals instead of decoded strings. The [decision to defer](../../scan/table_provider.rs) is made in [`configure_deferred_outputs()`][defer-decision].
+String columns are emitted as a [2-way `UnionArray`](../../../scan/deferred_encode.rs) (doc_address | term_ordinal) so intermediate nodes work with cheap integer ordinals instead of decoded strings. The [decision to defer](../../../scan/table_provider.rs) is made in [`configure_deferred_outputs()`][defer-decision].
 
 ### 5. Pruning Path
 
@@ -67,7 +67,7 @@ JoinScan does not use DataFusion's standard in-process multithreading. Since Pos
 
 Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizing joins. It assigns logical tasks across PostgreSQL parallel workers based on segment count:
 
-1. **Partition Output Definition**: Because index segments are checked out atomically from shared memory, [`PgSearchScanPlan`][scan-plan] natively partitions its output by the number of segments. In [`table_provider.rs`](../../scan/table_provider.rs), we formally expose the scan's output partition count as `min(segment_count, target_partitions)`. When the `RangePartitioningRule` has injected a range sample, the scan instead declares `Partitioning::Range` with the sample's split points, which lets DataFusion treat the two sides of a join as co-partitioned.
+1. **Partition Output Definition**: Because index segments are checked out atomically from shared memory, [`PgSearchScanPlan`][scan-plan] natively partitions its output by the number of segments. In [`table_provider.rs`](../../../scan/table_provider.rs), we formally expose the scan's output partition count as `min(segment_count, target_partitions)`. When the `RangePartitioningRule` has injected a range sample, the scan instead declares `Partitioning::Range` with the sample's split points, which lets DataFusion treat the two sides of a join as co-partitioned.
 2. **Task Estimation**: During MPP planning, [`PgSearchScanTaskEstimator`](../../../scan/execution_plan.rs) intercepts the leaf nodes and requests exactly this `partition_count` number of tasks.
 3. **Execution Routing**: For a viable MPP launch, tasks are assigned round-robin across the workers PostgreSQL attached, and each worker uses `ParallelScanState` to lazily claim segments. A one-task plan does not launch MPP workers and runs serially.
 
@@ -81,21 +81,21 @@ Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizin
 | [`planning.rs`](planning.rs)                               | Cost estimation, field validation, ORDER BY extraction                                |
 | [`predicate.rs`](predicate.rs)                             | Postgres expression → `JoinLevelExpr`                                                 |
 | [`range_partitioning_rule.rs`](range_partitioning_rule.rs) | Rules that synchronize Join-side MPP partition boundaries and co-partition the join   |
-| [`translator.rs`](translator.rs)                           | Postgres ↔ DataFusion expression mapping                                              |
-| [`explain.rs`](explain.rs)                                 | EXPLAIN output formatting                                                             |
+| [`translator.rs`](../datafusion/translator.rs)             | Postgres ↔ DataFusion expression mapping                                              |
+| [`explain.rs`](../datafusion/explain.rs)                   | EXPLAIN output formatting                                                             |
 
-Execution-layer files under [`pg_search/src/scan/`](../../scan/):
+Execution-layer files under [`pg_search/src/scan/`](../../../scan/):
 
-| File                                                  | Purpose                                                                                                                             |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [`segmented_topk_exec.rs`][topk-exec]                 | [`SegmentedTopKExec`][topk-exec] — per-segment heaps, [global heap][global-heap], [`build_global_filter_expression`][global-filter] |
-| [`segmented_topk_rule.rs`][topk-rule]                 | Optimizer rule, [`wrap_blocking_nodes`][wrap-blocking]                                                                              |
-| [`tantivy_lookup_exec.rs`][lookup-exec]               | Dictionary decode + [filter passthrough][lookup-passthrough]                                                                        |
-| [`filter_passthrough_exec.rs`][filter-passthrough]    | Transparent wrapper enabling filter pushdown through blocking nodes                                                                 |
-| [`batch_scanner.rs`](../../scan/batch_scanner.rs)     | [`Scanner::next()`][scanner-next] — batch iteration, pre-filter, visibility                                                         |
-| [`execution_plan.rs`](../../scan/execution_plan.rs)   | [`PgSearchScanPlan`][scan-plan] — dynamic filter integration                                                                        |
-| [`pre_filter.rs`](../../scan/pre_filter.rs)           | [`try_rewrite_binary`][rewrite-binary], [`collect_filters`][collect-filters]                                                        |
-| [`deferred_encode.rs`](../../scan/deferred_encode.rs) | 2-way UnionArray construction and unpacking                                                                                         |
+| File                                                     | Purpose                                                                                                                             |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [`segmented_topk_exec.rs`][topk-exec]                    | [`SegmentedTopKExec`][topk-exec] — per-segment heaps, [global heap][global-heap], [`build_global_filter_expression`][global-filter] |
+| [`segmented_topk_rule.rs`][topk-rule]                    | Optimizer rule, [`wrap_blocking_nodes`][wrap-blocking]                                                                              |
+| [`tantivy_lookup_exec.rs`][lookup-exec]                  | Dictionary decode + [filter passthrough][lookup-passthrough]                                                                        |
+| [`filter_passthrough_exec.rs`][filter-passthrough]       | Transparent wrapper enabling filter pushdown through blocking nodes                                                                 |
+| [`batch_scanner.rs`](../../../scan/batch_scanner.rs)     | [`Scanner::next()`][scanner-next] — batch iteration, pre-filter, visibility                                                         |
+| [`execution_plan.rs`](../../../scan/execution_plan.rs)   | [`PgSearchScanPlan`][scan-plan] — dynamic filter integration                                                                        |
+| [`pre_filter.rs`](../../../scan/pre_filter.rs)           | [`try_rewrite_binary`][rewrite-binary], [`collect_filters`][collect-filters]                                                        |
+| [`deferred_encode.rs`](../../../scan/deferred_encode.rs) | 2-way UnionArray construction and unpacking                                                                                         |
 
 ## GUCs
 
@@ -105,21 +105,21 @@ Execution-layer files under [`pg_search/src/scan/`](../../scan/):
 | `paradedb.enable_range_partitioned_join` | `false` | Range co-partitioned joins    |
 | `paradedb.enable_segmented_topk`         | `true`  | `SegmentedTopKExec` injection |
 
-[activation]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/mod.rs#L317
-[relnode]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/build.rs#L575
-[joincsc]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/build.rs#L796
-[optimizer-rules]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/scan_state.rs#L176-L213
-[topk-exec]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/segmented_topk_exec.rs#L150
-[global-filter]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/segmented_topk_exec.rs#L924
-[global-heap]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/segmented_topk_exec.rs#L447
-[topk-rule]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/segmented_topk_rule.rs#L63
-[wrap-blocking]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/segmented_topk_rule.rs#L284
-[filter-passthrough]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/filter_passthrough_exec.rs#L39
-[lookup-exec]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/tantivy_lookup_exec.rs#L60
-[lookup-passthrough]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/tantivy_lookup_exec.rs#L232
-[scan-plan]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/execution_plan.rs#L89
-[scanner-next]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/batch_scanner.rs#L259
-[rewrite-binary]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/pre_filter.rs#L383
-[collect-filters]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/pre_filter.rs#L254
-[defer-decision]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/scan/table_provider.rs#L126
-[try-pushdown]: ../../scan/pre_filter.rs
+[activation]: mod.rs
+[relnode]: build.rs
+[joincsc]: build.rs
+[optimizer-rules]: scan_state.rs
+[topk-exec]: ../../../scan/segmented_topk_exec.rs
+[global-filter]: ../../../scan/segmented_topk_exec.rs
+[global-heap]: ../../../scan/segmented_topk_exec.rs
+[topk-rule]: ../../../scan/segmented_topk_rule.rs
+[wrap-blocking]: ../../../scan/segmented_topk_rule.rs
+[filter-passthrough]: ../../../scan/filter_passthrough_exec.rs
+[lookup-exec]: ../../../scan/tantivy_lookup_exec.rs
+[lookup-passthrough]: ../../../scan/tantivy_lookup_exec.rs
+[scan-plan]: ../../../scan/execution_plan.rs
+[scanner-next]: ../../../scan/batch_scanner.rs
+[rewrite-binary]: ../../../scan/pre_filter.rs
+[collect-filters]: ../../../scan/pre_filter.rs
+[defer-decision]: ../../../scan/table_provider.rs
+[try-pushdown]: ../../../scan/pre_filter.rs

--- a/pg_search/tests/pg_regress/README.md
+++ b/pg_search/tests/pg_regress/README.md
@@ -74,7 +74,8 @@ cargo pgrx regress
 ### Run Specific Tests
 
 ```bash
-cargo pgrx regress -p pg_search --auto -- pg18 PREFIX_your_test
+cd pg_search
+cargo pgrx regress --auto pg18 PREFIX_your_test
 ```
 
 ## Common Pitfalls

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -1,44 +1,44 @@
 # Stressgres
 
-Stressgres is a stress-testing tool for ParadeDB and standard PostgreSQL, featuring both a text UI and an automated headless mode. We used it for local development and in CI to replicate and test against representative customer workloads, called suites.
+Stressgres is a stress-testing tool for ParadeDB and standard PostgreSQL, featuring both a text UI and an automated headless mode. We use it for local development and in CI to replicate and test against representative customer workloads, called suites.
 
 ## Quickstart
 
 - Run the interactive UI against a suite:
 
 ```bash
-cargo run -- ui suites/vanilla-postgres.toml
+cargo run -p stressgres -- ui stressgres/suites/vanilla-postgres.toml
 ```
 
 - Run headless mode with logging:
 
 ```bash
-cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
+cargo run -p stressgres -- headless stressgres/suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
 - Run headless mode tolerating transient database faults (e.g. under Antithesis)
 
 ```bash
-cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace=30000
+cargo run -p stressgres -- headless stressgres/suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace=30000
 ```
 
 - Run a suite against a throwaway Postgres cluster built from a given `pg_config`:
 
 ```bash
-cargo run -- auto /path/to/pg_config suites/vanilla-postgres.toml /tmp/stressgres-data --runtime 300000
+cargo run -p stressgres -- auto /path/to/pg_config stressgres/suites/vanilla-postgres.toml /tmp/stressgres-data --runtime 300000
 ```
 
-Suites are TOML files in `suites/`. The `vanilla-postgres.toml` suite exercises baseline Postgres features and works with any PostgreSQL-compatible server.
+Suites are TOML files in `stressgres/suites/`. The `vanilla-postgres.toml` suite exercises baseline Postgres features and works with any PostgreSQL-compatible server.
 
 ## Docker
 
 To run Stressgres from within Docker, use:
 
 ```bash
-docker run --rm paradedb/stressgres:latest cargo run -- headless suites/vanilla-postgres.toml
+docker run --rm paradedb/stressgres:latest /symbols/stressgres headless stressgres/suites/vanilla-postgres.toml
 ```
 
-The source, including all suites, are loaded in the Docker image. The image prebuilds Stressgres and can run in air-gapped environments like Antithesis.
+The source, including all suites, is included in the Docker image. The image prebuilds Stressgres at `/symbols/stressgres` and can run in air-gapped environments like Antithesis.
 
 For an interactive shell:
 
@@ -49,15 +49,15 @@ docker exec -it stressgres bash
 
 ### Docker Hub
 
-To publish the Stressgres image to Docker Hub, trigger a workflow dispatch of the `Publish Stressgres (Docker) from within the Actions tab. This is useful to get updated Stressgres binaries to our BYOC end-to-end testing framework.
+To publish the Stressgres image to Docker Hub, trigger a workflow dispatch of `Publish Stressgres (Docker)` from the Actions tab. This is useful to get updated Stressgres binaries to our BYOC end-to-end testing framework.
 
 ## Antithesis
 
-Antithesis is a deterministic simulation testing (DST) tool. Stressgres, via the Docker image, is able to run within Antithesis to execute suites in a fully deterministic environment. To execute a Stressgres suite within Antithesis, it needs to have its own `singleton_driver_` file defined within the `suites/antithesis/` folder. For more information on how Antithesis singleton drivers work, please refer to [the Antithesis documentation](https://antithesis.com/docs/getting_started/setup_k8s/#basic-test-template).
+Antithesis is a deterministic simulation testing (DST) tool. Stressgres runs inside Antithesis through the Docker image. Each suite has a `first_<suite>.sh` setup script under `stressgres/suites/antithesis/`; the shared `singleton_driver_stressgres.sh` then runs the selected workload under fault injection. For more information on Antithesis test commands, see [the Antithesis documentation](https://antithesis.com/docs/test_templates/first_test/).
 
 To add a new suite:
 
-- Create the corresponding singleton driver
+- Create the corresponding `first_<suite>.sh` setup script.
 
 - Trigger a release of the Docker image to the Antithesis registry via the `Test pg_search (Antithesis)` workflow. This workflow builds and publishes the latest commit ParadeDB and Stressgres Docker images to Antithesis, and triggers a test run.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ For a complete overview of ParadeDB's testing infrastructure (including unit tes
 
 ## Client Property Tests
 
-A particularly interesting subcategory of integration tests are our client property tests. Most of the client property tests live in [`tests/qgen.rs`](tests/qgen.rs), but there are other files which use `crate::fixtures::querygen` to generate tests as well.
+A particularly interesting subcategory of integration tests are our client property tests. Most of the client property tests live in [`qgen.rs`](tests/qgen.rs), but there are other files which use `crate::fixtures::querygen` to generate tests as well.
 
 ## Environment Variables
 
@@ -16,9 +16,9 @@ The tests require a `DATABASE_URL` environment variable to be set. The easiest w
 DATABASE_URL=postgres://USER_NAME@localhost:PORT/pg_search
 ```
 
-USER_NAME should be replaced with your system user name. (eg: output of `whoami`)
+`USER_NAME` should be replaced with your system username (for example, the output of `whoami`).
 
-PORT should be replaced with 28800 + your postgres version. (eg: 28818 for Postgres 18)
+`PORT` should be replaced with 28800 plus your PostgreSQL major version (for example, 28818 for PostgreSQL 18).
 
 ## Running Tests with pgrx-managed PostgreSQL
 
@@ -55,7 +55,7 @@ cargo pgrx install --package pg_search --pg-config /opt/homebrew/opt/postgresql@
 cargo test --package tests
 ```
 
-To run a single test, you can use the following command(replace `<testname>` with the test file name without the `.rs` extension):
+To run a single test, use the following command (replace `<testname>` with the test file name without the `.rs` extension):
 
 ```shell
 cargo test --package tests --test <testname>

--- a/tests/src/fixtures/mod.rs
+++ b/tests/src/fixtures/mod.rs
@@ -71,8 +71,8 @@ pub fn conn(database: Db) -> PgConnection {
     block_on(async {
         let mut conn = database.connection().await;
 
-        // pg_search declares `requires = 'vector'`, so CASCADE pulls pgvector
-        // in automatically (its extension script references the `vector` type).
+        // pg_search uses pgvector's types for vector fields in ParadeDB indexes, so
+        // pgvector must be available first. CASCADE installs it automatically.
         sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;")
             .execute(&mut conn)
             .await


### PR DESCRIPTION
## Summary
- correct documentation spelling, capitalization, grammar, and the 2026 copyright year
- align regression-test and Stressgres commands with the current CLIs and repository layout
- replace obsolete Mintlify CLI instructions
- repair JoinScan links after source files moved and replace stale commit-pinned references with durable relative links
- refresh Docker and Antithesis guidance
- clarify the qgen.rs link label while retaining its correct target at tests/tests/qgen.rs
- align Debian, Ubuntu, and RHEL package descriptions with current product messaging from #5909
- clarify pgvector requirements in the pg_search development README and integration-test fixture
- update executable deployment examples to the verified 0.25.3 release tags

## Audit scope
Reviewed every tracked README, including the GitHub Actions upgrade-test README, plus CONTRIBUTING.md, SECURITY.md, and CODE_OF_CONDUCT.md against current source files, manifests, workflows, and tool help.

## Testing
- targeted prek checks for every changed file
- cargo pgrx regress --dry-run --auto pg18 PREFIX_your_test
- cargo run -p stressgres -- --help
- local-link resolution check across all audited files
- verified the v0.25.3 release and both referenced Docker Hub tags

Standalone actionlint reports pre-existing findings elsewhere in the publish workflows; the imported sections introduce no new findings.