### PR TITLE
perf: lazy blocklist chunk directory for reader lookups

### DIFF
--- a/pg_search/src/postgres/storage/blocklist.rs
+++ b/pg_search/src/postgres/storage/blocklist.rs
@@ -497,6 +497,7 @@ pub mod reader {
             Self { blocks }
         }
 
+        #[allow(dead_code)]
         pub fn get(&self, i: usize) -> Option<pg_sys::BlockNumber> {
             self.blocks.get(i).cloned()
         }
@@ -508,6 +509,227 @@ pub mod reader {
 
         fn into_iter(self) -> Self::IntoIter {
             self.blocks.into_iter()
+        }
+    }
+
+    /// Lazily-parsed view of a blocklist, for point `get(ord)` lookups.
+    ///
+    /// The eager [`BlockList`] decompresses every ord -> blockno mapping up
+    /// front, which for large files means walking every blocklist page and
+    /// bit-unpacking hundreds of thousands of entries per reader — even when
+    /// a query resolves only a handful of ordinals. This variant parses chunk
+    /// headers incrementally (stopping as soon as the requested ordinal is
+    /// covered) and decompresses only the single chunk a lookup lands in,
+    /// memoizing the last decoded chunk. State lives only as long as the
+    /// reader (one query), so first-access cost is unchanged.
+    pub struct LazyBlockList {
+        state: std::cell::UnsafeCell<LazyState>,
+    }
+
+    // SAFETY: Postgres backends are single-threaded.
+    unsafe impl Send for LazyBlockList {}
+    unsafe impl Sync for LazyBlockList {}
+
+    impl std::fmt::Debug for LazyBlockList {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("LazyBlockList(..)")
+        }
+    }
+
+    struct ChunkMeta {
+        start_ord: usize,
+        len: usize,
+        blockno: pg_sys::BlockNumber,
+        /// offset of the chunk's tag byte within its page slice
+        tag_offset: usize,
+    }
+
+    struct LazyState {
+        chunks: Vec<ChunkMeta>,
+        covered: usize,
+        next_blockno: pg_sys::BlockNumber,
+        decoded: Option<(usize, Vec<pg_sys::BlockNumber>)>,
+    }
+
+    impl LazyBlockList {
+        pub fn new(starting_block: pg_sys::BlockNumber) -> Self {
+            Self {
+                state: std::cell::UnsafeCell::new(LazyState {
+                    chunks: Vec::new(),
+                    covered: 0,
+                    next_blockno: starting_block,
+                    decoded: None,
+                }),
+            }
+        }
+
+        pub fn get(&self, ord: usize, bman: &BufferManager) -> Option<pg_sys::BlockNumber> {
+            // SAFETY: Postgres backends are single-threaded.
+            let state = unsafe { &mut *self.state.get() };
+            while ord >= state.covered && state.next_blockno != pg_sys::InvalidBlockNumber {
+                Self::parse_next_page(state, bman);
+            }
+            if ord >= state.covered {
+                return None;
+            }
+            if let Some((idx, blocks)) = &state.decoded {
+                let meta = &state.chunks[*idx];
+                if ord >= meta.start_ord && ord < meta.start_ord + meta.len {
+                    return Some(blocks[ord - meta.start_ord]);
+                }
+            }
+            let idx = state.chunks.partition_point(|c| c.start_ord <= ord) - 1;
+            let blocks = Self::decode_chunk(&state.chunks[idx], bman);
+            let block = blocks.get(ord - state.chunks[idx].start_ord).copied();
+            state.decoded = Some((idx, blocks));
+            block
+        }
+
+        /// Parse the chunk headers of the next blocklist page into the
+        /// directory, without decompressing any chunk payloads.
+        fn parse_next_page(state: &mut LazyState, bman: &BufferManager) {
+            let blockno = state.next_blockno;
+            let block = bman.get_buffer(blockno);
+            let page = block.page();
+            let slice = page.as_slice();
+
+            let mut offset = 0;
+            loop {
+                let tag_offset = offset;
+                let tag = ChunkStyleTag::from(slice[offset]);
+                offset += 1;
+                let (len, payload) = match tag {
+                    ChunkStyleTag::Sorted1x | ChunkStyleTag::StrictlySorted1x => {
+                        let num_bits = slice[offset] as usize;
+                        offset += 1 + size_of::<pg_sys::BlockNumber>();
+                        (
+                            BitPacker1x::BLOCK_LEN,
+                            num_bits * BitPacker1x::BLOCK_LEN / 8,
+                        )
+                    }
+                    ChunkStyleTag::Sorted4x | ChunkStyleTag::StrictlySorted4x => {
+                        let num_bits = slice[offset] as usize;
+                        offset += 1 + size_of::<pg_sys::BlockNumber>();
+                        (
+                            BitPacker4x::BLOCK_LEN,
+                            num_bits * BitPacker4x::BLOCK_LEN / 8,
+                        )
+                    }
+                    ChunkStyleTag::Sorted8x | ChunkStyleTag::StrictlySorted8x => {
+                        let num_bits = slice[offset] as usize;
+                        offset += 1 + size_of::<pg_sys::BlockNumber>();
+                        (
+                            BitPacker8x::BLOCK_LEN,
+                            num_bits * BitPacker8x::BLOCK_LEN / 8,
+                        )
+                    }
+                    ChunkStyleTag::Uncompressed => {
+                        let len = slice[offset] as usize;
+                        offset += 1;
+                        (len, len * size_of::<pg_sys::BlockNumber>())
+                    }
+                };
+                offset += payload;
+                state.chunks.push(ChunkMeta {
+                    start_ord: state.covered,
+                    len,
+                    blockno,
+                    tag_offset,
+                });
+                state.covered += len;
+                if offset >= slice.len() {
+                    break;
+                }
+            }
+
+            state.next_blockno = page.special::<BM25PageSpecialData>().next_blockno;
+        }
+
+        /// Decompress a single chunk's blocknos.
+        fn decode_chunk(meta: &ChunkMeta, bman: &BufferManager) -> Vec<pg_sys::BlockNumber> {
+            let block = bman.get_buffer(meta.blockno);
+            let page = block.page();
+            let slice = page.as_slice();
+
+            let mut offset = meta.tag_offset;
+            let tag = ChunkStyleTag::from(slice[offset]);
+            offset += 1;
+            let mut blocks = vec![0; meta.len];
+            match tag {
+                ChunkStyleTag::Uncompressed => {
+                    offset += 1;
+                    let mut tmp = [0u8; size_of::<pg_sys::BlockNumber>()];
+                    for entry in blocks.iter_mut() {
+                        tmp.copy_from_slice(
+                            &slice[offset..offset + size_of::<pg_sys::BlockNumber>()],
+                        );
+                        offset += size_of::<pg_sys::BlockNumber>();
+                        *entry = u32::from_le_bytes(tmp);
+                    }
+                }
+                tag => {
+                    let num_bits = slice[offset];
+                    offset += 1;
+                    let initial = u32::from_le_bytes(
+                        slice[offset..offset + size_of::<pg_sys::BlockNumber>()]
+                            .try_into()
+                            .unwrap(),
+                    );
+                    offset += size_of::<pg_sys::BlockNumber>();
+                    match tag {
+                        ChunkStyleTag::Sorted1x => {
+                            BitPacker1x::new().decompress_sorted(
+                                initial,
+                                &slice[offset..],
+                                &mut blocks,
+                                num_bits,
+                            );
+                        }
+                        ChunkStyleTag::Sorted4x => {
+                            BitPacker4x::new().decompress_sorted(
+                                initial,
+                                &slice[offset..],
+                                &mut blocks,
+                                num_bits,
+                            );
+                        }
+                        ChunkStyleTag::Sorted8x => {
+                            BitPacker8x::new().decompress_sorted(
+                                initial,
+                                &slice[offset..],
+                                &mut blocks,
+                                num_bits,
+                            );
+                        }
+                        ChunkStyleTag::StrictlySorted1x => {
+                            BitPacker1x::new().decompress_strictly_sorted(
+                                (initial != 0).then_some(initial),
+                                &slice[offset..],
+                                &mut blocks,
+                                num_bits,
+                            );
+                        }
+                        ChunkStyleTag::StrictlySorted4x => {
+                            BitPacker4x::new().decompress_strictly_sorted(
+                                (initial != 0).then_some(initial),
+                                &slice[offset..],
+                                &mut blocks,
+                                num_bits,
+                            );
+                        }
+                        ChunkStyleTag::StrictlySorted8x => {
+                            BitPacker8x::new().decompress_strictly_sorted(
+                                (initial != 0).then_some(initial),
+                                &slice[offset..],
+                                &mut blocks,
+                                num_bits,
+                            );
+                        }
+                        ChunkStyleTag::Uncompressed => unreachable!(),
+                    }
+                }
+            }
+            blocks
         }
     }
 }

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -107,7 +107,7 @@ impl<T> UnsafeCache<T> {
 pub struct LinkedBytesList {
     bman: BufferManager,
     pub header_blockno: pg_sys::BlockNumber,
-    blocklist_reader: OnceLock<blocklist::reader::BlockList>,
+    blocklist_reader: OnceLock<blocklist::reader::LazyBlockList>,
     cache: UnsafeCache<CacheEntry>,
 }
 
@@ -225,12 +225,9 @@ impl LinkedList for LinkedBytesList {
     fn block_for_ord(&self, ord: usize) -> Option<pg_sys::BlockNumber> {
         self.blocklist_reader
             .get_or_init(|| {
-                blocklist::reader::BlockList::new(
-                    &self.bman,
-                    self.get_linked_list_data().blocklist_start,
-                )
+                blocklist::reader::LazyBlockList::new(self.get_linked_list_data().blocklist_start)
             })
-            .get(ord)
+            .get(ord, &self.bman)
     }
 }
 
@@ -334,15 +331,14 @@ impl LinkedBytesList {
     ///
     /// We take care of this, elsewhere, through our constructs like the `PinCushion`, the `MergeLock`,
     /// and atomically managing the segment entries list through an atomic copy-on-write approach.
-    pub fn freeable_blocks(mut self) -> impl Iterator<Item = pg_sys::BlockNumber> {
+    pub fn freeable_blocks(self) -> impl Iterator<Item = pg_sys::BlockNumber> {
         // in addition to the list itself, we also have a secondary list of linked blocks (which
         // contain the blocknumbers of this list) that needs to be marked deleted too
 
         let mut blocklist_blockno = self.get_linked_list_data().blocklist_start;
         // iterate the BlockList contents -- this is every block used by this LinkedBytesList
-        self.blocklist_reader
-            .take()
-            .unwrap_or_else(|| blocklist::reader::BlockList::new(&self.bman, blocklist_blockno))
+        // (eager materialization is fine here: freeing is a cold path that needs every block)
+        blocklist::reader::BlockList::new(&self.bman, blocklist_blockno)
             .into_iter()
             // include our header page
             .chain(std::iter::once(self.header_blockno))

--- a/pg_search/tests/pg_regress/expected/recursive_estimates.out
+++ b/pg_search/tests/pg_regress/expected/recursive_estimates.out
@@ -917,9 +917,9 @@ EXPLAIN (ANALYZE, VERBOSE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT * FROM rec
    Exec Method: NormalScanExecState
    Scores: false
    Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"running shoes","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true},"estimated_docs":1}},"estimated_docs":1}
-   Buffers: shared hit=23
+   Buffers: shared hit=26
  Planning:
-   Buffers: shared hit=45
+   Buffers: shared hit=49
 (14 rows)
 
 -- Test 7.3: Verify EXPLAIN without VERBOSE does NOT show estimates


### PR DESCRIPTION
## What

pg_search creates a new index reader for every query. Today each reader open eagerly decodes the full blocklist of every file it touches: the bitpacked ord→blockno mapping, often hundreds of thousands of entries. A query then resolves only a handful of ordinals from it.

This PR makes the blocklist lazy. The chunk directory is parsed incrementally, only the chunk a lookup lands in is decompressed, and the last chunk is memoized per reader. The state lives for one reader only. There is no cross-query cache, and the on-disk format does not change.

## Why

Profiles showed the eager decode as pure per-query waste: `BlockList::new` at 2.5–3.7% of cycles, allocation churn from unreserved Vec growth, and one buffer lookup per blocklist page per file per query.

Benchmark: 40-term HN-items top-10 mix, ~30M rows, 1 VU, 30-second runs, same index for both builds.

| | p50 | p95 | qps |
|---|---|---|---|
| main | 1.98 ms | 5.14 ms | 419 |
| **this PR** | **1.73 ms** | **4.81 ms** | **479** |

p50 drops 13%, p95 drops 6.4%, throughput rises 14%. The result repeated across two runs (p95 4.814 / 4.815 ms).

The win scales with segment and file count, because the eager decode is paid per file. This index has 7 segments. An earlier campaign measured the same change on a 32-segment index and saw first-10-query cold latency fall from 26.7 ms to 6 ms. On the 7-segment index, cold behavior is unchanged to slightly better.

Every reader open pays the eager decode today, so counts and aggregates benefit as well as search.

## How

`LazyBlockList` replaces the eager `BlockList` on the reader path. It parses chunk headers only until the requested ordinal is covered, decompresses just that chunk, and keeps the last decoded chunk for repeat lookups. Writers are unchanged. The eager decoder remains for the paths that genuinely need the full list.

## Tests

- Top-10 results (ids and scores to 4 decimal places, deterministic tie-break) are byte-identical between this build and main on the same index, for 5 terms including a multi-word term: 50 of 50 rows.
- Existing unit tests pass; the change is confined to `storage/blocklist.rs` and `storage/linked_bytes.rs`.



