### PR TITLE
chore: finish documentation and repository audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,5 +7,5 @@ ignore = [
   "RUSTSEC-2026-0235",
 ]
 
-# Unmaintained crates are warnings, not failures. The tree carries nine.
+# Unmaintained crates are warnings, not failures.
 informational_warnings = ["unmaintained", "unsound", "notice"]

--- a/.github/scripts/sqlalchemy_snippet_harness.py
+++ b/.github/scripts/sqlalchemy_snippet_harness.py
@@ -1,6 +1,6 @@
 """Execute extracted SQLAlchemy docs snippets against local verification tables."""
 
-# pylint: disable=import-error,too-few-public-methods
+# pylint: disable=import-error,too-few-public-methods,wrong-import-order
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import getpass
 import os
 from typing import Any
 
+from paradedb.sqlalchemy.vector import Vector
 from sqlalchemy import (
     Boolean,
     Date,
@@ -22,8 +23,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE, JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-
-from paradedb.sqlalchemy.vector import Vector
 
 
 def build_database_url() -> str:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -554,7 +554,7 @@
     "socials": {
       "github": "https://github.com/paradedb/paradedb",
       "slack": "https://paradedb.com/slack",
-      "twitter": "https://twitter.com/paradedb"
+      "twitter": "https://x.com/paradedb"
     }
   },
   "integrations": {

--- a/docs/override.js
+++ b/docs/override.js
@@ -1,9 +1,3 @@
-const input = document.getElementById("search-input");
-if (input) {
-  input.placeholder =
-    "Powered by Mintlify, the documentation platform of tomorrow";
-}
-
 // Inject ParadeDB Organization structured data. Mintlify auto-emits only a
 // generic WebSite node (whose creator is Mintlify), so the docs otherwise have
 // no ParadeDB identity markup. Reusing the same @id as paradedb.com lets search


### PR DESCRIPTION
## Summary
- remove the obsolete Mintlify promotional search placeholder override
- update the documentation footer from `twitter.com` to `x.com`
- remove the empty `.mintignore` file
- make the SQLAlchemy docs harness satisfy Ruff and Pylint simultaneously
- remove a stale dependency count from the RustSec policy comment

## Audit scope
Reviewed the full `docs/` tree and performed a final repository-wide audit across all 1,710 tracked files, including Rust source and tests, workspace manifests and dependencies, extension migrations, generated Dockerfiles, GitHub automation, shell scripts, release coverage, file modes, tracked artifacts, and version references.

The remaining dependency updates reported by `cargo outdated` are routine compatible releases or deliberate pins; `cargo audit` reports no vulnerabilities. Historical versions, compatibility migrations, generated CloudNativePG manifests, and ignored local build artifacts were left unchanged.

## Validation
- `cargo test --workspace --lib` (429 passed, 1 intentionally ignored)
- full prek suite: formatting, Clippy, cargo check, cargo doc, Ruff, Pylint, Prettier, Markdownlint, and file hygiene
- `cargo audit`
- `cargo machete`
- ShellCheck on every tracked shell script
- regenerated all supported Dockerfiles with no diff
- `mint validate`
- `mint broken-links`
- release-to-changelog, tracked artifact, file mode, case collision, and version consistency checks