### PR TITLE
feat: Unify planner warnings GUCs, and allow for converting them into errors.

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -26,14 +26,23 @@ use tantivy::aggregation::DEFAULT_BUCKET_LIMIT;
 
 use crate::postgres::options::MAX_MUTABLE_SEGMENT_ROWS;
 
+#[derive(pgrx::PostgresGucEnum, Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum PlannerWarnings {
+    Off,
+    #[default]
+    Warning,
+    Error,
+}
+
 /// Allows the user to toggle the use of our "ParadeDB Base Scan".
 static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Allows the user to toggle the use of our "ParadeDB Aggregate Scan".
 static ENABLE_AGGREGATE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
-/// Validate aggregate scan eligibility
-static CHECK_AGGREGATE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
+/// Controls the behavior of ParadeDB planner warnings when an optimized scan cannot be used
+static PLANNER_WARNINGS: GucSetting<PlannerWarnings> =
+    GucSetting::<PlannerWarnings>::new(PlannerWarnings::Warning);
 
 /// Allows the user to toggle the use of our "ParadeDB Join Scan".
 static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
@@ -102,9 +111,6 @@ static GLOBAL_TARGET_SEGMENT_COUNT: GucSetting<i32> = GucSetting::<i32>::new(0);
 static GLOBAL_ENABLE_BACKGROUND_MERGING: GucSetting<bool> = GucSetting::<bool>::new(true);
 static GLOBAL_MUTABLE_SEGMENT_ROWS: GucSetting<i32> = GucSetting::<i32>::new(-1);
 static EXPLAIN_RECURSIVE_ESTIMATES: GucSetting<bool> = GucSetting::<bool>::new(false);
-
-/// Validate Top K scan eligibility for LIMIT queries
-static CHECK_TOPK_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// When true, queries with expensive scorer construction (fuzzy, regex, range)
 /// use a cheap heuristic for selectivity estimation instead of building a full Tantivy scorer.
@@ -296,13 +302,13 @@ pub fn init() {
         GucFlags::default(),
     );
 
