### PR TITLE
feat(stressgres): add native plan assertions

### DIFF
--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -30,6 +30,17 @@ cargo run -p stressgres -- auto /path/to/pg_config stressgres/suites/single-node
 
 Suites are TOML files in `stressgres/suites/`. Each suite describes a planner workload or PostgreSQL topology exercised by Stressgres.
 
+A job can verify its query plan once whenever Stressgres opens a connection. Use a
+string for one required fragment or an array when several nodes must be present;
+the checks are case-insensitive and run after `on_connect` settings:
+
+```toml
+[[jobs]]
+on_connect = "SET max_parallel_workers_per_gather = 0"
+sql = "SELECT id FROM test WHERE message ||| 'beer' LIMIT 10"
+sql_plan_contains = ["TopKScanExecState", "Custom Scan"]
+```
+
 ## Docker
 
 To run Stressgres from within Docker, use:

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -294,6 +294,31 @@ impl Conn {
             conn.execute(query.sql, &[])?;
         }
 
+        if !job.sql_plan_contains.is_empty() {
+            let statements = job.sql();
+            anyhow::ensure!(
+                statements.len() == 1,
+                "job `{}` uses `sql_plan_contains`, but its `sql` contains {} statements; exactly one is required",
+                job.title(),
+                statements.len()
+            );
+            let explain = format!("EXPLAIN (VERBOSE) {}", statements[0].sql);
+            let plan = conn
+                .query(&explain, &[])?
+                .into_iter()
+                .map(|row| row.get::<_, String>(0))
+                .collect::<Vec<_>>()
+                .join("\n");
+            for expected in &job.sql_plan_contains {
+                anyhow::ensure!(
+                    plan.to_lowercase().contains(&expected.to_lowercase()),
+                    "plan assertion failed for job `{}`: expected `{expected}` in plan for `{}`. Actual plan:\n{plan}",
+                    job.title(),
+                    statements[0].sql
+                );
+            }
+        }
+
         Ok(conn)
     }
 }

--- a/stressgres/src/suite.rs
+++ b/stressgres/src/suite.rs
@@ -258,6 +258,10 @@ pub struct Job {
     pub title: Option<String>,
     pub on_connect: Option<String>,
     pub sql: String,
+    /// Text which must occur in the verbose plan for `sql` before the job starts.
+    /// A string is accepted for the common case; an array can assert multiple plan nodes.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub sql_plan_contains: Vec<String>,
     pub assert: Option<String>,
     pub window_height: Option<usize>,
     pub cancel_keycode: Option<char>,
@@ -303,12 +307,30 @@ where
     Ok(destinations)
 }
 
