### PR TITLE
ci: audit GitHub automation and templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/announcements.yml
+++ b/.github/DISCUSSION_TEMPLATE/announcements.yml
@@ -1,5 +1,4 @@
 title: "[Announcements] "
-labels: ["announcement"]
 body:
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -5,12 +5,11 @@ body:
     attributes:
       value: >
         This discussion type is for anything that doesn't fit in another category. If you are looking to raise an issue,
-        please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
+        please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
           * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
-          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
-          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
+          * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -8,12 +8,12 @@ body:
         please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
           * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
           * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
-          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
-          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -13,7 +13,6 @@ body:
           * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
-          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -5,10 +5,12 @@ body:
     attributes:
       value: >
         This discussion type is for anything that doesn't fit in another category. If you are looking to raise an issue,
-        please use the ParadeDB issue tracker:
+        please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
 
-          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
-          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
+          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
+          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -8,7 +8,12 @@ body:
         please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
+          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -5,10 +5,10 @@ body:
     attributes:
       value: >
         This discussion type is for anything that doesn't fit in another category. If you are looking to raise an issue,
-        please do so on the relevant ParadeDB repository:
+        please use the ParadeDB issue tracker:
 
-          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
-          * [paradedb/charts](https://github.com/paradedb/charts/issues/new/) - ParadeDB Helm Chart repository
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
+          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -8,12 +8,12 @@ body:
         please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
           * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
           * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
-          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
-          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,5 +1,5 @@
 title: "[Ideas] "
-labels: ["feature", "idea", "suggestion"]
+labels: ["feature"]
 body:
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -13,7 +13,6 @@ body:
           * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
-          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -5,12 +5,11 @@ body:
     attributes:
       value: >
         This discussion type is for discussing ideas and feature requests for ParadeDB. If you are looking to raise an issue,
-        please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
+        please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
           * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
-          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
-          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
+          * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -5,10 +5,12 @@ body:
     attributes:
       value: >
         This discussion type is for discussing ideas and feature requests for ParadeDB. If you are looking to raise an issue,
-        please use the ParadeDB issue tracker:
+        please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
 
-          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
-          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
+          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
+          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -5,10 +5,10 @@ body:
     attributes:
       value: >
         This discussion type is for discussing ideas and feature requests for ParadeDB. If you are looking to raise an issue,
-        please do so on the relevant ParadeDB repository:
+        please use the ParadeDB issue tracker:
 
-          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
-          * [paradedb/charts](https://github.com/paradedb/charts/issues/new/) - ParadeDB Helm Chart repository
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
+          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -8,7 +8,12 @@ body:
         please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
+          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -8,12 +8,12 @@ body:
         please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
           * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
           * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
-          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
-          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -5,12 +5,11 @@ body:
     attributes:
       value: >
         This discussion type is for questions about ParadeDB. If you are looking to raise an issue,
-        please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
+        please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
           * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
-          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
-          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
+          * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -13,7 +13,6 @@ body:
           * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
-          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -5,10 +5,12 @@ body:
     attributes:
       value: >
         This discussion type is for questions about ParadeDB. If you are looking to raise an issue,
-        please use the ParadeDB issue tracker:
+        please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
 
-          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
-          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
+          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
+          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -5,10 +5,10 @@ body:
     attributes:
       value: >
         This discussion type is for questions about ParadeDB. If you are looking to raise an issue,
-        please do so on the relevant ParadeDB repository:
+        please use the ParadeDB issue tracker:
 
-          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
-          * [paradedb/charts](https://github.com/paradedb/charts/issues/new/) - ParadeDB Helm Chart repository
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
+          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -8,7 +8,12 @@ body:
         please use the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
+          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,12 +1,1 @@
-# These are supported funding model platforms
-
-github: [paradedb] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github: paradedb

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,10 +9,12 @@ body:
   - type: markdown
     attributes:
       value: >
-        ParadeDB has multiple components. Please use the following links to report issues or inspect the relevant source:
+        ParadeDB components live across several repositories. Please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
 
-          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
-          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
+          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
+          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,12 +9,11 @@ body:
   - type: markdown
     attributes:
       value: >
-        ParadeDB components live across several repositories. Please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
+        ParadeDB components live across several repositories. Please file your report in the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
           * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
-          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
-          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
+          * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,6 @@ body:
           * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
-          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,10 +9,10 @@ body:
   - type: markdown
     attributes:
       value: >
-        ParadeDB has other repositories for different components. Please make sure you are filing your issue in the correct repository:
+        ParadeDB has multiple components. Please use the following links to report issues or inspect the relevant source:
 
-          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
-          * [paradedb/charts](https://github.com/paradedb/charts/issues/new/) - ParadeDB Helm Chart repository
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core, the pg_search extension, and the Helm chart
+          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,12 +12,12 @@ body:
         ParadeDB components live across several repositories. Please file your report in the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
           * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
           * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
-          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
-          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,12 @@ body:
         ParadeDB components live across several repositories. Please file your report in the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Issues for ParadeDB core and the pg_search extension
-          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
+          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,12 +9,12 @@ body:
         ParadeDB components live across several repositories. Please file your request in the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Requests for ParadeDB core and the pg_search extension
-          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
           * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
           * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
-          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
-          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,10 +6,10 @@ body:
   - type: markdown
     attributes:
       value: >
-        ParadeDB has other repositories for different components. Please make sure you are filing your issue in the correct repository:
+        ParadeDB has multiple components. Please use the following links to request features or inspect the relevant source:
 
-          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
-          * [paradedb/charts](https://github.com/paradedb/charts/issues/new/) - ParadeDB Helm Chart repository
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Requests for ParadeDB core, the pg_search extension, and the Helm chart
+          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,12 +6,11 @@ body:
   - type: markdown
     attributes:
       value: >
-        ParadeDB components live across several repositories. Please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
+        ParadeDB components live across several repositories. Please file your request in the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Requests for ParadeDB core and the pg_search extension
           * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
-          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
-          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
+          * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,10 +6,12 @@ body:
   - type: markdown
     attributes:
       value: >
-        ParadeDB has multiple components. Please use the following links to request features or inspect the relevant source:
+        ParadeDB components live across several repositories. Please use the most relevant repository; if it has Issues disabled, file in the core issue tracker:
 
-          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Requests for ParadeDB core, the pg_search extension, and the Helm chart
-          * [paradedb/charts](https://github.com/paradedb/charts) - ParadeDB Helm chart source and documentation
+          * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Requests for ParadeDB core and the pg_search extension
+          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * Developer and AI tooling - [Agent Skills](https://github.com/paradedb/agent-skills), [Benchmarker](https://github.com/paradedb/benchmarker), [Cursor plugin](https://github.com/paradedb/cursor-plugin), and [GitHub Actions](https://github.com/paradedb/actions)
+          * Deployment integrations - [Helm charts](https://github.com/paradedb/charts) and [Render blueprint](https://github.com/paradedb/render-blueprint)
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,6 @@ body:
           * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
           * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
-          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,12 @@ body:
         ParadeDB components live across several repositories. Please file your request in the most relevant issue tracker:
 
           * [ParadeDB issue tracker](https://github.com/paradedb/paradedb/issues/new/choose) - Requests for ParadeDB core and the pg_search extension
-          * ORM integrations - [Django](https://github.com/paradedb/django-paradedb), [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Entity Framework Core](https://github.com/paradedb/efcore-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb)
+          * [Django](https://github.com/paradedb/django-paradedb) - ParadeDB integration for Django
+          * [Drizzle](https://github.com/paradedb/drizzle-paradedb) - ParadeDB integration for Drizzle
+          * [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) - ParadeDB integration for Entity Framework Core
+          * [Prisma](https://github.com/paradedb/prisma-paradedb) - ParadeDB integration for Prisma
+          * [Rails](https://github.com/paradedb/rails-paradedb) - ParadeDB integration for Rails and Active Record
+          * [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) - ParadeDB integration for SQLAlchemy
           * [Benchmarker](https://github.com/paradedb/benchmarker) - Database benchmarking suite
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -58,6 +58,11 @@ runs:
     - name: Run Benchmarks
       working-directory: benchmarks/
       shell: bash
+      env:
+        DATASET: ${{ inputs.dataset }}
+        FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
+        INDEX: ${{ inputs.index }}
+        SIZE: ${{ inputs.size }}
       run: |
         POSTGRES_URL="postgresql://$(whoami)@localhost:288${{ env.pg_version }}/postgres"
 
@@ -65,14 +70,14 @@ runs:
         # index and runs queries against it.
         cargo run --release -- benchmark \
           --url "${POSTGRES_URL}" \
-          --dataset ${{ inputs.dataset }} \
-          --index ${{ inputs.index }} \
-          --size ${{ inputs.size }} \
+          --dataset "${DATASET}" \
+          --index "${INDEX}" \
+          --size "${SIZE}" \
           --runs 10 \
           --output json \
-          --fail-on-error ${{ inputs.fail_on_error }}
+          --fail-on-error "${FAIL_ON_ERROR}"
 
-        echo "ROWS_LABEL=${{ inputs.size }}" >> $GITHUB_ENV
+        echo "ROWS_LABEL=${SIZE}" >> "$GITHUB_ENV"
 
     - name: Print the Postgres Logs
       if: failure()

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -12,7 +12,7 @@ inputs:
   ref:
     description: "Git ref or short SHA to report in benchmarks"
     required: true
-  github_app_id:
+  github_app_client_id:
     description: "GitHub App client ID to authenticate with"
     required: true
   github_app_private_key:
@@ -34,14 +34,16 @@ runs:
     - name: Sanitize Inputs Into Variables
       id: sanitize-inputs
       shell: bash
+      env:
+        REF: ${{ inputs.ref }}
+        TEST_FILE: ${{ inputs.test_file }}
       run: |
         # Strip .toml from the test file name
-        echo "jobname=$(basename ${{ inputs.test_file }} .toml)" >> $GITHUB_OUTPUT
+        echo "jobname=$(basename "$TEST_FILE" .toml)" >> "$GITHUB_OUTPUT"
 
         # Strip slashes from the ref
-        ref="${{ inputs.ref }}"
-        safe_ref="${ref//\//-}"
-        echo "safe_ref=$safe_ref" >> $GITHUB_OUTPUT
+        safe_ref="${REF//\//-}"
+        echo "safe_ref=$safe_ref" >> "$GITHUB_OUTPUT"
 
     - name: Resolving ${{ inputs.ref }} into SHA
       id: resolve_ref
@@ -60,13 +62,16 @@ runs:
 
     - name: Run Stressgres Job
       shell: bash
+      env:
+        DURATION: ${{ inputs.duration }}
+        TEST_FILE: ${{ inputs.test_file }}
       run: |
         sudo chmod a+rwx /var/run/postgresql/
         stressgres headless \
-          stressgres/suites/${{ inputs.test_file }} \
+          "stressgres/suites/${TEST_FILE}" \
           --log-file stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.resolve_ref.outputs.sha }}.log \
           --pgversion pg18 \
-          --runtime ${{ inputs.duration }}
+          --runtime "${DURATION}"
 
     - name: Generate CSV
       shell: bash
@@ -104,7 +109,7 @@ runs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        client-id: ${{ inputs.github_app_id }}
+        client-id: ${{ inputs.github_app_client_id }}
         private-key: ${{ inputs.github_app_private_key }}
 
     - name: Wait for App Token to Become Usable
@@ -191,7 +196,8 @@ runs:
       if: always()
       shell: bash
       run: |
-        for f in `ls /tmp/stressgres/*.log`; do
-          echo $f
-          cat $f
+        shopt -s nullglob
+        for file in /tmp/stressgres/*.log; do
+          echo "$file"
+          cat "$file"
         done

--- a/.github/actions/benchmarks-from-main/action.yml
+++ b/.github/actions/benchmarks-from-main/action.yml
@@ -1,13 +1,13 @@
 name: Fetch Benchmark Sources from Main
-description: Fetch latest benchmark code, suites, and actions from `main`
+description: Fetch latest benchmark code and suites from `main`
 
 inputs:
   github-token:
     description: "GitHub token to authenticate with"
     required: true
 
-# We manually fetch the benchmark queries *and* our custom actions from `main` to make sure all are available
-# when backfilling old commits potentially created before new queries were added.
+# We manually fetch benchmark code from `main` when backfilling old commits that may predate
+# newer queries. Callers fetch composite actions separately before invoking this action.
 
 runs:
   using: "composite"

--- a/.github/actions/build-pg_search-source/action.yml
+++ b/.github/actions/build-pg_search-source/action.yml
@@ -55,7 +55,7 @@ runs:
         sudo install -d -m 0755 /usr/share/keyrings
         curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
           | sudo tee /usr/share/keyrings/postgresql.asc > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+        echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
           | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
         sudo apt-get update
         # clang for bindgen; libopenblas-dev for pg_search's BLAS backend

--- a/.github/actions/setup-benchmark-cluster/action.yml
+++ b/.github/actions/setup-benchmark-cluster/action.yml
@@ -31,10 +31,14 @@ runs:
     - name: Install & Configure Supported PostgreSQL Version
       shell: bash
       run: |
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        set -euo pipefail
+        curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+          | gpg --dearmor \
+          | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
+        echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+          | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
         sudo apt-get update && sudo apt-get install -y lld libopenblas-dev postgresql-${{ inputs.pg_version }} postgresql-server-dev-${{ inputs.pg_version }} postgresql-${{ inputs.pg_version }}-pgvector
-        echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> $GITHUB_PATH
+        echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> "$GITHUB_PATH"
 
     # Separate prefix-key from debug workflows - benchmarks compile with --release.
     # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
@@ -51,7 +55,7 @@ runs:
     - name: Extract pgrx Version
       id: pgrx
       shell: bash
-      run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+      run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> "$GITHUB_OUTPUT"
 
     - name: Install pgrx
       shell: bash
@@ -59,11 +63,11 @@ runs:
 
     - name: Initialize pgrx environment
       shell: bash
-      run: cargo pgrx init --pg${{ inputs.pg_version }}=`which pg_config`
+      run: cargo pgrx init "--pg${{ inputs.pg_version }}=$(command -v pg_config)"
 
     - name: Compile & install pg_search extension
       shell: bash
-      run: cargo pgrx install -p pg_search --sudo --release --pg-config `which pg_config` --features=pg${{ inputs.pg_version }} --no-default-features
+      run: cargo pgrx install -p pg_search --sudo --release --pg-config "$(command -v pg_config)" --features=pg${{ inputs.pg_version }} --no-default-features
 
     - name: Start Postgres
       shell: bash

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -109,7 +109,6 @@ jobs:
       RUN_COHERE: ${{ (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'cohere')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmark-cohere-hnsw", "benchmark-cohere-ivfflat", "benchmark-cohere-vchord", "benchmark-cohere-pg_search", "benchmark-cohere-pgvectorscale"]'), github.event.label.name)) }}
       # Only main writes the baseline. Every other run still fetches it and diffs against it,
       # so a PR gets its comparison without being able to move the reference point.
-      #
       PUBLISH_BASELINE: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.publish_baseline) }}
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-pgvectorscale' && 'pgvectorscale') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
     paths:
+      - ".github/actions/benchmark-queries/**"
+      - ".github/actions/benchmarks-from-main/**"
+      - ".github/actions/setup-benchmark-cluster/**"
+      - ".github/workflows/benchmark-pg_search-queries.yml"
       - "benchmarks/**"
       - "**/*.rs"
       - "**/*.toml"
@@ -106,10 +110,7 @@ jobs:
       # Only main writes the baseline. Every other run still fetches it and diffs against it,
       # so a PR gets its comparison without being able to move the reference point.
       #
-      # TEMP -- REVERT BEFORE MERGING (this is its own commit, so `git revert` it).
-      # claude/pgvectorscale is allowed to publish so the new arm gets a baseline ahead of merge.
-      # Anything published here becomes the reference the next run is diffed against.
-      PUBLISH_BASELINE: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/claude/pgvectorscale') && (github.event_name != 'workflow_dispatch' || inputs.publish_baseline) }}
+      PUBLISH_BASELINE: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.publish_baseline) }}
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-pgvectorscale' && 'pgvectorscale') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:
@@ -296,7 +297,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
+          fail_on_error: ${{ github.event_name != 'workflow_dispatch' || inputs.fail_on_error }}
           publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "stackoverflow" Heap Snapshot (1M)
@@ -328,7 +329,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
+          fail_on_error: ${{ github.event_name != 'workflow_dispatch' || inputs.fail_on_error }}
           publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "stackoverflow" Heap Snapshot (20M)
@@ -360,7 +361,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
+          fail_on_error: ${{ github.event_name != 'workflow_dispatch' || inputs.fail_on_error }}
           publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "cohere" Heap Snapshot (1M)
@@ -420,7 +421,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
+          fail_on_error: ${{ github.event_name != 'workflow_dispatch' || inputs.fail_on_error }}
           publish: ${{ env.PUBLISH_BASELINE }}
 
       - name: Restore "cohere" Heap Snapshot (10M)
@@ -474,7 +475,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
+          fail_on_error: ${{ github.event_name != 'workflow_dispatch' || inputs.fail_on_error }}
           publish: ${{ env.PUBLISH_BASELINE }}
 
       # Renders the operating points the benchmark selected. The benchmark step measures recall

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - main
     paths:
+      - ".github/actions/benchmark-stressgres/**"
+      - ".github/actions/benchmarks-from-main/**"
+      - ".github/workflows/benchmark-pg_search-stressgres.yml"
       - "stressgres/suites/**"
       - "**/*.rs"
       - "**/*.toml"
@@ -192,10 +195,14 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          set -euo pipefail
+          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }} postgresql-${{ env.pg_version }}-pgvector
-          echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> $GITHUB_PATH
+          echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> "$GITHUB_PATH"
 
       # Separate prefix-key from debug workflows — benchmarks compile with --release.
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
@@ -211,16 +218,16 @@ jobs:
 
       - name: Extract pgrx Version
         id: pgrx
-        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> "$GITHUB_OUTPUT"
 
       - name: Install pgrx
         run: cargo install cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug --locked
 
       - name: Initialize pgrx environment
-        run: cargo pgrx init --pg${{ env.pg_version }}=`which pg_config`
+        run: cargo pgrx init "--pg${{ env.pg_version }}=$(command -v pg_config)"
 
       - name: Compile & install pg_search extension
-        run: cargo pgrx install -p pg_search --sudo --release --pg-config `which pg_config` --features=pg${{ env.pg_version }} --no-default-features
+        run: cargo pgrx install -p pg_search --sudo --release --pg-config "$(command -v pg_config)" --features=pg${{ env.pg_version }} --no-default-features
 
       - name: Start Postgres
         working-directory: pg_search/
@@ -271,7 +278,7 @@ jobs:
         with:
           test_file: single-server.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_client_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -282,7 +289,7 @@ jobs:
         with:
           test_file: bulk-updates.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_client_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -293,7 +300,7 @@ jobs:
         with:
           test_file: wide-table.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_client_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -304,7 +311,7 @@ jobs:
         with:
           test_file: background-merge.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_client_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -315,7 +322,7 @@ jobs:
         with:
           test_file: logical-replication.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_client_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -326,7 +333,7 @@ jobs:
         with:
           test_file: logical-replication-merge.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_client_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -71,10 +71,14 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          set -euo pipefail
+          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update && sudo apt-get install -y lld libfontconfig1-dev libopenblas-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
 
       - name: Install pgrx
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -253,7 +253,7 @@ jobs:
 
           # Download PostgreSQL signing key & add PostgreSQL APT repository with signed-by
           wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/keyrings/postgresql.asc > /dev/null
-          sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
           # Install PostgreSQL + build tooling
           DEBIAN_FRONTEND=noninteractive sudo apt-get update

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -70,10 +70,14 @@ jobs:
 
       - name: Install & Configure PostgreSQL ${{ env.pg_version }}
         run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          set -euo pipefail
+          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }} libopenblas-dev lld
-          echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> $GITHUB_PATH
+          echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> "$GITHUB_PATH"
 
       - name: Install pgrx
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -254,7 +254,7 @@ jobs:
 
           # Download PostgreSQL signing key & add PostgreSQL APT repository with signed-by
           wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/keyrings/postgresql.asc > /dev/null
-          sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
           # Install PostgreSQL + build tooling
           DEBIAN_FRONTEND=noninteractive sudo apt-get update

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -77,10 +77,14 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          set -euo pipefail
+          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
 
       - name: Install OpenBLAS (superkmeans-rs BLAS backend)
         run: |

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -117,10 +117,14 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          set -euo pipefail
+          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
 
       # Needed for hybrid search unit tests
       - name: Install pgvector

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -131,10 +131,14 @@ jobs:
       - name: Install & Configure Supported PostgreSQL Version (system)
         if: matrix.pg_impl == 'system'
         run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          set -euo pipefail
+          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
 
       - name: Initialize pgrx environment (system)
         if: matrix.pg_impl == 'system'


### PR DESCRIPTION
## Summary

- restore benchmark baseline publishing to `main` only and make manual `fail_on_error: false` effective
- trigger benchmark runs when their local composite actions change
- harden benchmark composite-action shell inputs and align the GitHub App client-ID input name with its actual value
- replace deprecated global `apt-key` usage with scoped PostgreSQL repository keyrings and HTTPS package sources
- repair issue and discussion links and route users to the core, ORM, and benchmark repositories with active issue trackers
- reduce `FUNDING.yml` to the active GitHub Sponsors account and remove nonexistent discussion labels
- refresh the benchmark source action description to match its actual behavior

## Validation

- repository commit hooks
- Prettier across `.github` YAML
- Actionlint across all workflows, ignoring only known custom runner labels, Actionlint's stale `create-github-app-token@v3` metadata, and pre-existing inline ShellCheck findings
- Actionlint with inline ShellCheck enabled for the changed benchmark workflows
- Python syntax compilation for `.github/actions` and `.github/scripts`
- Bash syntax and ShellCheck for standalone `.github/scripts`
- live verification of issue destinations and the `paradedb/charts` Issues setting
- live verification of the GitHub Sponsors destination and repository labels used by templates
- `git diff --check`

## Audit notes

- generated code-snippet verification fixtures were treated as generated artifacts and were not hand-edited
- action major-version updates remain managed by Dependabot
- full benchmark, release, and publishing jobs require CI credentials/infrastructure and were not run locally
