### PR TITLE
docs: refresh architecture and development guidance

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -3,7 +3,6 @@ autor
 Bilt
 caf
 crate
-fillter
 Fo
 fo
 hel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# **Contributing to ParadeDB**
+# Contributing to ParadeDB
 
 Welcome! We're excited that you're interested in contributing to ParadeDB and want to make the process as smooth as possible.
 
@@ -18,9 +18,8 @@ This repository has a workflow that automatically assigns issues to new contribu
 from a maintainer to pick an issue.
 
 1. Before claiming an issue, ensure that:
-
-- It's not already assigned to someone else
-- There are no comments indicating ongoing work
+   - It's not already assigned to someone else.
+   - There are no comments indicating ongoing work.
 
 2. To claim an unassigned issue, comment `/take` on the issue. This will automatically assign the issue to you.
 
@@ -28,11 +27,14 @@ If you find yourself unable to make progress, don't hesitate to seek help in the
 
 ### Development Workflow
 
-ParadeDB is a Postgres extension, `pg_search`, written in Rust and packaged as either a standalone binary or a Docker image. The development of our Postgres extension is done via `pgrx`. For instructions on setting up your development environment, building, and running `pg_search` locally, see the [pg_search README](/pg_search/README.md).
+ParadeDB's `pg_search` Postgres extension is written in Rust and distributed as
+prebuilt extension packages and Docker images. Development is done with `pgrx`.
+For instructions on setting up your development environment, building, and running
+`pg_search` locally, see the [pg_search README](/pg_search/README.md).
 
 ### Pull Request Workflow
 
-All changes to ParadeDB happen through GitHub Pull Requests. Here is the recommended flow for making a change:
+All changes to ParadeDB happen through GitHub pull requests. Here is the recommended flow for making a change:
 
 1. Before working on a change, please check if there is already a GitHub issue open for it.
 2. If there is not, please open an issue first. This gives the community visibility into your work and allows others to make suggestions and leave comments.
@@ -55,11 +57,11 @@ ParadeDB's public-facing documentation is stored in the `docs` folder. If you ar
 
 ParadeDB has four main test categories. For a full overview of how and when to use them, please see their respective documentation:
 
-#### 1. pg regress tests
+#### 1. pg_regress tests
 
 Located in `pg_search/tests/pg_regress`.
 
-- **Purpose:** These are for output / golden testing, and are useful when the output is small enough that you can inspect it visually to determine correctness.
+- **Purpose:** These are golden-output tests, useful when the output is small enough to inspect visually for correctness.
 - **Running:** From `pg_search/`, run them with `cargo pgrx regress --auto`. To run a specific test, pass its name, for example `cargo pgrx regress --auto pg18 PREFIX_your_test`. There is no need to manually install the extension: it is handled automatically.
 - **Details:** See [`pg_search/tests/pg_regress/README.md`](pg_search/tests/pg_regress/README.md) for more details.
 

