### PR TITLE
chore: remove Elastic-quality from package descriptions

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -321,10 +321,10 @@ jobs:
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
-          echo ' pg_search upgrades Postgres with a single index for fast full-text and' >> $CONTROL_FILE
-          echo ' vector search, BM25 scoring, filtering, and aggregations. Search runs' >> $CONTROL_FILE
-          echo " inside your system of record with Postgres' transactional guarantees—no" >> $CONTROL_FILE
-          echo ' second system to deploy or keep in sync.' >> $CONTROL_FILE
+          echo ' pg_search upgrades Postgres with a custom index for fast full-text and' >> $CONTROL_FILE
+          echo ' vector search, BM25 scoring, filtering, and aggregations. Your application' >> $CONTROL_FILE
+          echo ' data and search engine live in one database, with no second system to' >> $CONTROL_FILE
+          echo ' deploy and nothing to sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the
           # CloudNativePG postgres-extensions-containers Dockerfiles, which

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -321,9 +321,10 @@ jobs:
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
-          echo ' pg_search adds full-text search, vector retrieval, and aggregations to' >> $CONTROL_FILE
-          echo ' Postgres. Your application data and your search engine' >> $CONTROL_FILE
-          echo ' live in one database, with no second system to deploy and nothing to sync.' >> $CONTROL_FILE
+          echo ' pg_search upgrades Postgres with a single index for fast full-text and' >> $CONTROL_FILE
+          echo ' vector search, BM25 scoring, filtering, and aggregations. Search runs' >> $CONTROL_FILE
+          echo " inside your system of record with Postgres' transactional guarantees—no" >> $CONTROL_FILE
+          echo ' second system to deploy or keep in sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the
           # CloudNativePG postgres-extensions-containers Dockerfiles, which

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -321,8 +321,8 @@ jobs:
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
-          echo ' pg_search adds Elastic-quality full-text search, vector retrieval, and' >> $CONTROL_FILE
-          echo ' aggregations to Postgres. Your application data and your search engine' >> $CONTROL_FILE
+          echo ' pg_search adds full-text search, vector retrieval, and aggregations to' >> $CONTROL_FILE
+          echo ' Postgres. Your application data and your search engine' >> $CONTROL_FILE
           echo ' live in one database, with no second system to deploy and nothing to sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -331,8 +331,8 @@ jobs:
           Requires:       openblas
 
           %description
-          pg_search adds Elastic-quality full-text search, vector retrieval, and
-          aggregations to Postgres. Your application data and your search engine
+          pg_search adds full-text search, vector retrieval, and aggregations to
+          Postgres. Your application data and your search engine
           live in one database, with no second system to deploy and nothing to sync.
 
           %install

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -331,9 +331,10 @@ jobs:
           Requires:       openblas
 
           %description
-          pg_search adds full-text search, vector retrieval, and aggregations to
-          Postgres. Your application data and your search engine
-          live in one database, with no second system to deploy and nothing to sync.
+          pg_search upgrades Postgres with a single index for fast full-text and
+          vector search, BM25 scoring, filtering, and aggregations. Search runs
+          inside your system of record with Postgres' transactional guarantees—no
+          second system to deploy or keep in sync.
 
           %install
           %{__rm} -rf %{buildroot}

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -331,10 +331,10 @@ jobs:
           Requires:       openblas
 
           %description
-          pg_search upgrades Postgres with a single index for fast full-text and
-          vector search, BM25 scoring, filtering, and aggregations. Search runs
-          inside your system of record with Postgres' transactional guarantees—no
-          second system to deploy or keep in sync.
+          pg_search upgrades Postgres with a custom index for fast full-text and
+          vector search, BM25 scoring, filtering, and aggregations. Your application
+          data and search engine live in one database, with no second system to
+          deploy and nothing to sync.
 
           %install
           %{__rm} -rf %{buildroot}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -317,8 +317,8 @@ jobs:
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
-          echo ' pg_search adds Elastic-quality full-text search, vector retrieval, and' >> $CONTROL_FILE
-          echo ' aggregations to Postgres. Your application data and your search engine' >> $CONTROL_FILE
+          echo ' pg_search adds full-text search, vector retrieval, and aggregations to' >> $CONTROL_FILE
+          echo ' Postgres. Your application data and your search engine' >> $CONTROL_FILE
           echo ' live in one database, with no second system to deploy and nothing to sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -317,10 +317,10 @@ jobs:
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
-          echo ' pg_search upgrades Postgres with a single index for fast full-text and' >> $CONTROL_FILE
-          echo ' vector search, BM25 scoring, filtering, and aggregations. Search runs' >> $CONTROL_FILE
-          echo " inside your system of record with Postgres' transactional guarantees—no" >> $CONTROL_FILE
-          echo ' second system to deploy or keep in sync.' >> $CONTROL_FILE
+          echo ' pg_search upgrades Postgres with a custom index for fast full-text and' >> $CONTROL_FILE
+          echo ' vector search, BM25 scoring, filtering, and aggregations. Your application' >> $CONTROL_FILE
+          echo ' data and search engine live in one database, with no second system to' >> $CONTROL_FILE
+          echo ' deploy and nothing to sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the
           # CloudNativePG postgres-extensions-containers Dockerfiles, which

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -317,9 +317,10 @@ jobs:
           echo 'Depends: postgresql-${{ matrix.pg_version }}, libopenblas0' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Full-text search, vector retrieval, and aggregations for Postgres' >> $CONTROL_FILE
