### PR TITLE
docs: fix query, aggregate and CI correctness issues from the docs audit

### DIFF
--- a/docs/deploy/ci/gitlab-ci.mdx
+++ b/docs/deploy/ci/gitlab-ci.mdx
@@ -11,14 +11,15 @@ paradedb-in-gitlab-ci:
   # The list of available tags can be found at https://hub.docker.com/r/paradedb/paradedb/tags
   image: paradedb/paradedb:latest
   services:
-    - postgres
+    - name: paradedb/paradedb:latest
+      alias: paradedb
   variables:
     POSTGRES_USER: testuser
     POSTGRES_DB: testdb
     POSTGRES_HOST_AUTH_METHOD: trust
   script:
-    - psql -h "postgres" -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
-    - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
-    - psql -h "postgres" -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
-    - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"
+    - psql -h "paradedb" -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
+    - psql -h "paradedb" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
+    - psql -h "paradedb" -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
+    - psql -h "paradedb" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"
 ```

--- a/docs/documentation/aggregates/bucket/filters.mdx
+++ b/docs/documentation/aggregates/bucket/filters.mdx
@@ -101,8 +101,12 @@ await dbContext
 </CodeGroup>
 
 <Note>
-  Use lowercase `electronics` and `footwear`. The default BM25 tokenizer
-  lowercases terms, so `Electronics` and `Footwear` would not match here.
+  `===` matches indexed terms exactly, so the casing depends on `category`'s
+  tokenizer. With the default tokenizer or
+  [`literal_normalized`](/documentation/tokenizers/available-tokenizers/literal-normalized),
+  terms are lowercased: use `electronics`. With the
+  [`literal`](/documentation/tokenizers/available-tokenizers/literal) tokenizer,
+  which preserves the original casing, use `Electronics`.
 </Note>
 
 ```ini Expected Response

--- a/docs/documentation/aggregates/bucket/range.mdx
+++ b/docs/documentation/aggregates/bucket/range.mdx
@@ -97,5 +97,13 @@ await dbContext
 (1 row)
 ```
 
+<Note>
+  The response contains a `6-*` bucket that was not requested. The range
+  aggregation automatically adds unbounded buckets so that the full value range
+  is covered: here the last requested range ends at `6`, so a `6-*` bucket
+  counts any values above it. This differs from Elasticsearch, which returns
+  only the requested ranges.
+</Note>
+
 See the [Tantivy documentation](https://docs.rs/tantivy/latest/tantivy/aggregation/bucket/struct.RangeAggregation.html)
 for all available options.

--- a/docs/documentation/aggregates/bucket/range.mdx
+++ b/docs/documentation/aggregates/bucket/range.mdx
@@ -98,11 +98,8 @@ await dbContext
 ```
 
 <Note>