-    GucRegistry::define_bool_guc(
-        c"paradedb.check_aggregate_scan",
-        c"Validate Aggregate scan eligibility",
-        c"When enabled, logs a warning if a query expected to use the aggregate scan cannot. \
-          This helps detect performance issues during development where queries expected \
-          to use the aggregate scan fall back to slower execution methods.",
-        &CHECK_AGGREGATE_SCAN,
+    GucRegistry::define_enum_guc(
+        c"paradedb.planner_warnings",
+        c"Controls the behavior of ParadeDB planner warnings when an optimized scan cannot be used",
+        c"When set to 'warning' (default), logs a warning if a query expected to use an optimized \
+          scan (BaseScan / Top K, AggregateScan, or JoinScan) cannot. When set to 'error', raises \
+          an error instead. When set to 'off', suppresses checks and warnings.",
+        &PLANNER_WARNINGS,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -533,17 +539,6 @@ pub fn init() {
     );
 
     GucRegistry::define_bool_guc(
-        c"paradedb.check_topk_scan",
-        c"Validate Top K scan eligibility for LIMIT queries",
-        c"When enabled, logs a warning if a query with LIMIT cannot use the Top K scan. \
-          This helps detect performance issues during development where queries expected \
-          to use the Top K optimization fall back to slower execution methods.",
-        &CHECK_TOPK_SCAN,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_bool_guc(
         c"paradedb.enable_heuristic_selectivity",
         c"Use heuristic selectivity for expensive query types",
         c"When enabled, fuzzy, regex, and range queries use a cheap heuristic for planner selectivity estimation instead of constructing a full Tantivy scorer. Default is true.",
@@ -736,8 +731,8 @@ pub fn enable_aggregate_custom_scan() -> bool {
     ENABLE_AGGREGATE_CUSTOM_SCAN.get()
 }
 
-pub fn check_aggregate_scan() -> bool {
-    CHECK_AGGREGATE_SCAN.get()
+pub fn planner_warnings() -> PlannerWarnings {
+    PLANNER_WARNINGS.get()
 }
 
 pub fn enable_join_custom_scan() -> bool {
@@ -897,10 +892,6 @@ pub fn global_mutable_segment_rows() -> Option<usize> {
 
 pub fn explain_recursive_estimates() -> bool {
     EXPLAIN_RECURSIVE_ESTIMATES.get()
-}
-
-pub fn check_topk_scan() -> bool {
-    CHECK_TOPK_SCAN.get()
 }
 
 pub fn enable_heuristic_selectivity() -> bool {

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -166,8 +166,11 @@ pub unsafe extern "C-unwind" fn _PG_init() {
     // that PostgreSQL does not flatten into joins, so `set_join_pathlist_hook` never fires.
     customscan::register_subplan_join_pathlist();
 
-    // Register global planner hook for window function support
-    customscan::register_window_aggregate_hook();
+    // Register hook for tracking explain statements (so planner warnings don't error under EXPLAIN)
+    postgres::planner_warnings::register_explain_hook();
+
+    // Register global planner hook for window function support and planner warning lifecycle
+    customscan::register_planner_hook();
 
     // Initialize the filter query builder
     customscan::aggregatescan::filterquery::init_filter_query_builder();

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -459,11 +459,13 @@ impl CustomScan for AggregateScan {
         if let Err(reason) = unsafe { validate_grouping_pushdown(builder.args()) } {
             if has_paradedb_agg {
                 pgrx::error!("Cannot execute pdb.agg: {}", reason.detail());
-            } else if gucs::enable_aggregate_custom_scan() && gucs::check_aggregate_scan() {
+            } else if gucs::enable_aggregate_custom_scan()
+                && gucs::planner_warnings() != gucs::PlannerWarnings::Off
+            {
                 Self::add_planner_warning(
                     format!(
                         "Aggregate Scan not used: {}. \
-                         To disable this warning: SET paradedb.check_aggregate_scan = false",
+                         To disable this warning: SET paradedb.planner_warnings = 'off'",
                         reason.detail()
                     ),
                     unsafe { resolve_decline_alias(builder.args()) },
@@ -1328,10 +1330,12 @@ impl AggregateScan {
             Err(CustomScanBuildError::Incompatible(e)) => {
                 if has_paradedb_agg {
                     pgrx::error!("Cannot execute pdb.agg: {}", e);
-                } else if gucs::enable_aggregate_custom_scan() && gucs::check_aggregate_scan() {
+                } else if gucs::enable_aggregate_custom_scan()
+                    && gucs::planner_warnings() != gucs::PlannerWarnings::Off
+                {
                     let warning_msg = format!(
                         "Aggregate Scan not used: {}. \
-                         To disable this warning: SET paradedb.check_aggregate_scan = false",
+                         To disable this warning: SET paradedb.planner_warnings = 'off'",
                         e,
                     );
                     Self::add_planner_warning(warning_msg, _table.name().to_string());
@@ -1355,7 +1359,7 @@ impl AggregateScan {
             Err(AggregatePathDecline::Warn(reason)) => {
                 if has_paradedb_agg {
                     reason.emit_error();
-                } else if gucs::check_aggregate_scan() {
+                } else if gucs::planner_warnings() != gucs::PlannerWarnings::Off {
                     reason.emit(alias);
                 }
                 Vec::new()

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -1973,7 +1973,7 @@ unsafe fn window_funcs_are_position_only(parse: *mut pg_sys::Query) -> bool {
 ///
 /// Validates whether a query that should use Top K scan is actually using it.
 ///
-/// When `paradedb.check_topk_scan` is enabled, this function checks if a query with LIMIT
+/// When `paradedb.planner_warnings` is not 'off', this function checks if a query with LIMIT
 /// that uses ParadeDB's search operators is using the Top K execution method. If Top K was
 /// expected but not chosen, it logs a warning with diagnostic information to help developers
 /// identify performance issues.
@@ -1988,7 +1988,7 @@ fn validate_topk_expectation(
     table_name: &str,
 ) {
     // Fast path: if validation is disabled, return immediately
-    if !crate::gucs::check_topk_scan() {
+    if crate::gucs::planner_warnings() == crate::gucs::PlannerWarnings::Off {
         return;
     }
 
@@ -2097,7 +2097,7 @@ fn validate_topk_expectation(
              Reason: {}. \
              This may cause poor performance on large datasets. \
              Remedies: {}. \
-             To disable this warning: SET paradedb.check_topk_scan = false",
+             To disable this warning: SET paradedb.planner_warnings = 'off'",
             limit, method_name, reason, remedies
         ),
         table_name,

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -330,7 +330,7 @@ pub extern "C-unwind" fn paradedb_upper_paths_callback<CS>(
 }
 
 /// Static variable to store the previous planner hook (e.g., from Citus or other extensions)
-/// This MUST be outside both register_window_aggregate_hook() and paradedb_planner_hook()
+/// This MUST be outside both register_planner_hook() and paradedb_planner_hook()
 /// so they both reference the same variable for proper hook chaining.
 static mut PREV_PLANNER_HOOK: pg_sys::planner_hook_type = None;
 
@@ -358,7 +358,7 @@ static mut PREV_PLANNER_HOOK: pg_sys::planner_hook_type = None;
 /// 3. **Simpler Integration**: The replacement happens once, early, and the rest
 ///    of the planning process sees our placeholder functions as regular function
 ///    calls that get projected through the plan tree.
-pub unsafe fn register_window_aggregate_hook() {
+pub unsafe fn register_planner_hook() {
     PREV_PLANNER_HOOK = pg_sys::planner_hook;
     pg_sys::planner_hook = Some(paradedb_planner_hook);
 }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -263,6 +263,9 @@ impl JoinDeclineReason {
     }
 
     fn emit(&self, aliases: &[String]) {
+        if crate::gucs::planner_warnings() == crate::gucs::PlannerWarnings::Off {
+            return;
+        }
         match self {
             Self::ContainsAggregate => {
                 if crate::gucs::enable_aggregate_custom_scan() {

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -65,8 +65,8 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::path::{plan_custom_path, reparameterize_custom_path_by_child};
 use crate::postgres::customscan::scan::create_custom_scan_state;
 pub use hook::{
-    register_join_pathlist, register_rel_pathlist, register_subplan_join_pathlist,
-    register_upper_path, register_window_aggregate_hook,
+    register_join_pathlist, register_planner_hook, register_rel_pathlist,
+    register_subplan_join_pathlist, register_upper_path,
 };
 
 // TODO: This trait should be expanded to include a `reset` method, which would become the

--- a/pg_search/src/postgres/planner_warnings.rs
+++ b/pg_search/src/postgres/planner_warnings.rs
@@ -192,9 +192,97 @@ pub fn clear_planner_warnings() {
     });
 }
 
+thread_local! {
+    /// Tracks whether the current execution is within an `EXPLAIN` statement.
+    ///
+    /// When `paradedb.planner_warnings` is set to `error`, queries that cannot use
+    /// accelerated ParadeDB custom scans fail with an `ERROR`. However, running `EXPLAIN`
+    /// on those queries should still succeed so users can inspect the fallback execution plan
+    /// and diagnose optimization issues. When `IN_EXPLAIN` is `true`, `emit_planner_warnings()`
+    /// downgrades errors to `WARNING`s.
+    static IN_EXPLAIN: Cell<bool> = const { Cell::new(false) };
+}
+
+/// An RAII guard that sets `IN_EXPLAIN` to `true` if `is_explain` is true, and restores
+/// the previous state when dropped (supporting nested utility statements and clean unwinds).
+pub struct ExplainGuard {
+    prev: bool,
+}
+
+impl ExplainGuard {
+    /// Creates a new `ExplainGuard`. If `is_explain` is `true`, marks the thread-local
+    /// state as being inside an `EXPLAIN` query.
+    pub fn new(is_explain: bool) -> Self {
+        let prev = IN_EXPLAIN.with(|cell| {
+            let prev = cell.get();
+            if is_explain {
+                cell.set(true);
+            }
+            prev
+        });
+        Self { prev }
+    }
+}
+
+impl Drop for ExplainGuard {
+    fn drop(&mut self) {
+        IN_EXPLAIN.with(|cell| cell.set(self.prev));
+    }
+}
+
+/// Returns whether the current thread is currently planning or executing an `EXPLAIN` query.
+pub fn is_in_explain() -> bool {
+    IN_EXPLAIN.with(|cell| cell.get())
+}
+
+static mut PREV_PROCESS_UTILITY_HOOK: pg_sys::ProcessUtility_hook_type = None;
+
+#[allow(clippy::too_many_arguments)]
+#[rustfmt::skip]
+#[pgrx::pg_guard]
+unsafe extern "C-unwind" fn paradedb_process_utility_hook(
+    pstmt: *mut pg_sys::PlannedStmt,
+    query_string: *const ::core::ffi::c_char,
+    read_only_tree: bool,
+    context: pg_sys::ProcessUtilityContext::Type,
+    params: pg_sys::ParamListInfo,
+    query_env: *mut pg_sys::QueryEnvironment,
+    dest: *mut pg_sys::DestReceiver,
+    qc: *mut pg_sys::QueryCompletion,
+) {
+    let is_explain = !pstmt.is_null()
+        && !(*pstmt).utilityStmt.is_null()
+        && (*(*pstmt).utilityStmt).type_ == pg_sys::NodeTag::T_ExplainStmt;
+    let _explain_guard = ExplainGuard::new(is_explain);
+
+    if let Some(prev_hook) = PREV_PROCESS_UTILITY_HOOK {
+        prev_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
+    } else {
+        pg_sys::standard_ProcessUtility(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
+    }
+}
+
+/// Register a `ProcessUtility_hook` to track when queries are being planned/executed under `EXPLAIN`.
+///
+/// This allows `emit_planner_warnings()` to downgrade `paradedb.planner_warnings = 'error'`
+/// to warnings during `EXPLAIN`, allowing users to inspect the query plan.
+pub unsafe fn register_explain_hook() {
+    PREV_PROCESS_UTILITY_HOOK = pg_sys::ProcessUtility_hook;
+    pg_sys::ProcessUtility_hook = Some(paradedb_process_utility_hook);
+}
+
 pub fn emit_planner_warnings() {
+    let mode = crate::gucs::planner_warnings();
+    if mode == crate::gucs::PlannerWarnings::Off {
+        return;
+    }
+
+    let in_explain = is_in_explain();
+
     PLANNER_STATE.with(|state| {
         let state = state.borrow();
+        let mut messages = Vec::new();
+
         // Flatten the map to iterate over all messages regardless of category
         for category_warnings in state.warnings.values() {
             for (message, warning_data) in category_warnings.iter() {
@@ -216,7 +304,7 @@ pub fn emit_planner_warnings() {
                 }
 
                 if warning_data.contexts.is_empty() {
-                    pgrx::warning!("{}", output);
+                    messages.push(output);
                 } else {
                     let label = if warning_data.contexts.len() > 1 {
                         "tables"
@@ -230,8 +318,25 @@ pub fn emit_planner_warnings() {
                         .cloned()
                         .collect::<Vec<_>>()
                         .join(", ");
-                    pgrx::warning!("{output} ({label}: {context_str})");
+                    messages.push(format!("{output} ({label}: {context_str})"));
                 }
+            }
+        }
+
+        if messages.is_empty() {
+            return;
+        }
+
+        if mode == crate::gucs::PlannerWarnings::Error && !in_explain {
+            if messages.len() == 1 {
+                pgrx::error!("{}", messages[0]);
+            } else {
+                let combined = messages.join("\n- ");
+                pgrx::error!("ParadeDB planner scan errors:\n- {combined}");
+            }
+        } else {
+            for msg in messages {
+                pgrx::warning!("{msg}");
             }
         }
     });

--- a/pg_search/tests/pg_regress/expected/agg-score.out
+++ b/pg_search/tests/pg_regress/expected/agg-score.out
@@ -21,7 +21,7 @@ SET min_parallel_table_scan_size = 0;
 -- Test case 1: Basic max(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -42,7 +42,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 (15 rows)
 
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      max     
 -------------
  0.057158466
@@ -51,7 +51,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 -- Test case 2: min(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT min(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -72,7 +72,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 (15 rows)
 
 SELECT min(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      min     
 -------------
  0.057158466
@@ -81,7 +81,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 -- Test case 3: avg(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT avg(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -102,7 +102,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 (15 rows)
 
 SELECT avg(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
          avg          
 ----------------------
  0.057158466428518295
@@ -131,7 +131,7 @@ SELECT count(*) FROM mock_items WHERE description @@@ 'keyboard' AND paradedb.sc
 -- Test case 5: sum(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT sum(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -152,7 +152,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 (15 rows)
 
 SELECT sum(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
     sum     
 ------------
  0.45726773
@@ -163,7 +163,7 @@ SET debug_parallel_query = off;
 SET max_parallel_workers_per_gather = 0;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -179,7 +179,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 (10 rows)
 
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      max     
 -------------
  0.057158466
@@ -191,7 +191,7 @@ SET max_parallel_workers_per_gather = 2;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT min(paradedb.score(id)), max(paradedb.score(id)), avg(paradedb.score(id)) 
 FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -213,7 +213,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 
 SELECT min(paradedb.score(id)), max(paradedb.score(id)), avg(paradedb.score(id)) 
 FROM mock_items WHERE description @@@ 'keyboard';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      min     |     max     |         avg          
 -------------+-------------+----------------------
  0.057158466 | 0.057158466 | 0.057158466428518295

--- a/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
+++ b/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
@@ -209,7 +209,7 @@ FROM groupby_conflict_test
 WHERE category @@@ 'electronics'
 GROUP BY title
 ORDER BY title;
-WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: groupby_conflict_test)
+WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field. To disable this warning: SET paradedb.planner_warnings = 'off' (table: groupby_conflict_test)
                                                                              QUERY PLAN                                                                              
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -237,7 +237,7 @@ WHERE category @@@ 'electronics'
 GROUP BY title
 ORDER BY title
 LIMIT 5;
-WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: groupby_conflict_test)
+WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field. To disable this warning: SET paradedb.planner_warnings = 'off' (table: groupby_conflict_test)
    title    |       avg_rating       | count 
 ------------+------------------------+-------
  Product A1 | 1.00000000000000000000 |     1

--- a/pg_search/tests/pg_regress/expected/aggregate.out
+++ b/pg_search/tests/pg_regress/expected/aggregate.out
@@ -432,7 +432,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(DISTINCT category), SUM(price)
 FROM products
 WHERE description @@@ 'laptop';
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -454,7 +454,7 @@ WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github
 SELECT COUNT(DISTINCT category), SUM(price)
 FROM products
 WHERE description @@@ 'laptop';
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
  count |        sum         
 -------+--------------------
      2 | 2799.9700000000003
@@ -466,7 +466,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG(LENGTH(description))
 FROM products
 WHERE category @@@ 'Electronics';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -484,7 +484,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG(LENGTH(description))
 FROM products
 WHERE category @@@ 'Electronics';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
          avg         
 ---------------------
  24.5000000000000000

--- a/pg_search/tests/pg_regress/expected/aliased_text_expression_topk_orderby.out
+++ b/pg_search/tests/pg_regress/expected/aliased_text_expression_topk_orderby.out
@@ -87,7 +87,7 @@ FROM mock_items
 WHERE description ||| 'sleek running shoes'
 ORDER BY upper(description)
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                                                              QUERY PLAN                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -106,7 +106,7 @@ FROM mock_items
 WHERE description ||| 'sleek running shoes'
 ORDER BY upper(description)
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      description     | rating 
 ---------------------+--------
  Sleek running shoes |      5

--- a/pg_search/tests/pg_regress/expected/cardinality_mvcc.out
+++ b/pg_search/tests/pg_regress/expected/cardinality_mvcc.out
@@ -47,14 +47,14 @@ SELECT pdb.agg('{"cardinality": {"field": "val"}}'::jsonb, false) FROM card_mvcc
 -- so the index still contains all 12 values
 DELETE FROM card_mvcc WHERE val = md5('cardtest' || 12)::uuid;
 DELETE FROM card_mvcc WHERE id % 10 = 0;
-SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SET paradedb.planner_warnings = 'off'; -- DISTINCT can't use the aggregate scan
 SELECT count(DISTINCT val) AS true_cardinality FROM card_mvcc;
  true_cardinality 
 ------------------
                11
 (1 row)
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 -- MVCC-correct: the fully-deleted value is not counted. A value whose first
 -- occurrences are dead but which still has live rows must be counted.
 SELECT pdb.agg('{"cardinality": {"field": "val"}}'::jsonb) FROM card_mvcc WHERE card_mvcc @@@ pdb.all();
@@ -181,14 +181,14 @@ SELECT count(*) >= 2 AS multiple_segments FROM paradedb.index_info('idx_card_mvc
 -- v0: dead in the first batch's segment, live in the second's. v1: dead everywhere.
 DELETE FROM card_mvcc_seg WHERE batch = 1 AND val = 'v0';
 DELETE FROM card_mvcc_seg WHERE val = 'v1';
-SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SET paradedb.planner_warnings = 'off'; -- DISTINCT can't use the aggregate scan
 SELECT count(DISTINCT val) AS true_cardinality FROM card_mvcc_seg;
  true_cardinality 
 ------------------
                 4
 (1 row)
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 SELECT pdb.agg('{"cardinality": {"field": "val"}}'::jsonb) FROM card_mvcc_seg WHERE card_mvcc_seg @@@ pdb.all();
       agg       
 ----------------

--- a/pg_search/tests/pg_regress/expected/citext.out
+++ b/pg_search/tests/pg_regress/expected/citext.out
@@ -375,7 +375,7 @@ SELECT category, COUNT(*) FROM citext_agg
 WHERE category ||| 'alpha beta gamma'
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: citext_agg)
+WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.planner_warnings = 'off' (table: citext_agg)
  category | count 
 ----------+-------
  Alpha    |     2
@@ -387,7 +387,7 @@ SELECT category, SUM(value) FROM citext_agg
 WHERE category ||| 'alpha beta'
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: citext_agg)
+WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.planner_warnings = 'off' (table: citext_agg)
  category | sum 
 ----------+-----
  Alpha    |  40

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
@@ -574,7 +574,7 @@ JOIN product_categories pc ON tp.id = pc.product_id
 JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
-WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: reviews)
                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -632,7 +632,7 @@ JOIN product_categories pc ON tp.id = pc.product_id
 JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
-WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: reviews)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5: Union of results from different tables
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -813,7 +813,7 @@ ORDER BY
     END DESC,
     pdb.score(p.id),
     p.price;
-WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: reviews)
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -857,7 +857,7 @@ ORDER BY
     END DESC,
     pdb.score(p.id),
     p.price;
-WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: reviews)
     name    | price |  review_status  
 ------------+-------+-----------------
  Product 19 |   240 | Great reviews

--- a/pg_search/tests/pg_regress/expected/empty_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/empty_aggregate.out
@@ -502,7 +502,7 @@ FROM empty_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 HAVING COUNT(*) > 0;
-WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.check_aggregate_scan = false (table: empty_test)
+WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.planner_warnings = 'off' (table: empty_test)
  category | cnt 
 ----------+-----
 (0 rows)
@@ -517,7 +517,7 @@ SELECT
 FROM empty_test
 WHERE id @@@ paradedb.all()
 GROUP BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: empty_test)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.planner_warnings = 'off' (table: empty_test)
  category | total_count | distinct_values | high_values | doubled_avg 
 ----------+-------------+-----------------+-------------+-------------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/fast_fields_options.out
+++ b/pg_search/tests/pg_regress/expected/fast_fields_options.out
@@ -69,7 +69,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY title
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: data_records)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -354,7 +354,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY price
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: data_records)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -374,7 +374,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY in_stock
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: data_records)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
+++ b/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
@@ -491,7 +491,7 @@ SELECT
     STDDEV(price) FILTER (WHERE category @@@ 'electronics') AS price_stddev,
     COUNT(*) FILTER (WHERE brand @@@ 'Apple') AS apple_count
 FROM filter_agg_test;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: stddev. To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: stddev. To disable this warning: SET paradedb.planner_warnings = 'off' (table: filter_agg_test)
  total |   price_stddev   | apple_count 
 -------+------------------+-------------
     20 | 901.871070925012 |           3
@@ -1031,7 +1031,7 @@ SELECT
     COUNT(DISTINCT category) AS unique_categories,
     COUNT(*) FILTER (WHERE brand @@@ 'Apple') AS apple_count
 FROM filter_agg_test;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.planner_warnings = 'off' (table: filter_agg_test)
  unique_categories | apple_count 
 -------------------+-------------
                  4 |           3

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -481,7 +481,7 @@ SELECT category, COUNT(DISTINCT rating), SUM(price)
 FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -505,7 +505,7 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     2 | 2529.96

--- a/pg_search/tests/pg_regress/expected/issue_2688.out
+++ b/pg_search/tests/pg_regress/expected/issue_2688.out
@@ -127,7 +127,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY quantity_range, valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: data_records)
  id |   title    | quantity_range |                          valid_period                           
 ----+------------+----------------+-----------------------------------------------------------------
  10 | Product 10 | [0,10)         | ["Wed Jan 11 00:00:00 2023 PST","Sat Feb 11 00:00:00 2023 PST")
@@ -148,7 +148,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY quantity_range, valid_period
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: data_records)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -167,7 +167,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY price ASC, valid_period ASC
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: data_records)
  id |   title    |  price   |                          valid_period                           
 ----+------------+----------+-----------------------------------------------------------------
   1 | Product 1  |  1000.00 | ["Mon Jan 02 00:00:00 2023 PST","Thu Feb 02 00:00:00 2023 PST")
@@ -188,7 +188,7 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY price ASC, valid_period ASC
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: data_records)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: data_records)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/issue_2932.out
+++ b/pg_search/tests/pg_regress/expected/issue_2932.out
@@ -11,7 +11,7 @@ CALL paradedb.create_paradedb_test_table(
 CREATE INDEX on mock_items USING paradedb (id, description, rating) WITH (key_field='id');
 -- Expressions involving pdb.score currently use a normal scan rather than Top K.
 SELECT description, pdb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      description     |       score       
 ---------------------+-------------------
  Generic shoes       | 5.754520416259766
@@ -20,7 +20,7 @@ WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). 
 (3 rows)
 
 SELECT description, rating, pdb.score(id) * rating AS score FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score DESC, rating LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      description     | rating |       score        
 ---------------------+--------+--------------------
  Sleek running shoes |      5 | 17.424533367156982
@@ -29,7 +29,7 @@ WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). 
 (3 rows)
 
 SELECT description, rating, pdb.score(id) AS score, pdb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score_times_rating DESC LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      description     | rating |   score   | score_times_rating 
 ---------------------+--------+-----------+--------------------
  Sleek running shoes |      5 | 3.4849067 | 17.424533367156982
@@ -62,7 +62,7 @@ SELECT id, pdb.score(id) AS score FROM mock_items WHERE description @@@ 'shoes' 
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id, pdb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
-WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 3 but is not using Top K scan (using Normal instead). Reason: ORDER BY expressions containing pdb.score() cannot be evaluated in the index. This may cause poor performance on large datasets. Remedies: Only standalone pdb.score() or sums of pdb.score() across tables are supported in ORDER BY. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/issue_3050.out
+++ b/pg_search/tests/pg_regress/expected/issue_3050.out
@@ -17,7 +17,7 @@ WHERE id @@@ paradedb.all()
 GROUP BY id, rating
 ORDER BY id, rating
 LIMIT 5;
-WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  Limit
@@ -41,7 +41,7 @@ WHERE id @@@ paradedb.all()
 GROUP BY id, rating
 ORDER BY id, rating
 LIMIT 5;
-WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
  id | rating | count 
 ----+--------+-------
   1 |      4 |     1

--- a/pg_search/tests/pg_regress/expected/issue_3196.out
+++ b/pg_search/tests/pg_regress/expected/issue_3196.out
@@ -47,7 +47,7 @@ SELECT COUNT(rating) FROM mock_items WHERE id @@@ paradedb.all();
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(metadata->>'color') FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate
@@ -61,7 +61,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 (8 rows)
 
 SELECT COUNT(metadata->>'color') FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
  count 
 -------
     41
@@ -86,7 +86,7 @@ SELECT COUNT(COALESCE(rating, 0)) FROM mock_items WHERE id @@@ paradedb.all();
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(COALESCE(metadata->>'color', 'red')) FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate
@@ -100,7 +100,7 @@ WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a 
 (8 rows)
 
 SELECT COUNT(COALESCE(metadata->>'color', 'red')) FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
+WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
  count 
 -------
     43

--- a/pg_search/tests/pg_regress/expected/issue_3678.out
+++ b/pg_search/tests/pg_regress/expected/issue_3678.out
@@ -86,7 +86,7 @@ WHERE company_name &&& 'Jarvi'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: nhfs_big)
                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -117,7 +117,7 @@ WHERE company_name &&& 'Jarvi'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: nhfs_big)
               profile_id              | best_score 
 --------------------------------------+------------
  a0000000-0000-0000-0000-000000000001 |  11.528142
@@ -137,7 +137,7 @@ WHERE title &&& 'developer'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: nhfs_big)
               profile_id              | best_score 
 --------------------------------------+------------
  a0000000-0000-0000-0000-000000000001 |  2.5257165
@@ -156,7 +156,7 @@ WHERE company_name &&& 'Jarvi'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: nhfs_big)
               profile_id              | best_score 
 --------------------------------------+------------
  a0000000-0000-0000-0000-000000000001 |  11.528142

--- a/pg_search/tests/pg_regress/expected/issue_3827.out
+++ b/pg_search/tests/pg_regress/expected/issue_3827.out
@@ -77,7 +77,7 @@ FROM issue_3827_t
 GROUP BY txt
 HAVING (txt @@@ pdb.parse('foo')) OR SUM(n) < 0
 ORDER BY txt;
-WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_3827_t)
  txt 
 -----
  foo
@@ -91,7 +91,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY not_indexed
 ORDER BY not_indexed;
-WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_3827_t)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  GroupAggregate
@@ -115,7 +115,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY not_indexed
 ORDER BY not_indexed;
-WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_3827_t)
  not_indexed | count 
 -------------+-------
           10 |     1
@@ -130,7 +130,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY txt, n
 ORDER BY txt, n;
-WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_3827_t)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  GroupAggregate
@@ -154,7 +154,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY txt, n
 ORDER BY txt, n;
-WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_3827_t)
  txt | n | count 
 -----+---+-------
  foo | 1 |     1

--- a/pg_search/tests/pg_regress/expected/issue_3998.out
+++ b/pg_search/tests/pg_regress/expected/issue_3998.out
@@ -33,7 +33,7 @@ WITH scores AS (
     WHERE content @@@ 'test'
 )
 SELECT (MAX(s) - MIN(s)) < 0.00001 as scores_are_identical FROM scores;
-WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.check_aggregate_scan = false (table: fieldnorms_test)
+WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.planner_warnings = 'off' (table: fieldnorms_test)
  scores_are_identical 
 ----------------------
  t

--- a/pg_search/tests/pg_regress/expected/issue_4906_ltree_desc_op_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/issue_4906_ltree_desc_op_pushdown.out
@@ -165,7 +165,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top_science
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  descendant_ids_top_science 
 ----------------------------
  {2,3,4,5,6,14,15,16,17,18}
@@ -184,7 +184,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top.Science'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top_science;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top_science 
 ----------------------------------------------------
  t
@@ -204,7 +204,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category @@@ 'Top.Science'
     ) AS ltree_descendant_pushdown_matches_facet_query_top_science;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  ltree_descendant_pushdown_matches_facet_query_top_science 
 -----------------------------------------------------------
  t
@@ -217,7 +217,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top_science_astronomy
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science.Astronomy'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  descendant_ids_top_science_astronomy 
 --------------------------------------
  {3,4,5,15,16,17}
@@ -234,7 +234,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top.Science.Astronomy'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top_science_astronomy;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top_science_astronomy 
 --------------------------------------------------------------
  t
@@ -251,7 +251,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category @@@ 'Top.Science.Astronomy'
     ) AS ltree_desc_pushdown_matches_facet_query_top_science_astron;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  ltree_desc_pushdown_matches_facet_query_top_science_astron 
 ------------------------------------------------------------
  t
@@ -264,7 +264,7 @@ FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND category = 'Top.Science'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  equality_is_included 
 ----------------------
  {2}
@@ -289,7 +289,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top
 FROM issue_4906_ltree
 WHERE category <@ 'Top'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
             descendant_ids_top            
 ------------------------------------------
  {1,2,3,4,5,6,7,8,9,10,11,14,15,16,17,18}
@@ -306,7 +306,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top 
 --------------------------------------------
  t
@@ -318,7 +318,7 @@ SELECT coalesce(array_agg(id ORDER BY id), ARRAY[]::bigint[]) AS no_match_ids
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science.Astronomy.Deep'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  no_match_ids 
 --------------
  {}
@@ -336,7 +336,7 @@ FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND (id + 0) >= 15
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree)
  combined_predicate_ids 
 ------------------------
  {15,16,17,18}
@@ -446,7 +446,7 @@ FROM issue_4906_ltree_partial
 WHERE is_indexed
   AND category <@ 'Top.Science'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree_partial)
  partial_index_descendant_ids 
 ------------------------------
  {1,2,3,4}
@@ -468,7 +468,7 @@ SELECT
         WHERE is_indexed
           AND category ^<@ 'Top.Science'::ltree
     ) AS partial_index_matches_ltree_noindex_semantics;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree_partial)
  partial_index_matches_ltree_noindex_semantics 
 -----------------------------------------------
  t
@@ -556,7 +556,7 @@ WHERE p.is_indexed
         ),
         false
       );
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_ltree_partial)
  partial_qual_subplan_ids 
 --------------------------
  {1,3,4}

--- a/pg_search/tests/pg_regress/expected/issue_4906_ltree_op_absent.out
+++ b/pg_search/tests/pg_regress/expected/issue_4906_ltree_op_absent.out
@@ -96,7 +96,7 @@ SELECT array_agg(id ORDER BY id) AS non_ltree_query_result_ids
 FROM issue_4906_without_ltree
 WHERE body @@@ 'document'
   AND rating > 1;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_without_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_4906_without_ltree)
  non_ltree_query_result_ids 
 ----------------------------
  {2,3}

--- a/pg_search/tests/pg_regress/expected/issue_5108.out
+++ b/pg_search/tests/pg_regress/expected/issue_5108.out
@@ -627,7 +627,7 @@ WITH matched AS (
 SELECT m.snip, d.filename
 FROM matched m JOIN issue_5108_docs d ON d.id = m.doc_id
 ORDER BY m.snip DESC, m.id;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: issue_5108_chunks)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_5108_chunks)
                                                                                                        QUERY PLAN                                                                                                       
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop
@@ -667,7 +667,7 @@ WITH matched AS (
 SELECT m.snip, d.filename
 FROM matched m JOIN issue_5108_docs d ON d.id = m.doc_id
 ORDER BY m.snip DESC, m.id;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: issue_5108_chunks)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: issue_5108_chunks)
             snip             |  filename  
 -----------------------------+------------
  <b>healthcare</b> notes 999 | doc_9.pdf