+fn deserialize_string_or_vec<'de, D>(d: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        String(String),
+        Vec(Vec<String>),
+    }
+
+    Ok(match StringOrVec::deserialize(d)? {
+        StringOrVec::String(value) => vec![value],
+        StringOrVec::Vec(values) => values,
+    })
+}
+
 impl Default for Job {
     fn default() -> Self {
         Self {
             title: None,
             on_connect: None,
             sql: "".to_string(),
+            sql_plan_contains: vec![],
             assert: None,
             window_height: None,
             cancel_keycode: None,
@@ -330,6 +352,32 @@ impl Job {
         } else {
             self.destinations.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Job;
+
+    #[test]
+    fn sql_plan_contains_accepts_a_string_or_array() {
+        let one: Job = toml::from_str(
+            r#"
+            sql = "SELECT 1"
+            sql_plan_contains = "Result"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(one.sql_plan_contains, ["Result"]);
+
+        let many: Job = toml::from_str(
+            r#"
+            sql = "SELECT 1"
+            sql_plan_contains = ["Result", "Output"]
+            "#,
+        )
+        .unwrap();
+        assert_eq!(many.sql_plan_contains, ["Result", "Output"]);
     }
 }
 

--- a/stressgres/suites/logical-replication-mixed-workload.toml
+++ b/stressgres/suites/logical-replication-mixed-workload.toml
@@ -112,25 +112,6 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION assert_plan_contains(
-    p_query text,
-    p_expected_text text
-) RETURNS boolean AS $$
-DECLARE
-    plan_line text;
-    full_plan text := '';
-BEGIN
-    FOR plan_line IN EXECUTE 'EXPLAIN (VERBOSE) ' || p_query LOOP
-        full_plan := full_plan || plan_line || chr(10);
-        IF plan_line ILIKE '%' || p_expected_text || '%' THEN
-            RETURN true;
-        END IF;
-    END LOOP;
-    RAISE EXCEPTION 'Plan assertion failed: expected "%" not found in plan for query: %. Actual plan:%',
-        p_expected_text, p_query, chr(10) || full_plan;
-END;
-$$ LANGUAGE plpgsql;
-
 ALTER SYSTEM SET autovacuum_naptime TO '1s';
 SELECT pg_reload_conf();
 """
@@ -168,12 +149,7 @@ destinations = ["Subscriber"]
 [[jobs]]
 refresh_ms = 5
 title = "Key-ordered Top K Base Scan"
-on_connect = """
-SELECT assert_plan_contains(
-    $q$ SELECT id, message FROM test WHERE message ||| 'beer' ORDER BY id DESC LIMIT 25 $q$,
-    'TopKScanExecState'
-);
-"""
+sql_plan_contains = "TopKScanExecState"
 sql = "SELECT id, message FROM test WHERE message ||| 'beer' ORDER BY id DESC LIMIT 25"
 destinations = ["Subscriber"]
 
@@ -182,11 +158,8 @@ refresh_ms = 5
 title = "Unordered Top K Base Scan"
 on_connect = """
 SET max_parallel_workers_per_gather = 0;
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, old_message FROM test WHERE message &&& 'beer wine' LIMIT 100 $q$,
-    'TopKScanExecState'
-);
 """
+sql_plan_contains = "TopKScanExecState"
 sql = """
 SELECT id, message, old_message FROM test WHERE message &&& 'beer wine' LIMIT 100;
 """
@@ -197,11 +170,8 @@ refresh_ms = 5
 title = "Normal Base Scan"
 on_connect = """
 SET max_parallel_workers_per_gather = 0;
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, old_message FROM test WHERE message &&& 'beer wine' $q$,
-    'NormalScanExecState'
-);
 """
+sql_plan_contains = "NormalScanExecState"
 sql = """
 SELECT id, message, old_message FROM test WHERE message &&& 'beer wine';
 """
@@ -213,15 +183,8 @@ title = "Parallel Normal Base Scan"
 on_connect = """
 SET debug_parallel_query TO ON;
 SET max_parallel_workers_per_gather = 2;
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, old_message FROM test WHERE message ||| 'cheese' $q$,
-    'Parallel Custom Scan'
-);
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, old_message FROM test WHERE message ||| 'cheese' $q$,
-    'NormalScanExecState'
-);
 """
+sql_plan_contains = ["Parallel Custom Scan", "NormalScanExecState"]
 sql = """
 SELECT id, message, old_message FROM test WHERE message ||| 'cheese';
 """
@@ -230,12 +193,7 @@ destinations = ["Subscriber"]
 [[jobs]]
 refresh_ms = 5
 title = "Aggregate Scan"
-on_connect = """
-SELECT assert_plan_contains(
-    $q$ SELECT count(*) FROM test WHERE message ||| 'beer' $q$,
-    'ParadeDB Aggregate Scan'
-);
-"""
+sql_plan_contains = "ParadeDB Aggregate Scan"
 sql = """
 SELECT assert(count(*), 5000), count(*) FROM test WHERE message ||| 'beer';
 """
@@ -244,12 +202,7 @@ destinations = ["Subscriber"]
 [[jobs]]
 refresh_ms = 5
 title = "Grouped Aggregate Scan"
-on_connect = """
-SELECT assert_plan_contains(
-    $q$ SELECT category_id, count(*) FROM test WHERE message ||| 'beer' GROUP BY category_id $q$,
-    'ParadeDB Aggregate Scan'
-);
-"""
+sql_plan_contains = "ParadeDB Aggregate Scan"
 sql = """
 SELECT category_id, count(*) FROM test WHERE message ||| 'beer' GROUP BY category_id;
 """
@@ -261,11 +214,8 @@ title = "Postgres Index Only Scan Fallback"
 on_connect = """
 SET max_parallel_workers = 0;
 SET paradedb.enable_custom_scan = off;