-  The response contains a `6-*` bucket that was not requested. The range
-  aggregation automatically adds unbounded buckets so that the full value range
-  is covered: here the last requested range ends at `6`, so a `6-*` bucket
-  counts any values above it. This differs from Elasticsearch, which returns
-  only the requested ranges.
+  The `6-*` bucket was not requested: the range aggregation automatically
+  appends an unbounded bucket for values above the last range.
 </Note>
 
 See the [Tantivy documentation](https://docs.rs/tantivy/latest/tantivy/aggregation/bucket/struct.RangeAggregation.html)

--- a/docs/documentation/aggregates/bucket/terms.mdx
+++ b/docs/documentation/aggregates/bucket/terms.mdx
@@ -181,3 +181,24 @@ await dbContext
 
 For performance reasons, we strongly recommend adding a `LIMIT` to the `GROUP BY`. Terms aggregations without a `LIMIT` consume more memory and
 are slower to execute. If a query does not have a limit and more than `65000` unique values are found in a field, an error will be returned.
+
+## JSON Syntax
+
+The SQL `GROUP BY` form above is the recommended way to run a terms aggregation. The same aggregation can also be
+expressed directly with `pdb.agg`, using the `terms` JSON syntax this page is named after:
+
+```sql
+SELECT pdb.agg('{"terms": {"field": "rating", "size": 5}}')
+FROM mock_items
+WHERE id @@@ pdb.all();
+```
+
+```ini Expected Response
+                                                                             agg
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": 4, "doc_count": 16}, {"key": 5, "doc_count": 12}, {"key": 3, "doc_count": 9}, {"key": 2, "doc_count": 3}, {"key": 1, "doc_count": 1}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+(1 row)
+```
+
+See the [Tantivy documentation](https://docs.rs/tantivy/latest/tantivy/aggregation/bucket/struct.TermsAggregation.html)
+for all available options.

--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -147,12 +147,9 @@ Filter pushdown is currently supported for the following combinations of types a
 |                                            | `int2`            |                    |
 |                                            | `int4`            |                    |
 |                                            | `int8`            |                    |
-|                                            | `int2`            |                    |
-|                                            | `int2`            |                    |
-|                                            | `int4`            |                    |
 |                                            | `float4`          |                    |
 |                                            | `float8`          |                    |
-|                                            | `float4`          |                    |
+|                                            | `numeric`         |                    |
 |                                            | `date`            |                    |
 |                                            | `time`            |                    |
 |                                            | `timetz`          |                    |

--- a/docs/documentation/migration/elasticsearch-feature-comparison.mdx
+++ b/docs/documentation/migration/elasticsearch-feature-comparison.mdx
@@ -28,8 +28,6 @@ all live inside Postgres — no ETL pipelines, no separate cluster to manage.
 - **Continue to use Postgres tooling.** Backups, replication, monitoring, and CI/CD integrate with standard Postgres tools
   you already use.
 
-## Feature Comparison
-
 ## Query Capabilities
 
 | Feature                     | Elasticsearch | ParadeDB | Notes                                                                                                                                                                     |


### PR DESCRIPTION
## Summary

Six medium-severity fixes from the docs correctness audit, queries/aggregates/misc half, one commit each:

- **Filter casing note**: bucket/filters said to always use lowercase, contradicting the aggregate section's `literal` tokenizer requirement. `===` matches indexed terms exactly, so the note now states the tokenizer dependency (verified live: default and `literal_normalized` match lowercase, `literal` matches original casing).
- **Filter pushdown table**: deduped the corrupted IS NULL rows (`int2` 3x, `int4` 2x, `float4` 2x) and added `numeric`; IS NULL pushdown is gated on the field being columnar, not on a type pair.
- **Empty `## Feature Comparison` header** removed from the Elasticsearch comparison.
- **Range aggregation**: explained the auto-generated `6-*` bucket (tantivy adds unbounded buckets to cover the value range, unlike Elasticsearch; verified live).
- **Terms aggregation**: the page never showed the `{"terms": ...}` JSON it is named after; added the direct `pdb.agg` form with verified output.
- **GitLab CI example**: `services: - postgres` started vanilla Postgres, so every script step failed. The service is now `paradedb/paradedb`, matching the GitHub Actions page. Not executed in a real GitLab pipeline; syntax follows GitLab's documented name/alias form.

Two audit items in this group were false positives and need no change: the `max_expansions` "contradiction" is two different query types with genuinely different defaults and overflow behavior (`regex_phrase`: 16384, errors; `phrase_prefix`: 50, truncates — both match tantivy), and verify-index's "bare headers" all have content after a blank line.

## Verification

- `===` casing, range `6-*` bucket, and terms JSON output all run against a live pg_search instance.
- IS NULL pushdown gating: `T_NullTest` handling in pg_search/src/postgres/customscan/qual_inspect.rs requires only a fast field.
- max_expansions defaults: tantivy `RegexPhraseQuery` (`1 << 14`, "exceeded max expansions") and `PhrasePrefixQuery` (`DEFAULT_MAX_EXPANSIONS = 50`, lexicographic truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)