--- a/pg_search/tests/pg_regress/expected/issue_5944.out
+++ b/pg_search/tests/pg_regress/expected/issue_5944.out
@@ -21,14 +21,14 @@ WITH (key_field = 'id', text_fields = '{"grp": {"fast": true}}');
 -- entries the aggregation should not count when solve_mvcc is enabled.
 DELETE FROM issue_5944_mvcc_facet WHERE id % 10 = 0;
 -- Visible after the delete: 9000 rows across 18 distinct buckets.
-SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SET paradedb.planner_warnings = 'off'; -- DISTINCT can't use the aggregate scan
 SELECT count(*) AS rows, count(DISTINCT grp) AS buckets FROM issue_5944_mvcc_facet;
  rows | buckets 
 ------+---------
  9000 |      18
 (1 row)
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 -- Case 1: ordered top-k with solve_mvcc=true. Baseline, already correct.
 -- pdb.agg OVER () must be a bare targetlist entry or the custom scan does
 -- not intercept it.

--- a/pg_search/tests/pg_regress/expected/json_agg.out
+++ b/pg_search/tests/pg_regress/expected/json_agg.out
@@ -128,7 +128,7 @@ FROM json_test
 WHERE id @@@ paradedb.exists('metadata_json.value')
 GROUP BY metadata_json->>'value'
 ORDER BY value;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test)
  value  | count | min_count | max_count 
 --------+-------+-----------+-----------
  apple  |     3 |         2 |         5