-SELECT assert_plan_contains(
-    $q$ SELECT id FROM test WHERE message ||| 'wine' LIMIT 100 $q$,
-    'Index Only Scan'
-);
 """
+sql_plan_contains = "Index Only Scan"
 sql = """
 SELECT id FROM test WHERE message ||| 'wine' LIMIT 100;
 """
@@ -278,11 +228,8 @@ on_connect = """
 SET max_parallel_workers = 0;
 SET paradedb.enable_custom_scan = off;
 SET enable_seqscan = off;
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, old_message FROM test WHERE message ||| 'wine' LIMIT 100 $q$,
-    'Index Scan'
-);
 """
+sql_plan_contains = "Index Scan"
 sql = """
 SELECT id, message, old_message FROM test WHERE message ||| 'wine' LIMIT 100;
 """
@@ -291,16 +238,7 @@ destinations = ["Subscriber"]
 [[jobs]]
 refresh_ms = 5
 title = "Postgres Sort over Normal Base Scan"
-on_connect = """
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, old_message FROM test WHERE message ||| 'wine beer' ORDER BY old_message LIMIT 20 $q$,
-    'NormalScanExecState'
-);
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, old_message FROM test WHERE message ||| 'wine beer' ORDER BY old_message LIMIT 20 $q$,
-    'Sort'
-);
-"""
+sql_plan_contains = ["NormalScanExecState", "Sort"]
 sql = """
 SELECT id, message, old_message
 FROM test
@@ -315,18 +253,8 @@ refresh_ms = 5
 title = "JoinScan"
 on_connect = """
 SET paradedb.enable_join_custom_scan = on;
-SELECT assert_plan_contains(
-    $q$
-    SELECT t.id, t.message, c.name
-    FROM test t
-    JOIN categories c ON t.category_id = c.id
-    WHERE t.message ||| 'beer'
-    ORDER BY t.id
-    LIMIT 25
-    $q$,
-    'ParadeDB Join Scan'
-);
 """
+sql_plan_contains = "ParadeDB Join Scan"
 sql = """
 SELECT t.id, t.message, c.name
 FROM test t

--- a/stressgres/suites/single-node-planner-paths.toml
+++ b/stressgres/suites/single-node-planner-paths.toml
@@ -65,26 +65,6 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION assert_plan_contains(
-    p_query text,
-    p_expected_text text
-) RETURNS boolean AS $$
-DECLARE
-    plan_line text;
-    full_plan text := '';
-BEGIN
-    FOR plan_line IN EXECUTE 'EXPLAIN (VERBOSE) ' || p_query LOOP
-        full_plan := full_plan || plan_line || chr(10);
-        IF plan_line ILIKE '%' || p_expected_text || '%' THEN
-            RETURN true;
-        END IF;
-    END LOOP;
-
-    RAISE EXCEPTION 'Plan assertion failed: expected "%" not found in plan for query: %. Actual plan:%',
-        p_expected_text, p_query, chr(10) || full_plan;
-END;
-$$ LANGUAGE plpgsql;
-
 ALTER SYSTEM SET autovacuum_naptime = '1s';
 SELECT pg_reload_conf();
 """
@@ -116,11 +96,8 @@ title = "Postgres Index Only Scan Fallback"
 log_tps = true
 on_connect = """
 SET paradedb.enable_custom_scan = off;
-SELECT assert_plan_contains(
-    $q$ SELECT id FROM test WHERE message ||| 'cheese' LIMIT 100 $q$,
-    'Index Only Scan'
-);
 """
+sql_plan_contains = "Index Only Scan"
 sql = """
 SELECT id FROM test WHERE message ||| 'cheese' LIMIT 100;
 """
@@ -133,11 +110,8 @@ on_connect = """
 SET max_parallel_workers = 0;
 SET paradedb.enable_custom_scan = off;
 SET enable_seqscan = off;
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, payload FROM test WHERE message ||| 'cheese' LIMIT 100 $q$,
-    'Index Scan'
-);
 """
+sql_plan_contains = "Index Scan"
 sql = """
 SELECT id, message, payload FROM test WHERE message ||| 'cheese' LIMIT 100;
 """
@@ -148,11 +122,8 @@ title = "Unordered Top K Base Scan"
 log_tps = true
 on_connect = """
 SET max_parallel_workers_per_gather = 0;
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, payload FROM test WHERE message ||| 'wine' LIMIT 100 $q$,
-    'TopKScanExecState'
-);
 """