--- a/THANKYOU.md
+++ b/THANKYOU.md
@@ -20,21 +20,40 @@ and correctness. ParadeDB's core is built on PostgreSQL.
 [pgrx](https://github.com/pgcentralfoundation/pgrx) is a powerful toolset for
 PostgreSQL extension development in Rust. It simplifies the process of creating,
 testing, and packaging extensions, enabling developers to harness the performance
-and safety guarantees of Rust within the PostgreSQL ecosystem. ParadeDB uses PGRX
+and safety guarantees of Rust within the PostgreSQL ecosystem. ParadeDB uses pgrx
 for developing our own PostgreSQL extensions, and has drawn inspiration from [ZomboDB](https://github.com/zombodb/zombodb),
-the first PGRX extension and primary example, for the architecture of our own extensions.
+the first pgrx extension and primary example, for the architecture of our own extensions.
+
+## pgvector
+
+[pgvector](https://github.com/pgvector/pgvector) provides open-source vector
+similarity search for PostgreSQL. ParadeDB uses pgvector's vector types and
+operators as its SQL interface for vector search.
 
 ## Tantivy
 
 [Tantivy](https://github.com/quickwit-oss/tantivy) is a full-text search library
 inspired by Apache Lucene, written entirely in Rust. ParadeDB uses Tantivy to power
-part of our search functionalities.
+its search index.
+
+## Lindera
+
+[Lindera](https://github.com/lindera/lindera) is a multilingual morphological
+analysis library written in Rust. ParadeDB uses Lindera to provide Chinese,
+Japanese, and Korean tokenization.
 
 ## Apache DataFusion
 
-[Apache DataFusion](https://github.com/apache/datafusion) is an extensible query execution framework,
-written in Rust, that uses Apache Arrow as its in-memory format. ParadeDB uses DataFusion to power
-our OLAP and analytical processing capabilities.
+[Apache DataFusion](https://github.com/apache/datafusion) is an extensible query
+execution framework written in Rust that uses [Apache Arrow](https://arrow.apache.org/)
+as its in-memory format. ParadeDB uses DataFusion to power its OLAP and analytical
+processing capabilities.
+
+## DataFusion Distributed
+
+[DataFusion Distributed](https://github.com/datafusion-contrib/datafusion-distributed)
+extends Apache DataFusion with distributed query execution. ParadeDB uses it to
+distribute query plans across PostgreSQL parallel workers.
 
 ## Docker
 

--- a/docs/welcome/architecture.mdx
+++ b/docs/welcome/architecture.mdx
@@ -39,11 +39,11 @@ In Tantivy these structures are referred to as [fast fields](https://docs.rs/tan
 
 To support real-time updates, the ParadeDB index uses a [Log-Structured Merge (LSM) tree](https://en.wikipedia.org/wiki/Log-structured_merge-tree).
 
-An LSM tree is a write-optimized data structure commonly used in systems like RocksDB and Cassandra. The core idea behind an LSM tree is to turn random writes into sequential ones. Incoming writes are first stored in an in-memory buffer, which is fast to update. Once the buffer fills up or the current statement finishes, it is flushed to disk as an immutable "segment" file.
+An LSM tree is a write-optimized data structure commonly used in systems like RocksDB and Cassandra. The core idea behind an LSM tree is to turn random writes into sequential ones. Incoming writes are appended to a mutable segment, which buffers rows across statements. Once the segment reaches the configured [`mutable_segment_rows`](/documentation/performance-tuning/writes#increase-mutable-segment-size) threshold—1,000 rows by default—it is frozen and becomes eligible for conversion into an immutable segment.
 
 These segment files are organized by size into layers or levels. Newer data is written to the topmost layer. Over time, data is gradually pushed down into lower levels through a process called merging or compaction, where data from smaller segments is merged, deduplicated, and rewritten into larger segments.
 
-In ParadeDB, every `INSERT`/`UPDATE`/`COPY` statement creates a new segment. Each segment has its own inverted index and columnar index, which means that the ParadeDB index
+ParadeDB reuses the current mutable segment across `INSERT`, `UPDATE`, and `COPY` statements until it reaches that threshold. Each resulting immutable segment has its own inverted index and columnar index, which means that the ParadeDB index
 is actually a collection of many inverted/columnar indexes, each of which allows for very dense intersection queries to rapidly filter matches.
 
 ## Query Execution
@@ -85,7 +85,7 @@ As a rule of thumb: if `EXPLAIN` shows a custom scan (or, in rare cases, a Parad
 
 ### Parallelization
 
-For queries that need to read large amounts of data like [Top K](/documentation/sorting/topk) or aggregate queries, the custom scan automatically spawns additional workers to execute the query
+For queries that need to read large amounts of data, such as [Top K](/documentation/sorting/topk) or aggregate queries, ParadeDB custom scans can use additional Postgres workers to execute the query
 in parallel. To see if a query was parallelized, run `EXPLAIN ANALYZE`:
 
 ```sql
@@ -100,8 +100,7 @@ ORDER BY rating LIMIT 5;
   workers](/documentation/performance-tuning/reads).
 </Note>
 
-Parallel workers are another reason why the ParadeDB index is significantly faster than Postgres' native text search and aggregates,
-which are mostly not capable of parallelization.
+Postgres also supports [parallel scans, joins, and two-stage aggregation](https://www.postgresql.org/docs/current/parallel-plans.html). ParadeDB builds on those parallel-worker primitives while pushing supported filters, Top K, joins, and aggregates into the index. For joins and aggregates, ParadeDB can distribute the pushed-down plan across workers using an MPP execution strategy.
 
 ## Design Philosophy
 

--- a/docs/welcome/architecture.mdx
+++ b/docs/welcome/architecture.mdx
@@ -100,7 +100,7 @@ ORDER BY rating LIMIT 5;
   workers](/documentation/performance-tuning/reads).
 </Note>
 
-Postgres also supports [parallel scans, joins, and two-stage aggregation](https://www.postgresql.org/docs/current/parallel-plans.html). ParadeDB builds on those parallel-worker primitives while pushing supported filters, Top K, joins, and aggregates into the index. For joins and aggregates, ParadeDB can distribute the pushed-down plan across workers using an MPP execution strategy.
+Postgres supports [parallel scans, joins, and two-stage aggregation](https://www.postgresql.org/docs/current/parallel-plans.html). ParadeDB builds on those parallel-worker primitives while pushing supported filters, Top K, joins, and aggregates into the index. For joins and aggregates, ParadeDB can distribute the pushed-down plan across workers using an MPP execution strategy.
 
 ## Design Philosophy
 

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stressgres"
-description = "A Postgres Stress Test Tool, as a TUI"
+description = "A stress-testing tool for PostgreSQL"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -19,14 +19,17 @@ cursive = { version = "0.21.1" }
 cursive-multiplex = "0.7.0"
 cursive_core = "0.4.6"
 cursive_table_view = "0.15.0"
+dst = { path = "../dst" }
 human_bytes = "0.4.3"
 humantime = "2.3.0"
 image = "0.25.9"
 libc = "0.2.186"
+openssl = "0.10.78"
 parking_lot = "0.12.5"
 pgrx-pg-config = "=0.19.2"
 plotters = "0.3.7"
 postgres = "0.19.13"
+postgres-openssl = "0.5.3"
 rust_decimal = { version = "1.41.0", features = ["db-postgres"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", features = [
@@ -37,9 +40,6 @@ shutdown_hooks = "0.1.0"
 sysinfo = { version = "0.39.6", features = ["multithread"] }
 toml = "1.1"
 url = "2.5.8"
-postgres-openssl = "0.5.3"
-openssl = "0.10.78"
-dst = { path = "../dst" }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/stressgres/runheadless.sh
+++ b/stressgres/runheadless.sh
@@ -4,18 +4,18 @@ set -Eeuo pipefail
 
 PGVER=18.6
 EXTENSION=pg_search
-MANIFEST=~/_work/$1/Cargo.toml
-MANIFESTDIR=$(dirname "${MANIFEST}")
 PGRX_HOME=~/.pgrx
 
-SUITE="$2"
-TIMEOUT="$3"
-HERE=$(pwd)
-
-if [ "$2" = "" ] || [ "$3" = "" ]; then
+if (( $# < 3 )); then
   echo "usage: runheadless.sh <crate-name> <suite.toml> <timeout_ms> [logfile]"
   exit 1
 fi
+
+MANIFEST=~/_work/$1/Cargo.toml
+MANIFESTDIR=$(dirname "${MANIFEST}")
+SUITE="$2"
+TIMEOUT="$3"
+HERE=$(pwd)
 
 LOGFILE=$(basename -- "${SUITE}")
 LOGFILE="${LOGFILE%.*}.log"
@@ -25,10 +25,10 @@ if [ "${4:-""}" != "" ]; then
 fi
 
 cd "${MANIFESTDIR}" || exit
-cargo pgrx install --profile prof --manifest-path "${MANIFEST}" --package "${EXTENSION}" --pg-config ${PGRX_HOME}/${PGVER}/pgrx-install/bin/pg_config || exit $?
+cargo pgrx install --profile prof --manifest-path "${MANIFEST}" --package "${EXTENSION}" --pg-config "${PGRX_HOME}/${PGVER}/pgrx-install/bin/pg_config"
 
 cd "${HERE}" || exit
 pwd
-cargo run --release headless "${SUITE}" --log-file="${LOGFILE}" --runtime "${TIMEOUT}"
+cargo run --release -- headless "${SUITE}" --log-file="${LOGFILE}" --runtime "${TIMEOUT}"
 
 cargo run --release -- graph "${LOGFILE}" "${LOGFILE}".png && open "${LOGFILE}".png

--- a/stressgres/runtui.sh
+++ b/stressgres/runtui.sh
@@ -4,21 +4,21 @@ set -Eeuo pipefail
 
 PGVER=18.6
 EXTENSION=pg_search
-MANIFEST=~/_work/$1/Cargo.toml
-MANIFESTDIR=$(dirname "${MANIFEST}")
 PGRX_HOME=~/.pgrx
 
-SUITE="$2"
-HERE=$(pwd)
-
-if [ "$2" = "" ]; then
+if (( $# < 2 )); then
   echo "usage: runtui.sh <crate-name> <suite.toml>"
   exit 1
 fi
 
+MANIFEST=~/_work/$1/Cargo.toml
+MANIFESTDIR=$(dirname "${MANIFEST}")
+SUITE="$2"
+HERE=$(pwd)
+
 cd "${MANIFESTDIR}" || exit
-cargo pgrx install --profile prof --manifest-path "${MANIFEST}" --package ${EXTENSION} --pg-config ${PGRX_HOME}/${PGVER}/pgrx-install/bin/pg_config || exit $?
+cargo pgrx install --profile prof --manifest-path "${MANIFEST}" --package "${EXTENSION}" --pg-config "${PGRX_HOME}/${PGVER}/pgrx-install/bin/pg_config"
 
 cd "${HERE}" || exit
 pwd
-cargo run --release ui "${SUITE}" --paused
+cargo run --release -- ui "${SUITE}" --paused

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -81,7 +81,8 @@ pub enum Command {
     /// Parse a log file and generate an aggregated CSV report of contained data
     Csv(CsvArgs),
 
-    /// Given the location of a `pg_config` automatically spin up an transient Postgres cluster (or two, if logical replication is enabled)
+    /// Given the location of a `pg_config`, automatically spin up a transient Postgres cluster
+    /// (or two, if logical replication is enabled).
     Auto(AutoArgs),
 }
 
@@ -140,8 +141,7 @@ pub struct GraphArgs {
     /// Path to the log file produced by a headless run.
     pub log_path: PathBuf,
 
-    /// Output image file prefix (e.g. "output").
-    /// We will create: output_tps.png, output_block_count.png, output_segment_count.png
+    /// Output PNG path.
     #[arg(default_value = "output.png")]
     pub output: String,
 }
@@ -152,8 +152,7 @@ pub struct CsvArgs {
     /// Path to the log file produced by a headless run.
     pub log_path: PathBuf,
 
-    /// Output image file prefix (e.g. "output").
-    /// We will create: output_tps.png, output_block_count.png, output_segment_count.png
+    /// Output CSV path.
     #[arg(default_value = "output.csv")]
     pub output: String,
 }

--- a/stressgres/src/graph.rs
+++ b/stressgres/src/graph.rs
@@ -17,19 +17,13 @@
 
 // -----------------------------------------------------------------------------
 //
-// This module adds a "parse-logs" subcommand to Stressgres. It reads the
+// This module implements the "graph" subcommand. It reads the
 // line-based logs from headless mode output, parses them into time-series
-// records, and generates a single PNG file that includes five sub-charts:
-//
-//    1) TPS vs Time
-//    2) block_count vs Time
-//    3) segment_count vs Time
-//    4) cpu vs Time
-//    5) mem vs Time
+// records, and generates a single PNG file with one chart per metric.
 //
 // We parse any numeric metric encountered (e.g. 'tps=12.34', 'cpu=3.77').
 // Lines containing 'ERROR=' are ignored. The final PNG is saved to
-// <your-prefix>.png
+// the requested output path.
 
 use crate::cli::GraphArgs;
 use crate::metrics::group_by_job;
@@ -46,7 +40,7 @@ use plotters::style::full_palette::{
 };
 
 /// Main entry point for the "graph" subcommand.
-/// Parses the log file, then generates one PNG with 5 sub-charts side by side.
+/// Parses the log file, then generates one PNG containing a chart for each metric.
 pub fn run(args: &GraphArgs) -> Result<()> {
     let records = metrics::load_metrics_lines(&args.log_path)?;
     println!(
@@ -55,7 +49,7 @@ pub fn run(args: &GraphArgs) -> Result<()> {
         args.log_path.display()
     );
 
-    // Write one PNG file with 5 sub-charts side by side
+    // Write one PNG file containing every metric chart.
     let out_name = args.output.to_string();
     let metrics = metrics::discover_metric_names(&records);
 
@@ -99,7 +93,7 @@ fn generate_graph(metrics: &[String], records: &[MetricsLine], output_path: &str
         .into_drawing_area();
     root.fill(BGCOLOR)?;
 
-    // We'll carve out each sub-chart horizontally with a gap in between
+    // Stack the charts vertically with a gap in between.
     let mut remainder = root.clone();
     for (i, metric_name) in metrics.iter().enumerate() {
         // 1) Split off the sub-chart area

--- a/stressgres/src/sqlscanner.rs
+++ b/stressgres/src/sqlscanner.rs
@@ -283,7 +283,7 @@ INSERT INTO test (message) VALUES ('wine cheese a');
 INSERT INTO test (message) VALUES ('wine a');
 INSERT INTO test (message) VALUES ('cheese a');
 
--- INSERT INTO test (message) SELECT 'space fillter ' || x FROM generate_series(1, 10000000) x;
+-- INSERT INTO test (message) SELECT 'space filler ' || x FROM generate_series(1, 10000000) x;
 
 CREATE INDEX idxtest ON test USING paradedb (id, message) WITH (key_field = 'id');
 CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS $$

--- a/stressgres/suites/antithesis/eventually_verify_index_consistency.sh
+++ b/stressgres/suites/antithesis/eventually_verify_index_consistency.sh
@@ -13,7 +13,7 @@ CONN="postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/pa
 
 # EXECUTE keeps the pdb reference out of parse time: the vanilla-postgres timeline has no
 # pg_search extension, so the DO block must no-op there.
-SQL=$(cat <<'EOF'
+read -r -d '' SQL <<'EOF' || true
 DO $$
 DECLARE
     bad text;
@@ -37,7 +37,6 @@ BEGIN
 END
 $$;
 EOF
-)
 
 # The deadline is 1.5x the workload's own 200s reconnect-grace: that grace holds under active
 # fault injection, while this command runs with all faults stopped, so a database that is still

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,20 +17,26 @@ crate-type = ["rlib"]
 dst = ["proptest/antithesis", "dst/enabled"]
 
 [dependencies]
-approx = "0.5.1"
-# Antithesis hooks; the macros are type-checked no-ops until `dst/enabled`.
-dst = { path = "../dst" }
 anyhow = "1.0.102"
+approx = "0.5.1"
 async-std = { version = "1.13.2", features = ["attributes"] }
 bigdecimal = { version = "0.4.10", features = ["serde"] }
 bytes = "1.11.1"
 chrono = { version = "0.4.44", features = ["clock", "alloc"] }
 cmd_lib = "2.0.0"
 dotenvy = "0.15.7"
+# Antithesis hooks; the macros are type-checked no-ops until `dst/enabled`.
+dst = { path = "../dst" }
+env_logger = "0.11.10"
 futures = "0.3.32"
 lockfree-object-pool = "0.1.6"
+num-traits = "0.2.19"
 pgvector = { version = "0.4.1", features = ["sqlx"] }
 pretty_assertions = "1.4.1"
+# Fork adds RngAlgorithm::Antithesis (crate version still 1.11.0).
+proptest = { git = "https://github.com/antithesishq/proptest", rev = "6061eb48d67ff76f882e709677308816d5791ce7" }
+# Stays on crates.io: the antithesis feature does not touch the derive crate.
+proptest-derive = "0.8.0"
 rand = "0.10.2"
 rstest = "0.26.1"
 rustc-hash = "2.1.2"
@@ -56,9 +62,3 @@ tokio = { version = "1.52.1", features = [
   "sync",
 ] }
 uuid = "1.23.1"
-num-traits = "0.2.19"
-# Fork adds RngAlgorithm::Antithesis (crate version still 1.11.0).
-proptest = { git = "https://github.com/antithesishq/proptest", rev = "6061eb48d67ff76f882e709677308816d5791ce7" }
-# Stays on crates.io: the antithesis feature does not touch the derive crate.
-proptest-derive = "0.8.0"
-env_logger = "0.11.10"

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ For a complete overview of ParadeDB's testing infrastructure (including unit tes
 
 ## Client Property Tests
 
-A particularly interesting subcategory of integration tests are our client property tests. Most of the client property tests live in [`qgen.rs`](tests/qgen.rs), but there are other files which use `crate::fixtures::querygen` to generate tests as well.
+Client property tests are a particularly interesting subcategory of integration tests. Most live in [`qgen.rs`](tests/qgen.rs), but other files also use `crate::fixtures::querygen` to generate tests.
 
 ## Environment Variables
 
@@ -20,19 +20,23 @@ DATABASE_URL=postgres://USER_NAME@localhost:PORT/pg_search
 
 `PORT` should be replaced with 28800 plus your PostgreSQL major version (for example, 28818 for PostgreSQL 18).
 
+Some tests also require `PG_CONFIG` to point to the `pg_config` binary for the PostgreSQL installation under test. The logical-replication test requires it, while the dump/restore test is skipped when it is not set.
+
 ## Running Tests with pgrx-managed PostgreSQL
 
 If you are using pgrx’s bundled PostgreSQL, follow these steps from the root of the repository:
 
 ```shell
-#! /bin/sh
+#!/bin/sh
 
 set -x
-export DATABASE_URL=postgresql://$(whoami)@localhost:28818/pg_search
+export DATABASE_URL="postgresql://$(whoami)@localhost:28818/pg_search"
+export PG_CONFIG="$HOME/.pgrx/18.6/pgrx-install/bin/pg_config"
 export RUST_BACKTRACE=1
 cargo pgrx stop --package pg_search
-cargo pgrx install --package pg_search --pg-config ~/.pgrx/18.6/pgrx-install/bin/pg_config
+cargo pgrx install --package pg_search --pg-config "$PG_CONFIG"
 cargo pgrx start --package pg_search
+createdb -h localhost -p 28818 pg_search || true
 
 cargo test --package tests
 ```
@@ -41,16 +45,18 @@ cargo test --package tests
 
 If you are using a self-hosted PostgreSQL installation, make sure your PostgreSQL server is already running, create a `pg_search` database on it,
 and install the `pg_search` extension files into that PostgreSQL instance instead of pgrx's bundled Postgres.
+The example below uses Homebrew's PostgreSQL 18 path; replace `PG_CONFIG` with the path to your installation's `pg_config` binary.
 
 ```shell
-#! /bin/sh
+#!/bin/sh
 
 set -x
-export DATABASE_URL=postgresql://$(whoami)@localhost:5432/pg_search
+export DATABASE_URL="postgresql://$(whoami)@localhost:5432/pg_search"
+export PG_CONFIG=/opt/homebrew/opt/postgresql@18/bin/pg_config
 export RUST_BACKTRACE=1
 
 createdb pg_search || true
-cargo pgrx install --package pg_search --pg-config /opt/homebrew/opt/postgresql@18/bin/pg_config
+cargo pgrx install --package pg_search --pg-config "$PG_CONFIG"
 
 cargo test --package tests
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,7 +27,7 @@ Some tests also require `PG_CONFIG` to point to the `pg_config` binary for the P
 If you are using pgrx’s bundled PostgreSQL, follow these steps from the root of the repository:
 
 ```shell
-#!/bin/sh
+#!/bin/bash
 
 set -x
 export DATABASE_URL="postgresql://$(whoami)@localhost:28818/pg_search"
@@ -48,7 +48,7 @@ and install the `pg_search` extension files into that PostgreSQL instance instea
 The example below uses Homebrew's PostgreSQL 18 path; replace `PG_CONFIG` with the path to your installation's `pg_config` binary.
 
 ```shell
-#!/bin/sh
+#!/bin/bash
 
 set -x
 export DATABASE_URL="postgresql://$(whoami)@localhost:5432/pg_search"

--- a/tests/antithesis/singleton_driver_property-tests.sh
+++ b/tests/antithesis/singleton_driver_property-tests.sh
@@ -3,7 +3,7 @@
 # Antithesis singleton driver: runs the `qgen` property tests once against the
 # in-cluster ParadeDB primary, with concurrency forced on and a server-side
 # statement_timeout enforced (see PARADEDB_FORCE_PARALLEL and
-# PARADEDB_QGEN_STATEMENT_TIMEOUT_MS in tests/tests/fixtures/querygen/mod.rs).
+# PARADEDB_QGEN_STATEMENT_TIMEOUT_MS in tests/src/fixtures/querygen/mod.rs).
 #
 # Antithesis singleton drivers must finish within the test duration; qgen
 # already iterates internally (24 tests * PROPTEST_CASES proptest cases each),


### PR DESCRIPTION
## Summary

- correct the architecture guide's description of mutable-segment buffering and PostgreSQL parallel execution
- refresh integration-test setup, dependency organization, paths, and shell examples
- audit Stressgres helpers, CLI guidance, package metadata, and Antithesis scripts
- fix Stressgres argument handling and Cargo invocation, plus a macOS Bash compatibility issue in the Antithesis consistency check
- update `THANKYOU.md` with pgvector, Lindera, DataFusion Distributed, and Apache Arrow
- correct packaging and `pg_regress` terminology in `CONTRIBUTING.md`

## Validation

- repository commit hooks
- `cargo test -p stressgres --no-default-features`
- `cargo test --package tests --no-run`
- `cargo fmt --all -- --check`
- `bash -n` and `shellcheck` on the changed shell scripts
- verified every Stressgres suite has a matching Antithesis setup script
- `mint validate`
- `mint broken-links`

## References

- [PostgreSQL parallel plans](https://www.postgresql.org/docs/current/parallel-plans.html)
