### PR TITLE
docs: qualify planner and vector filtering claims

### DIFF
--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -384,9 +384,7 @@ await dbContext
 (3 rows)
 ```
 
-Because `embedding` is part of the same index as `description` and `rating`, the entire query (the full-text match, the rating filter,
-and the nearest-neighbor ordering) executes inside the ParadeDB index. ParadeDB is the only Postgres index that can do this — every other
-Postgres vector index is a standalone index that requires separate pre/post filtering, which hurts performance and recall.
+Because `embedding` is part of the same index as `description` and `rating`, ParadeDB can evaluate the full-text match, rating filter, and nearest-neighbor ordering in a single index scan. By comparison, pgvector's approximate indexes apply filters separately from the vector index scan. pgvector supports [iterative index scans](https://github.com/pgvector/pgvector#filtering), which can scan more of an HNSW or IVFFlat index when filtering produces too few results.
 
 ## Top K Ordering
 

--- a/docs/welcome/architecture.mdx
+++ b/docs/welcome/architecture.mdx
@@ -62,7 +62,7 @@ ParadeDB’s custom query execution paths are only triggered when at least one o
 
 ### Custom Scan
 
-Whenever a ParadeDB operator is present in a query, ParadeDB will execute the query using a [custom scan](https://www.postgresql.org/docs/current/custom-scan.html).
+A ParadeDB operator makes a query eligible for a [custom scan](https://www.postgresql.org/docs/current/custom-scan.html). During planning, ParadeDB uses a custom scan when the expression is supported and the planner selects an appropriate ParadeDB index; otherwise, PostgreSQL uses another available plan.
 
 Custom scans are execution nodes set aside by Postgres that allow extensions to run custom logic during a query. They are more powerful and versatile than typical Postgres index scans because they
 allow the extension to "take over" large parts of the query, including aggregates, `WHERE`, and even [`GROUP BY` clauses](/welcome/roadmap#analytics).


### PR DESCRIPTION
## Summary
- clarify that ParadeDB operators make queries eligible for a custom scan rather than guaranteeing one
- explain that the planner chooses the custom scan only for supported expressions with an appropriate selected index
- replace the exclusive filtered-vector-search claim with ParadeDB's concrete single-index/single-scan differentiator
- acknowledge pgvector's iterative ANN index scans and link to its filtering documentation

## Validation
- `prek run --files docs/welcome/architecture.mdx docs/documentation/getting-started/queries.mdx`
- `mint validate`
- `mint broken-links`
