### PR TITLE
chore: Generate Dockerfiles for v0.25.4

### DIFF
--- a/docker/Dockerfile.official-15
+++ b/docker/Dockerfile.official-15
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="a20c99b1bfa4572039eb7e338b8fd7da9db0e77597583c7c812991371c98e292" ;; \
-        arm64) checksum="3312620746e60867368711df94883d9a99ba72cc1d4a607bc870339dbdcc4861" ;; \
+        amd64) checksum="fd5a8cc339c21aba7c1b533f285b1f05235468c096f0ec5a3a62c3265166956a" ;; \
+        arm64) checksum="7bf4a4c74ec86e1846579dd368d4fe4b8ec5d4f5e24ec5a825bf4311bd787859" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-15-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-15-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.official-16
+++ b/docker/Dockerfile.official-16
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="b2187f5b7dbf6775d1fd60e9b4244fc81070e3fb012dbc20aa99db1a26c558aa" ;; \
-        arm64) checksum="776585870aefa9ed770f2c2f5d20c731cd8c76cec9ddb9c77e6c498f74b8e6ac" ;; \
+        amd64) checksum="a2d39d58cd15902deee76f814b32e220ecb820cab2b11de216e53ba3a4daab48" ;; \
+        arm64) checksum="9b3b8acfce50d97db94540018b232524780321c1c2f197b9f16ce7d3e8eec795" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-16-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-16-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.official-17
+++ b/docker/Dockerfile.official-17
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="045b5f450622fb16366dc9ec027d76a7e9cc72410595d4f2a89354db9a7713d8" ;; \
-        arm64) checksum="b1bcfed18f63441e60ad9168831efbf86129501df7b41692b54ce3094a0cf143" ;; \
+        amd64) checksum="ca49a0fdc625b2e3bdb631417f9b58dece81ca2f37f72a9e3ba1f03f48d8238d" ;; \
+        arm64) checksum="8b7f01985c8c060202a5dd32dd95f32dab674b682578a381a5b81893ccb185d2" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-17-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-17-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.official-18
+++ b/docker/Dockerfile.official-18
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="29940e89dfa94882693928c587165998324c8630d9bd3a488bdcdd490ed9c9da" ;; \
-        arm64) checksum="df23250a9a6eaabd50fcae2f901cad24c56fbc2f3ac0d6d8e347ea4bdea18c76" ;; \
+        amd64) checksum="849cb8cd3e173c220a36a4d4e16e2d72f717a40122ea158e215494776bc9f8b6" ;; \
+        arm64) checksum="20d4fd631642112f2e0b66d683712bc0c61daac57e52194fc8fe7dd3771065c9" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-18-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-15
+++ b/docker/Dockerfile.paradedb-15
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="a20c99b1bfa4572039eb7e338b8fd7da9db0e77597583c7c812991371c98e292" ;; \
-        arm64) checksum="3312620746e60867368711df94883d9a99ba72cc1d4a607bc870339dbdcc4861" ;; \
+        amd64) checksum="fd5a8cc339c21aba7c1b533f285b1f05235468c096f0ec5a3a62c3265166956a" ;; \
+        arm64) checksum="7bf4a4c74ec86e1846579dd368d4fe4b8ec5d4f5e24ec5a825bf4311bd787859" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-15-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-15-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-16
+++ b/docker/Dockerfile.paradedb-16
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="b2187f5b7dbf6775d1fd60e9b4244fc81070e3fb012dbc20aa99db1a26c558aa" ;; \
-        arm64) checksum="776585870aefa9ed770f2c2f5d20c731cd8c76cec9ddb9c77e6c498f74b8e6ac" ;; \
+        amd64) checksum="a2d39d58cd15902deee76f814b32e220ecb820cab2b11de216e53ba3a4daab48" ;; \
+        arm64) checksum="9b3b8acfce50d97db94540018b232524780321c1c2f197b9f16ce7d3e8eec795" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-16-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-16-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-17
+++ b/docker/Dockerfile.paradedb-17
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="045b5f450622fb16366dc9ec027d76a7e9cc72410595d4f2a89354db9a7713d8" ;; \
-        arm64) checksum="b1bcfed18f63441e60ad9168831efbf86129501df7b41692b54ce3094a0cf143" ;; \
+        amd64) checksum="ca49a0fdc625b2e3bdb631417f9b58dece81ca2f37f72a9e3ba1f03f48d8238d" ;; \
+        arm64) checksum="8b7f01985c8c060202a5dd32dd95f32dab674b682578a381a5b81893ccb185d2" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-17-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-17-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-18
+++ b/docker/Dockerfile.paradedb-18
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="29940e89dfa94882693928c587165998324c8630d9bd3a488bdcdd490ed9c9da" ;; \
-        arm64) checksum="df23250a9a6eaabd50fcae2f901cad24c56fbc2f3ac0d6d8e347ea4bdea18c76" ;; \
+        amd64) checksum="849cb8cd3e173c220a36a4d4e16e2d72f717a40122ea158e215494776bc9f8b6" ;; \
+        arm64) checksum="20d4fd631642112f2e0b66d683712bc0c61daac57e52194fc8fe7dd3771065c9" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.3/postgresql-18-pg-search_0.25.3-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \


### PR DESCRIPTION
Updates generated Dockerfiles for v0.25.4 after the Docker images were published.