### PR TITLE
fix: keep negative NUMERIC(p>18) values sortable in the index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,9 +2578,8 @@ checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 
 [[package]]
 name = "decimal-bytes"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ca5c5cd9fae79b456f0a067c6b428ab1edad0c3a32b95c6e72ce8e777466cb"
+version = "0.5.0"
+source = "git+https://github.com/paradedb/decimal-bytes.git?rev=fb1d07652682bb08fcb55461995b341d2b4b30b2#fb1d07652682bb08fcb55461995b341d2b4b30b2"
 dependencies = [
  "serde",
  "thiserror 2.0.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,8 @@ checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 [[package]]
 name = "decimal-bytes"
 version = "0.5.0"
-source = "git+https://github.com/paradedb/decimal-bytes.git?rev=49702fbdd25d97cc145e7e5481036525e321bd5c#49702fbdd25d97cc145e7e5481036525e321bd5c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9afdc22865fc4fb579ebd6017e9f8f83c67175f4a8cfd9887056dac2981a5c"
 dependencies = [
  "serde",
  "thiserror 2.0.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 [[package]]
 name = "decimal-bytes"
 version = "0.5.0"
-source = "git+https://github.com/paradedb/decimal-bytes.git?rev=fb1d07652682bb08fcb55461995b341d2b4b30b2#fb1d07652682bb08fcb55461995b341d2b4b30b2"
+source = "git+https://github.com/paradedb/decimal-bytes.git?rev=49702fbdd25d97cc145e7e5481036525e321bd5c#49702fbdd25d97cc145e7e5481036525e321bd5c"
 dependencies = [
  "serde",
  "thiserror 2.0.19",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-bWpfZRQk9v0yNS8jeP5gx2iP2BjB9Z9moz/XdMrdMAI=";
+  cargoHash = "sha256-DZrnc7ej8ewWFmz8HiCw/jRKH3WoYYU3Pte4AjhQODM=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -84,7 +84,7 @@ lazy_static = "1.5.0"
 macros = { path = "../macros" }
 half = "2.7.1"
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
-decimal-bytes = "0.4.3"
+decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes.git", rev = "fb1d07652682bb08fcb55461995b341d2b4b30b2" }
 bigdecimal = "0.4.10"
 paste = "1.0.15"
 typetag = "0.2"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -84,7 +84,7 @@ lazy_static = "1.5.0"
 macros = { path = "../macros" }
 half = "2.7.1"
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
-decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes.git", rev = "fb1d07652682bb08fcb55461995b341d2b4b30b2" }
+decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes.git", rev = "49702fbdd25d97cc145e7e5481036525e321bd5c" }
 bigdecimal = "0.4.10"
 paste = "1.0.15"
 typetag = "0.2"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -84,7 +84,7 @@ lazy_static = "1.5.0"
 macros = { path = "../macros" }
 half = "2.7.1"
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
-decimal-bytes = { git = "https://github.com/paradedb/decimal-bytes.git", rev = "49702fbdd25d97cc145e7e5481036525e321bd5c" }
+decimal-bytes = "0.5.0"
 bigdecimal = "0.4.10"
 paste = "1.0.15"
 typetag = "0.2"

--- a/pg_search/src/api/version.rs
+++ b/pg_search/src/api/version.rs
@@ -34,6 +34,10 @@ pub const DATETIME_I64_STORAGE_VERSION: Version = Version::new(0, 24, 1);
 /// layout that sorts them correctly (`decimal-bytes` 0.5). Indexes created earlier keep receiving
 /// the previous layout for new rows and query terms, since the two layouts do not sort together;
 /// a `REINDEX` moves such an index to the current layout.
+///
+/// TODO: remove this constant, `stores_sortable_negative_numeric_bytes`, and the legacy branch in
+/// `decimal_to_index_bytes` once every deployment runs v0.25.4 or later and its indexes have been
+/// rebuilt. `Decimal::to_legacy_bytes` can go from `decimal-bytes` at the same time.
 pub const NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION: Version = Version::new(0, 25, 4);
 
 impl Version {

--- a/pg_search/src/api/version.rs
+++ b/pg_search/src/api/version.rs
@@ -35,9 +35,10 @@ pub const DATETIME_I64_STORAGE_VERSION: Version = Version::new(0, 24, 1);
 /// the previous layout for new rows and query terms, since the two layouts do not sort together;
 /// a `REINDEX` moves such an index to the current layout.
 ///
-/// TODO: remove this constant, `stores_sortable_negative_numeric_bytes`, and the legacy branch in
-/// `decimal_to_index_bytes` once every deployment runs v0.25.4 or later and its indexes have been
-/// rebuilt. `Decimal::to_legacy_bytes` can go from `decimal-bytes` at the same time.
+/// TODO: remove this constant, `stores_sortable_negative_numeric_bytes`, the legacy branch in
+/// `decimal_to_index_bytes`, and the JoinScan decline in `numeric_bytes_layouts_differ` once every
+/// deployment runs v0.25.4 or later and its indexes have been rebuilt. `Decimal::to_legacy_bytes`
+/// can go from `decimal-bytes` at the same time.
 pub const NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION: Version = Version::new(0, 25, 4);
 
 impl Version {

--- a/pg_search/src/api/version.rs
+++ b/pg_search/src/api/version.rs
@@ -30,6 +30,12 @@ pub struct Version {
 /// time to gate which storage representation an index uses.
 pub const DATETIME_I64_STORAGE_VERSION: Version = Version::new(0, 24, 1);
 
+/// The first pg_search version whose `NumericBytes` fast fields store negative values in a byte
+/// layout that sorts them correctly (`decimal-bytes` 0.5). Indexes created earlier keep receiving
+/// the previous layout for new rows and query terms, since the two layouts do not sort together;
+/// a `REINDEX` moves such an index to the current layout.
+pub const NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION: Version = Version::new(0, 25, 4);
+
 impl Version {
     pub const fn new(major: u16, minor: u16, patch: u16) -> Self {
         Self {
@@ -52,15 +58,23 @@ impl std::fmt::Display for Version {
 /// existed; for capability checks that gate new behavior, treat `None` as "does not have it".
 pub trait VersionInfo {
     fn stores_datetimes_in_i64(&self) -> bool;
+    fn stores_sortable_negative_numeric_bytes(&self) -> bool;
 }
 impl VersionInfo for Version {
     fn stores_datetimes_in_i64(&self) -> bool {
         self >= &DATETIME_I64_STORAGE_VERSION
     }
+    fn stores_sortable_negative_numeric_bytes(&self) -> bool {
+        self >= &NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION
+    }
 }
 impl VersionInfo for Option<Version> {
     fn stores_datetimes_in_i64(&self) -> bool {
         self.filter(|v| v.stores_datetimes_in_i64()).is_some()
+    }
+    fn stores_sortable_negative_numeric_bytes(&self) -> bool {
+        self.filter(|v| v.stores_sortable_negative_numeric_bytes())
+            .is_some()
     }
 }
 

--- a/pg_search/src/api/version.rs
+++ b/pg_search/src/api/version.rs
@@ -37,9 +37,9 @@ pub const DATETIME_I64_STORAGE_VERSION: Version = Version::new(0, 24, 1);
 ///
 /// TODO: remove this constant, `stores_sortable_negative_numeric_bytes`, the legacy branch in
 /// `decimal_to_index_bytes`, and the JoinScan decline in `numeric_bytes_layouts_differ` once every
-/// deployment runs v0.25.4 or later and its indexes have been rebuilt. `Decimal::to_legacy_bytes`
+/// deployment runs v0.25.5 or later and its indexes have been rebuilt. `Decimal::to_legacy_bytes`
 /// can go from `decimal-bytes` at the same time.
-pub const NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION: Version = Version::new(0, 25, 4);
+pub const NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION: Version = Version::new(0, 25, 5);
 
 impl Version {
     pub const fn new(major: u16, minor: u16, patch: u16) -> Self {

--- a/pg_search/src/postgres/build_partitioning.rs
+++ b/pg_search/src/postgres/build_partitioning.rs
@@ -35,6 +35,7 @@ use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
 use crate::api::FieldName;
+use crate::api::version::Version;
 use crate::index::kdtree::{KdTree, Point};
 use crate::postgres::composite::CompositeSlotValues;
 use crate::postgres::heap::{ExpressionState, HeapBufferPin};
@@ -172,6 +173,7 @@ unsafe fn sample_partition_fields(
         pg_sys::MakeTupleTableSlot(heaprel.rd_att, &raw const pg_sys::TTSOpsBufferHeapTuple)
     };
     let natts = unsafe { (*heaprel.rd_att).natts as usize };
+    let created_by_version = indexrel.created_by_version();
 
     let mut sample: Vec<Point> = Vec::new();
     let mut seen_rows = 0usize;
@@ -247,7 +249,8 @@ unsafe fn sample_partition_fields(
                         .map(|state| state.evaluate(slot))
                         .unwrap_or_default();
 
-                    let point = project_row(&fields, values, isnull, &expr_results);
+                    let point =
+                        project_row(&fields, values, isnull, &expr_results, created_by_version);
                     // The stored pointer targets this iteration's `tuple`; clear it before that
                     // goes out of scope, on the error path too.
                     pg_sys::ExecClearTuple(slot);
@@ -282,6 +285,7 @@ unsafe fn project_row(
     values: &[pg_sys::Datum],
     isnull: &[bool],
     expr_results: &[(pg_sys::Datum, bool)],
+    created_by_version: Option<Version>,
 ) -> anyhow::Result<Point> {
     let unpacked_composites = unsafe {
         CompositeSlotValues::from_composites(fields.iter().filter_map(|f| {
@@ -314,7 +318,12 @@ unsafe fn project_row(
             }
             let datum = unsafe { unwrap_alias_datum(datum, f.categorized.pg_type) };
             let value = unsafe {
-                scalar_datum_to_tantivy_value(datum, f.field.field_type(), f.categorized.base_oid)
+                scalar_datum_to_tantivy_value(
+                    datum,
+                    f.field.field_type(),
+                    f.categorized.base_oid,
+                    created_by_version,
+                )
             }
             .map_err(|e| {
                 anyhow::anyhow!(

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -32,6 +32,7 @@ use super::predicate::find_base_info_recursive;
 use super::privdat::{OutputColumnInfo, PrivateData};
 
 use crate::api::operator::anyelement_query_input_opoid;
+use crate::api::version::VersionInfo;
 use crate::api::{NullTestKind, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::nodecast;
@@ -54,6 +55,7 @@ use crate::postgres::utils::{
 };
 use crate::postgres::var::{fieldname_from_var, strip_identity_wrappers};
 use crate::query::SearchQueryInput;
+use crate::schema::SearchFieldType;
 
 use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_matching_fast_field;
 use crate::schema::SearchIndexSchema;
@@ -667,15 +669,29 @@ unsafe fn collect_join_sources_join_rel(
                     let outer_ir = PgSearchRelation::open(outer_indexrelid);
                     let inner_hr = PgSearchRelation::open(inner_heaprelid);
                     let inner_ir = PgSearchRelation::open(inner_indexrelid);
-                    if resolve_fast_field(jk.outer_attno as i32, &outer_hr.tuple_desc(), &outer_ir)
-                        .is_none()
-                        || resolve_fast_field(
+                    let (Some(outer_ff), Some(inner_ff)) = (
+                        resolve_fast_field(
+                            jk.outer_attno as i32,
+                            &outer_hr.tuple_desc(),
+                            &outer_ir,
+                        ),
+                        resolve_fast_field(
                             jk.inner_attno as i32,
                             &inner_hr.tuple_desc(),
                             &inner_ir,
-                        )
-                        .is_none()
-                    {
+                        ),
+                    ) else {
+                        return None;
+                    };
+
+                    // A `NumericBytes` key is hashed on its stored bytes, so both indexes must
+                    // encode negative values the same way or equal values never match.
+                    if numeric_bytes_layouts_differ(&outer_ff, &outer_ir, &inner_ff, &inner_ir) {
+                        crate::postgres::customscan::joinscan::JoinScan::add_planner_warning(
+                            "join key NUMERIC columns are stored in different byte layouts; \
+                             reindex the older index",
+                            (),
+                        );
                         return None;
                     }
                 }
@@ -1025,6 +1041,30 @@ unsafe fn try_extract_null_and_subplan(
         null_test_varno: null_varno,
         null_test_attno: null_attno,
     })
+}
+
+/// Whether two `NumericBytes` join keys come from indexes that encode negative values
+/// differently. See `NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION`.
+fn numeric_bytes_layouts_differ(
+    outer_ff: &WhichFastField,
+    outer_ir: &PgSearchRelation,
+    inner_ff: &WhichFastField,
+    inner_ir: &PgSearchRelation,
+) -> bool {
+    let is_numeric_bytes = |ff: &WhichFastField| {
+        matches!(
+            ff,
+            WhichFastField::Named(_, SearchFieldType::NumericBytes(..))
+        )
+    };
+    is_numeric_bytes(outer_ff)
+        && is_numeric_bytes(inner_ff)
+        && outer_ir
+            .created_by_version()
+            .stores_sortable_negative_numeric_bytes()
+            != inner_ir
+                .created_by_version()
+                .stores_sortable_negative_numeric_bytes()
 }
 
 /// Extracts equi-join keys from a subplan's testexpr for `Semi`/`Anti` joins.

--- a/pg_search/src/postgres/range.rs
+++ b/pg_search/src/postgres/range.rs
@@ -15,29 +15,45 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::api::version::Version;
 use crate::postgres::types::{TantivyValue, TantivyValueError};
-use crate::query::numeric::bytes_to_hex;
+use crate::query::numeric::{bytes_to_hex, decimal_to_index_bytes};
 use crate::schema::range::{TantivyRange, TantivyRangeBuilder};
-use decimal_bytes::Decimal;
+use decimal_bytes::{Decimal, DecimalError};
 use pgrx::datum::{Date, RangeBound, Timestamp, TimestampWithTimeZone};
+use pgrx::pg_sys::Datum;
+use pgrx::{AnyNumeric, FromDatum};
 use std::str::FromStr;
 
 use super::pdb_owned_value::PdbOwnedValue;
 
-/// A wrapper around `Decimal` that serializes to hex-encoded lexicographically sortable bytes.
-/// This allows string comparison in Tantivy's JSON fields to give correct numeric ordering.
+/// A NUMERIC range bound as lexicographically sortable bytes, which serialize to hex so that
+/// string comparison in Tantivy's JSON fields gives correct numeric ordering.
 ///
 /// Used for `numrange` to preserve full NUMERIC precision in range queries.
 #[derive(Clone, Debug)]
-pub(crate) struct SortableDecimal(pub Decimal);
+pub(crate) struct SortableDecimal(Vec<u8>);
 
-impl TryFrom<pgrx::AnyNumeric> for SortableDecimal {
-    type Error = decimal_bytes::DecimalError;
+impl SortableDecimal {
+    /// Encodes `val` in the byte layout of the index identified by `index_created_by_version`.
+    pub(crate) fn for_index(
+        val: AnyNumeric,
+        index_created_by_version: Option<Version>,
+    ) -> Result<Self, DecimalError> {
+        let decimal = Decimal::from_str(val.normalize())?;
+        Ok(SortableDecimal(decimal_to_index_bytes(
+            decimal,
+            index_created_by_version,
+        )))
+    }
+}
 
-    fn try_from(val: pgrx::AnyNumeric) -> Result<Self, Self::Error> {
-        let numeric_str = val.normalize().to_string();
-        let decimal = Decimal::from_str(&numeric_str)?;
-        Ok(SortableDecimal(decimal))
+impl TryFrom<AnyNumeric> for SortableDecimal {
+    type Error = DecimalError;
+
+    fn try_from(val: AnyNumeric) -> Result<Self, Self::Error> {
+        let decimal = Decimal::from_str(val.normalize())?;
+        Ok(SortableDecimal(decimal.into_bytes()))
     }
 }
 
@@ -49,8 +65,27 @@ impl TryFrom<SortableDecimal> for TantivyValue {
         // Hex encoding preserves lexicographic ordering since:
         // - Each byte maps to exactly 2 hex chars
         // - Hex chars compare in the same order as byte values
-        let hex_str = bytes_to_hex(value.0.as_bytes());
+        let hex_str = bytes_to_hex(&value.0);
         Ok(TantivyValue(PdbOwnedValue::Str(hex_str)))
+    }
+}
+
+impl TantivyValue {
+    /// Convert a NUMRANGE datum for writing into the index identified by
+    /// `index_created_by_version`, so its bounds use that index's byte layout.
+    pub unsafe fn try_from_numrange(
+        datum: Datum,
+        index_created_by_version: Option<Version>,
+    ) -> Result<Self, TantivyValueError> {
+        let range = unsafe { pgrx::Range::<AnyNumeric>::from_datum(datum, false) }
+            .ok_or(TantivyValueError::DatumDeref)?;
+        Self::from_range_with(range, |n| {
+            SortableDecimal::for_index(n, index_created_by_version).map_err(|e| {
+                TantivyValueError::NumericConversion(format!(
+                    "Failed to convert NUMRANGE bound to bytes: {e:?}"
+                ))
+            })
+        })
     }
 }
 
@@ -62,19 +97,26 @@ where
     TantivyValue: TryFrom<S, Error = TantivyValueError>,
 {
     fn from_range(val: pgrx::Range<T>) -> Result<TantivyValue, TantivyValueError> {
+        Self::from_range_with(val, |v| Ok(S::try_from(v).unwrap()))
+    }
+
+    fn from_range_with(
+        val: pgrx::Range<T>,
+        convert: impl Fn(T) -> Result<S, TantivyValueError>,
+    ) -> Result<TantivyValue, TantivyValueError> {
         match val.is_empty() {
             true => Ok(<TantivyValue as TryFrom<TantivyRange<S>>>::try_from(
                 TantivyRangeBuilder::<S>::new().empty(true).build(),
             )?),
             false => {
                 let lower = match val.lower() {
-                    Some(RangeBound::Inclusive(val)) => Some(S::try_from(val.clone()).unwrap()),
-                    Some(RangeBound::Exclusive(val)) => Some(S::try_from(val.clone()).unwrap()),
+                    Some(RangeBound::Inclusive(val)) => Some(convert(val.clone())?),
+                    Some(RangeBound::Exclusive(val)) => Some(convert(val.clone())?),
                     Some(RangeBound::Infinite) | None => None,
                 };
                 let upper = match val.upper() {
-                    Some(RangeBound::Inclusive(val)) => Some(S::try_from(val.clone()).unwrap()),
-                    Some(RangeBound::Exclusive(val)) => Some(S::try_from(val.clone()).unwrap()),
+                    Some(RangeBound::Inclusive(val)) => Some(convert(val.clone())?),
+                    Some(RangeBound::Exclusive(val)) => Some(convert(val.clone())?),
                     Some(RangeBound::Infinite) | None => None,
                 };
 

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::tokenizers::type_is_tokenizer;
+use crate::api::version::Version;
 use crate::nodecast;
 use crate::postgres::catalog::is_citext_oid;
 use crate::postgres::catalog::{facet_encoded_str_to_ltree_text, is_ltree_oid};
@@ -23,6 +24,7 @@ use crate::postgres::datetime::PostgresDateTime;
 use crate::postgres::jsonb_support::jsonb_datum_to_serde_json_value;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::range::RangeToTantivyValue;
+use crate::query::numeric::decimal_to_index_bytes;
 use crate::schema::AnyEnum;
 use ordered_float::OrderedFloat;
 use pgrx::PostgresType;
@@ -779,8 +781,12 @@ impl TantivyValue {
     /// Convert a PostgreSQL NUMERIC datum to a TantivyValue with raw bytes storage.
     /// Used for NUMERIC with precision > 18 or unlimited precision.
     ///
-    /// The byte encoding is lexicographically sortable, supporting range queries.
-    pub unsafe fn try_from_numeric_bytes(datum: Datum) -> Result<Self, TantivyValueError> {
+    /// The byte encoding is lexicographically sortable, supporting range queries. Its layout
+    /// follows the index the value is written to, see [`decimal_to_index_bytes`].
+    pub unsafe fn try_from_numeric_bytes(
+        datum: Datum,
+        index_created_by_version: Option<Version>,
+    ) -> Result<Self, TantivyValueError> {
         use decimal_bytes::Decimal;
         use std::str::FromStr;
 
@@ -798,7 +804,10 @@ impl TantivyValue {
         })?;
 
         // Store as raw bytes for Bytes field storage
-        Ok(TantivyValue(PdbOwnedValue::Bytes(decimal.into_bytes())))
+        Ok(TantivyValue(PdbOwnedValue::Bytes(decimal_to_index_bytes(
+            decimal,
+            index_created_by_version,
+        ))))
     }
 
     /// Convert a PostgreSQL NUMERIC[] array to TantivyValues with I64 fixed-point storage.
@@ -838,6 +847,7 @@ impl TantivyValue {
     /// Used for NUMERIC arrays with precision > 18 or unlimited precision.
     pub unsafe fn try_from_numeric_array_bytes(
         datum: Datum,
+        index_created_by_version: Option<Version>,
     ) -> Result<Vec<Self>, TantivyValueError> {
         use decimal_bytes::Decimal;
         use std::str::FromStr;
@@ -861,7 +871,10 @@ impl TantivyValue {
                 })?;
 
                 // Store as raw bytes for Bytes field storage
-                Ok(TantivyValue(PdbOwnedValue::Bytes(decimal.into_bytes())))
+                Ok(TantivyValue(PdbOwnedValue::Bytes(decimal_to_index_bytes(
+                    decimal,
+                    index_created_by_version,
+                ))))
             })
             .collect()
     }

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -814,7 +814,7 @@ pub unsafe fn row_to_search_document<'a>(
                     TantivyValue::try_from_numeric_array_i64(actual_datum, scale)
                 }
                 SearchFieldType::NumericBytes(..) => {
-                    TantivyValue::try_from_numeric_array_bytes(actual_datum)
+                    TantivyValue::try_from_numeric_array_bytes(actual_datum, created_by_version)
                 }
                 // Legacy pre-v0.22.0 indexes stored NUMERIC arrays as F64 in the tantivy schema.
                 SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
@@ -851,7 +851,12 @@ pub unsafe fn row_to_search_document<'a>(
             document.add_vector(search_field.field(), &vec);
         } else {
             let tv = unsafe {
-                scalar_datum_to_tantivy_value(actual_datum, search_field.field_type(), *base_oid)
+                scalar_datum_to_tantivy_value(
+                    actual_datum,
+                    search_field.field_type(),
+                    *base_oid,
+                    created_by_version,
+                )
             }
             .unwrap_or_else(|e| {
                 panic!("could not parse field `{}`: {e}", search_field.field_name())
@@ -872,10 +877,16 @@ pub unsafe fn scalar_datum_to_tantivy_value(
     datum: pg_sys::Datum,
     field_type: SearchFieldType,
     base_oid: PgOid,
+    created_by_version: Option<Version>,
 ) -> Result<TantivyValue, TantivyValueError> {
     match field_type {
         SearchFieldType::Numeric64(_, scale) => TantivyValue::try_from_numeric_i64(datum, scale),
-        SearchFieldType::NumericBytes(..) => TantivyValue::try_from_numeric_bytes(datum),
+        SearchFieldType::NumericBytes(..) => {
+            TantivyValue::try_from_numeric_bytes(datum, created_by_version)
+        }
+        SearchFieldType::Range(oid) if oid == pg_sys::NUMRANGEOID => {
+            TantivyValue::try_from_numrange(datum, created_by_version)
+        }
         // Legacy pre-v0.22.0 indexes stored NUMERIC as F64 in the tantivy schema.
         SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
             TantivyValue::try_from_numeric_f64(datum)

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -1434,16 +1434,22 @@ impl SearchQueryInput {
                 Ok(builder.build_leaf(query, || "Parse Query".to_string(), cloned_for_estimate))
             }
             SearchQueryInput::TermSet { terms: fields } => {
-                let query = Box::new(TermSetQuery::new(fields.into_iter().map(
-                    |TermInput { field, value }| {
+                let terms = fields
+                    .into_iter()
+                    .map(|TermInput { field, value }| {
                         let search_field = schema
                             .search_field(field.root())
-                            .ok_or_else(|| QueryError::NonIndexedField(field.clone()))
-                            .expect("could not find search field");
+                            .ok_or_else(|| QueryError::NonIndexedField(field.clone()))?;
                         let field_type = search_field.field_entry().field_type();
 
-                        // Convert string numeric values to appropriate types for JSON fields
-                        let value = convert_for_field_type(&value, field_type);
+                        // The tantivy `FieldType` can't tell a scaled `Numeric64` or an encoded
+                        // `NumericBytes` column from a plain `I64` or `Bytes` one, so the term has
+                        // to be converted from the schema-level type, same as a single `Term`.
+                        let value = numeric::convert_value_for_field(
+                            value,
+                            &search_field.field_type(),
+                            index_created_by_version,
+                        )?;
 
                         value_to_term(
                             search_field.field(),
@@ -1452,9 +1458,9 @@ impl SearchQueryInput {
                             field.path().as_deref(),
                             index_created_by_version,
                         )
-                        .expect("could not convert argument to search term")
-                    },
-                )));
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let query = Box::new(TermSetQuery::new(terms));
 
                 Ok(builder.build_leaf(query, || "TermSet Query".to_string(), cloned_for_estimate))
             }
@@ -1550,27 +1556,6 @@ impl SearchQueryInput {
             expr_context,
             planstate,
         )
-    }
-}
-
-/// Convert a string-encoded numeric value to the appropriate type based on field type.
-/// Used for JSON field comparisons where NUMERIC constants need to match stored JSON numbers.
-fn convert_for_field_type(value: &PdbOwnedValue, field_type: &FieldType) -> PdbOwnedValue {
-    use crate::query::numeric::{
-        string_to_f64, string_to_i64, string_to_json_numeric, string_to_u64,
-    };
-
-    // Only convert string values - other types pass through unchanged
-    if !matches!(value, PdbOwnedValue::Str(_)) {
-        return value.clone();
-    }
-
-    match field_type {
-        FieldType::JsonObject(_) => string_to_json_numeric(value.clone()),
-        FieldType::I64(_) => string_to_i64(value.clone()),
-        FieldType::U64(_) => string_to_u64(value.clone()),
-        FieldType::F64(_) => string_to_f64(value.clone()),
-        _ => value.clone(),
     }
 }
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -845,11 +845,12 @@ fn check_range_bounds(
     typeoid: PgOid,
     lower_bound: Bound<PdbOwnedValue>,
     upper_bound: Bound<PdbOwnedValue>,
+    index_created_by_version: Option<Version>,
 ) -> Result<(Bound<PdbOwnedValue>, Bound<PdbOwnedValue>), QueryError> {
     // For NUMRANGEOID, convert numeric values to hex-encoded sortable bytes
     // to match the indexed format (see SortableDecimal in range.rs)
-    let lower_bound = convert_numrange_bound(typeoid, lower_bound);
-    let upper_bound = convert_numrange_bound(typeoid, upper_bound);
+    let lower_bound = convert_numrange_bound(typeoid, lower_bound, index_created_by_version);
+    let upper_bound = convert_numrange_bound(typeoid, upper_bound, index_created_by_version);
 
     let lower_bound = match (typeoid, lower_bound.clone()) {
         // Excluded U64 needs to be canonicalized
@@ -979,7 +980,11 @@ fn check_range_bounds(
 
 /// Convert numeric values in NUMRANGEOID bounds to hex-encoded sortable bytes.
 /// This matches the format used for indexing (see SortableDecimal in range.rs).
-fn convert_numrange_bound(typeoid: PgOid, bound: Bound<PdbOwnedValue>) -> Bound<PdbOwnedValue> {
+fn convert_numrange_bound(
+    typeoid: PgOid,
+    bound: Bound<PdbOwnedValue>,
+    index_created_by_version: Option<Version>,
+) -> Bound<PdbOwnedValue> {
     use decimal_bytes::Decimal;
     use std::str::FromStr;
 
@@ -998,9 +1003,12 @@ fn convert_numrange_bound(typeoid: PgOid, bound: Bound<PdbOwnedValue>) -> Bound<
             _ => return None,
         };
 
-        Decimal::from_str(&numeric_str)
-            .ok()
-            .map(|dec| PdbOwnedValue::Str(numeric::bytes_to_hex(dec.as_bytes())))
+        Decimal::from_str(&numeric_str).ok().map(|dec| {
+            PdbOwnedValue::Str(numeric::bytes_to_hex(&numeric::decimal_to_index_bytes(
+                dec,
+                index_created_by_version,
+            )))
+        })
     };
 
     match bound {

--- a/pg_search/src/query/numeric.rs
+++ b/pg_search/src/query/numeric.rs
@@ -505,10 +505,13 @@ mod tests {
         assert_ne!(current, legacy);
 
         assert_eq!(decimal_to_index_bytes(decimal.clone(), None), legacy);
-        assert_eq!(
-            decimal_to_index_bytes(decimal.clone(), Some(Version::new(0, 25, 3))),
-            legacy
-        );
+        // The releases that shipped `decimal-bytes` 0.4 wrote the legacy layout.
+        for legacy_version in [Version::new(0, 25, 3), Version::new(0, 25, 4)] {
+            assert_eq!(
+                decimal_to_index_bytes(decimal.clone(), Some(legacy_version)),
+                legacy
+            );
+        }
         assert_eq!(
             decimal_to_index_bytes(
                 decimal.clone(),

--- a/pg_search/src/query/numeric.rs
+++ b/pg_search/src/query/numeric.rs
@@ -27,6 +27,7 @@
 use std::ops::Bound;
 use std::str::FromStr;
 
+use crate::api::version::{Version, VersionInfo};
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::schema::SearchFieldType;
 use anyhow::Result;
@@ -104,9 +105,6 @@ pub fn scale_owned_value(value: PdbOwnedValue, scale: i16) -> Result<PdbOwnedVal
 // NumericBytes Conversions
 // ============================================================================
 
-/// Convert a numeric value to a hex-encoded string for NumericBytes storage.
-///
-/// Used for NumericBytes storage where precision exceeds 18 digits.
 /// Convert a numeric value to its Decimal representation.
 /// Helper function used by both raw bytes and hex string conversions.
 fn value_to_decimal(value: &PdbOwnedValue) -> Result<Decimal> {
@@ -124,15 +122,37 @@ fn value_to_decimal(value: &PdbOwnedValue) -> Result<Decimal> {
     }
 }
 
+/// Encode `decimal` in the byte layout used by the index that `index_created_by_version`
+/// identifies. Stored values and query terms have to agree on the layout, because the index
+/// compares them bytewise.
+///
+/// See [`crate::api::version::NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION`].
+pub fn decimal_to_index_bytes(
+    decimal: Decimal,
+    index_created_by_version: Option<Version>,
+) -> Vec<u8> {
+    if index_created_by_version.stores_sortable_negative_numeric_bytes() {
+        decimal.into_bytes()
+    } else {
+        decimal.to_legacy_bytes()
+    }
+}
+
 /// Convert a numeric value to raw bytes (PdbOwnedValue::Bytes).
 ///
 /// Uses `decimal_bytes::Decimal` for arbitrary-precision decimal encoding.
 /// The byte encoding is lexicographically sortable for range queries.
 ///
 /// Used for NumericBytes fields which are stored as Tantivy Bytes columns.
-pub fn numeric_value_to_decimal_bytes(value: PdbOwnedValue) -> Result<PdbOwnedValue> {
+pub fn numeric_value_to_decimal_bytes(
+    value: PdbOwnedValue,
+    index_created_by_version: Option<Version>,
+) -> Result<PdbOwnedValue> {
     let decimal = value_to_decimal(&value)?;
-    Ok(PdbOwnedValue::Bytes(decimal.into_bytes()))
+    Ok(PdbOwnedValue::Bytes(decimal_to_index_bytes(
+        decimal,
+        index_created_by_version,
+    )))
 }
 
 /// Convert a numeric value to a hex-encoded string (PdbOwnedValue::Str).
@@ -145,9 +165,15 @@ pub fn numeric_value_to_decimal_bytes(value: PdbOwnedValue) -> Result<PdbOwnedVa
 ///
 /// TODO: Consider changing Range field storage to support raw bytes instead of JSON,
 /// which would eliminate the hex encoding overhead.
-pub fn numeric_value_to_hex_string(value: PdbOwnedValue) -> Result<PdbOwnedValue> {
+pub fn numeric_value_to_hex_string(
+    value: PdbOwnedValue,
+    index_created_by_version: Option<Version>,
+) -> Result<PdbOwnedValue> {
     let decimal = value_to_decimal(&value)?;
-    Ok(PdbOwnedValue::Str(bytes_to_hex(decimal.as_bytes())))
+    Ok(PdbOwnedValue::Str(bytes_to_hex(&decimal_to_index_bytes(
+        decimal,
+        index_created_by_version,
+    ))))
 }
 
 /// Convert a byte slice to a hex-encoded string.
@@ -300,8 +326,13 @@ pub fn scale_numeric_bound(
 
 /// Convert a numeric bound to lexicographically sortable raw bytes.
 /// Used for NumericBytes fields stored as Tantivy Bytes columns.
-pub fn numeric_bound_to_bytes(bound: Bound<PdbOwnedValue>) -> Result<Bound<PdbOwnedValue>> {
-    convert_bound(bound, numeric_value_to_decimal_bytes)
+pub fn numeric_bound_to_bytes(
+    bound: Bound<PdbOwnedValue>,
+    index_created_by_version: Option<Version>,
+) -> Result<Bound<PdbOwnedValue>> {
+    convert_bound(bound, |v| {
+        numeric_value_to_decimal_bytes(v, index_created_by_version)
+    })
 }
 
 // ============================================================================
@@ -319,6 +350,7 @@ pub fn numeric_bound_to_bytes(bound: Bound<PdbOwnedValue>) -> Result<Bound<PdbOw
 pub fn convert_value_for_range_field(
     value: PdbOwnedValue,
     field_type: &SearchFieldType,
+    index_created_by_version: Option<Version>,
 ) -> PdbOwnedValue {
     use pgrx::pg_sys::BuiltinOid;
 
@@ -353,7 +385,7 @@ pub fn convert_value_for_range_field(
         Ok(BuiltinOid::NUMRANGEOID) => {
             // Numeric ranges are indexed as hex-encoded sortable bytes
             // Use numeric_value_to_hex_string for JSON storage
-            numeric_value_to_hex_string(value.clone()).unwrap_or(value)
+            numeric_value_to_hex_string(value.clone(), index_created_by_version).unwrap_or(value)
         }
         _ => value,
     }
@@ -371,16 +403,20 @@ pub fn convert_value_for_range_field(
 /// # Arguments
 /// * `value` - The input value to convert
 /// * `field_type` - The target field type determining the conversion
+/// * `index_created_by_version` - Selects the `NumericBytes` byte layout
 ///
 /// # Returns
 /// The converted value, or an error if conversion fails for Numeric64/NumericBytes.
 pub fn convert_value_for_field(
     value: PdbOwnedValue,
     field_type: &SearchFieldType,
+    index_created_by_version: Option<Version>,
 ) -> Result<PdbOwnedValue> {
     match field_type {
         SearchFieldType::Numeric64(_, scale) => scale_owned_value(value, *scale),
-        SearchFieldType::NumericBytes(..) => numeric_value_to_decimal_bytes(value),
+        SearchFieldType::NumericBytes(..) => {
+            numeric_value_to_decimal_bytes(value, index_created_by_version)
+        }
         SearchFieldType::Json(_) => Ok(string_to_json_numeric(value)),
         SearchFieldType::I64(_) => Ok(string_to_i64(value)),
         SearchFieldType::U64(_) => Ok(string_to_u64(value)),
@@ -457,6 +493,36 @@ mod tests {
             string_to_json_numeric(PdbOwnedValue::Str("1e10".to_string())),
             PdbOwnedValue::F64(1e10)
         );
+    }
+
+    #[test]
+    fn test_decimal_to_index_bytes_follows_index_version() {
+        use crate::api::version::NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION;
+
+        let decimal = Decimal::from_str("-49990").unwrap();
+        let current = decimal.clone().into_bytes();
+        let legacy = decimal.to_legacy_bytes();
+        assert_ne!(current, legacy);
+
+        assert_eq!(decimal_to_index_bytes(decimal.clone(), None), legacy);
+        assert_eq!(
+            decimal_to_index_bytes(decimal.clone(), Some(Version::new(0, 25, 3))),
+            legacy
+        );
+        assert_eq!(
+            decimal_to_index_bytes(
+                decimal.clone(),
+                Some(NUMERIC_BYTES_SORTABLE_NEGATIVES_VERSION)
+            ),
+            current
+        );
+        assert_eq!(
+            decimal_to_index_bytes(decimal, Some(Version::new(1, 0, 0))),
+            current
+        );
+
+        // Both layouts decode to the same value.
+        assert_eq!(Decimal::from_bytes(&legacy).unwrap().to_string(), "-49990");
     }
 
     #[test]

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -822,13 +822,10 @@ fn term_set(
     let search_field_type = search_field.field_type();
 
     // Convert terms based on field type (uses same logic as term())
-    let converted_terms: Vec<PdbOwnedValue> = terms
+    let converted_terms = terms
         .into_iter()
-        .map(|term| {
-            convert_value_for_field(term, &search_field_type, index_created_by_version)
-                .unwrap_or(PdbOwnedValue::Null)
-        })
-        .collect();
+        .map(|term| convert_value_for_field(term, &search_field_type, index_created_by_version))
+        .collect::<anyhow::Result<Vec<PdbOwnedValue>>>()?;
 
     Ok(Box::new(TermSetQuery::new(
         converted_terms.into_iter().map(|term| {

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -825,7 +825,8 @@ fn term_set(
     let converted_terms: Vec<PdbOwnedValue> = terms
         .into_iter()
         .map(|term| {
-            convert_value_for_field(term, &search_field_type).unwrap_or(PdbOwnedValue::Null)
+            convert_value_for_field(term, &search_field_type, index_created_by_version)
+                .unwrap_or(PdbOwnedValue::Null)
         })
         .collect();
 
@@ -857,7 +858,8 @@ fn term(
     let search_field_type = search_field.field_type();
 
     // Convert value based on field type (handles NUMERIC scaling, JSON types, etc.)
-    let value = convert_value_for_field(value.clone(), &search_field_type)?;
+    let value =
+        convert_value_for_field(value.clone(), &search_field_type, index_created_by_version)?;
 
     let term = value_to_term(
         search_field.field(),
@@ -920,7 +922,8 @@ fn range_within(
         .search_field(field.root())
         .ok_or(QueryError::NonIndexedField(field.clone()))?;
     let typeoid = search_field.field_type().typeoid();
-    let (lower_bound, upper_bound) = check_range_bounds(typeoid, lower_bound, upper_bound)?;
+    let (lower_bound, upper_bound) =
+        check_range_bounds(typeoid, lower_bound, upper_bound, index_created_by_version)?;
 
     let range_field = RangeField::new(search_field.field());
 
@@ -1091,7 +1094,11 @@ fn range_term(
     // - INT4RANGEOID, INT8RANGEOID: indexed as i32/i64 → convert to I64
     // - NUMRANGEOID: indexed as hex-encoded sortable bytes (see SortableDecimal) → convert to hex string
     // - Date/time ranges: handling is determined by examining the schema
-    let value = convert_value_for_range_field(value.clone(), &search_field.field_type());
+    let value = convert_value_for_range_field(
+        value.clone(),
+        &search_field.field_type(),
+        index_created_by_version,
+    );
 
     let range_field = RangeField::new(search_field.field());
 
@@ -1205,7 +1212,8 @@ fn range_intersects(
         .ok_or(QueryError::NonIndexedField(field.clone()))?;
     let typeoid = search_field.field_type().typeoid();
 
-    let (lower_bound, upper_bound) = check_range_bounds(typeoid, lower_bound, upper_bound)?;
+    let (lower_bound, upper_bound) =
+        check_range_bounds(typeoid, lower_bound, upper_bound, index_created_by_version)?;
     let range_field = RangeField::new(search_field.field());
 
     let mut satisfies_lower_bound: Vec<(Occur, Box<dyn TantivyQuery>)> = vec![];
@@ -1376,7 +1384,8 @@ fn range_contains(
         .search_field(field.root())
         .ok_or(QueryError::NonIndexedField(field.clone()))?;
     let typeoid = search_field.field_type().typeoid();
-    let (lower_bound, upper_bound) = check_range_bounds(typeoid, lower_bound, upper_bound)?;
+    let (lower_bound, upper_bound) =
+        check_range_bounds(typeoid, lower_bound, upper_bound, index_created_by_version)?;
     let range_field = RangeField::new(search_field.field());
 
     let mut satisfies_lower_bound: Vec<(Occur, Box<dyn TantivyQuery>)> = vec![];
@@ -1560,36 +1569,36 @@ fn range(
         }
         SearchFieldType::NumericBytes(..) => {
             // Convert bounds to lexicographically sortable bytes
-            let lower = numeric_bound_to_bytes(lower_bound)?;
-            let upper = numeric_bound_to_bytes(upper_bound)?;
+            let lower = numeric_bound_to_bytes(lower_bound, index_created_by_version)?;
+            let upper = numeric_bound_to_bytes(upper_bound, index_created_by_version)?;
             (lower, upper)
         }
         SearchFieldType::Json(_) => {
             // For JSON fields, convert string numeric values to appropriate JSON types
             let lower = map_bound(lower_bound, string_to_json_numeric);
             let upper = map_bound(upper_bound, string_to_json_numeric);
-            check_range_bounds(typeoid, lower, upper)?
+            check_range_bounds(typeoid, lower, upper, index_created_by_version)?
         }
         SearchFieldType::I64(_) => {
             let lower = map_bound(lower_bound, string_to_i64);
             let upper = map_bound(upper_bound, string_to_i64);
-            check_range_bounds(typeoid, lower, upper)?
+            check_range_bounds(typeoid, lower, upper, index_created_by_version)?
         }
         SearchFieldType::U64(_) => {
             let lower = map_bound(lower_bound, string_to_u64);
             let upper = map_bound(upper_bound, string_to_u64);
-            check_range_bounds(typeoid, lower, upper)?
+            check_range_bounds(typeoid, lower, upper, index_created_by_version)?
         }
         SearchFieldType::F64(_) => {
             let lower = map_bound(lower_bound, string_to_f64);
             let upper = map_bound(upper_bound, string_to_f64);
-            check_range_bounds(typeoid, lower, upper)?
+            check_range_bounds(typeoid, lower, upper, index_created_by_version)?
         }
         _ => {
             // Standard path for other field types
             let lower_bound = coerce_bound_to_field_type(lower_bound, field_type);
             let upper_bound = coerce_bound_to_field_type(upper_bound, field_type);
-            check_range_bounds(typeoid, lower_bound, upper_bound)?
+            check_range_bounds(typeoid, lower_bound, upper_bound, index_created_by_version)?
         }
     };
 
@@ -1876,7 +1885,8 @@ fn parse_with_field<QueryParserCtor: Fn() -> QueryParser>(
     ) {
         // Convert the query string to the appropriate numeric format
         let value = PdbOwnedValue::Str(query_string.trim().to_string());
-        if let Ok(converted) = convert_value_for_field(value, &field_type) {
+        if let Ok(converted) = convert_value_for_field(value, &field_type, index_created_by_version)
+        {
             let tantivy_field_type = search_field.field_entry().field_type();
             let term = value_to_term(
                 search_field.field(),

--- a/pg_search/tests/pg_regress/expected/issue_6051.out
+++ b/pg_search/tests/pg_regress/expected/issue_6051.out
@@ -1,0 +1,490 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+-- NUMERIC with precision > 18 is stored as sortable bytes. Negative values whose digit
+-- strings share a prefix (e.g. -49990 and -49999) are the case where the byte order used
+-- to disagree with the numeric order.
+SET enable_seqscan = off;
+SET max_parallel_workers_per_gather = 0;
+CREATE TABLE amounts (
+    id serial PRIMARY KEY,
+    direction varchar NOT NULL,
+    amt_18 numeric(18,0) NOT NULL,
+    amt_78 numeric(78,0) NOT NULL,
+    amt_any numeric NOT NULL,
+    amt_scaled numeric(30,10) NOT NULL,
+    discarded_at timestamp
+);
+INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
+SELECT 'debit', -g, -g, -g, -g / 1000000.0
+FROM generate_series(1, 50000) g;
+INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
+VALUES
+    ('credit', 5, 5, 5, 0.5),
+    ('credit', 51, 51, 51, 0.51),
+    ('debit', -5, -5, -5, -0.5),
+    ('debit', -51, -51, -51, -0.51),
+    ('debit', -50001, -50001, -50001, -0.50001),
+    ('debit', -4999, -4999, -4999, -0.4999),
+    ('debit', -100001, -100001, -100001, -100.001),
+    ('debit', -999999999999999999, -100000000000000000000, -100000000000000000000, -1000000000000000000.0000000001),
+    ('zero', 0, 0, 0, 0);
+CREATE INDEX amounts_idx ON amounts USING bm25 (
+    id, (direction::pdb.literal), amt_18, amt_78, amt_any, amt_scaled, discarded_at
+) WITH (key_field = 'id') WHERE (discarded_at IS NULL);
+-- TopN ascending: the numeric(18,0) column is the reference ordering.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 ASC LIMIT 8;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Limit
+   Output: amt_78
+   ->  Custom Scan (ParadeDB Base Scan) on public.amounts
+         Output: amt_78
+         Table: amounts
+         Index: amounts_idx
+         Worker Selection: Row-capped
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: amt_78 asc
+            TopK Limit: 8
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"direction","value":"debit"}}}}
+(12 rows)
+
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 ASC LIMIT 8;
+         amt_78         
+------------------------
+ -100000000000000000000
+                -100001
+                 -50001
+                 -50000
+                 -49999
+                 -49998
+                 -49997
+                 -49996
+(8 rows)
+
+SELECT amt_18 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_18 ASC LIMIT 8;
+       amt_18        
+---------------------
+ -999999999999999999
+             -100001
+              -50001
+              -50000
+              -49999
+              -49998
+              -49997
+              -49996
+(8 rows)
+
+-- TopN descending over negatives only.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 DESC LIMIT 8;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Limit
+   Output: amt_78
+   ->  Custom Scan (ParadeDB Base Scan) on public.amounts
+         Output: amt_78
+         Table: amounts
+         Index: amounts_idx
+         Worker Selection: Row-capped
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: amt_78 desc
+            TopK Limit: 8
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"direction","value":"debit"}}}}
+(12 rows)
+
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 DESC LIMIT 8;
+ amt_78 
+--------
+     -1
+     -2
+     -3
+     -4
+     -5
+     -5
+     -6
+     -7
+(8 rows)
+
+-- Unlimited-precision NUMERIC takes the same storage path.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_any FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_any ASC LIMIT 8;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Limit
+   Output: amt_any
+   ->  Custom Scan (ParadeDB Base Scan) on public.amounts
+         Output: amt_any
+         Table: amounts
+         Index: amounts_idx
+         Worker Selection: Row-capped
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: amt_any asc
+            TopK Limit: 8
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"direction","value":"debit"}}}}
+(12 rows)
+
+SELECT amt_any FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_any ASC LIMIT 8;
+        amt_any         
+------------------------
+ -100000000000000000000
+                -100001
+                 -50001
+                 -50000
+                 -49999
+                 -49998
+                 -49997
+                 -49996
+(8 rows)
+
+-- Fractional negatives with a 20-digit integer part in the mix.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_scaled ASC LIMIT 4;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Limit
+   Output: amt_scaled
+   ->  Custom Scan (ParadeDB Base Scan) on public.amounts
+         Output: amt_scaled
+         Table: amounts
+         Index: amounts_idx
+         Worker Selection: Row-capped
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: amt_scaled asc
+            TopK Limit: 4
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"direction","value":"debit"}}}}
+(12 rows)
+
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_scaled ASC LIMIT 4;
+           amt_scaled            
+---------------------------------
+ -1000000000000000000.0000000001
+                 -100.0010000000
+                   -0.5100000000
+                   -0.5000100000
+(4 rows)
+
+-- Shared-prefix fractions: -0.51 < -0.50001 < -0.5 < -0.4999.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_scaled', numrange(-1, -0.4))
+ORDER BY amt_scaled ASC;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: amt_scaled
+   Sort Key: amounts.amt_scaled
+   ->  Custom Scan (ParadeDB Base Scan) on public.amounts
+         Output: amt_scaled
+         Table: amounts
+         Index: amounts_idx
+         Worker Selection: Row-capped
+         Exec Method: ColumnarExecState
+         Fast Fields: amt_scaled
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"range":{"field":"amt_scaled","lower_bound":{"included":"-1"},"upper_bound":{"excluded":"-0.4"}}}}}
+(12 rows)
+
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_scaled', numrange(-1, -0.4))
+ORDER BY amt_scaled ASC;
+  amt_scaled   
+---------------
+ -0.5100000000
+ -0.5000100000
+ -0.5000000000
+ -0.4999000000
+(4 rows)
+
+-- Whole-table ordering across the sign boundary.
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all()
+ORDER BY amt_78 ASC LIMIT 4;
+         amt_78         
+------------------------
+ -100000000000000000000
+                -100001
+                 -50001
+                 -50000
+(4 rows)
+
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all()
+ORDER BY amt_78 DESC LIMIT 4;
+ amt_78 
+--------
+     51
+      5
+      0
+     -1
+(4 rows)
+
+-- Range pushdown must not return rows outside the requested range.
+SELECT count(*) FROM (
+    SELECT amt_78 FROM amounts
+    WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_78', numrange(-20500, -20300))
+) s
+WHERE NOT (amt_78 >= -20500 AND amt_78 < -20300);
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: amounts)
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_78', numrange(-20500, -20300));
+ count 
+-------
+   200
+(1 row)
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_18', numrange(-20500, -20300));
+ count 
+-------
+   200
+(1 row)
+
+-- Range with a shared-prefix boundary: (-50000, -49990] must exclude -50000 and include -49990.
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_78', numrange(-50000, -49990, '(]'))
+ORDER BY amt_78;
+ amt_78 
+--------
+ -49999
+ -49998
+ -49997
+ -49996
+ -49995
+ -49994
+ -49993
+ -49992
+ -49991
+ -49990
+(10 rows)
+
+-- Heap-filter pushdown on the fast field.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 > -20500 AND amt_78 < -20300;
+                                                                                                                   QUERY PLAN                                                                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.amounts
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: amounts_idx
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":"all"}},{"range":{"field":"amt_78","lower_bound":{"excluded":"-20500"},"upper_bound":null}},{"range":{"field":"amt_78","lower_bound":null,"upper_bound":{"excluded":"-20300"}}}]}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 > -20500 AND amt_78 < -20300;
+ count 
+-------
+   199
+(1 row)
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_18 > -20500 AND amt_18 < -20300;
+ count 
+-------
+   199
+(1 row)
+
+-- Equality on values with shared digit prefixes.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -49990::numeric)
+ORDER BY id;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sort
+   Output: id, amt_78
+   Sort Key: amounts.id
+   ->  Custom Scan (ParadeDB Base Scan) on public.amounts
+         Output: id, amt_78
+         Table: amounts
+         Index: amounts_idx
+         Worker Selection: Row-capped
+         Exec Method: ColumnarExecState
+         Fast Fields: amt_78, id
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"amt_78","value":"-49990"}}}}
+(12 rows)
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -49990::numeric)
+ORDER BY id;
+  id   | amt_78 
+-------+--------
+ 49990 | -49990
+(1 row)
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -100001::numeric)
+ORDER BY id;
+  id   | amt_78  
+-------+---------
+ 50007 | -100001
+(1 row)
+
+SELECT id, amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_scaled', -0.5::numeric)
+ORDER BY id;
+  id   |  amt_scaled   
+-------+---------------
+ 50003 | -0.5000000000
+(1 row)
+
+-- Rows written after the index build take the same byte layout as the build.
+INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
+VALUES ('debit', -49995, -49995, -49995, -0.49995);
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 ASC LIMIT 8;
+         amt_78         
+------------------------
+ -100000000000000000000
+                -100001
+                 -50001
+                 -50000
+                 -49999
+                 -49998
+                 -49997
+                 -49996
+(8 rows)
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -49995::numeric)
+ORDER BY id;
+  id   | amt_78 
+-------+--------
+ 49995 | -49995
+ 50010 | -49995
+(2 rows)
+
+DROP TABLE amounts;
+-- numrange bounds are stored with the same encoding.
+CREATE TABLE spans (
+    id serial PRIMARY KEY,
+    span numrange
+);
+INSERT INTO spans (span) VALUES
+    ('[-50000, -49990)'),
+    ('[-49999, -49991]'),
+    ('(-49990, -49000]'),
+    ('[-0.51, -0.5)'),
+    ('[-0.5, 0.5]');
+CREATE INDEX spans_idx ON spans USING bm25 (id, span) WITH (key_field = 'id');
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -49995::numeric)
+ORDER BY id;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort
+   Output: id, span
+   Sort Key: spans.id
+   ->  Custom Scan (ParadeDB Base Scan) on public.spans
+         Output: id, span
+         Table: spans
+         Index: spans_idx
+         Worker Selection: Row-capped
+         Exec Method: NormalScanExecState
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"range_term":{"field":"span","value":"-49995"}}}}
+(11 rows)
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -49995::numeric)
+ORDER BY id;
+ id |      span       
+----+-----------------
+  1 | [-50000,-49990)
+  2 | [-49999,-49991]
+(2 rows)
+
+SELECT id, span FROM spans
+WHERE span @> -49995::numeric
+ORDER BY id;
+ id |      span       
+----+-----------------
+  1 | [-50000,-49990)
+  2 | [-49999,-49991]
+(2 rows)
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -49990::numeric)
+ORDER BY id;
+ id | span 
+----+------
+(0 rows)
+
+SELECT id, span FROM spans
+WHERE span @> -49990::numeric
+ORDER BY id;
+ id | span 
+----+------
+(0 rows)
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -0.5::numeric)
+ORDER BY id;
+ id |    span    
+----+------------
+  5 | [-0.5,0.5]
+(1 row)
+
+SELECT id, span FROM spans
+WHERE span @> -0.5::numeric
+ORDER BY id;
+ id |    span    
+----+------------
+  5 | [-0.5,0.5]
+(1 row)
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', numrange(-49992, -49991), 'Intersects')
+ORDER BY id;
+ id |      span       
+----+-----------------
+  1 | [-50000,-49990)
+  2 | [-49999,-49991]
+(2 rows)
+
+SELECT id, span FROM spans
+WHERE span && numrange(-49992, -49991)
+ORDER BY id;
+ id |      span       
+----+-----------------
+  1 | [-50000,-49990)
+  2 | [-49999,-49991]
+(2 rows)
+
+DROP TABLE spans;

--- a/pg_search/tests/pg_regress/expected/issue_6051.out
+++ b/pg_search/tests/pg_regress/expected/issue_6051.out
@@ -251,7 +251,7 @@ SELECT count(*) FROM (
     WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_78', numrange(-20500, -20300))
 ) s
 WHERE NOT (amt_78 >= -20500 AND amt_78 < -20300);
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: amounts)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: amounts)
  count 
 -------
      0

--- a/pg_search/tests/pg_regress/expected/issue_6051.out
+++ b/pg_search/tests/pg_regress/expected/issue_6051.out
@@ -48,7 +48,7 @@ ORDER BY amt_78 ASC LIMIT 8;
          Output: amt_78
          Table: amounts
          Index: amounts_idx
-         Worker Selection: Row-capped
+         Worker Selection: Cost model
          Exec Method: TopKScanExecState
          Scores: false
             TopK Order By: amt_78 asc
@@ -99,7 +99,7 @@ ORDER BY amt_78 DESC LIMIT 8;
          Output: amt_78
          Table: amounts
          Index: amounts_idx
-         Worker Selection: Row-capped
+         Worker Selection: Cost model
          Exec Method: TopKScanExecState
          Scores: false
             TopK Order By: amt_78 desc
@@ -135,7 +135,7 @@ ORDER BY amt_any ASC LIMIT 8;
          Output: amt_any
          Table: amounts
          Index: amounts_idx
-         Worker Selection: Row-capped
+         Worker Selection: Cost model
          Exec Method: TopKScanExecState
          Scores: false
             TopK Order By: amt_any asc
@@ -171,7 +171,7 @@ ORDER BY amt_scaled ASC LIMIT 4;
          Output: amt_scaled
          Table: amounts
          Index: amounts_idx
-         Worker Selection: Row-capped
+         Worker Selection: Cost model
          Exec Method: TopKScanExecState
          Scores: false
             TopK Order By: amt_scaled asc
@@ -204,7 +204,7 @@ ORDER BY amt_scaled ASC;
          Output: amt_scaled
          Table: amounts
          Index: amounts_idx
-         Worker Selection: Row-capped
+         Worker Selection: Cost model
          Exec Method: ColumnarExecState
          Fast Fields: amt_scaled
          Scores: false
@@ -331,7 +331,7 @@ ORDER BY id;
          Output: id, amt_78
          Table: amounts
          Index: amounts_idx
-         Worker Selection: Row-capped
+         Worker Selection: Cost model
          Exec Method: ColumnarExecState
          Fast Fields: amt_78, id
          Scores: false
@@ -415,7 +415,7 @@ ORDER BY id;
          Output: id, span
          Table: spans
          Index: spans_idx
-         Worker Selection: Row-capped
+         Worker Selection: Cost model
          Exec Method: NormalScanExecState
          Scores: false
          Tantivy Query: {"with_index":{"query":{"range_term":{"field":"span","value":"-49995"}}}}

--- a/pg_search/tests/pg_regress/expected/issue_6051.out
+++ b/pg_search/tests/pg_regress/expected/issue_6051.out
@@ -362,6 +362,50 @@ ORDER BY id;
  50003 | -0.5000000000
 (1 row)
 
+-- IN (...) is pushed down as a term set and has to use the same term conversion.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 IN (-49999, -49990, 5)
+ORDER BY id;
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: id, amt_78
+   Sort Key: amounts.id
+   ->  Custom Scan (ParadeDB Base Scan) on public.amounts
+         Output: id, amt_78
+         Table: amounts
+         Index: amounts_idx
+         Worker Selection: Cost model
+         Exec Method: ColumnarExecState
+         Fast Fields: amt_78, id
+         Scores: false
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":"all"}},{"term_set":{"terms":[{"field":"amt_78","value":"-49999"},{"field":"amt_78","value":"-49990"},{"field":"amt_78","value":"5"}]}}]}}
+(12 rows)
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 IN (-49999, -49990, 5)
+ORDER BY id;
+  id   | amt_78 
+-------+--------
+ 49990 | -49990
+ 49999 | -49999
+ 50001 |      5
+(3 rows)
+
+SELECT id, amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_scaled IN (-0.5, -0.50001)
+ORDER BY id;
+  id   |  amt_scaled   
+-------+---------------
+ 50003 | -0.5000000000
+ 50005 | -0.5000100000
+(2 rows)
+
+-- A term that can't be parsed as a number is an error, not an empty match.
+SELECT id FROM amounts
+WHERE discarded_at IS NULL AND amt_78 @@@ pdb.term_set(ARRAY['not-a-number']::text[]);
+ERROR:  Failed to parse numeric 'not-a-number': InvalidFormat("Invalid character: n")
 -- Rows written after the index build take the same byte layout as the build.
 INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
 VALUES ('debit', -49995, -49995, -49995, -0.49995);
@@ -390,6 +434,44 @@ ORDER BY id;
 (2 rows)
 
 DROP TABLE amounts;
+-- NUMERIC with precision <= 18 is stored as a scaled integer, and IN (...) has to scale too.
+CREATE TABLE prices (
+    id serial PRIMARY KEY,
+    price numeric(10,2)
+);
+INSERT INTO prices (price) VALUES (1.23), (4.56), (1.00), (4.00), (-1.23);
+CREATE INDEX prices_idx ON prices USING bm25 (id, price) WITH (key_field = 'id');
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, price FROM prices
+WHERE id @@@ paradedb.all() AND price IN (1.23, 4.56, -1.23)
+ORDER BY id;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: id, price
+   Sort Key: prices.id
+   ->  Custom Scan (ParadeDB Base Scan) on public.prices
+         Output: id, price
+         Table: prices
+         Index: prices_idx
+         Worker Selection: Cost model
+         Exec Method: ColumnarExecState
+         Fast Fields: id, price
+         Scores: false
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":"all"}},{"term_set":{"terms":[{"field":"price","value":"1.23"},{"field":"price","value":"4.56"},{"field":"price","value":"-1.23"}]}}]}}
+(12 rows)
+
+SELECT id, price FROM prices
+WHERE id @@@ paradedb.all() AND price IN (1.23, 4.56, -1.23)
+ORDER BY id;
+ id | price 
+----+-------
+  1 |  1.23
+  2 |  4.56
+  5 | -1.23
+(3 rows)
+
+DROP TABLE prices;
 -- numrange bounds are stored with the same encoding.
 CREATE TABLE spans (
     id serial PRIMARY KEY,

--- a/pg_search/tests/pg_regress/sql/issue_6051.sql
+++ b/pg_search/tests/pg_regress/sql/issue_6051.sql
@@ -1,0 +1,216 @@
+\i common/common_setup.sql
+
+-- NUMERIC with precision > 18 is stored as sortable bytes. Negative values whose digit
+-- strings share a prefix (e.g. -49990 and -49999) are the case where the byte order used
+-- to disagree with the numeric order.
+
+SET enable_seqscan = off;
+SET max_parallel_workers_per_gather = 0;
+
+CREATE TABLE amounts (
+    id serial PRIMARY KEY,
+    direction varchar NOT NULL,
+    amt_18 numeric(18,0) NOT NULL,
+    amt_78 numeric(78,0) NOT NULL,
+    amt_any numeric NOT NULL,
+    amt_scaled numeric(30,10) NOT NULL,
+    discarded_at timestamp
+);
+
+INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
+SELECT 'debit', -g, -g, -g, -g / 1000000.0
+FROM generate_series(1, 50000) g;
+
+INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
+VALUES
+    ('credit', 5, 5, 5, 0.5),
+    ('credit', 51, 51, 51, 0.51),
+    ('debit', -5, -5, -5, -0.5),
+    ('debit', -51, -51, -51, -0.51),
+    ('debit', -50001, -50001, -50001, -0.50001),
+    ('debit', -4999, -4999, -4999, -0.4999),
+    ('debit', -100001, -100001, -100001, -100.001),
+    ('debit', -999999999999999999, -100000000000000000000, -100000000000000000000, -1000000000000000000.0000000001),
+    ('zero', 0, 0, 0, 0);
+
+CREATE INDEX amounts_idx ON amounts USING bm25 (
+    id, (direction::pdb.literal), amt_18, amt_78, amt_any, amt_scaled, discarded_at
+) WITH (key_field = 'id') WHERE (discarded_at IS NULL);
+
+-- TopN ascending: the numeric(18,0) column is the reference ordering.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 ASC LIMIT 8;
+
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 ASC LIMIT 8;
+
+SELECT amt_18 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_18 ASC LIMIT 8;
+
+-- TopN descending over negatives only.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 DESC LIMIT 8;
+
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 DESC LIMIT 8;
+
+-- Unlimited-precision NUMERIC takes the same storage path.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_any FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_any ASC LIMIT 8;
+
+SELECT amt_any FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_any ASC LIMIT 8;
+
+-- Fractional negatives with a 20-digit integer part in the mix.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_scaled ASC LIMIT 4;
+
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_scaled ASC LIMIT 4;
+
+-- Shared-prefix fractions: -0.51 < -0.50001 < -0.5 < -0.4999.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_scaled', numrange(-1, -0.4))
+ORDER BY amt_scaled ASC;
+
+SELECT amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_scaled', numrange(-1, -0.4))
+ORDER BY amt_scaled ASC;
+
+-- Whole-table ordering across the sign boundary.
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all()
+ORDER BY amt_78 ASC LIMIT 4;
+
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all()
+ORDER BY amt_78 DESC LIMIT 4;
+
+-- Range pushdown must not return rows outside the requested range.
+SELECT count(*) FROM (
+    SELECT amt_78 FROM amounts
+    WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_78', numrange(-20500, -20300))
+) s
+WHERE NOT (amt_78 >= -20500 AND amt_78 < -20300);
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_78', numrange(-20500, -20300));
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_18', numrange(-20500, -20300));
+
+-- Range with a shared-prefix boundary: (-50000, -49990] must exclude -50000 and include -49990.
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.range('amt_78', numrange(-50000, -49990, '(]'))
+ORDER BY amt_78;
+
+-- Heap-filter pushdown on the fast field.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 > -20500 AND amt_78 < -20300;
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 > -20500 AND amt_78 < -20300;
+
+SELECT count(*) FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_18 > -20500 AND amt_18 < -20300;
+
+-- Equality on values with shared digit prefixes.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -49990::numeric)
+ORDER BY id;
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -49990::numeric)
+ORDER BY id;
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -100001::numeric)
+ORDER BY id;
+
+SELECT id, amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_scaled', -0.5::numeric)
+ORDER BY id;
+
+-- Rows written after the index build take the same byte layout as the build.
+INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
+VALUES ('debit', -49995, -49995, -49995, -0.49995);
+
+SELECT amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('direction', 'debit')
+ORDER BY amt_78 ASC LIMIT 8;
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -49995::numeric)
+ORDER BY id;
+
+DROP TABLE amounts;
+
+-- numrange bounds are stored with the same encoding.
+CREATE TABLE spans (
+    id serial PRIMARY KEY,
+    span numrange
+);
+
+INSERT INTO spans (span) VALUES
+    ('[-50000, -49990)'),
+    ('[-49999, -49991]'),
+    ('(-49990, -49000]'),
+    ('[-0.51, -0.5)'),
+    ('[-0.5, 0.5]');
+
+CREATE INDEX spans_idx ON spans USING bm25 (id, span) WITH (key_field = 'id');
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -49995::numeric)
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -49995::numeric)
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE span @> -49995::numeric
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -49990::numeric)
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE span @> -49990::numeric
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', -0.5::numeric)
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE span @> -0.5::numeric
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE id @@@ paradedb.range_term('span', numrange(-49992, -49991), 'Intersects')
+ORDER BY id;
+
+SELECT id, span FROM spans
+WHERE span && numrange(-49992, -49991)
+ORDER BY id;
+
+DROP TABLE spans;

--- a/pg_search/tests/pg_regress/sql/issue_6051.sql
+++ b/pg_search/tests/pg_regress/sql/issue_6051.sql
@@ -147,6 +147,24 @@ SELECT id, amt_scaled FROM amounts
 WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_scaled', -0.5::numeric)
 ORDER BY id;
 
+-- IN (...) is pushed down as a term set and has to use the same term conversion.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 IN (-49999, -49990, 5)
+ORDER BY id;
+
+SELECT id, amt_78 FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_78 IN (-49999, -49990, 5)
+ORDER BY id;
+
+SELECT id, amt_scaled FROM amounts
+WHERE discarded_at IS NULL AND id @@@ paradedb.all() AND amt_scaled IN (-0.5, -0.50001)
+ORDER BY id;
+
+-- A term that can't be parsed as a number is an error, not an empty match.
+SELECT id FROM amounts
+WHERE discarded_at IS NULL AND amt_78 @@@ pdb.term_set(ARRAY['not-a-number']::text[]);
+
 -- Rows written after the index build take the same byte layout as the build.
 INSERT INTO amounts (direction, amt_18, amt_78, amt_any, amt_scaled)
 VALUES ('debit', -49995, -49995, -49995, -0.49995);
@@ -160,6 +178,27 @@ WHERE discarded_at IS NULL AND id @@@ paradedb.term('amt_78', -49995::numeric)
 ORDER BY id;
 
 DROP TABLE amounts;
+
+-- NUMERIC with precision <= 18 is stored as a scaled integer, and IN (...) has to scale too.
+CREATE TABLE prices (
+    id serial PRIMARY KEY,
+    price numeric(10,2)
+);
+
+INSERT INTO prices (price) VALUES (1.23), (4.56), (1.00), (4.00), (-1.23);
+
+CREATE INDEX prices_idx ON prices USING bm25 (id, price) WITH (key_field = 'id');
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, price FROM prices
+WHERE id @@@ paradedb.all() AND price IN (1.23, 4.56, -1.23)
+ORDER BY id;
+
+SELECT id, price FROM prices
+WHERE id @@@ paradedb.all() AND price IN (1.23, 4.56, -1.23)
+ORDER BY id;
+
+DROP TABLE prices;
 
 -- numrange bounds are stored with the same encoding.
 CREATE TABLE spans (


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #6051

## What

This PR fixes TopN ordering and range pushdown for negative values in `NumericBytes` fast fields (`NUMERIC` with precision > 18 or no precision). Positive values were fine, and `NUMERIC(18,0)` was fine, since that goes through `Numeric64`.

## Why

`decimal-bytes` stored a negative mantissa as bitwise-inverted BCD with no terminator. When a shorter mantissa is a prefix of a longer one, the shorter one sorts first in byte order, but it's the larger number: `-49990` (`B6 66`) came before `-49999` (`B6 66 6F`). TopN, `paradedb.range`, heap-filter pushdown, and `numrange` bounds all compare those bytes directly.

## How

The encoding fix is paradedb/decimal-bytes#19, released as `0.5.0`. Negative digits are nine's-complemented and end with a `0xFF` terminator. The old layout still decodes, and `Decimal::to_legacy_bytes` produces it.

The two layouts don't sort together, so an index has to stay on one of them. Same as #5245 did for datetimes, the choice follows the index's `created_by_version`. Indexes created before `0.25.5` keep writing and querying the old layout, so existing rows and new rows stay comparable (and the ordering bug stays until `REINDEX`). Indexes built by `0.25.5` or later use the fixed layout. `query::numeric::decimal_to_index_bytes` is the one place that picks, and it's threaded through query terms, range bounds, the index write path, and `numrange` bounds.

Please note that:
- The gate is `0.25.5`, the version `main` carries after the `0.25.4` release. If that release doesn't ship this fix, the constant has to move.
- A JoinScan between a legacy index and a rebuilt one on a `NUMERIC(p > 18)` key won't match negative values until both are rebuilt.

## Tests

- `issue_6051` regress test: TopN asc/desc, unbounded `numeric`, `numeric(30,10)` fractions with shared prefixes, `paradedb.range` (no rows outside the range), heap-filter pushdown, equality, rows inserted after the build, and `numrange` containment and intersection. The `numeric(18,0)` column serves as the reference for the counts and orderings.
- Unit test in `query/numeric.rs` for the layout choice by version.
- The legacy layout itself is covered in the crate. The regress test only builds indexes with this version, so the legacy write path isn't covered end to end here.