--- a/pg_search/tests/pg_regress/expected/json_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_aggregate.out
@@ -120,7 +120,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT SUM((metadata->>'price')::numeric) as total_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Aggregate
@@ -139,7 +139,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT SUM((metadata->>'price')::numeric) as total_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  total_price 
 -------------
         3862
@@ -150,7 +150,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT SUM((metadata->>'price')::numeric) as electronics_total
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -168,7 +168,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT SUM((metadata->>'price')::numeric) as electronics_total
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  electronics_total 
 -------------------
               3097
@@ -179,7 +179,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT SUM((data->>'stock')::integer) as total_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('data.stock');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  Aggregate
@@ -197,7 +197,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT SUM((data->>'stock')::integer) as total_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('data.stock');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  total_stock 
 -------------
          125
@@ -211,7 +211,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG((metadata->>'price')::numeric) as avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Aggregate
@@ -230,7 +230,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG((metadata->>'price')::numeric) as avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
       avg_price       
 ----------------------
  482.7500000000000000
@@ -241,7 +241,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG((metadata->>'price')::numeric) as apple_avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.brand', 'Apple');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Aggregate
@@ -259,7 +259,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG((metadata->>'price')::numeric) as apple_avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.brand', 'Apple');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  apple_avg_price 
 -----------------
                 
@@ -270,7 +270,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG((data->>'stock')::integer) as avg_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'clothing');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
  Aggregate
@@ -288,7 +288,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG((data->>'stock')::integer) as avg_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'clothing');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
       avg_stock      
 ---------------------
  25.0000000000000000
@@ -304,7 +304,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Aggregate
@@ -325,7 +325,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  min_price | max_price 
 -----------+-----------
         79 |      1299
@@ -338,7 +338,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_electronics_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -358,7 +358,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_electronics_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  min_electronics_price | max_electronics_price 
 -----------------------+-----------------------
                    799 |                  1299
@@ -371,7 +371,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.brand');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Aggregate
@@ -391,7 +391,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.brand');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  first_brand | last_brand 
 -------------+------------
  Adidas      | Samsung