-          echo ' pg_search adds full-text search, vector retrieval, and aggregations to' >> $CONTROL_FILE
-          echo ' Postgres. Your application data and your search engine' >> $CONTROL_FILE
-          echo ' live in one database, with no second system to deploy and nothing to sync.' >> $CONTROL_FILE
+          echo ' pg_search upgrades Postgres with a single index for fast full-text and' >> $CONTROL_FILE
+          echo ' vector search, BM25 scoring, filtering, and aggregations. Search runs' >> $CONTROL_FILE
+          echo " inside your system of record with Postgres' transactional guarantees—no" >> $CONTROL_FILE
+          echo ' second system to deploy or keep in sync.' >> $CONTROL_FILE
 
           # Copyright file (Debian Policy §12.5). Also consumed by the
           # CloudNativePG postgres-extensions-containers Dockerfiles, which

--- a/META.json.in
+++ b/META.json.in
@@ -39,23 +39,13 @@
    },
    "tags": [
       "paradedb",
+      "postgres",
       "search",
       "bm25",
-      "text search",
       "full text search",
-      "full-text search",
       "hybrid search",
-      "vector",
       "vector search",
-      "vector retrieval",
-      "similarity search",
-      "semantic search",
-      "embeddings",
       "faceted search",
-      "facets",
-      "aggregations",
-      "analytics",
-      "columnar",
-      "olap"
+      "aggregations"
    ]
 }

--- a/META.json.in
+++ b/META.json.in
@@ -40,14 +40,21 @@
    "tags": [
       "paradedb",
       "search",
-      "analytics",
       "bm25",
       "text search",
       "full text search",
       "full-text search",
       "hybrid search",
+      "vector",
+      "vector search",
+      "vector retrieval",
+      "similarity search",
+      "semantic search",
+      "embeddings",
       "faceted search",
       "facets",
+      "aggregations",
+      "analytics",
       "columnar",
       "olap"
    ]

--- a/META.json.in
+++ b/META.json.in
@@ -1,7 +1,7 @@
 {
    "name": "pg_search",
    "abstract": "@CRATE_DESC@",
-   "description": "ParadeDB pg_search adds full-text search, vector retrieval, and aggregations to Postgres. Your application data and your search engine live in one database, with no second system to deploy and nothing to sync.",
+   "description": "pg_search upgrades Postgres with a single index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Search runs inside your system of record with Postgres' transactional guarantees—no second system to deploy or keep in sync.",
    "version": "@CRATE_VERSION@",
    "maintainer": [
       "ParadeDB <support@paradedb.com>"

--- a/META.json.in
+++ b/META.json.in
@@ -1,7 +1,7 @@
 {
    "name": "pg_search",
    "abstract": "@CRATE_DESC@",
-   "description": "pg_search upgrades Postgres with a single index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Search runs inside your system of record with Postgres' transactional guarantees—no second system to deploy or keep in sync.",
+   "description": "pg_search upgrades Postgres with a custom index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Your application data and search engine live in one database, with no second system to deploy and nothing to sync.",
    "version": "@CRATE_VERSION@",
    "maintainer": [
       "ParadeDB <support@paradedb.com>"

--- a/META.json.in
+++ b/META.json.in
@@ -1,7 +1,7 @@
 {
    "name": "pg_search",
    "abstract": "@CRATE_DESC@",
-   "description": "ParadeDB pg_search is a Postgres extension that brings fast full-text search, vector retrieval, and aggregations to Postgres tables. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
+   "description": "ParadeDB pg_search adds full-text search, vector retrieval, and aggregations to Postgres. Your application data and your search engine live in one database, with no second system to deploy and nothing to sync.",
    "version": "@CRATE_VERSION@",
    "maintainer": [
       "ParadeDB <support@paradedb.com>"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When you're ready to deploy, check out our [hosting options](https://docs.parade
 
 ## What is ParadeDB?
 
-[ParadeDB](https://paradedb.com) upgrades Postgres with `pg_search`, a custom index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Your application data and search engine live in one database, with no second system to deploy and nothing to sync.
+[ParadeDB](https://paradedb.com) upgrades Postgres with a custom index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Your application data and search engine live in one database, with no second system to deploy and nothing to sync.
 
 Vectors are currently indexed using the [pgvector](https://github.com/pgvector/pgvector) extension, but native vector support is coming to our search index soon.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When you're ready to deploy, check out our [hosting options](https://docs.parade
 
 ## What is ParadeDB?
 
-[ParadeDB](https://paradedb.com) upgrades Postgres with `pg_search`, a single index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Search runs inside your system of record with Postgres' transactional guarantees—no second system to deploy or keep in sync.
+[ParadeDB](https://paradedb.com) upgrades Postgres with `pg_search`, a custom index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Your application data and search engine live in one database, with no second system to deploy and nothing to sync.
 
 Vectors are currently indexed using the [pgvector](https://github.com/pgvector/pgvector) extension, but native vector support is coming to our search index soon.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When you're ready to deploy, check out our [hosting options](https://docs.parade
 
 ## What is ParadeDB?
 
-[ParadeDB](https://paradedb.com) adds Elastic-quality full-text search, vector retrieval, and aggregations to Postgres with the `pg_search` extension. Your application data and your search engine live in one database, with no second system to deploy and nothing to sync.
+[ParadeDB](https://paradedb.com) upgrades Postgres with `pg_search`, a single index for fast full-text and vector search, BM25 scoring, filtering, and aggregations. Search runs inside your system of record with Postgres' transactional guarantees—no second system to deploy or keep in sync.
 
 Vectors are currently indexed using the [pgvector](https://github.com/pgvector/pgvector) extension, but native vector support is coming to our search index soon.
 


### PR DESCRIPTION
## What

- update `META.json.in` with the new package description from #5909 without the “Elastic-quality” claim
- remove the same wording from the Debian, Ubuntu, and RHEL package descriptions

## Testing

- pre-commit hooks
- `git diff --check`
- confirmed the affected files contain no remaining `Elastic-quality` mentions