### PR TITLE
perf: single-fetch MVCC Count collector for bare counts on not-all-visible heaps

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -483,6 +483,22 @@ pub fn execute_aggregate(
                 let count = reader.count_matched_docs()?;
                 return Ok(bare_count_results(count as f64));
             }
+            // The heap is not fully all-visible, so per-document MVCC checks are required --
+            // but a count still doesn't need the aggregation framework: wrap tantivy's plain
+            // `Count` collector in the MVCC filter so ctids are fetched once (for the
+            // visibility check) and visible documents are merely counted, instead of running
+            // a `value_count` aggregation that decodes the ctid fast field a second time.
+            if let Some(heaprel) = index.heap_relation() {
+                let mvcc_count = MVCCFilterCollector::new(
+                    tantivy::collector::Count,
+                    crate::postgres::heap::VisibilityChecker::with_rel_and_snap(
+                        &heaprel,
+                        pg_sys::GetActiveSnapshot(),
+                    ),
+                );
+                let count = reader.collect(InterruptableCollector::new(mvcc_count)) as f64;
+                return Ok(bare_count_results(count));
+            }
         }
 
         let ambulkdelete_epoch = MetaPage::open(index).ambulkdelete_epoch();


### PR DESCRIPTION
# Not ready for review
## Note

This PR is stacked on #6040. It handles the case #6040 cannot: the heap has at least one page that is not all-visible, so every document needs an MVCC check.

## What

Even when a bare `count(*)` needs MVCC checks, it does not need the aggregation framework. This PR wraps tantivy's plain `Count` collector in the existing `MVCCFilterCollector`. Ctids are fetched once. The existing batched, block-sorted visibility check runs. Visible documents are counted. Nothing else happens.

## Why

The framework path reads the ctid column twice for every matched document: once for the MVCC filter, once for the `value_count` aggregation. It then runs the full aggregation machinery to produce one integer. Its cost is the same whether the table is dirty or clean, so any table with churn pays it on every count.

A/B on the identical dirty table (2 not-all-visible pages, same 40-term mix):

| | p50 | p95 | qps |
|---|---|---|---|
| main | 18.57 ms | 32.98 ms | 54 |
| **this PR** | **10.77 ms** | **20.17 ms** | **91** |

p95 drops 38.8% and p50 drops 42%. With #6040, a table that loses all-visibility now goes 1.9 ms → 20 ms → (vacuum) → 1.9 ms, instead of staying at 33 ms.

## How

The change reuses `MVCCFilterCollector` and `VisibilityChecker` unchanged. The visibility semantics are identical to the framework path. Only the inner collector differs, and it is trivial.

The path returns before the parallel aggregation machinery, so bare counts that main would run with parallel workers now run on the leader. At these latencies that is a win: worker launch costs ~5–7 ms per query, and a one-worker-plus-leader configuration measured slower (p50 13.8 → 20.5 ms) than single-threaded. Very large counts with many workers could cross over; that case favors the framework path this PR bypasses. Only the bare-count shape is affected — grouped, filtered, and multi-aggregate counts keep their parallel eligibility.

## Tests

- The same 7-term parity suite as #6040 was run entirely on this path, with the fast-path gate held off by a dirty heap. All counts match an unpatched instance.
- The MVCC sequence (in-transaction count N−1, rollback restores N) runs on this path and is correct.