@@ -412,7 +412,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
                                                                                                                                     QUERY PLAN                                                                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -438,7 +438,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_agg_test)
  item_count | total_value |      avg_price       | min_price | max_price | first_brand | last_brand 
 ------------+-------------+----------------------+-----------+-----------+-------------+------------
           8 |        3862 | 482.7500000000000000 |        79 |      1299 | Adidas      | Samsung

--- a/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
@@ -182,7 +182,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  GroupAggregate
@@ -208,7 +208,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
  category | total_price 
 ----------+-------------
           |        3285
@@ -223,7 +223,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -250,7 +250,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
   brand  |       avg_price       | item_count 
 ---------+-----------------------+------------
  Apple   | 1149.0000000000000000 |          2
@@ -268,7 +268,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -296,7 +296,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
  category | min_price | max_price | item_count 
 ----------+-----------+-----------+------------
           |        89 |      1299 |          5
@@ -314,7 +314,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
                                                                                                                  QUERY PLAN                                                                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -344,7 +344,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_aggregates)
   brand  | item_count | total_value |       avg_price       | min_price | max_price 
 ---------+------------+-------------+-----------------------+-----------+-----------
  Apple   |          2 |        2298 | 1149.0000000000000000 |       999 |      1299
@@ -810,7 +810,7 @@ WHERE id @@@ paradedb.exists('document.source.system')
   AND id @@@ paradedb.exists('document.metrics.category')
 GROUP BY document->'source'->>'system', document->'metrics'->>'category'
 ORDER BY source_system, metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_complex)
                                                                                               QUERY PLAN                                                                                              
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -839,7 +839,7 @@ WHERE id @@@ paradedb.exists('document.source.system')
   AND id @@@ paradedb.exists('document.metrics.category')
 GROUP BY document->'source'->>'system', document->'metrics'->>'category'
 ORDER BY source_system, metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_complex)
  source_system | metric_category | count |      avg_score      
 ---------------+-----------------+-------+---------------------
  billing       | A               |     1 | 95.0000000000000000
@@ -860,7 +860,7 @@ FROM json_test_complex
 WHERE id @@@ paradedb.exists('document.metrics.score')
 GROUP BY document->'metrics'->>'category'
 ORDER BY metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_complex)
                                                                                                                                                                        QUERY PLAN                                                                                                                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -890,7 +890,7 @@ FROM json_test_complex
 WHERE id @@@ paradedb.exists('document.metrics.score')
 GROUP BY document->'metrics'->>'category'
 ORDER BY metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_complex)
  metric_category | total_records | total_score |      avg_score      | min_score | max_score 
 -----------------+---------------+-------------+---------------------+-----------+-----------
  A               |             2 |         180 | 90.0000000000000000 |        85 |        95
@@ -1162,7 +1162,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('order_details.category')
 GROUP BY user_profile->>'department', order_details->>'category'
 ORDER BY department, product_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_multi_subfields)
                                                                                              QUERY PLAN                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -1192,7 +1192,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('order_details.category')
 GROUP BY user_profile->>'department', order_details->>'category'
 ORDER BY department, product_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_multi_subfields)
  department  | product_category | order_count | total_quantity 
 -------------+------------------+-------------+----------------
  Engineering | electronics      |           3 |              9
@@ -1218,7 +1218,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
 GROUP BY user_profile->>'department', user_profile->>'location', 
          order_details->>'product', order_details->>'category'
 ORDER BY department, location, product;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_multi_subfields)
                                                                                                                                          QUERY PLAN                                                                                                                                         
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -1252,7 +1252,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
 GROUP BY user_profile->>'department', user_profile->>'location', 
          order_details->>'product', order_details->>'category'
 ORDER BY department, location, product;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.planner_warnings = 'off' (table: json_test_multi_subfields)
  department  | location | product |  category   | order_count |       avg_price       | total_quantity 
 -------------+----------+---------+-------------+-------------+-----------------------+----------------
  Engineering | NYC      | mouse   | electronics |           1 |   25.0000000000000000 |              5

--- a/pg_search/tests/pg_regress/expected/lateral-join.out
+++ b/pg_search/tests/pg_regress/expected/lateral-join.out
@@ -246,7 +246,7 @@ WHERE a.content @@@ 'database'
   AND c.comment_count > 5
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -281,7 +281,7 @@ WHERE a.content @@@ 'database'
   AND c.comment_count > 5
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
  id |              title               |   score   | comment_count 
 ----+----------------------------------+-----------+---------------
   4 | Database Security Best Practices | 1.4766761 |             7
@@ -360,7 +360,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'machine learning'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 10;
-WARNING:  Aggregate Scan not used: field 'rating' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: field 'rating' does not support aggregate pushdown. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -395,7 +395,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'machine learning'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 10;
-WARNING:  Aggregate Scan not used: field 'rating' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: field 'rating' does not support aggregate pushdown. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
  id |          title          | total_comments | avg_rating 
 ----+-------------------------+----------------+------------
   2 | Machine Learning Basics |              7 |       2.00
@@ -420,7 +420,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'cloud'
 ORDER BY a.created_at DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -453,7 +453,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'cloud'
 ORDER BY a.created_at DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
  id |           title           |        created_at        |       comment_time       
 ----+---------------------------+--------------------------+--------------------------
   3 | Cloud Native Applications | Wed Jan 03 00:00:00 2024 | Thu Jan 04 20:00:00 2024
@@ -551,7 +551,7 @@ WHERE a.content @@@ 'machine learning'
   AND a.author_id IN (1, 2)
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
                                                                                                                                                              QUERY PLAN                                                                                                                                                             
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -586,7 +586,7 @@ WHERE a.content @@@ 'machine learning'
   AND a.author_id IN (1, 2)
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
  id |          title          | score_value |   score   |       last_comment       
 ----+-------------------------+-------------+-----------+--------------------------
   2 | Machine Learning Basics |       82.30 | 4.5998363 | Thu Jan 04 19:00:00 2024
@@ -615,7 +615,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'encryption'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -652,7 +652,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'encryption'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
+WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.planner_warnings = 'off' (table: comments)
  id |          title          | has_comments | comment_count 
 ----+-------------------------+--------------+---------------
  14 | Encryption Fundamentals | t            |             6

--- a/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
+++ b/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
@@ -128,7 +128,7 @@ SELECT count(*) FROM (
                SELECT id FROM lp_categories
                WHERE name = 'rare_category'))
 ) sub;
-WARNING:  Aggregate Scan not used: could not extract search query from quals. To disable this warning: SET paradedb.check_aggregate_scan = false (table: lp_items)
+WARNING:  Aggregate Scan not used: could not extract search query from quals. To disable this warning: SET paradedb.planner_warnings = 'off' (table: lp_items)
  count 
 -------
    150

--- a/pg_search/tests/pg_regress/expected/order_by_collation.out
+++ b/pg_search/tests/pg_regress/expected/order_by_collation.out
@@ -124,7 +124,7 @@ SELECT id, name_icu FROM collation_test
 WHERE id @@@ paradedb.all()
 ORDER BY name_icu
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Columnar instead). Reason: ORDER BY columns whose collation is not byte-ordered (C-like) cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Specify COLLATE "C" in your query, or use a byte-ordered collation instead. To disable this warning: SET paradedb.check_topk_scan = false (table: collation_test)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Columnar instead). Reason: ORDER BY columns whose collation is not byte-ordered (C-like) cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Specify COLLATE "C" in your query, or use a byte-ordered collation instead. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Limit
@@ -189,7 +189,7 @@ SELECT id, name_c FROM collation_test
 WHERE id @@@ paradedb.all()
 ORDER BY name_c COLLATE "test_icu"
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns whose collation is not byte-ordered (C-like) cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Specify COLLATE "C" in your query, or use a byte-ordered collation instead. To disable this warning: SET paradedb.check_topk_scan = false (table: collation_test)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns whose collation is not byte-ordered (C-like) cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Specify COLLATE "C" in your query, or use a byte-ordered collation instead. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Limit
@@ -307,7 +307,7 @@ FROM collation_test
 WHERE id @@@ paradedb.all()
 GROUP BY name_case_insensitive
 ORDER BY name;
-WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Sort
@@ -330,7 +330,7 @@ FROM collation_test
 WHERE id @@@ paradedb.all()
 GROUP BY name_case_insensitive
 ORDER BY name;
-WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
     name     | count 
 -------------+-------
  clothing    |     1
@@ -345,7 +345,7 @@ SELECT name_c, COUNT(*)
 FROM collation_test
 WHERE id @@@ paradedb.all()
 GROUP BY GROUPING SETS ((name_c), ());
-WARNING:  Aggregate Scan not used: GROUPING SETS are not supported. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: GROUPING SETS are not supported. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                         QUERY PLAN                        
 ----------------------------------------------------------
  MixedAggregate
@@ -368,7 +368,7 @@ FROM (
     WHERE id @@@ paradedb.all()
     GROUP BY GROUPING SETS ((name_c), ())
 ) AS grouped;
-WARNING:  Aggregate Scan not used: GROUPING SETS are not supported. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: GROUPING SETS are not supported. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
  group_count 
 -------------
            6
@@ -386,7 +386,7 @@ SELECT name_c, COUNT(*)
 FROM collation_test
 WHERE name_c = 'apple' AND id @@@ paradedb.all()
 GROUP BY name_c;
-WARNING:  Aggregate Scan not used: could not verify GROUP BY semantics. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: could not verify GROUP BY semantics. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                                                                                              QUERY PLAN                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -413,7 +413,7 @@ SELECT name_case_insensitive, COUNT(*)
 FROM collation_test
 WHERE id @@@ paradedb.all()
 GROUP BY name_case_insensitive;
-WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                         QUERY PLAN                        
 ----------------------------------------------------------
  HashAggregate
@@ -435,7 +435,7 @@ FROM (
     WHERE id @@@ paradedb.all()
     GROUP BY name_case_insensitive
 ) AS grouped;
-WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
  group_count 
 -------------
            3
@@ -457,7 +457,7 @@ SELECT name_c, name_case_insensitive, COUNT(*) FROM collation_test
 WHERE id @@@ paradedb.all()
 GROUP BY name_c, name_case_insensitive
 ORDER BY name_c, name_case_insensitive;
-WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.check_aggregate_scan = false (table: collation_test)
+WARNING:  Aggregate Scan not used: GROUP BY uses a nondeterministic collation. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
  GroupAggregate
@@ -891,7 +891,7 @@ SELECT id, name_c, name_icu FROM collation_test
 WHERE id @@@ paradedb.all()
 ORDER BY name_c, name_icu
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: collation_test)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Limit
@@ -913,7 +913,7 @@ SELECT id, priority, name_icu FROM collation_test
 WHERE id @@@ paradedb.all()
 ORDER BY priority, name_icu
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: collation_test)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: collation_test)
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/order_by_range.out
+++ b/pg_search/tests/pg_regress/expected/order_by_range.out
@@ -365,7 +365,7 @@ SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY nr, id LIMIT 5;
 
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: range_items)
                                                                         QUERY PLAN                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -380,7 +380,7 @@ WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id, nr FROM range_items WHERE title @@@ 'doc' ORDER BY id, nr LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: only partial prefix of ORDER BY can be pushed down (1 columns matched). This may cause poor performance on large datasets. Remedies: Ensure all ORDER BY columns are indexed with pdb::literal tokenizer for strings, or verify that normalizer/collation matches the index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: range_items)
  id |   nr   
 ----+--------
   1 | empty
@@ -395,7 +395,7 @@ WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). 
 -- must not be mistaken for a sort on `nr`. It stays a Postgres Sort.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT id FROM range_items WHERE title @@@ 'doc' ORDER BY lower(nr) LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: range_items)
                                                                         QUERY PLAN                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -410,7 +410,7 @@ WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id, lower(nr) FROM range_items WHERE title @@@ 'doc' ORDER BY lower(nr), id LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: range_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: range_items)
  id |    lower     
 ----+--------------
  13 |     -0.00001

--- a/pg_search/tests/pg_regress/expected/partial_index_gating.out
+++ b/pg_search/tests/pg_regress/expected/partial_index_gating.out
@@ -36,7 +36,7 @@ END $$ LANGUAGE plpgsql;
 SELECT plan_uses(
   $$SELECT count(*) FROM pig_left WHERE category @@@ 'a'$$,
   'ParadeDB Aggregate Scan') AS agg_when_predicate_missing;
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: pig_left)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: pig_left)
  agg_when_predicate_missing 
 ----------------------------
  f

--- a/pg_search/tests/pg_regress/expected/rrf_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/rrf_pushdown.out
@@ -265,7 +265,7 @@ ORDER BY grp DESC LIMIT 3;
 (3 rows)
 
 -- GROUP BY on an expression the Aggregate Scan can't resolve, so it falls through to Base Scan
-SET paradedb.check_aggregate_scan = false;
+SET paradedb.planner_warnings = 'off';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT grp + 0 AS g, RANK() OVER (ORDER BY grp + 0 DESC) AS rank
 FROM wlp WHERE label @@@ 'shoes'
@@ -307,7 +307,7 @@ GROUP BY grp + 0 HAVING count(*) > 0 ORDER BY grp + 0 DESC LIMIT 3;
  1 |    3
 (3 rows)
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 -- ============================================================
 -- The RRF shape itself: both branches must be Top K
 -- ============================================================

--- a/pg_search/tests/pg_regress/expected/select_distinct.out
+++ b/pg_search/tests/pg_regress/expected/select_distinct.out
@@ -286,9 +286,9 @@ WARNING:  Aggregate Scan (DataFusion) not used: DISTINCT column dist_products.na
  Office Laptop
 (3 rows)
 
--- With paradedb.check_aggregate_scan = false the decline warning must be
+-- With paradedb.planner_warnings = 'off' the decline warning must be
 -- suppressed; the query still runs correctly via native PG.
-SET paradedb.check_aggregate_scan = false;
+SET paradedb.planner_warnings = 'off';
 SELECT DISTINCT name
 FROM dist_products
 WHERE name @@@ 'laptop'
@@ -300,7 +300,7 @@ ORDER BY name;
  Office Laptop
 (3 rows)
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 -- =============================================================================
 -- TEST 6: DISTINCT ON - must fall back gracefully (DISTINCT ON is not supported)
 -- DISTINCT ON is not a plain GROUP BY and cannot be modelled as an aggregate.
@@ -336,9 +336,9 @@ WARNING:  Aggregate Scan (DataFusion) not used: DISTINCT ON is not supported (ta
  Electronics | Gaming Laptop
 (2 rows)
 
--- With paradedb.check_aggregate_scan = false the decline warning must be
+-- With paradedb.planner_warnings = 'off' the decline warning must be
 -- suppressed; the query still runs correctly via native PG.
-SET paradedb.check_aggregate_scan = false;
+SET paradedb.planner_warnings = 'off';
 SELECT DISTINCT ON (category) category, name
 FROM dist_products
 WHERE name @@@ 'laptop OR keyboard'
@@ -349,7 +349,7 @@ ORDER BY category, name;
  Electronics | Gaming Laptop
 (2 rows)
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 -- =============================================================================
 -- TEST 7: DISTINCT with empty result set
 -- WHERE clause matches nothing; DISTINCT must return zero rows.

--- a/pg_search/tests/pg_regress/expected/sequential_scan.out
+++ b/pg_search/tests/pg_regress/expected/sequential_scan.out
@@ -22,7 +22,7 @@ $$;
 -- Tiny work_mem: the ~20k-key match set exceeds it and spills; count is still correct.
 SET work_mem = '64kB';
 SELECT explain_seqscan($$SELECT count(*) FROM sequential_scan WHERE body ||| 'keyword'$$);
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
                                                                                                               explain_seqscan                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -31,7 +31,7 @@ WARNING:  Aggregate Scan not used: query does not imply the partial index predic
 (3 rows)
 
 SELECT count(*) FROM sequential_scan WHERE body ||| 'keyword';
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
  count 
 -------
  20000
@@ -63,7 +63,7 @@ WARNING:  the query's filter match set exceeded work_mem and spilled to a tempor
 
 -- Negation over the spilled set: everything matched, so NOT (...) excludes all rows.
 SELECT explain_seqscan($$SELECT count(*) FROM sequential_scan WHERE NOT (body ||| 'keyword')$$);
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
                                                                                                                  explain_seqscan                                                                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -72,7 +72,7 @@ WARNING:  Aggregate Scan not used: query does not imply the partial index predic
 (3 rows)
 
 SELECT count(*) FROM sequential_scan WHERE NOT (body ||| 'keyword');
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
  count 
 -------
      0
@@ -80,7 +80,7 @@ WARNING:  Aggregate Scan not used: query does not imply the partial index predic
 
 -- A term matched by no row -> empty set -> nothing matches (no spill).
 SELECT explain_seqscan($$SELECT count(*) FROM sequential_scan WHERE body ||| 'nonexistentterm'$$);
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
                                                                                                                   explain_seqscan                                                                                                                  
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -89,7 +89,7 @@ WARNING:  Aggregate Scan not used: query does not imply the partial index predic
 (3 rows)
 
 SELECT count(*) FROM sequential_scan WHERE body ||| 'nonexistentterm';
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
  count 
 -------
      0
@@ -98,7 +98,7 @@ WARNING:  Aggregate Scan not used: query does not imply the partial index predic
 -- With ample work_mem the identical query stays in memory: no spill WARNING.
 SET work_mem = '256MB';
 SELECT explain_seqscan($$SELECT count(*) FROM sequential_scan WHERE body ||| 'keyword'$$);
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
                                                                                                               explain_seqscan                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -107,7 +107,7 @@ WARNING:  Aggregate Scan not used: query does not imply the partial index predic
 (3 rows)
 
 SELECT count(*) FROM sequential_scan WHERE body ||| 'keyword';
-WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.check_aggregate_scan = false (table: sequential_scan)
+WARNING:  Aggregate Scan not used: query does not imply the partial index predicate. To disable this warning: SET paradedb.planner_warnings = 'off' (table: sequential_scan)
  count 
 -------
  20000

--- a/pg_search/tests/pg_regress/expected/term_set_agg.out
+++ b/pg_search/tests/pg_regress/expected/term_set_agg.out
@@ -48,7 +48,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.planner_warnings = 'off' (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id |    name     
 ----+-------------
@@ -74,7 +74,7 @@ FROM paradedb.aggregate(
   ),
   '{"count":{"value_count":{"field":"genus_id"}}}'
 );
-WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.planner_warnings = 'off' (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
          aggregate         
 ---------------------------
@@ -94,7 +94,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
-WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.planner_warnings = 'off' (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id | name 
 ----+------

--- a/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
@@ -150,7 +150,7 @@ SELECT metadata->>'key', COUNT(*) FROM tokenizer_fast WHERE id @@@ pdb.all() GRO
 -- Order by JSON not supported
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT * FROM tokenizer_fast WHERE id @@@ pdb.all() ORDER BY metadata->>'key', id LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: tokenizer_fast)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: tokenizer_fast)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
@@ -165,7 +165,7 @@ WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT * FROM tokenizer_fast WHERE id @@@ pdb.all() ORDER BY metadata->>'key', id LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: tokenizer_fast)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: tokenizer_fast)
  id |   t   |     t_long      |                metadata                
 ----+-------+-----------------+----------------------------------------
   3 | world | Quick brown fox | {"key": "Quick brown fox", "value": 2}

