### PR TITLE
ci: run the benchmarker suite on the metal benchmark runner

### DIFF
--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -46,10 +46,12 @@ jobs:
     name: Run Benchmarker Suite
     runs-on:
       - runs-on=${{ github.run_id }}
-      # 8 vCPU / 32 GiB Graviton4 + NVMe. The hn-ci compose pins the DB to
-      # cores 0-3 and pgbouncer to 4; k6 is tasksetted onto 5-7 in the run
-      # step. Bump the size for wider concurrency.
-      - family=m8gd.2xlarge
+      # Same whole-host metal runner as the queries/stressgres benchmarks: no
+      # noisy neighbours sharing memory bandwidth, so run-to-run numbers are
+      # comparable (a .2xlarge slice swung ~±15% between runs). The hn-ci
+      # compose still pins the DB to cores 0-3 and pgbouncer to 4; k6 is
+      # tasksetted onto 5-7 in the run step.
+      - family=m8gd.metal-24xl # Chosen for its performance consistency across hosts
       - image=ubuntu24-full-arm64
       - extras=s3-cache # S3-backed cache; https://runs-on.com/caching/magic-cache/
       # No EBS volume: on-machine NVMe avoids run-to-run variance.

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -46,11 +46,6 @@ jobs:
     name: Run Benchmarker Suite
     runs-on:
       - runs-on=${{ github.run_id }}
-      # Same whole-host metal runner as the queries/stressgres benchmarks: no
-      # noisy neighbours sharing memory bandwidth, so run-to-run numbers are
-      # comparable (a .2xlarge slice swung ~±15% between runs). The hn-ci
-      # compose still pins the DB to cores 0-3 and pgbouncer to 4; k6 is
-      # tasksetted onto 5-7 in the run step.
       - family=m8gd.metal-24xl # Chosen for its performance consistency across hosts
       - image=ubuntu24-full-arm64
       - extras=s3-cache # S3-backed cache; https://runs-on.com/caching/magic-cache/


### PR DESCRIPTION
Moves `benchmark-benchmarker` from `m8gd.2xlarge` to `m8gd.metal-24xl`, the same whole-host runner the queries and stressgres benchmarks already use ("chosen for its performance consistency across hosts").

## Why

The tracked `hn-ci` latency series swings ~±15% between runs on identical code: the last 12 runs on main range from 1.75 ms to 2.28 ms mean latency, including docs-only commits, and this tripped a false regression alert on 4696391e4 (a version bump). The workload itself is flat run-to-run on dedicated hardware, so the variance is per-run environment. A `.2xlarge` is a 1/12th slice of a shared metal host: vCPUs are dedicated, but memory bandwidth and the system-level cache are shared with whoever else is on the box that run.

A whole host removes the noisy neighbours, matching what the other benchmark suites concluded.

## What doesn't change

- Core pinning is untouched and works identically on the same Graviton4 silicon: DB on cores 0-3, pgbouncer on 4, k6 tasksetted onto 5-7.
- Still no EBS data volume; the metal host's local NVMe serves the same role.

## Notes

- The series may show a small step (likely faster) at the first metal run, since the benchmark cores now get the chip's system-level cache to themselves. Alerts only fire on regressions, so no false page, but the history chart will have a seam.
- Runner cost per run goes up (~$5.40/hr vs ~$0.45/hr on-demand), the same trade the other benchmark workflows accepted.

**Testing:** add the `benchmark-benchmarker` label to run on this PR; re-dispatching on the same commit a few times afterwards will show whether metal flattens the spread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)