### PR TITLE
chore: finish repository maintenance audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,5 +7,5 @@ ignore = [
   "RUSTSEC-2026-0235",
 ]
 
-# Unmaintained crates are warnings, not failures. The tree carries nine.
+# Unmaintained crates are warnings, not failures.
 informational_warnings = ["unmaintained", "unsound", "notice"]

--- a/.github/scripts/sqlalchemy_snippet_harness.py
+++ b/.github/scripts/sqlalchemy_snippet_harness.py
@@ -1,6 +1,6 @@
 """Execute extracted SQLAlchemy docs snippets against local verification tables."""
 
-# pylint: disable=import-error,too-few-public-methods
+# pylint: disable=import-error,too-few-public-methods,wrong-import-order
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import getpass
 import os
 from typing import Any
 
+from paradedb.sqlalchemy.vector import Vector
 from sqlalchemy import (
     Boolean,
     Date,
@@ -22,8 +23,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE, JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-
-from paradedb.sqlalchemy.vector import Vector
 
 
 def build_database_url() -> str:


### PR DESCRIPTION
## Summary
- make the SQLAlchemy docs harness satisfy Ruff and Pylint simultaneously
- remove a stale count of unmaintained dependencies from the RustSec policy comment

## Audit scope
Performed a final repository-wide audit across all 1,710 tracked files, including Rust source and tests, workspace manifests and dependencies, extension migrations, generated Dockerfiles, GitHub automation, shell scripts, documentation and release coverage, file modes, tracked artifacts, and version references.

The remaining dependency updates reported by `cargo outdated` are routine compatible releases or deliberate pins; `cargo audit` reports no vulnerabilities. Historical versions, compatibility migrations, generated CloudNativePG manifests, and ignored local build artifacts were left unchanged.

## Validation
- `cargo test --workspace --lib` (429 passed, 1 intentionally ignored)
- full prek suite: formatting, Clippy, cargo check, cargo doc, Ruff, Pylint, Prettier, Markdownlint, and file hygiene
- `cargo audit`
- `cargo machete`
- `cargo fmt --all -- --check`
- ShellCheck on every tracked shell script
- regenerated all supported Dockerfiles from `docker/Dockerfile.template` with no diff
- release-to-changelog coverage comparison
- tracked artifact, file mode, case collision, and version consistency checks