--- a/pg_search/tests/pg_regress/expected/tokenizer_literal_normalized.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer_literal_normalized.out
@@ -17,7 +17,7 @@ SELECT text, pdb.agg('{"value_count": {"field": "id"}}') FROM test_table WHERE i
 ERROR:  Cannot execute pdb.agg: grouping column text exists, but is not a fast field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT * FROM test_table WHERE id @@@ pdb.all() ORDER BY text LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: test_table)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: test_table)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/top_k_scan.out
+++ b/pg_search/tests/pg_regress/expected/top_k_scan.out
@@ -427,7 +427,7 @@ FROM records
 WHERE id @@@ paradedb.all()
 ORDER BY state, flow_type, currency_code, tenant_id, source_id, id
     LIMIT 25;
-WARNING:  Query has LIMIT 25 but is not using Top K scan (using Normal instead). Reason: ORDER BY has 6 columns but Top K supports maximum 5. This may cause poor performance on large datasets. Remedies: Reduce ORDER BY columns to 5 or fewer. To disable this warning: SET paradedb.check_topk_scan = false (table: records)
+WARNING:  Query has LIMIT 25 but is not using Top K scan (using Normal instead). Reason: ORDER BY has 6 columns but Top K supports maximum 5. This may cause poor performance on large datasets. Remedies: Reduce ORDER BY columns to 5 or fewer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: records)
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -98,7 +98,7 @@ SELECT description, rating FROM mock_items
 WHERE description === 'sleek running shoes'
 ORDER BY upper(description) DESC
     LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/topk-lower-text.out
+++ b/pg_search/tests/pg_regress/expected/topk-lower-text.out
@@ -44,7 +44,7 @@ EXPLAIN SELECT description, rating FROM mock_items
 WHERE description === 'sleek running shoes'
 ORDER BY description DESC
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit  (cost=10.03..10.03 rows=1 width=36)
@@ -63,7 +63,7 @@ SELECT description, rating FROM mock_items
 WHERE description === 'sleek running shoes'
 ORDER BY description DESC
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: mock_items)
      description     | rating 
 ---------------------+--------
  Sleek running shoes |      5

--- a/pg_search/tests/pg_regress/expected/topk_validation.out
+++ b/pg_search/tests/pg_regress/expected/topk_validation.out
@@ -1,5 +1,5 @@
 -- Test Top K scan validation feature
--- This test validates that paradedb.check_topk_scan correctly warns when
+-- This test validates that paradedb.planner_warnings correctly warns or errors when
 -- queries with LIMIT cannot use Top K scan optimization
 \i common/common_setup.sql
 CREATE EXTENSION IF NOT EXISTS pg_search;
@@ -13,7 +13,7 @@ CALL paradedb.create_paradedb_test_table(
   table_name => 'test_products'
 );
 -- Scenario 1: Index WITHOUT lower() but query uses lower() in ORDER BY
--- This should trigger a warning when check_topk_scan is enabled
+-- This should trigger a warning when planner_warnings is enabled
 CREATE INDEX products_base_idx ON test_products
 USING paradedb (id, description, category, rating)
 WITH (
@@ -24,10 +24,10 @@ WITH (
     }',
     numeric_fields='{"rating": {"fast": true}}'
 );
--- Test 1: Validation OFF (default) - should not warn
+-- Test 1: Validation OFF - should not warn
 \echo 'Test 1: Validation OFF (no warning expected)'
 Test 1: Validation OFF (no warning expected)
-SET paradedb.check_topk_scan = false;
+SET paradedb.planner_warnings = 'off';
 SELECT id, description FROM test_products
 WHERE description @@@ 'shoes'
 ORDER BY description  -- Missing fast field
@@ -39,15 +39,15 @@ LIMIT 5;
   4 | White jogging shoes
 (3 rows)
 
--- Test 2: Enable validation - should warn about missing fast field
-\echo 'Test 2: Validation ON - warning expected (ORDER BY not a fast field)'
-Test 2: Validation ON - warning expected (ORDER BY not a fast field)
-SET paradedb.check_topk_scan = true;
+-- Test 2: Enable validation (warning mode) - should warn about missing fast field
+\echo 'Test 2: Validation WARNING - warning expected (ORDER BY not a fast field)'
+Test 2: Validation WARNING - warning expected (ORDER BY not a fast field)
+SET paradedb.planner_warnings = 'warning';
 SELECT id, description FROM test_products
 WHERE description @@@ 'shoes'
 ORDER BY description  -- Not marked as fast
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: test_products)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: test_products)
  id |     description     
 ----+---------------------
   5 | Generic shoes
@@ -89,7 +89,7 @@ SELECT id FROM test_products
 WHERE category @@@ 'electronics'
 ORDER BY rating DESC, created_at DESC, id DESC, category DESC, description DESC, last_updated_date DESC  -- 6 columns, max is 5
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY has 6 columns but Top K supports maximum 5. This may cause poor performance on large datasets. Remedies: Reduce ORDER BY columns to 5 or fewer. To disable this warning: SET paradedb.check_topk_scan = false (table: test_products)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY has 6 columns but Top K supports maximum 5. This may cause poor performance on large datasets. Remedies: Reduce ORDER BY columns to 5 or fewer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: test_products)
  id 
 ----
 (0 rows)
@@ -117,7 +117,7 @@ SELECT id, category FROM test_products
 WHERE category === 'Electronics'
 ORDER BY category DESC  -- Doesn't match - index has lower()
 LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: test_products)
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: test_products)
  id | category 
 ----+----------
 (0 rows)
@@ -140,7 +140,7 @@ SELECT id FROM test_products
 WHERE category === 'Electronics'
 ORDER BY category DESC  -- Should warn
 LIMIT 10;
-WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: test_products)
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: test_products)
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
  Limit
@@ -154,10 +154,40 @@ WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead).
                Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"Electronics"}}}}
 (9 rows)
 
--- Test 8: Disable validation mid-session
-\echo 'Test 8: Disable validation (no warning)'
-Test 8: Disable validation (no warning)
-SET paradedb.check_topk_scan = false;
+-- Test 8: Error mode - query fails, but EXPLAIN succeeds with warnings
+\echo 'Test 8: Error mode'
+Test 8: Error mode
+SET paradedb.planner_warnings = 'error';
+-- EXPLAIN should succeed and show warnings
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM test_products
+WHERE category === 'Electronics'
+ORDER BY category DESC
+LIMIT 10;
+WARNING:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: test_products)
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: category DESC
+         ->  Custom Scan (ParadeDB Base Scan) on test_products
+               Table: test_products
+               Index: products_lower_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"Electronics"}}}}
+(9 rows)
+
+-- Direct SELECT should fail with ERROR
+SELECT id FROM test_products
+WHERE category === 'Electronics'
+ORDER BY category DESC
+LIMIT 10;
+ERROR:  Query has LIMIT 10 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: test_products)
+-- Test 9: Disable validation mid-session
+\echo 'Test 9: Disable validation (no warning)'
+Test 9: Disable validation (no warning)
+SET paradedb.planner_warnings = 'off';
 SELECT id FROM test_products
 WHERE category === 'Electronics'
 ORDER BY category DESC  -- No warning now
@@ -167,6 +197,7 @@ LIMIT 10;
 (0 rows)
 
 -- Cleanup
+RESET paradedb.planner_warnings;
 DROP INDEX products_lower_idx;
 DROP TABLE test_products;
 \i common/common_cleanup.sql

--- a/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
+++ b/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
@@ -973,7 +973,7 @@ WHERE
   AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 1978) OR products.id < 1978 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 1978))
 ORDER BY products.created_at DESC, products.id DESC
 LIMIT 100;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: products)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
  id 
 ----
 (0 rows)
@@ -988,7 +988,7 @@ WHERE
   AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 7) OR products.id < 7 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 7))
 ORDER BY products.created_at DESC, products.id DESC
 LIMIT 100;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: products)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
  id 
 ----
 (0 rows)
@@ -1004,7 +1004,7 @@ WHERE
   AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 8) OR products.id < 8 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 8))
 ORDER BY products.created_at DESC, products.id DESC
 LIMIT 100;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: products)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
  id 
 ----
   6
@@ -1022,7 +1022,7 @@ WHERE
   AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 8) OR products.id < 8 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 8))
 ORDER BY products.created_at DESC, products.id DESC
 LIMIT 100;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: products)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
  id 
 ----
   7
@@ -1041,7 +1041,7 @@ WHERE
   AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 99999) OR products.id < 5)
 ORDER BY products.created_at DESC, products.id DESC
 LIMIT 100;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: products)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
  id 
 ----
   4
@@ -1059,7 +1059,7 @@ WHERE
   AND (products.description NOT LIKE (SELECT description FROM products WHERE products.id = 88888))
 ORDER BY products.created_at DESC, products.id DESC
 LIMIT 100;
-WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: products)
+WARNING:  Query has LIMIT 100 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.planner_warnings = 'off' (table: products)
  id 
 ----
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
@@ -56,7 +56,7 @@ SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 -- mismatch: <=> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
@@ -71,7 +71,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
  id 
 ----
   1
@@ -81,7 +81,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 -- mismatch: <#> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
@@ -96,7 +96,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
  id 
 ----
   1
@@ -113,7 +113,7 @@ CREATE INDEX vsp_idx ON vsp
 -- mismatch: <-> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
@@ -128,7 +128,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
  id 
 ----
   1
@@ -161,7 +161,7 @@ SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 -- mismatch: <#> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
@@ -176,7 +176,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
  id 
 ----
   1
@@ -193,7 +193,7 @@ CREATE INDEX vsp_idx ON vsp
 -- mismatch: <-> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
@@ -208,7 +208,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
  id 
 ----
   1
@@ -218,7 +218,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 -- mismatch: <=> falls back, planner warns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
@@ -233,7 +233,7 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (9 rows)
 
 SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
+WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.planner_warnings = 'off' (table: vsp)
  id 
 ----
   1