+sql_plan_contains = "TopKScanExecState"
 sql = """
 SELECT id, message, payload FROM test WHERE message ||| 'wine' LIMIT 100;
 """
@@ -163,11 +134,8 @@ title = "Normal Base Scan"
 log_tps = true
 on_connect = """
 SET max_parallel_workers_per_gather = 0;
-SELECT assert_plan_contains(
-    $q$ SELECT id, message, payload FROM test WHERE message &&& 'beer wine' $q$,
-    'NormalScanExecState'
-);
 """
+sql_plan_contains = "NormalScanExecState"
 sql = """
 SELECT id, message, payload FROM test WHERE message &&& 'beer wine';
 """
@@ -178,11 +146,8 @@ title = "Columnar Base Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_columnar_exec = on;
-SELECT assert_plan_contains(
-    $q$ SELECT id, category FROM test WHERE message ||| 'beer' AND category === 'rare' $q$,
-    'ColumnarExecState'
-);
 """
+sql_plan_contains = "ColumnarExecState"
 sql = """
 SELECT id, category FROM test WHERE message ||| 'beer' AND category === 'rare';
 """
@@ -191,12 +156,7 @@ SELECT id, category FROM test WHERE message ||| 'beer' AND category === 'rare';
 refresh_ms = 5
 title = "Aggregate Scan"
 log_tps = true
-on_connect = """
-SELECT assert_plan_contains(
-    $q$ SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb) FROM test WHERE message ||| 'beer' $q$,
-    'ParadeDB Aggregate Scan'
-);
-"""
+sql_plan_contains = "ParadeDB Aggregate Scan"
 sql = """
 SELECT assert((pdb.agg('{"value_count": {"field": "id"}}'::jsonb)->>'value')::numeric::bigint, 5000::bigint) FROM test WHERE message ||| 'beer';
 """
@@ -205,12 +165,7 @@ SELECT assert((pdb.agg('{"value_count": {"field": "id"}}'::jsonb)->>'value')::nu
 refresh_ms = 5
 title = "Grouped Aggregate Scan"
 log_tps = true
-on_connect = """
-SELECT assert_plan_contains(
-    $q$ SELECT category_id, count(*) FROM test WHERE message ||| 'beer' GROUP BY category_id $q$,
-    'ParadeDB Aggregate Scan'
-);
-"""
+sql_plan_contains = "ParadeDB Aggregate Scan"
 sql = """
 SELECT category_id, count(*) FROM test WHERE message ||| 'beer' GROUP BY category_id;
 """
@@ -219,12 +174,7 @@ SELECT category_id, count(*) FROM test WHERE message ||| 'beer' GROUP BY categor
 refresh_ms = 5
 title = "Score-ordered Top K Base Scan"
 log_tps = true
-on_connect = """
-SELECT assert_plan_contains(
-    $q$ SELECT id FROM test WHERE message ||| 'beer' ORDER BY paradedb.score(id) DESC LIMIT 10 $q$,
-    'TopKScanExecState'
-);
-"""
+sql_plan_contains = "TopKScanExecState"
 sql = """
 SELECT id FROM test WHERE message ||| 'beer' ORDER BY paradedb.score(id) DESC LIMIT 10;
 """
@@ -235,18 +185,8 @@ title = "JoinScan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_join_custom_scan = on;
-SELECT assert_plan_contains(
-    $q$
-    SELECT t.id, t.message, c.name
-    FROM test t
-    JOIN categories c ON t.category_id = c.id
-    WHERE t.message ||| 'beer'
-    ORDER BY t.id
-    LIMIT 25
-    $q$,
-    'ParadeDB Join Scan'
-);
 """
+sql_plan_contains = "ParadeDB Join Scan"
 sql = """
 SELECT t.id, t.message, c.name
 FROM test t


### PR DESCRIPTION
## Summary
- add a native `sql_plan_contains` job option that runs `EXPLAIN (VERBOSE)` after `on_connect`
- accept either one plan fragment or an array of required fragments
- remove duplicated query text and PL/pgSQL plan helpers from the logical-replication and single-node planner suites
- document the new suite option

## Testing
- `cargo test -p stressgres --no-default-features` (18 passed)
- pre-commit hooks (including fmt, clippy, cargo check, cargo doc, TOML/Markdown formatting)

Stacked on #5889 (`test/stressgres-plan-assertions-5500`).