### PR TITLE
perf: MVCC-safe all-visible gate for the bare-count fast path

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -369,6 +369,42 @@ impl ParallelWorker for ParallelAggregationWorker<'_> {
     }
 }
 
+/// True if every page of the index's heap relation is all-visible according to the visibility
+/// map, in which case every document the index returns is visible to the current snapshot and
+/// per-document MVCC checks can be skipped.
+///
+/// Caller must be in a path that already holds at least AccessShareLock on `heaprel` for the
+/// statement's duration (true in the executor, where the heap is range-table-locked): the two
+/// reads below take no lock of their own and are only safe because concurrent truncation is
+/// excluded. The reads are not atomic either — extension between them biases toward `false`,
+/// never toward a false `true` (new pages are never all-visible).
+fn heap_is_all_visible(heaprel: &PgSearchRelation) -> bool {
+    unsafe {
+        let nblocks = pg_sys::RelationGetNumberOfBlocksInFork(
+            heaprel.as_ptr(),
+            pg_sys::ForkNumber::MAIN_FORKNUM,
+        );
+        let mut all_visible: pg_sys::BlockNumber = 0;
+        pg_sys::visibilitymap_count(heaprel.as_ptr(), &mut all_visible, std::ptr::null_mut());
+        all_visible == nblocks
+    }
+}
+
+/// Wrap a raw matched-doc count in the [`AggregationResults`] shape the caller expects.
+/// Key "0" matches `CollectAggregations::collect`'s enumeration of the single aggregate.
+fn bare_count_results(count: f64) -> AggregationResults {
+    let mut results = AggregationResults::default();
+    results.0.insert(
+        "0".to_string(),
+        tantivy::aggregation::agg_result::AggregationResult::MetricResult(
+            tantivy::aggregation::agg_result::MetricResult::Count(
+                tantivy::aggregation::metric::SingleMetricResult { value: Some(count) },
+            ),
+        ),
+    );
+    results
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn execute_aggregate(
     index: &PgSearchRelation,
@@ -425,24 +461,28 @@ pub fn execute_aggregate(
         // `Weight::count` — a stored-doc_freq metadata read for term queries
         // on delete-free segments, a scoreless docset drain otherwise —
         // skipping the aggregation framework's per-doc column iteration.
-        if !solve_mvcc
+        //
+        // With `solve_mvcc`, this is only valid when every heap page is all-visible: then every
+        // document in the index snapshot is visible, which is the whole-table version of the
+        // per-block visibility-map check `MVCCFilterCollector` would otherwise perform per
+        // document.
+        // Queries with heap-field filters are excluded: their per-document heap
+        // expression evaluation dominates the count and parallelizes across
+        // workers, which the framework path keeps and this leader-only path
+        // forfeits. Single-threaded the two paths measure at parity, so the
+        // exclusion costs nothing where the fast path would otherwise win.
+        if !query.has_heap_filter()
             && matches!(&agg_req, AggregateRequest::Sql(clause) if clause.is_bare_doc_count())
         {
-            let count = reader.count_matched_docs()?;
-            let mut results = AggregationResults::default();
-            // Key "0" matches `CollectAggregations::collect`'s enumeration of
-            // the single aggregate.
-            results.0.insert(
-                "0".to_string(),
-                tantivy::aggregation::agg_result::AggregationResult::MetricResult(
-                    tantivy::aggregation::agg_result::MetricResult::Count(
-                        tantivy::aggregation::metric::SingleMetricResult {
-                            value: Some(count as f64),
-                        },
-                    ),
-                ),
-            );
-            return Ok(results);
+            let skip_mvcc = !solve_mvcc
+                || index
+                    .heap_relation()
+                    .map(|heaprel| heap_is_all_visible(&heaprel))
+                    .unwrap_or(false);
+            if skip_mvcc {
+                let count = reader.count_matched_docs()?;
+                return Ok(bare_count_results(count as f64));
+            }
         }
 
         let ambulkdelete_epoch = MetaPage::open(index).ambulkdelete_epoch();

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -473,6 +473,39 @@ impl SearchQueryInput {
         }
     }
 
+    /// Returns `true` if any part of this query evaluates a heap-field filter
+    /// (a Postgres expression checked per candidate document against the heap,
+    /// e.g. an ILIKE alongside an indexed predicate). Such queries should not
+    /// take count fast paths that drain a raw scorer: the per-document heap
+    /// evaluation dominates, and the aggregation framework path handles it.
+    pub fn has_heap_filter(&self) -> bool {
+        match self {
+            SearchQueryInput::HeapFilter { .. } => true,
+
+            SearchQueryInput::Boolean {
+                must,
+                should,
+                must_not,
+                ..
+            } => must
+                .iter()
+                .chain(should.iter())
+                .chain(must_not.iter())
+                .any(Self::has_heap_filter),
+            SearchQueryInput::Boost { query, .. }
+            | SearchQueryInput::ConstScore { query, .. }
+            | SearchQueryInput::WithIndex { query, .. } => query.has_heap_filter(),
+            SearchQueryInput::DisjunctionMax { disjuncts, .. } => {
+                disjuncts.iter().any(Self::has_heap_filter)
+            }
+            SearchQueryInput::ScoreFilter {
+                query: Some(query), ..
+            } => query.has_heap_filter(),
+
+            _ => false,
+        }
+    }
+
     /// Returns `true` if constructing a Tantivy Scorer for this query would be expensive.
     /// Used by `estimate_selectivity` to short-circuit and return a heuristic instead.
     pub fn is_expensive_to_estimate(&self) -> bool {


### PR DESCRIPTION
## What

#5947 added a fast path for bare doc counts (`COUNT(*)`, or a single `value_count` over the key field or ctid). It answers them from `Weight::count`. It only fires when `solve_mvcc` is off.

This PR extends the gate. When every heap page is all-visible in the visibility map, the fast path now also fires with MVCC on. MVCC on is the default for `count(*)`.

Queries with heap-field filters (a Postgres expression evaluated per candidate document, e.g. `tags @@@ pdb.regex(…) AND tags ILIKE …`) are excluded from the fast path, including from the pre-existing `solve_mvcc`-off branch. Their per-document heap evaluation dominates the count and parallelizes across workers; the leader-only fast path forfeits that (6.5× on the `regex-and-heap` benchmark) while measuring at parity single-threaded, so they keep the framework path.

**Caveat:** the gate is all-or-nothing. One dead tuple disables the fast path for the whole table. Even one LP_DEAD line pointer left by vacuum's index-cleanup bypass does this. Plain `VACUUM` does not always fix it. `VACUUM (INDEX_CLEANUP ON)` fixes it. While the gate is off, counts use the normal path. The gate is on only between a vacuum that marks the whole table all-visible and the next write. A static table stays on after one vacuum. An append-only table comes back on after each autovacuum. A table with update or delete churn depends on vacuum keeping up — and because the index-cleanup bypass fires exactly when few tuples are dead, a lightly-churned table can stay off until a manual `VACUUM (INDEX_CLEANUP ON)`.

## Why

The default `count(*)` currently runs the full aggregation framework. Benchmark: 40-term HN-items count mix, ~30M rows, 1 VU, 30-second runs, clean all-visible index.

| | p50 | p95 | qps |
|---|---|---|---|
| main, `count(*)` (MVCC on) | 17.79 ms | 32.07 ms | 57 |
| main, `pdb.agg(…, false)` (MVCC off, #5947 path) | 1.12 ms | 1.90 ms | 812 |
| **this PR, `count(*)` (MVCC on)** | **1.41 ms** | **2.34 ms** | **649** |

p95 drops 93%. The default, MVCC-correct count now matches the speed that before required turning MVCC off. The gap between the last two rows is index state, not the VM check: the patched run's index carried a delete in one large segment, and any delete disables that segment's stored-doc_freq shortcut. The VM check itself costs nothing measurable.

Multi-term and phrase counts use the same gate. They cannot use the stored doc_freq, so `Weight::count` walks their postings. The win is smaller but still 3.4–9×. Conditions: warm single-query timings, this PR with MVCC on vs main with MVCC on, clean all-visible index.

| query | matches | main | this PR |
|---|---|---|---|
| `show hn` `\|\|\|` (OR) | 267,065 | 64.0 ms | 7.3 ms |
| `show hn` `&&&` (AND) | 110,535 | 50.4 ms | 7.6 ms |
| `show hn` `###` (phrase) | 110,211 | 59.4 ms | 17.5 ms |
| `machine learning` `\|\|\|` | 44,339 | 37.7 ms | 5.3 ms |
| `open source` `\|\|\|` | 59,328 | 41.4 ms | 5.6 ms |

## How

An all-visible page holds only tuples that every current snapshot can see. Index-only scans rely on the same rule. If the whole table is all-visible, no document needs an MVCC check. So we compare `visibilitymap_count` with the relation's block count, once per query. If they match, `count_matched_docs()` (from #5947) answers directly.

The helper takes no lock of its own. It relies on the AccessShareLock the executor already holds on the heap. That lock blocks concurrent truncation. The two reads are not atomic, but a race can only make the check return false. It can never produce a wrong true. This contract is documented on the function.

## Tests

- 7 of 7 single-term counts match an unpatched instance. This includes a multi-word term and a zero-match term.
- All 9 two-word combinations (OR / AND / phrase × 3 terms) return the same count on every path.
- MVCC: an uncommitted UPDATE that removes a match lowers the in-transaction count by 1. Rollback restores it (via the fallback path, because the heap is now dirty). Vacuum restores the fast path.
- Empty table: the gate reports all-visible, which is correct. An empty heap means an empty visible index.