--- a/pg_search/tests/pg_regress/sql/cardinality_mvcc.sql
+++ b/pg_search/tests/pg_regress/sql/cardinality_mvcc.sql
@@ -33,9 +33,9 @@ SELECT pdb.agg('{"cardinality": {"field": "val"}}'::jsonb, false) FROM card_mvcc
 -- so the index still contains all 12 values
 DELETE FROM card_mvcc WHERE val = md5('cardtest' || 12)::uuid;
 DELETE FROM card_mvcc WHERE id % 10 = 0;
-SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SET paradedb.planner_warnings = 'off'; -- DISTINCT can't use the aggregate scan
 SELECT count(DISTINCT val) AS true_cardinality FROM card_mvcc;
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 
 -- MVCC-correct: the fully-deleted value is not counted. A value whose first
 -- occurrences are dead but which still has live rows must be counted.
@@ -109,9 +109,9 @@ SELECT count(*) >= 2 AS multiple_segments FROM paradedb.index_info('idx_card_mvc
 -- v0: dead in the first batch's segment, live in the second's. v1: dead everywhere.
 DELETE FROM card_mvcc_seg WHERE batch = 1 AND val = 'v0';
 DELETE FROM card_mvcc_seg WHERE val = 'v1';
-SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SET paradedb.planner_warnings = 'off'; -- DISTINCT can't use the aggregate scan
 SELECT count(DISTINCT val) AS true_cardinality FROM card_mvcc_seg;
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 
 SELECT pdb.agg('{"cardinality": {"field": "val"}}'::jsonb) FROM card_mvcc_seg WHERE card_mvcc_seg @@@ pdb.all();
 SELECT pdb.agg('{"cardinality": {"field": "val"}}'::jsonb, false) FROM card_mvcc_seg WHERE card_mvcc_seg @@@ pdb.all();

--- a/pg_search/tests/pg_regress/sql/issue_5944.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5944.sql
@@ -26,9 +26,9 @@ WITH (key_field = 'id', text_fields = '{"grp": {"fast": true}}');
 DELETE FROM issue_5944_mvcc_facet WHERE id % 10 = 0;
 
 -- Visible after the delete: 9000 rows across 18 distinct buckets.
-SET paradedb.check_aggregate_scan = false; -- DISTINCT can't use the aggregate scan
+SET paradedb.planner_warnings = 'off'; -- DISTINCT can't use the aggregate scan
 SELECT count(*) AS rows, count(DISTINCT grp) AS buckets FROM issue_5944_mvcc_facet;
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 
 -- Case 1: ordered top-k with solve_mvcc=true. Baseline, already correct.
 -- pdb.agg OVER () must be a bare targetlist entry or the custom scan does

--- a/pg_search/tests/pg_regress/sql/rrf_pushdown.sql
+++ b/pg_search/tests/pg_regress/sql/rrf_pushdown.sql
@@ -139,7 +139,7 @@ FROM wlp WHERE label @@@ 'shoes'
 ORDER BY grp DESC LIMIT 3;
 
 -- GROUP BY on an expression the Aggregate Scan can't resolve, so it falls through to Base Scan
-SET paradedb.check_aggregate_scan = false;
+SET paradedb.planner_warnings = 'off';
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT grp + 0 AS g, RANK() OVER (ORDER BY grp + 0 DESC) AS rank
@@ -154,7 +154,7 @@ SELECT grp + 0 AS g, RANK() OVER (ORDER BY grp + 0 DESC) AS rank
 FROM wlp WHERE label @@@ 'shoes'
 GROUP BY grp + 0 HAVING count(*) > 0 ORDER BY grp + 0 DESC LIMIT 3;
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 
 -- ============================================================
 -- The RRF shape itself: both branches must be Top K

--- a/pg_search/tests/pg_regress/sql/select_distinct.sql
+++ b/pg_search/tests/pg_regress/sql/select_distinct.sql
@@ -181,16 +181,16 @@ FROM dist_products
 WHERE name @@@ 'laptop'
 ORDER BY name;
 
--- With paradedb.check_aggregate_scan = false the decline warning must be
+-- With paradedb.planner_warnings = 'off' the decline warning must be
 -- suppressed; the query still runs correctly via native PG.
-SET paradedb.check_aggregate_scan = false;
+SET paradedb.planner_warnings = 'off';
 
 SELECT DISTINCT name
 FROM dist_products
 WHERE name @@@ 'laptop'
 ORDER BY name;
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 
 -- =============================================================================
 -- TEST 6: DISTINCT ON - must fall back gracefully (DISTINCT ON is not supported)
@@ -209,16 +209,16 @@ FROM dist_products
 WHERE name @@@ 'laptop OR keyboard'
 ORDER BY category, name;
 
--- With paradedb.check_aggregate_scan = false the decline warning must be
+-- With paradedb.planner_warnings = 'off' the decline warning must be
 -- suppressed; the query still runs correctly via native PG.
-SET paradedb.check_aggregate_scan = false;
+SET paradedb.planner_warnings = 'off';
 
 SELECT DISTINCT ON (category) category, name
 FROM dist_products
 WHERE name @@@ 'laptop OR keyboard'
 ORDER BY category, name;
 
-RESET paradedb.check_aggregate_scan;
+RESET paradedb.planner_warnings;
 
 -- =============================================================================
 -- TEST 7: DISTINCT with empty result set

--- a/pg_search/tests/pg_regress/sql/topk_validation.sql
+++ b/pg_search/tests/pg_regress/sql/topk_validation.sql
@@ -1,5 +1,5 @@
 -- Test Top K scan validation feature
--- This test validates that paradedb.check_topk_scan correctly warns when
+-- This test validates that paradedb.planner_warnings correctly warns or errors when
 -- queries with LIMIT cannot use Top K scan optimization
 
 \i common/common_setup.sql
@@ -11,7 +11,7 @@ CALL paradedb.create_paradedb_test_table(
 );
 
 -- Scenario 1: Index WITHOUT lower() but query uses lower() in ORDER BY
--- This should trigger a warning when check_topk_scan is enabled
+-- This should trigger a warning when planner_warnings is enabled
 CREATE INDEX products_base_idx ON test_products
 USING paradedb (id, description, category, rating)
 WITH (
@@ -23,17 +23,17 @@ WITH (
     numeric_fields='{"rating": {"fast": true}}'
 );
 
--- Test 1: Validation OFF (default) - should not warn
+-- Test 1: Validation OFF - should not warn
 \echo 'Test 1: Validation OFF (no warning expected)'
-SET paradedb.check_topk_scan = false;
+SET paradedb.planner_warnings = 'off';
 SELECT id, description FROM test_products
 WHERE description @@@ 'shoes'
 ORDER BY description  -- Missing fast field
 LIMIT 5;
 
--- Test 2: Enable validation - should warn about missing fast field
-\echo 'Test 2: Validation ON - warning expected (ORDER BY not a fast field)'
-SET paradedb.check_topk_scan = true;
+-- Test 2: Enable validation (warning mode) - should warn about missing fast field
+\echo 'Test 2: Validation WARNING - warning expected (ORDER BY not a fast field)'
+SET paradedb.planner_warnings = 'warning';
 SELECT id, description FROM test_products
 WHERE description @@@ 'shoes'
 ORDER BY description  -- Not marked as fast
@@ -99,15 +99,33 @@ WHERE category === 'Electronics'
 ORDER BY category DESC  -- Should warn
 LIMIT 10;
 
--- Test 8: Disable validation mid-session
-\echo 'Test 8: Disable validation (no warning)'
-SET paradedb.check_topk_scan = false;
+-- Test 8: Error mode - query fails, but EXPLAIN succeeds with warnings
+\echo 'Test 8: Error mode'
+SET paradedb.planner_warnings = 'error';
+
+-- EXPLAIN should succeed and show warnings
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM test_products
+WHERE category === 'Electronics'
+ORDER BY category DESC
+LIMIT 10;
+
+-- Direct SELECT should fail with ERROR
+SELECT id FROM test_products
+WHERE category === 'Electronics'
+ORDER BY category DESC
+LIMIT 10;
+
+-- Test 9: Disable validation mid-session
+\echo 'Test 9: Disable validation (no warning)'
+SET paradedb.planner_warnings = 'off';
 SELECT id FROM test_products
 WHERE category === 'Electronics'
 ORDER BY category DESC  -- No warning now
 LIMIT 10;
 
 -- Cleanup
+RESET paradedb.planner_warnings;
 DROP INDEX products_lower_idx;
 DROP TABLE test_products;
 


### PR DESCRIPTION
## What

Replaces the separate boolean GUCs `paradedb.check_aggregate_scan` and `paradedb.check_topk_scan` with a single unified enum GUC, `paradedb.planner_warnings` (`off`, `warning`, `error`, defaulting to `warning`).

When set to `error`, queries that cannot use an optimized ParadeDB scan (`basescan` / Top K, `aggregatescan`, or `joinscan`) raise an error during execution instead of logging a warning.

## Why

In CI and staging environments, users and tests need a strict mode where fallback to unoptimized execution paths immediately fails the query rather than logging warnings.

## How

- Replaced boolean GUCs with `paradedb.planner_warnings` (`off`, `warning`, `error`).
- Added `ProcessUtility_hook` interception in `pg_search/src/postgres/planner_warnings.rs` to track `EXPLAIN` queries via thread-local state, in order to allow `EXPLAIN` to be rendered rather than erroring.
- Updated `emit_planner_warnings()` in `pg_search/src/postgres/planner_warnings.rs` to suppress messages when `off`, raise `pgrx::error!` when `error` (downgraded to `pgrx::warning!` during `EXPLAIN`), and emit `pgrx::warning!` when `warning`.

## Tests

Added regression tests in `pg_search/tests/pg_regress/sql/topk_validation.sql` verifying `off`, `warning`, and `error` modes, including `EXPLAIN` behavior under `error` mode.