### PR TITLE
docs: update documentation URLs

### DIFF
--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -130,9 +130,9 @@ jobs:
               continue
             fi
 
-            # Build expected canonical: https://docs.paradedb.com/<relative path without .mdx>
+            # Build expected canonical: https://www.paradedb.com/docs/<relative path without .mdx>
             relative_path=$(echo "$file" | sed 's|^\./||; s|\.mdx$||; s|^docs/||')
-            expected_canonical="https://docs.paradedb.com/${relative_path}"
+            expected_canonical="https://www.paradedb.com/docs/${relative_path}"
 
             # Extract canonical from file (strip 'canonical:' and whitespace)
             found_canonical=$(echo "$canonical" | sed 's/^canonical:[[:space:]]*//')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # ParadeDB Changelog
 
-Our full changelog can be found in the [ParadeDB changelog directory](https://docs.paradedb.com/changelog/).
+Our full changelog can be found in the [ParadeDB changelog directory](https://www.paradedb.com/docs/changelog/).

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 
 <h3 align="center">
   <a href="https://paradedb.com">Website</a> &bull;
-  <a href="https://docs.paradedb.com">Docs</a> &bull;
+  <a href="https://www.paradedb.com/docs">Docs</a> &bull;
   <a href="https://paradedb.com/slack">Community</a> &bull;
   <a href="https://paradedb.com/blog/">Blog</a> &bull;
-  <a href="https://docs.paradedb.com/changelog/">Changelog</a>
+  <a href="https://www.paradedb.com/docs/changelog/">Changelog</a>
 </h3>
 
 <p align="center">
@@ -39,7 +39,7 @@ To install ParadeDB locally in a fresh Docker container and drop straight into a
 curl -fsSL https://paradedb.com/install.sh | sh
 ```
 
-When you're ready to deploy, check out our [hosting options](https://docs.paradedb.com/deploy/overview).
+When you're ready to deploy, check out our [hosting options](https://www.paradedb.com/docs/deploy/overview).
 
 ## What is ParadeDB?
 
@@ -47,21 +47,21 @@ When you're ready to deploy, check out our [hosting options](https://docs.parade
 
 Vectors are currently indexed using the [pgvector](https://github.com/pgvector/pgvector) extension, but native vector support is coming to our search index soon.
 
-- [x] [Full-Text Search](https://docs.paradedb.com/documentation/full-text/overview)
-  - [x] [BM25 Scoring](https://docs.paradedb.com/documentation/sorting/score)
-  - [x] [Top K](https://docs.paradedb.com/documentation/sorting/topk)
-  - [x] [Highlighting](https://docs.paradedb.com/documentation/full-text/highlight)
-  - [x] [Tokenizers & Token Filters](https://docs.paradedb.com/documentation/tokenizers/overview)
-- [x] [Filtering](https://docs.paradedb.com/documentation/filtering)
-- [x] [Aggregates](https://docs.paradedb.com/documentation/aggregates/overview)
-  - [x] [Columnar Storage](https://docs.paradedb.com/documentation/indexing/columnar)
-  - [x] [Bucket & Metrics](https://docs.paradedb.com/documentation/aggregates/overview)
-  - [x] [Facets](https://docs.paradedb.com/documentation/aggregates/facets)
-- [x] [JOINs](https://docs.paradedb.com/documentation/joins/overview)
+- [x] [Full-Text Search](https://www.paradedb.com/docs/documentation/full-text/overview)
+  - [x] [BM25 Scoring](https://www.paradedb.com/docs/documentation/sorting/score)
+  - [x] [Top K](https://www.paradedb.com/docs/documentation/sorting/topk)
+  - [x] [Highlighting](https://www.paradedb.com/docs/documentation/full-text/highlight)
+  - [x] [Tokenizers & Token Filters](https://www.paradedb.com/docs/documentation/tokenizers/overview)
+- [x] [Filtering](https://www.paradedb.com/docs/documentation/filtering)
+- [x] [Aggregates](https://www.paradedb.com/docs/documentation/aggregates/overview)
+  - [x] [Columnar Storage](https://www.paradedb.com/docs/documentation/indexing/columnar)
+  - [x] [Bucket & Metrics](https://www.paradedb.com/docs/documentation/aggregates/overview)
+  - [x] [Facets](https://www.paradedb.com/docs/documentation/aggregates/facets)
+- [x] [JOINs](https://www.paradedb.com/docs/documentation/joins/overview)
 - [ ] Native Vector Search (coming soon)
 - [ ] Native Hybrid Search (coming soon)
 
-Star and watch this repository to follow along. See our [current projects](https://github.com/paradedb/paradedb/projects?query=is%3Aopen) and [long-term roadmap](https://docs.paradedb.com/welcome/roadmap).
+Star and watch this repository to follow along. See our [current projects](https://github.com/paradedb/paradedb/projects?query=is%3Aopen) and [long-term roadmap](https://www.paradedb.com/docs/welcome/roadmap).
 
 ## How It Works
 
@@ -71,7 +71,7 @@ ParadeDB integrates battle-tested Rust libraries for search and analytics inside
 - [Tantivy](https://github.com/quickwit-oss/tantivy) — powers full-text search
 - [Apache DataFusion](https://github.com/apache/datafusion) — handles OLAP processing
 
-For a deeper dive, see our [architecture docs](https://docs.paradedb.com/welcome/architecture) or [CMU Database Group talk](https://db.cs.cmu.edu/events/building-blocks-paradedb-philippe-noel/).
+For a deeper dive, see our [architecture docs](https://www.paradedb.com/docs/welcome/architecture) or [CMU Database Group talk](https://db.cs.cmu.edu/events/building-blocks-paradedb-philippe-noel/).
 
 ## Integrations
 
@@ -89,14 +89,14 @@ ParadeDB integrates with the tools you already use, with more on the way.
 ### AI Agents
 
 - [Agent Skills](https://github.com/paradedb/agent-skills)
-- [MCP Integration](https://docs.paradedb.com/documentation/getting-started/ai-agents)
+- [MCP Integration](https://www.paradedb.com/docs/documentation/getting-started/ai-agents)
 - [Cursor Plugin](https://cursor.com/marketplace/parade-db)
 
 ### PaaS & Cloud Platforms
 
-- [Railway](https://docs.paradedb.com/deploy/cloud-platforms/railway)
-- [Render](https://docs.paradedb.com/deploy/cloud-platforms/render)
-- [DigitalOcean](https://docs.paradedb.com/deploy/cloud-platforms/digitalocean)
+- [Railway](https://www.paradedb.com/docs/deploy/cloud-platforms/railway)
+- [Render](https://www.paradedb.com/docs/deploy/cloud-platforms/render)
+- [DigitalOcean](https://www.paradedb.com/docs/deploy/cloud-platforms/digitalocean)
 - More coming (Heroku, and others)
 
 ## Community & Support
@@ -112,4 +112,4 @@ We welcome contributions of all sizes! Check out our [good first issues](https:/
 
 ## License
 
-ParadeDB Community is licensed under the [GNU Affero General Public License v3.0](LICENSE). For [ParadeDB Enterprise](https://docs.paradedb.com/deploy/enterprise) licensing, contact [sales@paradedb.com](mailto:sales@paradedb.com).
+ParadeDB Community is licensed under the [GNU Affero General Public License v3.0](LICENSE). For [ParadeDB Enterprise](https://www.paradedb.com/docs/deploy/enterprise) licensing, contact [sales@paradedb.com](mailto:sales@paradedb.com).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # ParadeDB Documentation
 
-ParadeDB [documentation](https://docs.paradedb.com) is built using [Mintlify](https://mintlify.com/docs/quickstart).
+ParadeDB [documentation](https://www.paradedb.com/docs) is built using [Mintlify](https://mintlify.com/docs/quickstart).
 
 ## 👩‍💻 Development
 

--- a/docs/changelog/0.20.0.mdx
+++ b/docs/changelog/0.20.0.mdx
@@ -61,7 +61,7 @@ Standard PostgreSQL aggregations like [`COUNT(*)`](/documentation/aggregates/met
 
 The v2 API has reached feature parity (except for custom stopwords and dismax) with the legacy API.
 
-It has now been promoted to the default API and can be found documented at [http://docs.paradedb.com/documentation](/documentation/). The old API can be found [here](https://github.com/paradedb/paradedb/tree/main/docs/legacy/indexing/create-index.mdx) and will be removed in a future version.
+It has now been promoted to the default API and can be found documented at [http://www.paradedb.com/docs/documentation](/documentation/). The old API can be found [here](https://github.com/paradedb/paradedb/tree/main/docs/legacy/indexing/create-index.mdx) and will be removed in a future version.
 
 As a reminder the v2 API has the following improvements:
 

--- a/docs/deploy/byoc.mdx
+++ b/docs/deploy/byoc.mdx
@@ -1,7 +1,7 @@
 ---
 title: ParadeDB BYOC
 description: Deploy ParadeDB Bring Your Own Cloud (BYOC) within your cloud environment
-canonical: https://docs.paradedb.com/deploy/byoc
+canonical: https://www.paradedb.com/docs/deploy/byoc
 ---
 
 <Info>

--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: GitHub Actions
 description: How to run ParadeDB in Github Actions CI
-canonical: https://docs.paradedb.com/deploy/ci/github-actions
+canonical: https://www.paradedb.com/docs/deploy/ci/github-actions
 ---
 
 ## Sample GitHub Actions Workflow

--- a/docs/deploy/ci/gitlab-ci.mdx
+++ b/docs/deploy/ci/gitlab-ci.mdx
@@ -1,7 +1,7 @@
 ---
 title: GitLab CI
 description: How to run ParadeDB in Gitlab CI
-canonical: https://docs.paradedb.com/deploy/ci/gitlab-ci
+canonical: https://www.paradedb.com/docs/deploy/ci/gitlab-ci
 ---
 
 ## Sample GitLab CI Workflow

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using ParadeDB with Citus
 description: Distributed full-text search with Citus and ParadeDB
-canonical: https://docs.paradedb.com/deploy/citus
+canonical: https://www.paradedb.com/docs/deploy/citus
 ---
 
 [Citus](https://github.com/citusdata/citus) transforms PostgreSQL into a distributed database with horizontal sharding. ParadeDB is fully compatible with Citus, enabling distributed full-text search across sharded tables.

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -1,7 +1,7 @@
 ---
 title: DigitalOcean
 description: Deploy ParadeDB on a DigitalOcean Droplet
-canonical: https://docs.paradedb.com/deploy/cloud-platforms/digitalocean
+canonical: https://www.paradedb.com/docs/deploy/cloud-platforms/digitalocean
 ---
 
 <Note>

--- a/docs/deploy/cloud-platforms/railway.mdx
+++ b/docs/deploy/cloud-platforms/railway.mdx
@@ -1,7 +1,7 @@
 ---
 title: Railway
 description: Deploy ParadeDB on Railway with one click
-canonical: https://docs.paradedb.com/deploy/cloud-platforms/railway
+canonical: https://www.paradedb.com/docs/deploy/cloud-platforms/railway
 ---
 
 <Note>

--- a/docs/deploy/cloud-platforms/render.mdx
+++ b/docs/deploy/cloud-platforms/render.mdx
@@ -1,7 +1,7 @@
 ---
 title: Render
 description: Deploy ParadeDB on Render with one click
-canonical: https://docs.paradedb.com/deploy/cloud-platforms/render
+canonical: https://www.paradedb.com/docs/deploy/cloud-platforms/render
 ---
 
 <Note>

--- a/docs/deploy/enterprise.mdx
+++ b/docs/deploy/enterprise.mdx
@@ -1,7 +1,7 @@
 ---
 title: ParadeDB Enterprise
 description: Feature comparison between ParadeDB Community and Enterprise
-canonical: https://docs.paradedb.com/deploy/enterprise
+canonical: https://www.paradedb.com/docs/deploy/enterprise
 ---
 
 <Note>

--- a/docs/deploy/logical-replication/configuration.mdx
+++ b/docs/deploy/logical-replication/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schema Changes
 description: Handle DDL/schema changes when running ParadeDB as a logical replica
-canonical: https://docs.paradedb.com/deploy/logical-replication/configuration
+canonical: https://www.paradedb.com/docs/deploy/logical-replication/configuration
 ---
 
 <Note>

--- a/docs/deploy/logical-replication/getting-started.mdx
+++ b/docs/deploy/logical-replication/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Logical Replication
 description: Configure ParadeDB as a logical subscriber to an existing Postgres primary
-canonical: https://docs.paradedb.com/deploy/logical-replication/getting-started
+canonical: https://www.paradedb.com/docs/deploy/logical-replication/getting-started
 ---
 
 <Note>

--- a/docs/deploy/logical-replication/multi-database.mdx
+++ b/docs/deploy/logical-replication/multi-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Multi-Database Replication for Microservices
 description: Consolidate multiple microservice databases into a single ParadeDB instance for app-wide search and cross-database joins
-canonical: https://docs.paradedb.com/deploy/logical-replication/multi-database
+canonical: https://www.paradedb.com/docs/deploy/logical-replication/multi-database
 ---
 
 ## Problem Statement

--- a/docs/deploy/logical-replication/operational-guide.mdx
+++ b/docs/deploy/logical-replication/operational-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: Logical Replication Operational Guide
 description: Monitor, troubleshoot, and safely operate ParadeDB as a permanent logical replica
-canonical: https://docs.paradedb.com/deploy/logical-replication/operational-guide
+canonical: https://www.paradedb.com/docs/deploy/logical-replication/operational-guide
 ---
 
 This guide covers how to operate ParadeDB after logical replication has been

--- a/docs/deploy/overview.mdx
+++ b/docs/deploy/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploying ParadeDB
 description: Explore the different ways to deploy ParadeDB into production
-canonical: https://docs.paradedb.com/deploy/overview
+canonical: https://www.paradedb.com/docs/deploy/overview
 ---
 
 <Note>

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -1,7 +1,7 @@
 ---
 title: Extension
 description: How to install ParadeDB as an extension inside an existing self-managed Postgres
-canonical: https://docs.paradedb.com/deploy/self-hosted/extension
+canonical: https://www.paradedb.com/docs/deploy/self-hosted/extension
 ---
 
 <Note>

--- a/docs/deploy/self-hosted/high-availability.mdx
+++ b/docs/deploy/self-hosted/high-availability.mdx
@@ -1,7 +1,7 @@
 ---
 title: High Availability
 description: Use read replicas to minimize downtime in production
-canonical: https://docs.paradedb.com/deploy/self-hosted/high-availability
+canonical: https://www.paradedb.com/docs/deploy/self-hosted/high-availability
 ---
 
 High availability (HA) minimizes downtime in the event of failures and is crucial for production deployments. To achieve high availability, you need to have

--- a/docs/deploy/self-hosted/kubernetes.mdx
+++ b/docs/deploy/self-hosted/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes
 description: How to deploy ParadeDB as a Kubernetes cluster into production
-canonical: https://docs.paradedb.com/deploy/self-hosted/kubernetes
+canonical: https://www.paradedb.com/docs/deploy/self-hosted/kubernetes
 ---
 
 Kubernetes is the recommended way to run ParadeDB in production. Both ParadeDB Community and Enterprise binaries

--- a/docs/deploy/third-party-extensions.mdx
+++ b/docs/deploy/third-party-extensions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installing Third Party Extensions
 description: How to install additional extensions into ParadeDB
-canonical: https://docs.paradedb.com/deploy/third-party-extensions
+canonical: https://www.paradedb.com/docs/deploy/third-party-extensions
 ---
 
 <Note>

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrading ParadeDB
 description: How to update ParadeDB to the latest version
-canonical: https://docs.paradedb.com/deploy/upgrading
+canonical: https://www.paradedb.com/docs/deploy/upgrading
 ---
 
 ## Overview

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -542,7 +542,7 @@
             },
             {
               "key": "url",
-              "value": "https://docs.paradedb.com$path"
+              "value": "https://www.paradedb.com/docs$path"
             }
           ]
         }

--- a/docs/documentation/aggregates/bucket/datehistogram.mdx
+++ b/docs/documentation/aggregates/bucket/datehistogram.mdx
@@ -1,7 +1,7 @@
 ---
 title: Date Histogram
 description: Count the number of occurrences over fixed time intervals
-canonical: https://docs.paradedb.com/documentation/aggregates/bucket/datehistogram
+canonical: https://www.paradedb.com/docs/documentation/aggregates/bucket/datehistogram
 ---
 
 The date histogram aggregation constructs a histogram for date fields.

--- a/docs/documentation/aggregates/bucket/filters.mdx
+++ b/docs/documentation/aggregates/bucket/filters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Filters
 description: Compute aggregations over multiple filters in one query
-canonical: https://docs.paradedb.com/documentation/aggregates/bucket/filters
+canonical: https://www.paradedb.com/docs/documentation/aggregates/bucket/filters
 ---
 
 The filters aggregation allows a single query to return aggregations for multiple search queries at a time.

--- a/docs/documentation/aggregates/bucket/histogram.mdx
+++ b/docs/documentation/aggregates/bucket/histogram.mdx
@@ -1,7 +1,7 @@
 ---
 title: Histogram
 description: Count the number of occurrences over some interval
-canonical: https://docs.paradedb.com/documentation/aggregates/bucket/histogram
+canonical: https://www.paradedb.com/docs/documentation/aggregates/bucket/histogram
 ---
 
 The histogram aggregation dynamically creates buckets for a given `interval` and counts the number of occurrences

--- a/docs/documentation/aggregates/bucket/range.mdx
+++ b/docs/documentation/aggregates/bucket/range.mdx
@@ -1,7 +1,7 @@
 ---
 title: Range
 description: Count the number of occurrences over user-defined buckets
-canonical: https://docs.paradedb.com/documentation/aggregates/bucket/range
+canonical: https://www.paradedb.com/docs/documentation/aggregates/bucket/range
 ---
 
 The range aggregation counts the number of occurrences over user-defined buckets. The buckets must be continuous and cannot overlap.

--- a/docs/documentation/aggregates/bucket/terms.mdx
+++ b/docs/documentation/aggregates/bucket/terms.mdx
@@ -1,7 +1,7 @@
 ---
 title: Terms
 description: Count the number of occurrences for each value in a result set
-canonical: https://docs.paradedb.com/documentation/aggregates/bucket/terms
+canonical: https://www.paradedb.com/docs/documentation/aggregates/bucket/terms
 ---
 
 <Note>

--- a/docs/documentation/aggregates/facets.mdx
+++ b/docs/documentation/aggregates/facets.mdx
@@ -1,7 +1,7 @@
 ---
 title: Facets
 description: Compute a Top K and aggregate in one query
-canonical: https://docs.paradedb.com/documentation/aggregates/facets
+canonical: https://www.paradedb.com/docs/documentation/aggregates/facets
 ---
 
 A common pattern in search is to query for both an aggregate and a set of search results. For example, "find the top 10

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Limitations
 description: Caveats for aggregate support
-canonical: https://docs.paradedb.com/documentation/aggregates/limitations
+canonical: https://www.paradedb.com/docs/documentation/aggregates/limitations
 ---
 
 ## ParadeDB Operator

--- a/docs/documentation/aggregates/metrics/average.mdx
+++ b/docs/documentation/aggregates/metrics/average.mdx
@@ -1,7 +1,7 @@
 ---
 title: Average
 description: Compute the average value of a field
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/average
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/average
 ---
 
 The following query computes the average value over a specific field:

--- a/docs/documentation/aggregates/metrics/cardinality.mdx
+++ b/docs/documentation/aggregates/metrics/cardinality.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cardinality
 description: Compute the number of distinct values in a field
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/cardinality
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/cardinality
 ---
 
 The cardinality aggregation estimates the number of distinct values in a field.

--- a/docs/documentation/aggregates/metrics/count.mdx
+++ b/docs/documentation/aggregates/metrics/count.mdx
@@ -1,7 +1,7 @@
 ---
 title: Count
 description: Count the number of values in a field
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/count
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/count
 ---
 
 The following query counts the number of values in a field:

--- a/docs/documentation/aggregates/metrics/minmax.mdx
+++ b/docs/documentation/aggregates/metrics/minmax.mdx
@@ -1,7 +1,7 @@
 ---
 title: Min/Max
 description: Compute the min/max value of a field
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/minmax
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/minmax
 ---
 
 `min` and `max` return the smallest and largest values of a column, respectively.

--- a/docs/documentation/aggregates/metrics/percentiles.mdx
+++ b/docs/documentation/aggregates/metrics/percentiles.mdx
@@ -1,7 +1,7 @@
 ---
 title: Percentiles
 description: Analyze the distribution of a field
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/percentiles
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/percentiles
 ---
 
 The percentiles aggregation computes the values below which a given percentage of the data falls.

--- a/docs/documentation/aggregates/metrics/stats.mdx
+++ b/docs/documentation/aggregates/metrics/stats.mdx
@@ -1,7 +1,7 @@
 ---
 title: Stats
 description: Compute several metrics at once
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/stats
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/stats
 ---
 
 The stats aggregation returns the count, sum, min, max, and average all at once.

--- a/docs/documentation/aggregates/metrics/sum.mdx
+++ b/docs/documentation/aggregates/metrics/sum.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sum
 description: Compute the sum of a field
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/sum
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/sum
 ---
 
 The sum aggregation computes the sum of a field.

--- a/docs/documentation/aggregates/metrics/tophits.mdx
+++ b/docs/documentation/aggregates/metrics/tophits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Top Hits
 description: Compute the top hits for each bucket in a terms aggregation
-canonical: https://docs.paradedb.com/documentation/aggregates/metrics/tophits
+canonical: https://www.paradedb.com/docs/documentation/aggregates/metrics/tophits
 ---
 
 The top hits aggregation is meant to be used in conjunction with the [terms](/documentation/aggregates/bucket/terms)

--- a/docs/documentation/aggregates/overview.mdx
+++ b/docs/documentation/aggregates/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aggregate Syntax
 description: Accelerate aggregates with the ParadeDB index
-canonical: https://docs.paradedb.com/documentation/aggregates/overview
+canonical: https://www.paradedb.com/docs/documentation/aggregates/overview
 ---
 
 The `pdb.agg` function accepts an Elasticsearch-compatible JSON aggregate query string. It executes the aggregate using the

--- a/docs/documentation/aggregates/tuning.mdx
+++ b/docs/documentation/aggregates/tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: Performance Tuning
 description: Several settings can be tuned to improve the performance of aggregates in ParadeDB
-canonical: https://docs.paradedb.com/documentation/aggregates/tuning
+canonical: https://www.paradedb.com/docs/documentation/aggregates/tuning
 ---
 
 ### Configure Parallel Workers

--- a/docs/documentation/filtering.mdx
+++ b/docs/documentation/filtering.mdx
@@ -1,7 +1,7 @@
 ---
 title: Filtering
 description: Filter search results based on metadata from other fields
-canonical: https://docs.paradedb.com/documentation/filtering
+canonical: https://www.paradedb.com/docs/documentation/filtering
 ---
 
 Adding filters to a search query is as simple as using PostgreSQL's built-in `WHERE` clauses and operators.

--- a/docs/documentation/full-text/fuzzy.mdx
+++ b/docs/documentation/full-text/fuzzy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Fuzzy
 description: Allow for typos in the query string
-canonical: https://docs.paradedb.com/documentation/full-text/fuzzy
+canonical: https://www.paradedb.com/docs/documentation/full-text/fuzzy
 ---
 
 Fuzziness allows for tokens to be considered a match even if they are not identical, allowing for typos

--- a/docs/documentation/full-text/highlight.mdx
+++ b/docs/documentation/full-text/highlight.mdx
@@ -1,7 +1,7 @@
 ---
 title: Highlighting
 description: Generate snippets for portions of the source text that match the query string
-canonical: https://docs.paradedb.com/documentation/full-text/highlight
+canonical: https://www.paradedb.com/docs/documentation/full-text/highlight
 ---
 
 <Note>

--- a/docs/documentation/full-text/match.mdx
+++ b/docs/documentation/full-text/match.mdx
@@ -1,7 +1,7 @@
 ---
 title: Match
 description: Returns documents that match the provided query string, which is tokenized before matching
-canonical: https://docs.paradedb.com/documentation/full-text/match
+canonical: https://www.paradedb.com/docs/documentation/full-text/match
 ---
 
 Match queries are the go-to query type for text search in ParadeDB. There are two types of match queries:

--- a/docs/documentation/full-text/overview.mdx
+++ b/docs/documentation/full-text/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: How Text Search Works
 description: Understand how ParadeDB uses token matching to efficiently search large corpuses of text
-canonical: https://docs.paradedb.com/documentation/full-text/overview
+canonical: https://www.paradedb.com/docs/documentation/full-text/overview
 ---
 
 Text search in ParadeDB, like Elasticsearch and most search engines, is centered around the concept of **token matching**.

--- a/docs/documentation/full-text/phrase.mdx
+++ b/docs/documentation/full-text/phrase.mdx
@@ -1,7 +1,7 @@
 ---
 title: Phrase
 description: Phrase queries are like match queries, but with order and position of matching tokens enforced
-canonical: https://docs.paradedb.com/documentation/full-text/phrase
+canonical: https://www.paradedb.com/docs/documentation/full-text/phrase
 ---
 
 Phrase queries work exactly like [match conjunction](/documentation/full-text/match#match-conjunction), but are more strict in that they require the

--- a/docs/documentation/full-text/proximity.mdx
+++ b/docs/documentation/full-text/proximity.mdx
@@ -1,7 +1,7 @@
 ---
 title: Proximity
 description: Match documents based on token proximity within the source document
-canonical: https://docs.paradedb.com/documentation/full-text/proximity
+canonical: https://www.paradedb.com/docs/documentation/full-text/proximity
 ---
 
 Proximity queries are used to match documents containing tokens that are within a certain token distance of one another.

--- a/docs/documentation/full-text/term.mdx
+++ b/docs/documentation/full-text/term.mdx
@@ -1,7 +1,7 @@
 ---
 title: Term
 description: Look for exact token matches in the source document, without any further processing of the query string
-canonical: https://docs.paradedb.com/documentation/full-text/term
+canonical: https://www.paradedb.com/docs/documentation/full-text/term
 ---
 
 Term queries look for exact token matches. A term query is like an exact string match, but at the

--- a/docs/documentation/getting-started/ai-agents.mdx
+++ b/docs/documentation/getting-started/ai-agents.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrate with AI
 description: Teach your coding assistant to use ParadeDB
-canonical: https://docs.paradedb.com/documentation/getting-started/ai-agents
+canonical: https://www.paradedb.com/docs/documentation/getting-started/ai-agents
 ---
 
 Before getting started, let's give your coding agent full context of ParadeDB by adding the ParadeDB agent skill.
@@ -22,7 +22,7 @@ ParadeDB documentation is available via the [Model Context Protocol (MCP)](https
 **MCP Endpoint:**
 
 ```
-https://docs.paradedb.com/mcp
+https://www.paradedb.com/docs/mcp
 ```
 
 This allows MCP-enabled tools to query ParadeDB documentation programmatically and provide contextual assistance.

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure your Environment
 description: Configure your environment for querying ParadeDB
-canonical: https://docs.paradedb.com/documentation/getting-started/environment
+canonical: https://www.paradedb.com/docs/documentation/getting-started/environment
 ---
 
 This guide will walk you through setting up your environment to run queries against ParadeDB. Choose your preferred tool below:

--- a/docs/documentation/getting-started/install.mdx
+++ b/docs/documentation/getting-started/install.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install ParadeDB
 description: How to run the ParadeDB Docker image
-canonical: https://docs.paradedb.com/documentation/getting-started/install
+canonical: https://www.paradedb.com/docs/documentation/getting-started/install
 ---
 
 The fastest way to install ParadeDB is by pulling the ParadeDB Docker image and running it locally. If

--- a/docs/documentation/getting-started/load.mdx
+++ b/docs/documentation/getting-started/load.mdx
@@ -1,7 +1,7 @@
 ---
 title: Load Data from Postgres
 description: Dump data from an existing Postgres and load into ParadeDB
-canonical: https://docs.paradedb.com/documentation/getting-started/load
+canonical: https://www.paradedb.com/docs/documentation/getting-started/load
 ---
 
 The easiest way to copy data from another Postgres into ParadeDB is with the `pg_dump` and `pg_restore` utilities. These are
@@ -55,4 +55,4 @@ pg_restore --verbose --clean --no-acl --no-owner \
     old_db.dump
 ```
 
-Congratulations! You are now ready to run real queries over your data. To get started, refer to our [full text search documentation](https://docs.paradedb.com/documentation/full-text/overview).
+Congratulations! You are now ready to run real queries over your data. To get started, refer to our [full text search documentation](https://www.paradedb.com/docs/documentation/full-text/overview).

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -1,7 +1,7 @@
 ---
 title: Run Queries
 description: Run your first queries on ParadeDB
-canonical: https://docs.paradedb.com/documentation/getting-started/queries
+canonical: https://www.paradedb.com/docs/documentation/getting-started/queries
 ---
 
 Now that your [environment is configured](/documentation/getting-started/environment), select the codetab for your tool and run some queries.

--- a/docs/documentation/hybrid/overview.mdx
+++ b/docs/documentation/hybrid/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: How Hybrid Search Works
 description: Understand how ParadeDB combines text and vector search into a single ranking
-canonical: https://docs.paradedb.com/documentation/hybrid/overview
+canonical: https://www.paradedb.com/docs/documentation/hybrid/overview
 ---
 
 <Note>

--- a/docs/documentation/hybrid/rrf.mdx
+++ b/docs/documentation/hybrid/rrf.mdx
@@ -1,7 +1,7 @@
 ---
 title: Reciprocal Rank Fusion
 description: Combine full text and vector search results into a single ranking
-canonical: https://docs.paradedb.com/documentation/hybrid/rrf
+canonical: https://www.paradedb.com/docs/documentation/hybrid/rrf
 ---
 
 <Note>

--- a/docs/documentation/indexing/columnar.mdx
+++ b/docs/documentation/indexing/columnar.mdx
@@ -1,7 +1,7 @@
 ---
 title: Columnar Storage
 description: Column-oriented indexing for fast filtering, sorting, and aggregates
-canonical: https://docs.paradedb.com/documentation/indexing/columnar
+canonical: https://www.paradedb.com/docs/documentation/indexing/columnar
 ---
 
 By default, all non-text and non-JSON fields are indexed using ParadeDB's columnar format.

--- a/docs/documentation/indexing/create-index.mdx
+++ b/docs/documentation/indexing/create-index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create an Index
 description: Index a Postgres table for full text search
-canonical: https://docs.paradedb.com/documentation/indexing/create-index
+canonical: https://www.paradedb.com/docs/documentation/indexing/create-index
 ---
 
 Before a table can be searched, it must be indexed. ParadeDB uses a custom index type called the ParadeDB index.

--- a/docs/documentation/indexing/indexing-arrays.mdx
+++ b/docs/documentation/indexing/indexing-arrays.mdx
@@ -1,7 +1,7 @@
 ---
 title: Indexing Text Arrays
 description: Add text arrays to the index
-canonical: https://docs.paradedb.com/documentation/indexing/indexing-arrays
+canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-arrays
 ---
 
 The ParadeDB index accepts arrays of type `text[]` or `varchar[]`.

--- a/docs/documentation/indexing/indexing-composite.mdx
+++ b/docs/documentation/indexing/indexing-composite.mdx
@@ -1,7 +1,7 @@
 ---
 title: Indexing 32+ Columns
 description: Use composite types to index more than 32 columns
-canonical: https://docs.paradedb.com/documentation/indexing/indexing-composite
+canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-composite
 ---
 
 <Note>This is a beta feature available in versions `0.22.0` and above.</Note>

--- a/docs/documentation/indexing/indexing-expressions.mdx
+++ b/docs/documentation/indexing/indexing-expressions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Indexing Expressions
 description: Add Postgres expressions to the index
-canonical: https://docs.paradedb.com/documentation/indexing/indexing-expressions
+canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-expressions
 ---
 
 In addition to indexing columns, Postgres expressions can also be indexed.

--- a/docs/documentation/indexing/indexing-json.mdx
+++ b/docs/documentation/indexing/indexing-json.mdx
@@ -1,7 +1,7 @@
 ---
 title: Indexing JSON
 description: Add JSON and JSONB types to the index
-canonical: https://docs.paradedb.com/documentation/indexing/indexing-json
+canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-json
 ---
 
 When indexing JSON, ParadeDB automatically indexes all sub-fields of the JSON object. The type of each sub-field is also inferred automatically.

--- a/docs/documentation/indexing/indexing-partial.mdx
+++ b/docs/documentation/indexing/indexing-partial.mdx
@@ -1,7 +1,7 @@
 ---
 title: Partial Indexes
 description: Add row filters to the ParadeDB index
-canonical: https://docs.paradedb.com/documentation/indexing/indexing-partial
+canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-partial
 ---
 
 A partial index is an index that only includes rows that satisfy a `WHERE` condition.

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Indexing Vectors
 description: Vectors live alongside text and filters in the ParadeDB index
-canonical: https://docs.paradedb.com/documentation/indexing/indexing-vectors
+canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-vectors
 ---
 
 <Note>

--- a/docs/documentation/indexing/reindexing.mdx
+++ b/docs/documentation/indexing/reindexing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Reindexing
 description: Rebuild an existing index with zero downtime
-canonical: https://docs.paradedb.com/documentation/indexing/reindexing
+canonical: https://www.paradedb.com/docs/documentation/indexing/reindexing
 ---
 
 ## Changing the Schema

--- a/docs/documentation/indexing/verify-index.mdx
+++ b/docs/documentation/indexing/verify-index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verify Index Integrity
 description: Check ParadeDB indexes for corruption and structural issues
-canonical: https://docs.paradedb.com/documentation/indexing/verify-index
+canonical: https://www.paradedb.com/docs/documentation/indexing/verify-index
 ---
 
 ParadeDB provides `amcheck`-style index verification functions to detect corruption and validate the structural integrity of ParadeDB indexes.

--- a/docs/documentation/joins/overview.mdx
+++ b/docs/documentation/joins/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Joins Overview
 description: Optimize JOIN queries in ParadeDB
-canonical: https://docs.paradedb.com/documentation/joins/overview
+canonical: https://www.paradedb.com/docs/documentation/joins/overview
 ---
 
 ParadeDB supports all standard PostgreSQL `JOIN` types, including:

--- a/docs/documentation/migration/elasticsearch-feature-comparison.mdx
+++ b/docs/documentation/migration/elasticsearch-feature-comparison.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrating from Elasticsearch
 description: Feature comparison and migration guide for Elasticsearch users moving to ParadeDB
-canonical: https://docs.paradedb.com/documentation/migration/elasticsearch-feature-comparison
+canonical: https://www.paradedb.com/docs/documentation/migration/elasticsearch-feature-comparison
 ---
 
 This page is for developers who are evaluating or actively migrating from Elasticsearch (or OpenSearch) to ParadeDB.

--- a/docs/documentation/performance-tuning/create-index.mdx
+++ b/docs/documentation/performance-tuning/create-index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Index Creation
 description: Settings to make index creation faster
-canonical: https://docs.paradedb.com/documentation/performance-tuning/create-index
+canonical: https://www.paradedb.com/docs/documentation/performance-tuning/create-index
 ---
 
 These actions can improve the performance and memory consumption of `CREATE INDEX` and `REINDEX` statements.

--- a/docs/documentation/performance-tuning/overview.mdx
+++ b/docs/documentation/performance-tuning/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to Tune ParadeDB
 description: Settings for better read and write performance
-canonical: https://docs.paradedb.com/documentation/performance-tuning/overview
+canonical: https://www.paradedb.com/docs/documentation/performance-tuning/overview
 ---
 
 ParadeDB uses Postgres' settings, which can be found in the `postgresql.conf` file. To find your `postgresql.conf` file, use `SHOW`.

--- a/docs/documentation/performance-tuning/reads.mdx
+++ b/docs/documentation/performance-tuning/reads.mdx
@@ -1,7 +1,7 @@
 ---
 title: Read Throughput
 description: Settings to improve read performance
-canonical: https://docs.paradedb.com/documentation/performance-tuning/reads
+canonical: https://www.paradedb.com/docs/documentation/performance-tuning/reads
 ---
 
 As a general rule of thumb, the performance of expensive search queries can be greatly improved

--- a/docs/documentation/performance-tuning/writes.mdx
+++ b/docs/documentation/performance-tuning/writes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Write Throughput
 description: Settings to improve write performance
-canonical: https://docs.paradedb.com/documentation/performance-tuning/writes
+canonical: https://www.paradedb.com/docs/documentation/performance-tuning/writes
 ---
 
 These actions can improve the throughput of `INSERT`/`UPDATE`/`COPY` statements to the ParadeDB index.

--- a/docs/documentation/query-builder/compound/all.mdx
+++ b/docs/documentation/query-builder/compound/all.mdx
@@ -1,7 +1,7 @@
 ---
 title: All
 description: Search all rows in the index
-canonical: https://docs.paradedb.com/documentation/query-builder/compound/all
+canonical: https://www.paradedb.com/docs/documentation/query-builder/compound/all
 ---
 
 The all query means "search all rows in the index."

--- a/docs/documentation/query-builder/compound/query-parser.mdx
+++ b/docs/documentation/query-builder/compound/query-parser.mdx
@@ -1,7 +1,7 @@
 ---
 title: Query Parser
 description: Accept raw user-provided query strings
-canonical: https://docs.paradedb.com/documentation/query-builder/compound/query-parser
+canonical: https://www.paradedb.com/docs/documentation/query-builder/compound/query-parser
 ---
 
 The parse query accepts a [Tantivy query string](https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html).

--- a/docs/documentation/query-builder/overview.mdx
+++ b/docs/documentation/query-builder/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: How Advanced Query Functions Work
 description: ParadeDB's query builder functions provide advanced query types
-canonical: https://docs.paradedb.com/documentation/query-builder/overview
+canonical: https://www.paradedb.com/docs/documentation/query-builder/overview
 ---
 
 In addition to basic [match](/documentation/full-text/match), [phrase](/documentation/full-text/phrase), and

--- a/docs/documentation/query-builder/phrase/phrase-prefix.mdx
+++ b/docs/documentation/query-builder/phrase/phrase-prefix.mdx
@@ -1,7 +1,7 @@
 ---
 title: Phrase Prefix
 description: Finds documents containing a phrase followed by a term prefix
-canonical: https://docs.paradedb.com/documentation/query-builder/phrase/phrase-prefix
+canonical: https://www.paradedb.com/docs/documentation/query-builder/phrase/phrase-prefix
 ---
 
 Phrase prefix identifies documents containing a phrase followed by a term prefix.

--- a/docs/documentation/query-builder/phrase/regex-phrase.mdx
+++ b/docs/documentation/query-builder/phrase/regex-phrase.mdx
@@ -1,7 +1,7 @@
 ---
 title: Regex Phrase
 description: Matches a specific sequence of regex queries
-canonical: https://docs.paradedb.com/documentation/query-builder/phrase/regex-phrase
+canonical: https://www.paradedb.com/docs/documentation/query-builder/phrase/regex-phrase
 ---
 
 Regex phrase matches a specific sequence of regex queries. Think of it like a conjunction of [regex](/documentation/query-builder/term/regex)

--- a/docs/documentation/query-builder/specialized/more-like-this.mdx
+++ b/docs/documentation/query-builder/specialized/more-like-this.mdx
@@ -1,7 +1,7 @@
 ---
 title: More Like This
 description: Finds documents that are "like" another document.
-canonical: https://docs.paradedb.com/documentation/query-builder/specialized/more-like-this
+canonical: https://www.paradedb.com/docs/documentation/query-builder/specialized/more-like-this
 ---
 
 The more like this (MLT) query finds documents that are "like" another document.

--- a/docs/documentation/query-builder/term/range-term.mdx
+++ b/docs/documentation/query-builder/term/range-term.mdx
@@ -1,7 +1,7 @@
 ---
 title: Range Term
 description: Filters over Postgres range types
-canonical: https://docs.paradedb.com/documentation/query-builder/term/range-term
+canonical: https://www.paradedb.com/docs/documentation/query-builder/term/range-term
 ---
 
 `range_term` is the equivalent of Postgres' operators over [range types](https://www.postgresql.org/docs/current/rangetypes.html).

--- a/docs/documentation/query-builder/term/regex.mdx
+++ b/docs/documentation/query-builder/term/regex.mdx
@@ -1,7 +1,7 @@
 ---
 title: Regex
 description: Searches for terms that match a regex pattern
-canonical: https://docs.paradedb.com/documentation/query-builder/term/regex
+canonical: https://www.paradedb.com/docs/documentation/query-builder/term/regex
 ---
 
 Regex queries search for terms that follow a pattern. For example, the wildcard pattern `key.*` finds all terms that start with `key`.

--- a/docs/documentation/sorting/boost.mdx
+++ b/docs/documentation/sorting/boost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Relevance Tuning
 description: Tune the BM25 score by adjusting the weights of individual queries
-canonical: https://docs.paradedb.com/documentation/sorting/boost
+canonical: https://www.paradedb.com/docs/documentation/sorting/boost
 ---
 
 ## Boosting

--- a/docs/documentation/sorting/score.mdx
+++ b/docs/documentation/sorting/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: BM25 Scoring
 description: BM25 scores sort the result set by relevance
-canonical: https://docs.paradedb.com/documentation/sorting/score
+canonical: https://www.paradedb.com/docs/documentation/sorting/score
 ---
 
 BM25 scores measure how relevant a document is for a given query. Higher scores indicate higher relevance.

--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Top K
 description: ParadeDB is optimized for quickly finding the Top K results in a table
-canonical: https://docs.paradedb.com/documentation/sorting/topk
+canonical: https://www.paradedb.com/docs/documentation/sorting/topk
 ---
 
 <Note>

--- a/docs/documentation/token-filters/alphanumeric.mdx
+++ b/docs/documentation/token-filters/alphanumeric.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alpha Numeric Only
 description: Removes any tokens that contain characters that are not ASCII letters
-canonical: https://docs.paradedb.com/documentation/token-filters/alphanumeric
+canonical: https://www.paradedb.com/docs/documentation/token-filters/alphanumeric
 ---
 
 The alpha numeric only filter removes any tokens that contain characters that are not ASCII letters (i.e. `a` to `z` and `A` to `Z`) or digits

--- a/docs/documentation/token-filters/ascii-folding.mdx
+++ b/docs/documentation/token-filters/ascii-folding.mdx
@@ -1,7 +1,7 @@
 ---
 title: ASCII Folding
 description: Strips away diacritical marks like accents
-canonical: https://docs.paradedb.com/documentation/token-filters/ascii-folding
+canonical: https://www.paradedb.com/docs/documentation/token-filters/ascii-folding
 ---
 
 The ASCII folding filter strips away diacritical marks (accents, umlauts, tildes, etc.) while leaving the base character intact.

--- a/docs/documentation/token-filters/lowercase.mdx
+++ b/docs/documentation/token-filters/lowercase.mdx
@@ -1,7 +1,7 @@
 ---
 title: Lowercase
 description: Converts all characters to lowercase
-canonical: https://docs.paradedb.com/documentation/token-filters/lowercase
+canonical: https://www.paradedb.com/docs/documentation/token-filters/lowercase
 ---
 
 The lowercase filter converts all characters to lowercase, allowing for case-insensitive queries. It is enabled by default but can be

--- a/docs/documentation/token-filters/overview.mdx
+++ b/docs/documentation/token-filters/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: How Token Filters Work
 description: Token filters apply additional processing to tokens like lowercasing or stemming
-canonical: https://docs.paradedb.com/documentation/token-filters/overview
+canonical: https://www.paradedb.com/docs/documentation/token-filters/overview
 ---
 
 After a [tokenizer](/documentation/tokenizers/overview) splits up text into tokens, token filters

--- a/docs/documentation/token-filters/stemming.mdx
+++ b/docs/documentation/token-filters/stemming.mdx
@@ -1,7 +1,7 @@
 ---
 title: Stemmer
 description: Reduces words to their root form for a given language
-canonical: https://docs.paradedb.com/documentation/token-filters/stemming
+canonical: https://www.paradedb.com/docs/documentation/token-filters/stemming
 ---
 
 Stemming is the process of reducing words to their root form. In English, for example, the root form of "running" and "runs" is "run".

--- a/docs/documentation/token-filters/stopwords.mdx
+++ b/docs/documentation/token-filters/stopwords.mdx
@@ -1,7 +1,7 @@
 ---
 title: Remove Stopwords
 description: Remove language-specific stopwords from the index
-canonical: https://docs.paradedb.com/documentation/token-filters/stopwords
+canonical: https://www.paradedb.com/docs/documentation/token-filters/stopwords
 ---
 
 Stopwords are words that are so common or semantically insignificant in most contexts that they can be ignored during indexing.

--- a/docs/documentation/token-filters/token-length.mdx
+++ b/docs/documentation/token-filters/token-length.mdx
@@ -1,7 +1,7 @@
 ---
 title: Token Length
 description: Remove tokens that are above or below a certain byte length from the index
-canonical: https://docs.paradedb.com/documentation/token-filters/token-length
+canonical: https://www.paradedb.com/docs/documentation/token-filters/token-length
 ---
 
 The token length filter automatically removes tokens that are above or below a certain length in bytes.

--- a/docs/documentation/token-filters/trim.mdx
+++ b/docs/documentation/token-filters/trim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Trim
 description: Remove trailing and leading whitespace from a token
-canonical: https://docs.paradedb.com/documentation/token-filters/trim
+canonical: https://www.paradedb.com/docs/documentation/token-filters/trim
 ---
 
 The trim filter removes leading and trailing whitespace from a token (but not whitespace in the middle). If a token consists

--- a/docs/documentation/tokenizers/available-tokenizers/chinese-compatible.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/chinese-compatible.mdx
@@ -1,7 +1,7 @@
 ---
 title: Chinese Compatible
 description: A simple tokenizer for Chinese, Japanese, and Korean characters
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/chinese-compatible
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/chinese-compatible
 ---
 
 The Chinese compatible tokenizer is like the [simple](/documentation/tokenizers/available-tokenizers/simple) tokenizer -- it lowercases non-CJK characters and splits on

--- a/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
@@ -1,7 +1,7 @@
 ---
 title: Edge Ngram
 description: Generates prefix n-grams per word, ideal for search-as-you-type
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/edge-ngrams
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/edge-ngrams
 ---
 
 The edge ngram tokenizer first splits text into words at character-class boundaries, then generates n-grams anchored

--- a/docs/documentation/tokenizers/available-tokenizers/icu.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/icu.mdx
@@ -1,7 +1,7 @@
 ---
 title: ICU
 description: Splits text according to the Unicode standard
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/icu
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/icu
 ---
 
 The ICU (International Components for Unicode) tokenizer breaks down text according to the Unicode standard. It can be used to tokenize most languages and recognizes the nuances in word boundaries across different languages.

--- a/docs/documentation/tokenizers/available-tokenizers/jieba.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/jieba.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jieba
 description: The most advanced Chinese tokenizer that leverages both a dictionary and statistical models
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/jieba
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/jieba
 ---
 
 The Jieba tokenizer is a tokenizer for Chinese text that leverages both a dictionary and statistical models. It is generally considered to be better at identifying ambiguous Chinese word boundaries

--- a/docs/documentation/tokenizers/available-tokenizers/lindera.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/lindera.mdx
@@ -1,7 +1,7 @@
 ---
 title: Lindera
 description: Uses prebuilt dictionaries to tokenize Chinese, Japanese, and Korean text
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/lindera
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/lindera
 ---
 
 The Lindera tokenizer is a more advanced CJK tokenizer that uses prebuilt Chinese, Japanese, or Korean dictionaries to break text into meaningful tokens (words or phrases) rather than on individual characters.

--- a/docs/documentation/tokenizers/available-tokenizers/literal-normalized.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/literal-normalized.mdx
@@ -1,7 +1,7 @@
 ---
 title: Literal Normalized
 description: Like the literal tokenizer, but allows for token filters
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/literal-normalized
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal-normalized
 ---
 
 <Note>

--- a/docs/documentation/tokenizers/available-tokenizers/literal.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/literal.mdx
@@ -1,7 +1,7 @@
 ---
 title: Literal
 description: Indexes the text in its raw form, without any splitting or processing
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/literal
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal
 ---
 
 <Note>

--- a/docs/documentation/tokenizers/available-tokenizers/ngrams.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/ngrams.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ngram
 description: Splits text into small chunks called grams, useful for partial matching
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/ngrams
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/ngrams
 ---
 
 The ngram tokenizer splits text into "grams," where each "gram" is of a certain length.

--- a/docs/documentation/tokenizers/available-tokenizers/regex.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/regex.mdx
@@ -1,7 +1,7 @@
 ---
 title: Regex Patterns
 description: Tokenizes text using a regular expression
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/regex
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/regex
 ---
 
 The `regex_pattern` tokenizer tokenizes text using a regular expression. The regular expression can be specified with the pattern parameter.

--- a/docs/documentation/tokenizers/available-tokenizers/simple.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/simple.mdx
@@ -1,7 +1,7 @@
 ---
 title: Simple
 description: Splits on any non-alphanumeric character
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/simple
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/simple
 ---
 
 The simple tokenizer splits on any non-alphanumeric character (e.g. whitespace, punctuation, symbols). All characters are

--- a/docs/documentation/tokenizers/available-tokenizers/source-code.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/source-code.mdx
@@ -1,7 +1,7 @@
 ---
 title: Source Code
 description: Tokenizes text that is actually code
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/source-code
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/source-code
 ---
 
 The source code tokenizer is intended for tokenizing code. In addition to splitting on whitespace,

--- a/docs/documentation/tokenizers/available-tokenizers/unicode.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/unicode.mdx
@@ -1,7 +1,7 @@
 ---
 title: Unicode
 description: The default text tokenizer in ParadeDB
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/unicode
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/unicode
 ---
 
 The unicode tokenizer splits text according to word boundaries defined by the [Unicode Standard Annex #29](https://www.unicode.org/reports/tr29/)

--- a/docs/documentation/tokenizers/available-tokenizers/whitespace.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/whitespace.mdx
@@ -1,7 +1,7 @@
 ---
 title: Whitespace
 description: Tokenizes text by splitting on whitespace
-canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/whitespace
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/whitespace
 ---
 
 The whitespace tokenizer splits only on whitespace. It also [lowercases](/documentation/token-filters/lowercase) characters by default.

--- a/docs/documentation/tokenizers/multiple-per-field.mdx
+++ b/docs/documentation/tokenizers/multiple-per-field.mdx
@@ -1,7 +1,7 @@
 ---
 title: Multiple Tokenizers Per Field
 description: Apply different token configurations to the same field
-canonical: https://docs.paradedb.com/documentation/tokenizers/multiple-per-field
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/multiple-per-field
 ---
 
 In many cases, a text field needs to be tokenized multiple ways. For instance, using the [unicode](/documentation/tokenizers/available-tokenizers/unicode)

--- a/docs/documentation/tokenizers/overview.mdx
+++ b/docs/documentation/tokenizers/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: How Tokenizers Work
 description: Tokenizers split large chunks of text into small, searchable units called tokens
-canonical: https://docs.paradedb.com/documentation/tokenizers/overview
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/overview
 ---
 
 Before text is indexed, it is first split into searchable units called tokens.

--- a/docs/documentation/tokenizers/search-tokenizer.mdx
+++ b/docs/documentation/tokenizers/search-tokenizer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Search Tokenizer
 description: Use a different tokenizer at search time than at index time
-canonical: https://docs.paradedb.com/documentation/tokenizers/search-tokenizer
+canonical: https://www.paradedb.com/docs/documentation/tokenizers/search-tokenizer
 ---
 
 By default, ParadeDB uses the same tokenizer at both index time and search time. This makes sense for most cases — you want queries

--- a/docs/documentation/vector/overview.mdx
+++ b/docs/documentation/vector/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: How Vector Search Works
 description: Understand how ParadeDB natively supports vector types
-canonical: https://docs.paradedb.com/documentation/vector/overview
+canonical: https://www.paradedb.com/docs/documentation/vector/overview
 ---
 
 <Note>This is a beta feature available in versions `0.25.0` and above.</Note>

--- a/docs/documentation/vector/querying.mdx
+++ b/docs/documentation/vector/querying.mdx
@@ -1,7 +1,7 @@
 ---
 title: Querying Vectors
 description: Run nearest-neighbor vector search inside the ParadeDB index
-canonical: https://docs.paradedb.com/documentation/vector/querying
+canonical: https://www.paradedb.com/docs/documentation/vector/querying
 ---
 
 <Note>

--- a/docs/documentation/vector/tuning.mdx
+++ b/docs/documentation/vector/tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tuning Recall and Latency
 description: Trade recall against latency for vector search
-canonical: https://docs.paradedb.com/documentation/vector/tuning
+canonical: https://www.paradedb.com/docs/documentation/vector/tuning
 ---
 
 Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. One session-level setting controls this tradeoff:

--- a/docs/welcome/architecture.mdx
+++ b/docs/welcome/architecture.mdx
@@ -1,7 +1,7 @@
 ---
 title: Architecture
 description: A deep dive into how ParadeDB is built on Postgres
-canonical: https://docs.paradedb.com/welcome/architecture
+canonical: https://www.paradedb.com/docs/welcome/architecture
 ---
 
 ParadeDB introduces modern query execution paths and data structures, optimized for high-ingest search and analytics workloads, to Postgres.

--- a/docs/welcome/guarantees.mdx
+++ b/docs/welcome/guarantees.mdx
@@ -1,7 +1,7 @@
 ---
 title: Guarantees
 description: ParadeDB ensures ACID compliance, concurrency, data integrity, and replication safety
-canonical: https://docs.paradedb.com/welcome/guarantees
+canonical: https://www.paradedb.com/docs/welcome/guarantees
 ---
 
 ### ACID

--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -2,7 +2,7 @@
 title: Introduction to ParadeDB and pg_search
 sidebarTitle: Introduction
 description: Developer documentation for ParadeDB and the pg_search extension — installation, indexing, query syntax, and deployment guides.
-canonical: https://docs.paradedb.com/welcome/introduction
+canonical: https://www.paradedb.com/docs/welcome/introduction
 ---
 
 ![ParadeDB Banner](/images/paradedb_banner.png)

--- a/docs/welcome/limitations.mdx
+++ b/docs/welcome/limitations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Limitations & Tradeoffs
 description: Understand ParadeDB's key limitations and tradeoffs
-canonical: https://docs.paradedb.com/welcome/limitations
+canonical: https://www.paradedb.com/docs/welcome/limitations
 ---
 
 ## Distributed Workloads

--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -1,7 +1,7 @@
 ---
 title: Roadmap
 description: The main features that we are currently working on
-canonical: https://docs.paradedb.com/welcome/roadmap
+canonical: https://www.paradedb.com/docs/welcome/roadmap
 ---
 
 We're a lean team that likes to ship at [incredibly high velocity](https://github.com/paradedb/paradedb/releases).

--- a/docs/welcome/support.mdx
+++ b/docs/welcome/support.mdx
@@ -1,7 +1,7 @@
 ---
 title: Help and Support
 description: How to obtain support for ParadeDB
-canonical: https://docs.paradedb.com/welcome/support
+canonical: https://www.paradedb.com/docs/welcome/support
 ---
 
 For questions regarding enterprise support or commercial licensing, please [contact sales](mailto:sales@paradedb.com).

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -3,7 +3,7 @@
 <br>
 </h1>
 
-This README covers development of the `pg_search` extension. For installation, deployment, and usage, see the [top-level ParadeDB README](../README.md) or the [ParadeDB documentation](https://docs.paradedb.com).
+This README covers development of the `pg_search` extension. For installation, deployment, and usage, see the [top-level ParadeDB README](../README.md) or the [ParadeDB documentation](https://www.paradedb.com/docs).
 
 `pg_search` is supported on official PostgreSQL Global Development Group Postgres versions, starting at PostgreSQL 15.
 

--- a/pg_search/src/api/operator/proximity.rs
+++ b/pg_search/src/api/operator/proximity.rs
@@ -47,7 +47,7 @@ fn rhs_prox(left: ProximityClause, right: ProximityClause) -> ProximityClause {
                 right: Box::new(right),
             }
         }
-        _ => panic!("left hand side of `##` must be a `<token-expression> ## <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity"),
+        _ => panic!("left hand side of `##` must be a `<token-expression> ## <distance>`, see https://www.paradedb.com/docs/documentation/full-text/proximity"),
     }
 }
 
@@ -80,6 +80,6 @@ fn rhs_prox_in_order(left: ProximityClause, right: ProximityClause) -> Proximity
                 right: Box::new(right),
             }
         }
-        _ => panic!("left hand side of `##>` must be a `<token-expression> ##> <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity"),
+        _ => panic!("left hand side of `##>` must be a `<token-expression> ##> <distance>`, see https://www.paradedb.com/docs/documentation/full-text/proximity"),
     }
 }

--- a/pg_search/tests/pg_regress/expected/proximity.out
+++ b/pg_search/tests/pg_regress/expected/proximity.out
@@ -168,6 +168,6 @@ SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('z' ##>24##> 'a');   -- no ma
 -- mismatched proximity operators should error
 --
 SELECT * FROM prox WHERE text @@@ ('a' ##>1## 'b');   -- error: left is ##>, right is ##
-ERROR:  left hand side of `##` must be a `<token-expression> ## <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity
+ERROR:  left hand side of `##` must be a `<token-expression> ## <distance>`, see https://www.paradedb.com/docs/documentation/full-text/proximity
 SELECT * FROM prox WHERE text @@@ ('a' ##1##> 'b');   -- error: left is ##, right is ##>
-ERROR:  left hand side of `##>` must be a `<token-expression> ##> <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity
+ERROR:  left hand side of `##>` must be a `<token-expression> ##> <distance>`, see https://www.paradedb.com/docs/documentation/full-text/proximity


### PR DESCRIPTION
Backports #6052 to `0.25.x`.

Updates documentation and canonical URLs from `docs.paradedb.com` to `www.paradedb.com/docs`, including the SEO validator. This fixes the docs failure observed on #6059.