### PR TITLE
feat: add thresholded visibility variant for aggregates

### DIFF
--- a/docs/changelog/unreleased/6099.features.mdx
+++ b/docs/changelog/unreleased/6099.features.mdx
@@ -1,0 +1,5 @@
+---
+header: features
+---
+
+Aggregates accept a new `visibility` parameter with three modes. `'transaction'` (the default) applies MVCC visibility checks to matching index entries, `'raw'` skips them entirely, and `'threshold'` applies them only when the estimated matching row count is below the new `paradedb.visibility_threshold` GUC, which defaults to 10000. The `solve_mvcc` parameter is deprecated and is still accepted as an alias.

--- a/docs/documentation/aggregates/overview.mdx
+++ b/docs/documentation/aggregates/overview.mdx
@@ -247,14 +247,20 @@ await dbContext
 
 ## Performance Optimization
 
-By default, `pdb.agg` runs MVCC visibility checks to ensure that deleted or updated-away rows are not factored into the result set. This behavior is controlled by the `solve_mvcc` argument, which defaults to `true`.
+By default, `pdb.agg` runs transaction visibility checks so that deleted or updated-away rows are not factored into the result set. This behavior is controlled by the `visibility` argument, which takes one of three modes.
 
-If your table is not frequently updated or you can tolerate an approximate result, the performance of aggregate queries can be improved by disabling these visibility checks.
-To do so, set `solve_mvcc` to `false`.
+| Mode | Behavior |
+| --- | --- |
+| `'transaction'` | Check transaction visibility. Aggregate results match vanilla Postgres. This is the default. |
+| `'raw'` | Skip the checks and aggregate raw index data. Faster, and approximate whenever the index still holds entries for rows your transaction cannot see. |
+| `'threshold'` | Check transaction visibility only when the query's estimated matching row count is below `paradedb.visibility_threshold`. |
+
+If your table is not frequently updated or you can tolerate an approximate result, the performance of aggregate queries can be improved by skipping these visibility checks.
+To do so, set `visibility` to `'raw'`.
 
 <CodeGroup>
 ```sql SQL
-SELECT pdb.agg('{"value_count": {"field": "id"}}', false)
+SELECT pdb.agg('{"value_count": {"field": "id"}}', 'raw')
 FROM mock_items
 WHERE description ||| 'running shoes';
 ```
@@ -309,10 +315,32 @@ await dbContext
 
 </CodeGroup>
 
-Disabling this check can improve query times by 2-4x in some cases (at the expense of correctness).
+Skipping this check can improve query times by 2-4x in some cases, at the expense of correctness.
+
+### Thresholded Visibility
+
+An unvacuumed dead tuple skews a small result visibly and a large one barely at all, so the tradeoff above is really a function of how many rows the query matches. `visibility => 'threshold'` makes that decision per query instead of hardcoding it in your application: visibility checks run when the estimated matching row count is below `paradedb.visibility_threshold`, and the aggregate reads raw index data otherwise.
+
+```sql
+SELECT pdb.agg('{"value_count": {"field": "id"}}', 'threshold')
+FROM mock_items
+WHERE description ||| 'running shoes';
+```
+
+`paradedb.visibility_threshold` defaults to `10000` and can be set at the system, database, session, or transaction level.
+
+```sql
+SET paradedb.visibility_threshold = 50000;
+```
+
+The estimate is made for the query as a whole, so a bucketed aggregation such as `GROUP BY` or `terms` resolves to one decision for every bucket. A query matching a million rows across fifty thousand buckets aggregates every bucket from raw index data, including the low-cardinality ones.
 
 <Note>
-If a single query contains multiple `pdb.agg` calls, all of them must use the same visibility setting (either all `true` or all `false`).
+If a single query contains multiple `pdb.agg` calls, all of them must use the same `visibility` setting. Omitting the argument selects `'transaction'`, so an omitted argument alongside an explicit `'raw'` is a conflict, not a default.
+</Note>
+
+<Note>
+The `solve_mvcc` argument is deprecated in favor of `visibility`. Passing a boolean is still accepted, where `true` means `'transaction'` and `false` means `'raw'`.
 </Note>
 
 ## JSON Fields

--- a/docs/welcome/guarantees.mdx
+++ b/docs/welcome/guarantees.mdx
@@ -21,7 +21,7 @@ whereas writes can be improved by increasing [per-statement memory](/documentati
 
 ### Correctness vs. Performance
 
-By default, ParadeDB favors correctness, even when it comes at the cost of slower query execution. For `pdb.agg`, MVCC visibility filtering is enabled by default. If your workload can tolerate potentially stale aggregate results, you can disable it with `solve_mvcc => false` to improve performance.
+By default, ParadeDB favors correctness, even when it comes at the cost of slower query execution. For `pdb.agg`, transaction visibility filtering is enabled by default. If your workload can tolerate potentially stale aggregate results, you can skip it with `visibility => 'raw'` to improve performance, or let the query's size decide with `visibility => 'threshold'`.
 
 ### Replication Safety
 

--- a/pg_search/sql/unreleased/6099.rename_solve_mvcc_to_visibility.sql
+++ b/pg_search/sql/unreleased/6099.rename_solve_mvcc_to_visibility.sql
@@ -1,0 +1,41 @@
+-- Rename the `solve_mvcc` aggregate parameter to `visibility` and make it ternary
+-- (#6074).
+--
+-- Every CREATE below is the SchemaBot/pgrx canonical text verbatim (the schema
+-- checker compares statements textually); the DROPs keep the fragment re-runnable.
+
+-- `paradedb.aggregate` gains a trailing `visibility` argument. The previous
+-- six-argument signature has to go: leaving both in place would make every call
+-- that relies on the defaults ambiguous. These two statements are SchemaBot's
+-- emitted text verbatim, which for a replaced function differs from pgrx's
+-- generated form (named parameters, `pg_catalog.int8`, `CREATE OR REPLACE`).
+DROP FUNCTION IF EXISTS aggregate(index regclass, query searchqueryinput, agg json, solve_mvcc bool, memory_limit pg_catalog.int8, bucket_limit pg_catalog.int8);
+CREATE OR REPLACE FUNCTION aggregate(index regclass, query searchqueryinput, agg json, solve_mvcc bool DEFAULT NULL, memory_limit pg_catalog.int8 DEFAULT '500000000', bucket_limit pg_catalog.int8 DEFAULT NULL, visibility text DEFAULT NULL) RETURNS jsonb AS 'MODULE_PATHNAME', 'aggregate_wrapper' LANGUAGE c;
+
+-- The `pdb.agg(jsonb, text)` overload carrying the visibility mode. The existing
+-- `pdb.agg(jsonb, bool)` overload is left in place: it is the deprecated
+-- `solve_mvcc` spelling and existing queries still resolve to it.
+DROP AGGREGATE IF EXISTS pdb.agg(jsonb, TEXT);
+DROP FUNCTION IF EXISTS pdb."agg_placeholder_visibility_agg_placeholder_visibility_state"(internal, jsonb, TEXT);
+DROP FUNCTION IF EXISTS pdb."agg_placeholder_visibility_agg_placeholder_visibility_finalize"(internal);
+CREATE  FUNCTION pdb."agg_placeholder_visibility_agg_placeholder_visibility_state"(
+	"this" internal, /* Internal */
+	"arg_one" jsonb, /* JsonB */
+	"arg_two" TEXT /* String */
+) RETURNS internal /* Internal */
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_state_wrapper';
+CREATE  FUNCTION pdb."agg_placeholder_visibility_agg_placeholder_visibility_finalize"(
+	"this" internal /* Internal */
+) RETURNS jsonb /* JsonB */
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_finalize_wrapper';
+CREATE AGGREGATE pdb.agg (
+	jsonb, /* JsonB */
+	TEXT /* String */
+)
+(
+	SFUNC = pdb."agg_placeholder_visibility_agg_placeholder_visibility_state", /* pg_search::api::aggregate::pdb::AggPlaceholderVisibility::state */
+	STYPE = internal, /* Internal */
+	FINALFUNC = pdb."agg_placeholder_visibility_agg_placeholder_visibility_finalize" /* pg_search::api::aggregate::pdb::AggPlaceholderVisibility::final */
+);

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -23,8 +23,8 @@ use std::ptr::NonNull;
 use crate::aggregate::exec::AggregationExec;
 use crate::aggregate::interrupt_collector::InterruptableCollector;
 use crate::aggregate::mvcc_collector::MVCCFilterCollector;
-use crate::api::HashSet;
 use crate::api::version::VersionInfo;
+use crate::api::{HashSet, MvccVisibility};
 use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::index::reader::index::SearchIndexReader;
 use crate::launch_parallel_process;
@@ -428,13 +428,19 @@ pub fn execute_aggregate(
     index: &PgSearchRelation,
     query: SearchQueryInput,
     mut agg_req: AggregateRequest,
-    solve_mvcc: bool,
+    visibility: MvccVisibility,
     memory_limit: u64,
     bucket_limit: u32,
     expr_context: *mut pg_sys::ExprContext,
     planstate: *mut pg_sys::PlanState,
     mut bitmap_exec: Option<&mut BitmapExec>,
 ) -> Result<AggregationResults, Box<dyn Error>> {
+    // Resolve `visibility` to a single decision for this execution before anything
+    // branches on it. `threshold` estimates the query's matching row count here
+    // rather than at plan time so that the `paradedb.aggregate()` UDF, which the
+    // planner never sees, resolves the same way as the custom scan paths.
+    let solve_mvcc = visibility.resolve_filtering(index, &query);
+
     if index.created_by_version().stores_datetimes_in_i64() {
         // We need to rewrite date_histogram requests to regular histogram requests because we are
         // no longer storing dates in tantivy's DateTime.

--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -17,7 +17,7 @@
 
 //! Aggregate functions for ParadeDB search.
 //!
-//! ## User-Facing Function: `pdb.agg(jsonb)` and `pdb.agg(jsonb, bool)`
+//! ## User-Facing Function: `pdb.agg(jsonb)`, `pdb.agg(jsonb, text)` and `pdb.agg(jsonb, bool)`
 //!
 //! This is the public API for users to specify custom Tantivy aggregations.
 //! When used in window function context (`OVER ()`), it gets intercepted at planning
@@ -26,12 +26,17 @@
 //!
 //! Example: `SELECT *, pdb.agg('{"avg": {"field": "price"}}'::jsonb) OVER () FROM products`
 //!
-//! The optional second argument controls MVCC visibility filtering:
-//! - 'enabled' (default): Apply MVCC filtering for transaction-accurate aggregates
-//! - 'disabled': Skip MVCC filtering for faster but potentially stale aggregates
+//! The optional second argument is the `visibility` mode:
+//! - 'transaction' (default): check transaction visibility, matching Postgres semantics
+//! - 'raw': skip the checks and aggregate raw index data, faster but approximate
+//! - 'threshold': check only when the estimated matching row count is below
+//!   `paradedb.visibility_threshold`
 //!
-//! Example with MVCC disabled:
-//! `SELECT *, pdb.agg('{"avg": {"field": "price"}}'::jsonb, false) OVER () FROM products`
+//! Example opting into raw index data:
+//! `SELECT *, pdb.agg('{"avg": {"field": "price"}}'::jsonb, 'raw') OVER () FROM products`
+//!
+//! The `bool` overload is the deprecated `solve_mvcc` spelling, kept so existing
+//! queries keep working: `true` means 'transaction' and `false` means 'raw'.
 //!
 //! When used with GROUP BY, the aggregate currently returns an error indicating it's not supported.
 //! The window function variant is the primary use case.
@@ -55,8 +60,10 @@ use pgrx::{Json, JsonB, PgRelation, default, pg_extern};
 use serde::{Deserialize, Serialize};
 
 use crate::aggregate::{AggregateRequest, execute_aggregate};
+use crate::api::operator::estimate_matching_rows;
 use crate::api::version::VersionInfo;
 use crate::gucs;
+use crate::nodecast;
 use crate::postgres::customscan::aggregatescan::aggregate_type::validate_agg_json_fields;
 use crate::postgres::customscan::aggregatescan::json_rewrite::rewrite_aggregate_result_json_timestamps;
 use crate::postgres::rel::PgSearchRelation;
@@ -68,7 +75,7 @@ fn aggregate_impl(
     index: PgRelation,
     query: SearchQueryInput,
     agg: Json,
-    solve_mvcc: bool,
+    visibility: MvccVisibility,
     memory_limit: i64,
     bucket_limit: i64,
 ) -> Result<JsonB, Box<dyn Error>> {
@@ -101,7 +108,7 @@ fn aggregate_impl(
         &relation,
         query,
         AggregateRequest::Json(serde_json::from_value(agg.0)?),
-        solve_mvcc,
+        visibility,
         memory_limit.try_into()?,
         bucket_limit_u32,
         standalone_context.as_ptr(),
@@ -132,22 +139,56 @@ fn aggregate_impl(
     Ok(JsonB(output))
 }
 
-/// SQL: aggregate(index, query, agg, solve_mvcc=true, memory_limit=..., bucket_limit=GUC)
-/// SQL: aggregate(index, query, agg, solve_mvcc=true, memory_limit=..., bucket_limit=NULL)
+/// Resolve the UDF's visibility from its two spellings.
+///
+/// `visibility` is the supported parameter; `solve_mvcc` is deprecated and maps onto
+/// it. Supplying both is an error rather than a precedence rule, because either
+/// choice of winner would silently ignore something the caller asked for.
+fn resolve_udf_visibility(solve_mvcc: Option<bool>, visibility: Option<String>) -> MvccVisibility {
+    match (solve_mvcc, visibility) {
+        (Some(_), Some(_)) => pgrx::error!(
+            "cannot specify both `solve_mvcc` and `visibility`. \
+             `solve_mvcc` is deprecated: pass `visibility` alone."
+        ),
+        (Some(solve_mvcc), None) => {
+            let visibility = if solve_mvcc {
+                MvccVisibility::Transaction
+            } else {
+                MvccVisibility::Raw
+            };
+            pgrx::warning!(
+                "`solve_mvcc` is deprecated and will be removed in a future release. \
+                 Use `visibility => '{}'` instead.",
+                visibility.as_sql_value()
+            );
+            visibility
+        }
+        (None, Some(visibility)) => MvccVisibility::from_sql_value(&visibility),
+        (None, None) => MvccVisibility::default(),
+    }
+}
+
+/// SQL: aggregate(index, query, agg, solve_mvcc=NULL, memory_limit=..., bucket_limit=GUC, visibility=NULL)
 /// - bucket_limit=NULL => use GUC paradedb.max_term_agg_buckets
+/// - solve_mvcc is deprecated in favor of visibility; see `resolve_udf_visibility`
+///
+/// `visibility` is appended after `bucket_limit` rather than replacing `solve_mvcc`
+/// in place so that positional calls written against the old signature still resolve.
 #[pg_extern]
 pub fn aggregate(
     index: PgRelation,
     query: SearchQueryInput,
     agg: Json,
-    solve_mvcc: default!(bool, true),
+    solve_mvcc: default!(Option<bool>, "NULL"),
     memory_limit: default!(i64, 500000000),
     bucket_limit: default!(Option<i64>, "NULL"),
+    visibility: default!(Option<String>, "NULL"),
 ) -> Result<JsonB, Box<dyn Error>> {
     // bucket_limit NULL => use GUC
     let bucket_limit = bucket_limit.unwrap_or_else(|| gucs::max_term_agg_buckets() as i64);
+    let visibility = resolve_udf_visibility(solve_mvcc, visibility);
 
-    aggregate_impl(index, query, agg, solve_mvcc, memory_limit, bucket_limit)
+    aggregate_impl(index, query, agg, visibility, memory_limit, bucket_limit)
 }
 
 #[pgrx::pg_schema]
@@ -162,11 +203,11 @@ mod pdb {
     ///
     /// Usage:
     /// ```sql
-    /// -- Default (solve_mvcc = true)
+    /// -- Default (visibility => 'transaction')
     /// pdb.agg('{"avg": {"field": "price"}}'::jsonb)
     ///
-    /// -- Disable MVCC filtering for performance  
-    /// pdb.agg('{"avg": {"field": "price"}}'::jsonb, false)
+    /// -- Aggregate raw index data for performance
+    /// pdb.agg('{"avg": {"field": "price"}}'::jsonb, 'raw')
     /// ```
     #[derive(pgrx::AggregateName, Default)]
     #[aggregate_name = "agg"]
@@ -205,11 +246,13 @@ mod pdb {
         }
     }
 
-    /// Placeholder aggregate for `pdb.agg(jsonb, bool)` with explicit MVCC control.
+    /// Placeholder aggregate for the deprecated `pdb.agg(jsonb, bool)` overload.
     ///
-    /// The second parameter (solve_mvcc) controls MVCC visibility filtering:
-    /// - `true`: Apply MVCC filtering for transaction-accurate aggregates
-    /// - `false`: Skip MVCC filtering for faster but potentially stale aggregates
+    /// The second parameter is the old `solve_mvcc` boolean:
+    /// - `true`: equivalent to `visibility => 'transaction'`
+    /// - `false`: equivalent to `visibility => 'raw'`
+    ///
+    /// Kept so that queries written against the old signature keep working.
     #[derive(pgrx::AggregateName, Default)]
     #[aggregate_name = "agg"]
     pub struct AggPlaceholderWithMvcc;
@@ -217,6 +260,53 @@ mod pdb {
     #[pgrx::pg_aggregate(parallel_safe)]
     impl Aggregate<AggPlaceholderWithMvcc> for AggPlaceholderWithMvcc {
         type Args = (JsonB, bool);
+        type State = Internal;
+        type Finalize = JsonB;
+
+        fn state(
+            _current: Self::State,
+            _arg: Self::Args,
+            _fcinfo: pgrx::pg_sys::FunctionCallInfo,
+        ) -> Self::State {
+            pgrx::error!(
+                "pdb.agg() must be handled by ParadeDB's custom scan. \
+             This error usually means the query syntax is not supported. \
+             Try adding '@@@ pdb.all()' to your WHERE clause to force custom scan usage, \
+             or file an issue at https://github.com/paradedb/paradedb/issues if this should be supported."
+            )
+        }
+
+        fn finalize(
+            _current: Self::State,
+            _direct_arg: Self::OrderedSetArgs,
+            _fcinfo: pgrx::pg_sys::FunctionCallInfo,
+        ) -> Self::Finalize {
+            pgrx::error!(
+                "pdb.agg() must be handled by ParadeDB's custom scan. \
+             This error usually means the query syntax is not supported. \
+             Try adding '@@@ paradedb.all()' to your WHERE clause to force custom scan usage, \
+             or file an issue at https://github.com/paradedb/paradedb/issues if this should be supported."
+            )
+        }
+    }
+
+    /// Placeholder aggregate for `pdb.agg(jsonb, text)`, the `visibility` overload.
+    ///
+    /// The second parameter is the visibility mode: `'transaction'` (the default),
+    /// `'raw'`, or `'threshold'`. An unknown-typed literal such as `'threshold'`
+    /// resolves here rather than to the `bool` overload, because Postgres prefers
+    /// the string category when disambiguating an untyped literal.
+    ///
+    /// Keep the struct name short. `pg_aggregate` derives `<snake>_<snake>_finalize`
+    /// from it, so each character costs two and Postgres truncates past 63. The
+    /// current name lands at 61.
+    #[derive(pgrx::AggregateName, Default)]
+    #[aggregate_name = "agg"]
+    pub struct AggPlaceholderVisibility;
+
+    #[pgrx::pg_aggregate(parallel_safe)]
+    impl Aggregate<AggPlaceholderVisibility> for AggPlaceholderVisibility {
+        type Args = (JsonB, String);
         type State = Internal;
         type Finalize = JsonB;
 
@@ -275,10 +365,65 @@ pub fn agg_funcoid() -> pgrx::pg_sys::Oid {
     lookup_pdb_function("agg", &[pgrx::pg_sys::JSONBOID])
 }
 
-/// Get the OID of the pdb.agg(jsonb, bool) aggregate function with solve_mvcc parameter
+/// Get the OID of the deprecated pdb.agg(jsonb, bool) aggregate function
 /// Returns InvalidOid if the function doesn't exist yet (e.g., during extension creation)
-pub fn agg_with_solve_mvcc_funcoid() -> pgrx::pg_sys::Oid {
+fn agg_with_solve_mvcc_funcoid() -> pgrx::pg_sys::Oid {
     lookup_pdb_function("agg", &[pgrx::pg_sys::JSONBOID, pgrx::pg_sys::BOOLOID])
+}
+
+/// Get the OID of the pdb.agg(jsonb, text) aggregate function with the `visibility` parameter
+/// Returns InvalidOid if the function doesn't exist yet (e.g., during extension creation)
+fn agg_with_visibility_funcoid() -> pgrx::pg_sys::Oid {
+    lookup_pdb_function("agg", &[pgrx::pg_sys::JSONBOID, pgrx::pg_sys::TEXTOID])
+}
+
+/// The OIDs of every `pdb.agg()` overload: the one-argument form, the deprecated
+/// `(jsonb, bool)` form, and the `(jsonb, text)` form.
+///
+/// Each entry is a catalog lookup, so hoist this out of any loop that walks an
+/// expression tree rather than calling `is_agg_funcoid` per node.
+pub fn agg_funcoids() -> [u32; 3] {
+    [
+        agg_funcoid().to_u32(),
+        agg_with_solve_mvcc_funcoid().to_u32(),
+        agg_with_visibility_funcoid().to_u32(),
+    ]
+}
+
+/// True for any `pdb.agg()` overload. Convenient for a one-off check; use
+/// `agg_funcoids()` when the check is inside a tree walk.
+pub fn is_agg_funcoid(aggfnoid: u32) -> bool {
+    agg_funcoids().contains(&aggfnoid)
+}
+
+/// Decode the visibility argument of a `pdb.agg()` call.
+///
+/// `second_arg` is the second argument's expression, or `None` for the one-argument
+/// overload. A non-`Const` or NULL argument, and any overload without a visibility
+/// argument, yield the default: an undecodable mode must not silently downgrade
+/// accuracy.
+///
+/// # Safety
+/// The caller must ensure `second_arg`, when present, is a valid `Node` pointer.
+pub unsafe fn visibility_from_agg_arg(
+    aggfnoid: u32,
+    second_arg: Option<*mut pgrx::pg_sys::Node>,
+) -> MvccVisibility {
+    let Some(const_node) = second_arg.and_then(|node| nodecast!(Const, T_Const, node)) else {
+        return MvccVisibility::default();
+    };
+
+    if aggfnoid == agg_with_solve_mvcc_funcoid().to_u32() {
+        if extract_solve_mvcc_from_const(const_node) {
+            MvccVisibility::Transaction
+        } else {
+            MvccVisibility::Raw
+        }
+    } else if aggfnoid == agg_with_visibility_funcoid().to_u32() {
+        extract_visibility_from_const(const_node)
+    } else {
+        MvccVisibility::default()
+    }
 }
 
 /// Extract solve_mvcc boolean from a Const node.
@@ -286,7 +431,7 @@ pub fn agg_with_solve_mvcc_funcoid() -> pgrx::pg_sys::Oid {
 ///
 /// # Safety
 /// The caller must ensure `const_node` is a valid pointer to a Const node.
-pub unsafe fn extract_solve_mvcc_from_const(const_node: *mut pgrx::pg_sys::Const) -> bool {
+unsafe fn extract_solve_mvcc_from_const(const_node: *mut pgrx::pg_sys::Const) -> bool {
     if const_node.is_null() || (*const_node).constisnull {
         return true;
     }
@@ -294,47 +439,202 @@ pub unsafe fn extract_solve_mvcc_from_const(const_node: *mut pgrx::pg_sys::Const
     pgrx::FromDatum::from_datum(bool_datum, false).unwrap_or(true)
 }
 
-/// Controls MVCC visibility filtering for aggregate computations.
+/// Extract a `visibility` mode from a `text` Const node. A NULL or undecodable
+/// value yields the default; an unrecognized string is an error.
 ///
-/// This enum determines whether aggregations should apply Postgres MVCC
-/// (Multi-Version Concurrency Control) filtering to ensure transaction-consistent results.
+/// # Safety
+/// The caller must ensure `const_node` is a valid pointer to a Const node.
+unsafe fn extract_visibility_from_const(const_node: *mut pgrx::pg_sys::Const) -> MvccVisibility {
+    if const_node.is_null() || (*const_node).constisnull {
+        return MvccVisibility::default();
+    }
+    let datum = (*const_node).constvalue;
+    match <String as pgrx::FromDatum>::from_datum(datum, false) {
+        Some(value) => MvccVisibility::from_sql_value(&value),
+        None => MvccVisibility::default(),
+    }
+}
+
+/// Controls transaction visibility filtering for aggregate computations.
 ///
-/// The values are designed to be extensible for future enhancements, such as:
-/// - Dynamic MVCC based on query estimate (for small result sets, accuracy matters more)
-/// - Sampling-based MVCC for very large result sets
+/// Aggregates read the index rather than the heap, so an index entry for a row that
+/// is dead or invisible to the current snapshot is only excluded if it is checked
+/// against the heap. This enum decides whether that check runs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum MvccVisibility {
-    /// Apply MVCC filtering for transaction-accurate aggregates.
-    /// This is the default behavior - aggregates will only include rows
-    /// visible to the current transaction.
+    /// Apply visibility checking, so aggregates count only rows visible to the
+    /// current transaction. The default, and the only mode that matches vanilla
+    /// Postgres semantics.
     #[default]
-    Enabled,
-    /// Skip MVCC filtering for performance.
-    /// Aggregates may include rows that are not visible to the current transaction,
-    /// but computation will be faster.
-    Disabled,
+    Transaction,
+    /// Skip visibility checking and aggregate raw index data. Faster, and
+    /// approximate whenever the index holds entries for rows the transaction
+    /// cannot see.
+    Raw,
+    /// Apply visibility checking only when the query's estimated matching row
+    /// count is below `paradedb.visibility_threshold`. Resolved per execution,
+    /// not per plan.
+    Threshold,
 }
 
 impl MvccVisibility {
-    /// Parse from a string value (case-insensitive).
-    /// Returns the default (Enabled) for unrecognized values with a warning.
-    pub fn from_str_or_default(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "enabled" | "true" | "on" | "1" => MvccVisibility::Enabled,
-            "disabled" | "false" | "off" | "0" => MvccVisibility::Disabled,
-            other => {
-                pgrx::warning!(
-                    "Unknown MVCC visibility mode '{}'. Using 'enabled'. \
-                     Valid values: 'enabled', 'disabled'.",
-                    other
-                );
-                MvccVisibility::Enabled
+    /// Parse a SQL-level `visibility` value (case-insensitive), or `None` when the
+    /// value is not one of the recognized spellings.
+    ///
+    /// The legacy `solve_mvcc` spellings are accepted as aliases so that queries
+    /// written against the old parameter keep working.
+    ///
+    /// Kept free of `pgrx::error!` so it stays a pure function. Reporting the error
+    /// is `from_sql_value`'s job: a unit test that reached the reporting path would
+    /// pull Postgres's `ereport` symbols into the test binary, which does not link
+    /// on Linux.
+    pub fn try_from_sql_value(value: &str) -> Option<Self> {
+        Some(match value.trim().to_lowercase().as_str() {
+            // The boolean spellings are the ones Postgres itself accepts for a
+            // `boolean` input, since this value used to be one.
+            "transaction" | "true" | "t" | "yes" | "y" | "on" | "1" | "enabled" | "always" => {
+                MvccVisibility::Transaction
             }
+            "raw" | "false" | "f" | "no" | "n" | "off" | "0" | "disabled" | "never" => {
+                MvccVisibility::Raw
+            }
+            "threshold" | "estimated" => MvccVisibility::Threshold,
+            _ => return None,
+        })
+    }
+
+    /// Parse a SQL-level `visibility` value, erroring on an unrecognized one rather
+    /// than guessing. Guessing wrong either costs accuracy silently or costs the
+    /// performance the caller asked for.
+    pub fn from_sql_value(value: &str) -> Self {
+        Self::try_from_sql_value(value).unwrap_or_else(|| {
+            pgrx::error!(
+                "unrecognized visibility mode '{value}'. \
+                 Valid values: 'transaction' (default), 'raw', 'threshold'."
+            )
+        })
+    }
+
+    /// The canonical SQL spelling, for error and deprecation messages.
+    pub fn as_sql_value(&self) -> &'static str {
+        match self {
+            MvccVisibility::Transaction => "transaction",
+            MvccVisibility::Raw => "raw",
+            MvccVisibility::Threshold => "threshold",
         }
     }
 
-    /// Returns true if MVCC filtering should be applied
-    pub fn should_filter(&self) -> bool {
-        matches!(self, MvccVisibility::Enabled)
+    /// Resolve to whether visibility checking actually runs for this execution.
+    ///
+    /// `Threshold` estimates the query's matching row count, which costs one extra
+    /// single-segment index open. Anything we cannot estimate falls back to
+    /// checking: an unknown row count must not silently downgrade accuracy.
+    ///
+    /// The estimate opens the index without an expression context, so a query
+    /// carrying heap filters or unsolved Postgres expressions is not estimated at
+    /// all. Building a Tantivy query for those shapes requires the context, and
+    /// the accurate side of the branch is the safe place to land.
+    pub fn resolve_filtering(&self, indexrel: &PgSearchRelation, query: &SearchQueryInput) -> bool {
+        match self {
+            MvccVisibility::Transaction => true,
+            MvccVisibility::Raw => false,
+            MvccVisibility::Threshold => {
+                if query.has_heap_filters() || query.has_postgres_expressions() {
+                    return true;
+                }
+                estimate_matching_rows(indexrel, query.clone())
+                    .is_none_or(|rows| rows < gucs::visibility_threshold())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MvccVisibility;
+
+    // These exercise `try_from_sql_value`, never `from_sql_value`. The erroring
+    // wrapper calls `pgrx::error!`, and referencing it from a unit test pulls
+    // Postgres's `ereport` symbols into the lib test binary, which does not link
+    // on Linux. The SQL-level error is covered by the `visibility` regress test.
+
+    #[test]
+    fn parses_canonical_visibility_values() {
+        assert_eq!(
+            MvccVisibility::try_from_sql_value("transaction"),
+            Some(MvccVisibility::Transaction)
+        );
+        assert_eq!(
+            MvccVisibility::try_from_sql_value("raw"),
+            Some(MvccVisibility::Raw)
+        );
+        assert_eq!(
+            MvccVisibility::try_from_sql_value("threshold"),
+            Some(MvccVisibility::Threshold)
+        );
+    }
+
+    #[test]
+    fn parses_legacy_solve_mvcc_spellings() {
+        for value in ["true", "t", "yes", "y", "on", "1", "enabled", "always"] {
+            assert_eq!(
+                MvccVisibility::try_from_sql_value(value),
+                Some(MvccVisibility::Transaction),
+                "{value} should map to transaction"
+            );
+        }
+        for value in ["false", "f", "no", "n", "off", "0", "disabled", "never"] {
+            assert_eq!(
+                MvccVisibility::try_from_sql_value(value),
+                Some(MvccVisibility::Raw),
+                "{value} should map to raw"
+            );
+        }
+        assert_eq!(
+            MvccVisibility::try_from_sql_value("estimated"),
+            Some(MvccVisibility::Threshold)
+        );
+    }
+
+    #[test]
+    fn parsing_ignores_case_and_surrounding_whitespace() {
+        assert_eq!(
+            MvccVisibility::try_from_sql_value("  ThReSHoLd \t"),
+            Some(MvccVisibility::Threshold)
+        );
+        assert_eq!(
+            MvccVisibility::try_from_sql_value("RAW"),
+            Some(MvccVisibility::Raw)
+        );
+    }
+
+    #[test]
+    fn rejects_unrecognized_values() {
+        for value in ["nonsense", "", "  ", "transactional", "rawish", "10000"] {
+            assert_eq!(
+                MvccVisibility::try_from_sql_value(value),
+                None,
+                "{value:?} should not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn transaction_is_the_default() {
+        assert_eq!(MvccVisibility::default(), MvccVisibility::Transaction);
+    }
+
+    #[test]
+    fn sql_values_round_trip() {
+        for visibility in [
+            MvccVisibility::Transaction,
+            MvccVisibility::Raw,
+            MvccVisibility::Threshold,
+        ] {
+            assert_eq!(
+                MvccVisibility::try_from_sql_value(visibility.as_sql_value()),
+                Some(visibility)
+            );
+        }
     }
 }

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -34,8 +34,7 @@ use pgrx::{
 };
 
 pub use aggregate::{
-    MvccVisibility, agg_fn_oid, agg_funcoid, agg_with_solve_mvcc_funcoid,
-    extract_solve_mvcc_from_const,
+    MvccVisibility, agg_fn_oid, agg_funcoid, agg_funcoids, is_agg_funcoid, visibility_from_agg_arg,
 };
 pub use rustc_hash::FxHashMap as HashMap;
 pub use rustc_hash::FxHashSet as HashSet;

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -389,6 +389,29 @@ pub(crate) fn estimate_selectivity(
     estimate_selectivity_and_cost(indexrel, search_query_input).0
 }
 
+/// The estimated number of heap rows matching `search_query_input`, scaled from the
+/// largest segment up to the whole relation. Unlike `estimate_selectivity` this is an
+/// absolute row count, which is what `visibility => 'threshold'` compares against
+/// `paradedb.visibility_threshold`.
+///
+/// `None` when there is nothing to estimate from: an index that can't be opened, or an
+/// expensive-to-estimate query (#4172) over a heap with no `reltuples`.
+pub(crate) fn estimate_matching_rows(
+    indexrel: &PgSearchRelation,
+    search_query_input: SearchQueryInput,
+) -> Option<u64> {
+    if estimate_heuristically(&search_query_input) {
+        let selectivity = search_query_input.selectivity_heuristic();
+        return indexrel
+            .heap_relation()
+            .and_then(|heap| heap.reltuples())
+            .map(|reltuples| (selectivity * reltuples as f64) as u64);
+    }
+
+    open_and_estimate_docs(indexrel, search_query_input)
+        .map(|estimate| estimate.matching_docs as u64)
+}
+
 /// Estimate the query's Tantivy `DocSet::cost()` -- a synthetic measure of how much work
 /// driving the docset takes -- for the score-DESC TopK worker decision
 /// (`decide_nonprunable_topk_workers`). `None` (caller falls back to the general worker

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -80,6 +80,13 @@ static MAX_TOPK_CHUNK_SIZE: GucSetting<i32> = GucSetting::<i32>::new(100_000);
 /// The maximum number of buckets that can be returned by a TermsAggregation
 static MAX_TERM_AGG_BUCKETS: GucSetting<i32> = GucSetting::<i32>::new(DEFAULT_BUCKET_LIMIT as i32);
 
+/// Estimated matching row count below which `visibility => 'threshold'` applies
+/// transaction visibility checking. At or above it, the aggregate reads raw index
+/// data. Small result sets are where an unvacuumed dead tuple visibly skews the
+/// answer, so those keep the checks; large ones trade a negligible error margin
+/// for the scan.
+static VISIBILITY_THRESHOLD: GucSetting<i32> = GucSetting::<i32>::new(10_000);
+
 /// The maximum response size in bytes for a window aggregate.
 static MAX_WINDOW_AGGREGATE_RESPONSE_BYTES: GucSetting<i32> = GucSetting::<i32>::new(1_048_576);
 
@@ -454,6 +461,17 @@ pub fn init() {
         &MAX_TERM_AGG_BUCKETS,
         1,
         DEFAULT_BUCKET_LIMIT as i32,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.visibility_threshold",
+        c"Estimated matching row count below which `visibility => 'threshold'` applies transaction visibility checking",
+        c"An aggregate using `visibility => 'threshold'` applies MVCC visibility checking when the query's estimated matching row count is strictly less than this, and reads raw index data otherwise. Has no effect on `visibility => 'transaction'` or `visibility => 'raw'`.",
+        &VISIBILITY_THRESHOLD,
+        0,
+        i32::MAX,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -880,6 +898,10 @@ pub fn limit_fetch_multiplier() -> f64 {
 
 pub fn expensive_query_cost_factor() -> f64 {
     EXPENSIVE_QUERY_COST_FACTOR.get()
+}
+
+pub fn visibility_threshold() -> u64 {
+    VISIBILITY_THRESHOLD.get().max(0) as u64
 }
 
 pub fn max_term_agg_buckets() -> i32 {

--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::api::{
-    FieldName, HashSet, MvccVisibility, agg_funcoid, agg_with_solve_mvcc_funcoid,
-    extract_solve_mvcc_from_const,
-};
+use crate::api::{FieldName, HashSet, MvccVisibility, is_agg_funcoid, visibility_from_agg_arg};
 use crate::customscan::builders::custom_path::RestrictInfoType;
 use crate::customscan::solve_expr::SolvePostgresExpressions;
 use crate::nodecast;
@@ -146,11 +143,8 @@ impl AggregateType {
         };
         let filter_query = filter_expr.map(|qual| SearchQueryInput::from(&qual));
 
-        // Check for pdb.agg() custom aggregate (both overloads)
-        let agg_oid = agg_funcoid().to_u32();
-        let agg_with_mvcc_oid = agg_with_solve_mvcc_funcoid().to_u32();
-
-        if aggfnoid == agg_oid || aggfnoid == agg_with_mvcc_oid {
+        // Check for pdb.agg() custom aggregate (any overload)
+        if is_agg_funcoid(aggfnoid) {
             // Extract JSON argument (first arg)
             let arg = args.get_ptr(0).expect("pdb.agg missing argument");
             let expr = (*arg).expr;
@@ -169,21 +163,12 @@ impl AggregateType {
                 return Err("pdb.agg argument must be a constant for aggregate pushdown".into());
             };
 
-            // Extract solve_mvcc bool argument (second arg) if using the two-arg overload
-            let solve_mvcc = if aggfnoid == agg_with_mvcc_oid {
-                args.get_ptr(1)
-                    .and_then(|mvcc_arg| nodecast!(Const, T_Const, (*mvcc_arg).expr))
-                    .map(|const_node| extract_solve_mvcc_from_const(const_node))
-                    .unwrap_or(true)
-            } else {
-                true // Single-arg overload: default to solve_mvcc = true
-            };
-
-            let mvcc_visibility = if solve_mvcc {
-                MvccVisibility::Enabled
-            } else {
-                MvccVisibility::Disabled
-            };
+            // Decode the visibility argument (second arg) of the two-arg overloads;
+            // the one-arg overload has none and takes the default.
+            let mvcc_visibility = visibility_from_agg_arg(
+                aggfnoid,
+                args.get_ptr(1).map(|arg| (*arg).expr as *mut pg_sys::Node),
+            );
 
             // Check if any existing fields in the custom aggregate are NUMERIC
             // NUMERIC fields do not support aggregate pushdown
@@ -346,9 +331,9 @@ impl AggregateType {
         }
     }
 
-    /// Get the MVCC visibility setting for this aggregate.
-    /// Only Custom aggregates (pdb.agg) can have non-default MVCC settings.
-    /// All standard SQL aggregates (COUNT, SUM, etc.) use the default (Enabled).
+    /// Get the visibility setting for this aggregate.
+    /// Only Custom aggregates (pdb.agg) can have a non-default setting.
+    /// All standard SQL aggregates (COUNT, SUM, etc.) use the default (Transaction).
     pub fn mvcc_visibility(&self) -> MvccVisibility {
         match self {
             AggregateType::Custom {
@@ -359,35 +344,38 @@ impl AggregateType {
         }
     }
 
-    /// Determines if MVCC filtering should be enabled for a group of aggregates.
-    /// Validates that there are no contradicting solve_mvcc settings among custom aggregates.
-    pub fn resolve_mvcc_enabled<'a>(aggregates: impl Iterator<Item = &'a AggregateType>) -> bool {
-        let custom_mvcc_settings: Vec<MvccVisibility> = aggregates
-            .filter_map(|agg_type| {
-                if let AggregateType::Custom {
-                    mvcc_visibility, ..
-                } = agg_type
-                {
-                    Some(*mvcc_visibility)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if !custom_mvcc_settings.is_empty() {
-            let has_enabled = custom_mvcc_settings.contains(&MvccVisibility::Enabled);
-            let has_disabled = custom_mvcc_settings.contains(&MvccVisibility::Disabled);
-            if has_enabled && has_disabled {
-                pgrx::error!(
-                    "pdb.agg() calls have contradicting solve_mvcc settings. \
-                     All pdb.agg() calls in a query must use the same solve_mvcc value. \
-                     Either use solve_mvcc=true (or omit) for all, or solve_mvcc=false for all."
-                );
+    /// Determines the single query-level visibility setting for a group of aggregates.
+    ///
+    /// A query resolves to exactly one visibility decision, so every `pdb.agg()` call in
+    /// it has to agree. Two different settings are an error even when one of them came
+    /// from an omitted argument, since an omitted argument is indistinguishable from an
+    /// explicit `'transaction'` by the time we see it.
+    pub fn resolve_visibility<'a>(
+        aggregates: impl Iterator<Item = &'a AggregateType>,
+    ) -> MvccVisibility {
+        let mut resolved: Option<MvccVisibility> = None;
+        for visibility in aggregates.filter_map(|agg_type| match agg_type {
+            AggregateType::Custom {
+                mvcc_visibility, ..
+            } => Some(*mvcc_visibility),
+            // Standard SQL aggregates carry no setting of their own.
+            _ => None,
+        }) {
+            match resolved {
+                None => resolved = Some(visibility),
+                Some(previous) if previous == visibility => {}
+                Some(previous) => pgrx::error!(
+                    "pdb.agg() calls have contradicting visibility settings: \
+                     '{}' and '{}'. All pdb.agg() calls in a query must use the same \
+                     visibility value, and omitting the argument selects '{}'.",
+                    previous.as_sql_value(),
+                    visibility.as_sql_value(),
+                    MvccVisibility::default().as_sql_value()
+                ),
             }
         }
 
-        !custom_mvcc_settings.contains(&MvccVisibility::Disabled)
+        resolved.unwrap_or_default()
     }
 
     pub fn result_type_oid(&self) -> pg_sys::Oid {

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -17,7 +17,7 @@
 
 use crate::api::SortDirection;
 use crate::api::version::Version;
-use crate::api::{FieldName, HashSet, OrderByFeature};
+use crate::api::{FieldName, HashSet, MvccVisibility, OrderByFeature};
 use crate::gucs;
 use crate::postgres::PgSearchRelation;
 use crate::postgres::customscan::CreateUpperPathsHookArgs;
@@ -154,8 +154,8 @@ pub trait CollectAggregations {
 
 impl CollectAggregations for AggregateCSClause {
     fn collect(&self) -> Result<Aggregations> {
-        // Validate that no contradicting solve_mvcc settings exist among custom aggregates
-        self.mvcc_enabled();
+        // Validate that no contradicting visibility settings exist among custom aggregates
+        self.visibility();
 
         // Validate that all fields referenced in custom aggregates exist in the index schema
         if self.indexrelid != pg_sys::InvalidOid {
@@ -328,10 +328,10 @@ impl AggregateCSClause {
         self.index_created_by_version
     }
 
-    /// Determines if MVCC filtering should be enabled for this aggregate scan.
-    /// Also validates that there are no contradicting solve_mvcc settings among custom aggregates.
-    pub fn mvcc_enabled(&self) -> bool {
-        AggregateType::resolve_mvcc_enabled(self.aggregates())
+    /// The query-level visibility setting for this aggregate scan.
+    /// Also validates that there are no contradicting settings among custom aggregates.
+    pub fn visibility(&self) -> MvccVisibility {
+        AggregateType::resolve_visibility(self.aggregates())
     }
 
     /// True when this clause is a single doc-count aggregate with no GROUP BY,

--- a/pg_search/src/postgres/customscan/aggregatescan/exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/exec.rs
@@ -70,7 +70,7 @@ pub fn aggregation_results_iter(
 
     // Use the GUC for term aggregation bucket limits (single source of truth).
     let bucket_limit: u32 = gucs::max_term_agg_buckets() as u32;
-    let mvcc_enabled = aggregate_clause.mvcc_enabled();
+    let visibility = aggregate_clause.visibility();
     let grouping_fields: Vec<String> = aggregate_clause
         .grouping_columns()
         .into_iter()
@@ -92,7 +92,7 @@ pub fn aggregation_results_iter(
         state.custom_state().indexrel(),
         query,
         AggregateRequest::Sql(aggregate_clause),
-        mvcc_enabled,
+        visibility,
         WorkMem::Tantivy.bytes().try_into().unwrap(),
         bucket_limit,
         expr_context,

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -463,9 +463,7 @@ pub unsafe fn extract_aggregate_targetlist(
             };
 
             // Reject pdb.agg()
-            let pdb_agg_oid = crate::api::agg_funcoid().to_u32();
-            let pdb_agg_mvcc_oid = crate::api::agg_with_solve_mvcc_funcoid().to_u32();
-            if aggfnoid == pdb_agg_oid || aggfnoid == pdb_agg_mvcc_oid {
+            if crate::api::is_agg_funcoid(aggfnoid) {
                 return Err(
                     "pdb.agg() is not supported on joins - use standard SQL aggregates (COUNT, SUM, AVG, MIN, MAX)".into()
                 );

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -212,10 +212,11 @@ impl TopKScanExecState {
             }
         }
 
-        // Determine if MVCC filtering should be enabled.
-        // Check for contradicting solve_mvcc settings - error if some have true and some have false.
-        // Only consider Custom aggregates (pdb.agg) since standard SQL aggregates always use default.
-        let mvcc_enabled = AggregateType::resolve_mvcc_enabled(combined_agg_types.iter());
+        // Determine the query-level visibility setting, erroring on contradicting
+        // settings, then resolve it against this execution. Only Custom aggregates
+        // (pdb.agg) carry a setting; standard SQL aggregates always use the default.
+        let mvcc_enabled = AggregateType::resolve_visibility(combined_agg_types.iter())
+            .resolve_filtering(state.indexrel(), state.search_query_input());
 
         // Convert aggregates to Tantivy Aggregations
         let mut aggregations: tantivy::aggregation::agg_req::Aggregations = Default::default();

--- a/pg_search/src/postgres/customscan/basescan/projections/window_agg.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/window_agg.rs
@@ -69,9 +69,7 @@
 
 use crate::api::FieldName;
 use crate::api::window_aggregate::window_agg_oid;
-use crate::api::{
-    MvccVisibility, agg_funcoid, agg_with_solve_mvcc_funcoid, extract_solve_mvcc_from_const,
-};
+use crate::api::{is_agg_funcoid, visibility_from_agg_arg};
 use crate::nodecast;
 use crate::postgres::PgSearchRelation;
 use crate::postgres::customscan::aggregatescan::aggregate_type::{
@@ -320,11 +318,8 @@ unsafe fn convert_window_func_to_aggregate_type(
         None
     };
 
-    // Handle custom agg function pdb.agg() (both overloads)
-    let custom_agg_oid = agg_funcoid().to_u32();
-    let custom_agg_with_mvcc_oid = agg_with_solve_mvcc_funcoid().to_u32();
-
-    if aggfnoid == custom_agg_oid || aggfnoid == custom_agg_with_mvcc_oid {
+    // Handle custom agg function pdb.agg() (any overload)
+    if is_agg_funcoid(aggfnoid) {
         if args.is_empty() {
             return None;
         }
@@ -341,21 +336,9 @@ unsafe fn convert_window_func_to_aggregate_type(
             jsonb.0
         };
 
-        // Extract solve_mvcc bool argument (second arg) if using the two-arg overload
-        let solve_mvcc = if aggfnoid == custom_agg_with_mvcc_oid {
-            args.get_ptr(1)
-                .and_then(|mvcc_arg| nodecast!(Const, T_Const, mvcc_arg))
-                .map(|const_node| extract_solve_mvcc_from_const(const_node))
-                .unwrap_or(true)
-        } else {
-            true // Single-arg overload: default to solve_mvcc = true
-        };
-
-        let mvcc_visibility = if solve_mvcc {
-            MvccVisibility::Enabled
-        } else {
-            MvccVisibility::Disabled
-        };
+        // Decode the visibility argument (second arg) of the two-arg overloads;
+        // the one-arg overload has none and takes the default.
+        let mvcc_visibility = visibility_from_agg_arg(aggfnoid, args.get_ptr(1));
 
         // Validate that the JSON is a valid Tantivy aggregation
         // It should be a single aggregation definition (e.g., {"terms": {...}}, {"avg": {...}})

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::api::agg_funcoids;
 use crate::api::operator::{anyelement_search_opoids, is_paradedb_search_operator};
 use crate::api::window_aggregate::window_agg_oid;
-use crate::api::{agg_funcoid, agg_with_solve_mvcc_funcoid};
 use crate::gucs;
 use crate::nodecast;
 use crate::postgres::customscan::aggregatescan::targetlist::TargetList;
@@ -813,13 +813,13 @@ unsafe fn expr_contains_paradedb_operator(node: *mut pg_sys::Node) -> bool {
 ///
 /// TODO: Consider unifying this logic to avoid duplication (see GitHub issue #3455)
 pub(crate) unsafe fn query_has_paradedb_agg(parse: *mut pg_sys::Query, recursive: bool) -> bool {
-    let paradedb_agg_oid = agg_funcoid().to_u32();
-    let paradedb_agg_mvcc_oid = agg_with_solve_mvcc_funcoid().to_u32();
+    // Hoisted out of the walk: each is a catalog lookup and the walker visits every
+    // node in the expression tree.
+    let paradedb_agg_oids = agg_funcoids();
     let window_agg_proc_oid = window_agg_oid();
 
     struct WalkerContext {
-        paradedb_agg_oid: u32,
-        paradedb_agg_mvcc_oid: u32,
+        paradedb_agg_oids: [u32; 3],
         window_agg_proc_oid: pg_sys::Oid,
         found: bool,
     }
@@ -836,21 +836,23 @@ pub(crate) unsafe fn query_has_paradedb_agg(parse: *mut pg_sys::Query, recursive
         let ctx = context.cast::<WalkerContext>();
 
         // Check for window function usage (before planner hook replacement)
-        if let Some(window_func) = nodecast!(WindowFunc, T_WindowFunc, node) {
-            let oid = (*window_func).winfnoid.to_u32();
-            if oid == (*ctx).paradedb_agg_oid || oid == (*ctx).paradedb_agg_mvcc_oid {
-                (*ctx).found = true;
-                return true; // Stop walking
-            }
+        if let Some(window_func) = nodecast!(WindowFunc, T_WindowFunc, node)
+            && (*ctx)
+                .paradedb_agg_oids
+                .contains(&(*window_func).winfnoid.to_u32())
+        {
+            (*ctx).found = true;
+            return true; // Stop walking
         }
 
         // Check for aggregate function usage (GROUP BY context)
-        if let Some(aggref) = nodecast!(Aggref, T_Aggref, node) {
-            let oid = (*aggref).aggfnoid.to_u32();
-            if oid == (*ctx).paradedb_agg_oid || oid == (*ctx).paradedb_agg_mvcc_oid {
-                (*ctx).found = true;
-                return true; // Stop walking
-            }
+        if let Some(aggref) = nodecast!(Aggref, T_Aggref, node)
+            && (*ctx)
+                .paradedb_agg_oids
+                .contains(&(*aggref).aggfnoid.to_u32())
+        {
+            (*ctx).found = true;
+            return true; // Stop walking
         }
 
         // Check for window_agg() placeholder (after planner hook replacement)
@@ -868,8 +870,7 @@ pub(crate) unsafe fn query_has_paradedb_agg(parse: *mut pg_sys::Query, recursive
     }
 
     let mut context = WalkerContext {
-        paradedb_agg_oid,
-        paradedb_agg_mvcc_oid,
+        paradedb_agg_oids,
         window_agg_proc_oid,
         found: false,
     };

--- a/pg_search/tests/pg_regress/expected/agg-validate.out
+++ b/pg_search/tests/pg_regress/expected/agg-validate.out
@@ -124,12 +124,12 @@ SELECT *, pdb.agg('{"avg": {"field": "rating"}}'::jsonb) OVER ()
 FROM mock_items
 WHERE id @@@ pdb.all()
 ORDER BY id DESC LIMIT 3;
-                                                                                                                                    QUERY PLAN                                                                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, rating, created_at, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, rating, created_at, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.mock_items
-         Output: id, description, rating, created_at, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, rating, created_at, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: mock_items
          Index: mock_items_idx
          Worker Selection: Cost model

--- a/pg_search/tests/pg_regress/expected/aggregate-udf.out
+++ b/pg_search/tests/pg_regress/expected/aggregate-udf.out
@@ -11,20 +11,20 @@ CREATE INDEX idxpr2625 ON pr2625 USING paradedb (id, k, v) WITH (key_field = 'id
 --
 INSERT INTO pr2625(k, v) SELECT paradedb.random_words(1), x::float8 from generate_series(1, 1000) x;
 SET parallel_leader_participation = true;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
            aggregate           
 -------------------------------
  {"average": {"value": 500.5}}
 (1 row)
 
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>false);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'raw');
            aggregate           
 -------------------------------
  {"average": {"value": 500.5}}
 (1 row)
 
 SET parallel_leader_participation = false;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
            aggregate           
 -------------------------------
  {"average": {"value": 500.5}}
@@ -40,20 +40,20 @@ INSERT INTO pr2625(k, v) SELECT paradedb.random_words(1), x::float8 from generat
 INSERT INTO pr2625(k, v) SELECT paradedb.random_words(1), x::float8 from generate_series(1, 1000) x;
 INSERT INTO pr2625(k, v) SELECT paradedb.random_words(1), x::float8 from generate_series(1, 1000) x;
 SET parallel_leader_participation = true;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
            aggregate           
 -------------------------------
  {"average": {"value": 500.5}}
 (1 row)
 
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>false);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'raw');
            aggregate           
 -------------------------------
  {"average": {"value": 500.5}}
 (1 row)
 
 SET parallel_leader_participation = false;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
            aggregate           
 -------------------------------
  {"average": {"value": 500.5}}
@@ -64,7 +64,7 @@ SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=
 --
 SET parallel_leader_participation = false;
 SET max_parallel_workers = 0;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
            aggregate           
 -------------------------------
  {"average": {"value": 500.5}}

--- a/pg_search/tests/pg_regress/expected/aggregate_edgecases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_edgecases.out
@@ -37,15 +37,15 @@ FROM large_agg_test
 WHERE id @@@ paradedb.all()
 ORDER BY id
 LIMIT 1;
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                               QUERY PLAN                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":50000,"field":"data"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), id
+   Output: (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":50000,"field":"data"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), id
    ->  Gather Merge
-         Output: (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":50000,"field":"data"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), id
+         Output: (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":50000,"field":"data"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), id
          Workers Planned: 1
          ->  Parallel Custom Scan (ParadeDB Base Scan) on public.large_agg_test
-               Output: pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":50000,"field":"data"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), id
+               Output: pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":50000,"field":"data"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), id
                Table: large_agg_test
                Index: large_agg_test_idx
                Worker Selection: Cost model (LIMIT)
@@ -153,12 +153,12 @@ FROM delete_agg_test
 WHERE id @@@ paradedb.all()
 ORDER BY id
 LIMIT 1;
-                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: (pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"value_count":{"field":"id"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), id
+   Output: (pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"value_count":{"field":"id"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), id
    ->  Custom Scan (ParadeDB Base Scan) on public.delete_agg_test
-         Output: pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"value_count":{"field":"id"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), id
+         Output: pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"value_count":{"field":"id"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), id
          Table: delete_agg_test
          Index: delete_agg_test_idx
          Worker Selection: Cost model (LIMIT)
@@ -244,7 +244,7 @@ SELECT
     pdb.agg('{"value_count": {"field": "id"}}'::jsonb, false),
     pdb.agg('{"value_count": {"field": "category"}}'::jsonb, true)
 FROM mvcc_agg_test WHERE id @@@ paradedb.all();
-ERROR:  pdb.agg() calls have contradicting solve_mvcc settings. All pdb.agg() calls in a query must use the same solve_mvcc value. Either use solve_mvcc=true (or omit) for all, or solve_mvcc=false for all.
+ERROR:  pdb.agg() calls have contradicting visibility settings: 'raw' and 'transaction'. All pdb.agg() calls in a query must use the same visibility value, and omitting the argument selects 'transaction'.
 DROP TABLE mvcc_agg_test;
 -- =====================================================================
 -- SECTION 4: pdb.agg() with ||| operator (GitHub Issue #4456)

--- a/pg_search/tests/pg_regress/expected/cardinality_mvcc.out
+++ b/pg_search/tests/pg_regress/expected/cardinality_mvcc.out
@@ -102,12 +102,12 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT id, pdb.agg('{"cardinality": {"field": "val"}}'::jsonb, true) OVER () AS agg
 FROM card_mvcc WHERE card_mvcc @@@ pdb.all()
 ORDER BY id DESC LIMIT 1 OFFSET 0;
-                                                                                                                      QUERY PLAN                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"cardinality":{"field":"val"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"cardinality":{"field":"val"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.card_mvcc
-         Output: id, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"cardinality":{"field":"val"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"cardinality":{"field":"val"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: card_mvcc
          Index: idx_card_mvcc
          Worker Selection: Row-capped

--- a/pg_search/tests/pg_regress/expected/custom-agg.out
+++ b/pg_search/tests/pg_regress/expected/custom-agg.out
@@ -82,12 +82,12 @@ SELECT *, pdb.agg('{"avg": {"field": "response_time"}}'::jsonb) OVER ()
 FROM logs
 WHERE description @@@ 'error'
 ORDER BY timestamp DESC LIMIT 10;
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.logs
-         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: logs
          Index: logs_idx
          Worker Selection: Cost model
@@ -229,12 +229,12 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT *, pdb.agg('{"avg": {"field": "response_time"}}'::jsonb) OVER ()
 FROM logs
 ORDER BY timestamp DESC LIMIT 10;
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.logs
-         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: logs
          Index: logs_idx
          Worker Selection: Cost model
@@ -272,12 +272,12 @@ SELECT *, pdb.agg('{"avg": {"field": "response_time"}}'::jsonb) OVER ()
 FROM logs
 WHERE status_code >= 500
 ORDER BY timestamp DESC LIMIT 10;
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.logs
-         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: logs
          Index: logs_idx
          Worker Selection: Cost model
@@ -794,12 +794,12 @@ SELECT *,
 FROM logs
 WHERE description @@@ 'error'
 ORDER BY timestamp DESC LIMIT 10;
-                                                                                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"max":{"field":"status_code"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"max":{"field":"status_code"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.logs
-         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"max":{"field":"status_code"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"max":{"field":"status_code"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: logs
          Index: logs_idx
          Worker Selection: Cost model
@@ -835,12 +835,12 @@ SELECT *,
 FROM logs
 WHERE description @@@ 'error'
 ORDER BY timestamp DESC LIMIT 10;
-                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.logs
-         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: logs
          Index: logs_idx
          Worker Selection: Cost model
@@ -875,12 +875,12 @@ SELECT *,
 FROM logs
 WHERE description @@@ 'error'
 ORDER BY response_time DESC LIMIT 5;
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.logs
-         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"response_time"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: logs
          Index: logs_idx
          Worker Selection: Cost model
@@ -1337,12 +1337,12 @@ SELECT *,
 FROM logs
 WHERE description @@@ 'error'
 ORDER BY timestamp DESC LIMIT 10;
-                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"response_time","ranges":[{"to":100,"key":"fast"},{"to":1000,"key":"medium","from":100},{"key":"slow","from":1000}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"response_time","ranges":[{"to":100,"key":"fast"},{"to":1000,"key":"medium","from":100},{"key":"slow","from":1000}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.logs
-         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"response_time","ranges":[{"to":100,"key":"fast"},{"to":1000,"key":"medium","from":100},{"key":"slow","from":1000}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, severity, category, response_time, unindexed_metric, status_code, "timestamp", pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"response_time","ranges":[{"to":100,"key":"fast"},{"to":1000,"key":"medium","from":100},{"key":"slow","from":1000}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: logs
          Index: logs_idx
          Worker Selection: Cost model
@@ -2070,12 +2070,12 @@ SELECT *, pdb.agg('{"avg": {"field": "value"}}'::jsonb) OVER () AS avg_value
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-                                                                                                                                  QUERY PLAN                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                    QUERY PLAN                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.mvcc_test
-         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: mvcc_test
          Index: mvcc_test_idx
          Worker Selection: Cost model
@@ -2104,12 +2104,12 @@ SELECT *, pdb.agg('{"avg": {"field": "value"}}'::jsonb, true) OVER () AS avg_val
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-                                                                                                                                  QUERY PLAN                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                    QUERY PLAN                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.mvcc_test
-         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: mvcc_test
          Index: mvcc_test_idx
          Worker Selection: Cost model
@@ -2138,12 +2138,12 @@ SELECT *, pdb.agg('{"avg": {"field": "value"}}'::jsonb, false) OVER () AS avg_va
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-                                                                                                                                  QUERY PLAN                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                QUERY PLAN                                                                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.mvcc_test
-         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: mvcc_test
          Index: mvcc_test_idx
          Worker Selection: Cost model
@@ -2171,12 +2171,12 @@ SELECT *, pdb.agg('{"terms": {"field": "category"}}'::jsonb, false) OVER () AS c
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.mvcc_test
-         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: mvcc_test
          Index: mvcc_test_idx
          Worker Selection: Cost model
@@ -2207,12 +2207,12 @@ SELECT *,
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.mvcc_test
-         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"value"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: mvcc_test
          Index: mvcc_test_idx
          Worker Selection: Cost model
@@ -2244,7 +2244,7 @@ SELECT *,
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-ERROR:  pdb.agg() calls have contradicting solve_mvcc settings. All pdb.agg() calls in a query must use the same solve_mvcc value. Either use solve_mvcc=true (or omit) for all, or solve_mvcc=false for all.
+ERROR:  pdb.agg() calls have contradicting visibility settings: 'transaction' and 'raw'. All pdb.agg() calls in a query must use the same visibility value, and omitting the argument selects 'transaction'.
 -- Test 67c: Multiple pdb.agg() - default (true) mixed with explicit false should also ERROR
 SELECT *,
        pdb.agg('{"avg": {"field": "value"}}'::jsonb) OVER () AS avg_default,
@@ -2252,7 +2252,7 @@ SELECT *,
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-ERROR:  pdb.agg() calls have contradicting solve_mvcc settings. All pdb.agg() calls in a query must use the same solve_mvcc value. Either use solve_mvcc=true (or omit) for all, or solve_mvcc=false for all.
+ERROR:  pdb.agg() calls have contradicting visibility settings: 'transaction' and 'raw'. All pdb.agg() calls in a query must use the same visibility value, and omitting the argument selects 'transaction'.
 -- Test 67d: Multiple pdb.agg() - all with default (true) should work fine
 SELECT *,
        pdb.agg('{"avg": {"field": "value"}}'::jsonb) OVER () AS avg_default,
@@ -2323,12 +2323,12 @@ SELECT *, pdb.agg('{"range": {"field": "value", "ranges": [{"to": 200}, {"from":
 FROM mvcc_test
 WHERE description @@@ 'test'
 ORDER BY id DESC LIMIT 3;
-                                                                                                                                                                QUERY PLAN                                                                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                             QUERY PLAN                                                                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"value","ranges":[{"to":200},{"to":400,"from":200},{"from":400}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, description, category, value, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"value","ranges":[{"to":200},{"to":400,"from":200},{"from":400}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.mvcc_test
-         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"value","ranges":[{"to":200},{"to":400,"from":200},{"from":400}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, description, category, value, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"range":{"field":"value","ranges":[{"to":200},{"to":400,"from":200},{"from":400}]}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: mvcc_test
          Index: mvcc_test_idx
          Worker Selection: Cost model

--- a/pg_search/tests/pg_regress/expected/fn_wrapped_agg.out
+++ b/pg_search/tests/pg_regress/expected/fn_wrapped_agg.out
@@ -36,12 +36,12 @@ SELECT log_id, description, category, pdb.agg('{"terms": {"field": "category"}}'
 FROM fn_wrapped_agg_logs
 WHERE description @@@ paradedb.all()
 ORDER BY log_id DESC LIMIT 3;
-                                                                                                                                   QUERY PLAN                                                                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                     QUERY PLAN                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: log_id, description, category, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: log_id, description, category, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.fn_wrapped_agg_logs
-         Output: log_id, description, category, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: log_id, description, category, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: fn_wrapped_agg_logs
          Index: fn_wrapped_agg_logs_idx
          Worker Selection: Row-capped
@@ -70,12 +70,12 @@ SELECT log_id, description, category, jsonb_pretty(pdb.agg('{"terms": {"field": 
 FROM fn_wrapped_agg_logs
 WHERE description @@@ paradedb.all()
 ORDER BY log_id DESC LIMIT 3;
-                                                                                                                                          QUERY PLAN                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                            QUERY PLAN                                                                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: log_id, description, category, (jsonb_pretty(pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)))
+   Output: log_id, description, category, (jsonb_pretty(pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)))
    ->  Custom Scan (ParadeDB Base Scan) on public.fn_wrapped_agg_logs
-         Output: log_id, description, category, jsonb_pretty(pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+         Output: log_id, description, category, jsonb_pretty(pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
          Table: fn_wrapped_agg_logs
          Index: fn_wrapped_agg_logs_idx
          Worker Selection: Row-capped
@@ -158,15 +158,15 @@ WITH agg AS (
     ORDER BY log_id DESC LIMIT 3
 )
 SELECT * FROM agg;
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CTE Scan on agg
    Output: agg.log_id, agg.description, agg.category, agg.agg_result
    CTE agg
      ->  Limit
-           Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+           Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
            ->  Custom Scan (ParadeDB Base Scan) on public.fn_wrapped_agg_logs
-                 Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+                 Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
                  Table: fn_wrapped_agg_logs
                  Index: fn_wrapped_agg_logs_idx
                  Worker Selection: Row-capped
@@ -201,15 +201,15 @@ WITH agg AS (
     ORDER BY log_id DESC LIMIT 3
 )
 SELECT log_id, description, category, jsonb_pretty(agg_result) FROM agg;
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CTE Scan on agg
    Output: agg.log_id, agg.description, agg.category, jsonb_pretty(agg.agg_result)
    CTE agg
      ->  Limit
-           Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+           Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
            ->  Custom Scan (ParadeDB Base Scan) on public.fn_wrapped_agg_logs
-                 Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+                 Output: fn_wrapped_agg_logs.log_id, fn_wrapped_agg_logs.description, fn_wrapped_agg_logs.category, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"category"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
                  Table: fn_wrapped_agg_logs
                  Index: fn_wrapped_agg_logs_idx
                  Worker Selection: Row-capped

--- a/pg_search/tests/pg_regress/expected/json_agg.out
+++ b/pg_search/tests/pg_regress/expected/json_agg.out
@@ -148,7 +148,7 @@ SELECT * FROM paradedb.aggregate(
     index=>'json_test_idx',
     query=>paradedb.exists('metadata_json.value'),
     agg=>'{"buckets": { "terms": { "field": "metadata_json.value" }}}',
-    solve_mvcc=>true
+    visibility=>'transaction'
 ) ORDER BY 1;
                                                                                                              aggregate                                                                                                             
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/pg_search/tests/pg_regress/expected/topk-agg-facet.out
+++ b/pg_search/tests/pg_regress/expected/topk-agg-facet.out
@@ -2383,12 +2383,12 @@ FROM products
 WHERE description @@@ 'laptop'
 ORDER BY rating DESC
 LIMIT 10;
-                                                                                                                                          QUERY PLAN                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                            QUERY PLAN                                                                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, name, description, category, brand, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), rating
+   Output: id, name, description, category, brand, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), rating
    ->  Custom Scan (ParadeDB Base Scan) on public.products
-         Output: id, name, description, category, brand, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), rating
+         Output: id, name, description, category, brand, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), rating
          Table: products
          Index: products_idx
          Worker Selection: Cost model
@@ -2420,12 +2420,12 @@ FROM products
 WHERE description @@@ 'laptop'
 ORDER BY rating DESC
 LIMIT 10;
-                                                                                                                                         QUERY PLAN                                                                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, name, description, category, brand, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), rating
+   Output: id, name, description, category, brand, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), rating
    ->  Custom Scan (ParadeDB Base Scan) on public.products
-         Output: id, name, description, category, brand, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), rating
+         Output: id, name, description, category, brand, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"avg":{"field":"rating"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), rating
          Table: products
          Index: products_idx
          Worker Selection: Cost model
@@ -2458,12 +2458,12 @@ FROM products
 WHERE description @@@ 'laptop'
 ORDER BY rating DESC
 LIMIT 5;
-                                                                                                                                                       QUERY PLAN                                                                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                         QUERY PLAN                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, name, brand, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"aggs":{"avg_rating":{"avg":{"field":"rating"}}},"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), rating
+   Output: id, name, brand, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"aggs":{"avg_rating":{"avg":{"field":"rating"}}},"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)), rating
    ->  Custom Scan (ParadeDB Base Scan) on public.products
-         Output: id, name, brand, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"aggs":{"avg_rating":{"avg":{"field":"rating"}}},"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), rating
+         Output: id, name, brand, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"aggs":{"avg_rating":{"avg":{"field":"rating"}}},"terms":{"field":"brand"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Transaction"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), rating
          Table: products
          Index: products_idx
          Worker Selection: Cost model

--- a/pg_search/tests/pg_regress/expected/visibility.out
+++ b/pg_search/tests/pg_regress/expected/visibility.out
@@ -1,0 +1,291 @@
+-- Tests the `visibility` argument of pdb.agg() and paradedb.aggregate(): the
+-- 'transaction' / 'raw' / 'threshold' modes, the paradedb.visibility_threshold
+-- GUC, the legacy solve_mvcc spellings, and the errors for a conflicting or
+-- unrecognized setting.
+\echo 'Test: aggregate visibility modes'
+Test: aggregate visibility modes
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS vis_test;
+CREATE TABLE vis_test (
+    id serial8,
+    description text NOT NULL,
+    value int NOT NULL
+) WITH (autovacuum_enabled = off);
+INSERT INTO vis_test (description, value)
+SELECT 'shoes running test', x FROM generate_series(1, 1000) x;
+CREATE INDEX idx_vis_test ON vis_test
+USING bm25 (id, description, value)
+WITH (key_field = 'id', numeric_fields = '{"value": {"fast": true}}');
+-- Delete a tenth of the rows without vacuuming, so the index still holds
+-- entries for 1000 rows while only 900 are visible. Every assertion below turns
+-- on that gap: 900 means the visibility check ran, 1000 means it did not.
+DELETE FROM vis_test WHERE id % 10 = 0;
+--
+-- pdb.agg(): the three modes
+--
+-- Default: transaction visibility, so 900.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb)
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+-- Explicit 'transaction' matches the default.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'transaction')
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+-- 'raw' counts the dead index entries too, so 1000.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+-- An explicit ::text cast resolves to the same overload as the bare literal.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw'::text)
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+--
+-- pdb.agg(): 'threshold' against the GUC
+--
+-- The GUC's default is 10000, comfortably above this query's ~1000 matching
+-- rows, so the checks run.
+SHOW paradedb.visibility_threshold;
+ paradedb.visibility_threshold 
+-------------------------------
+ 10000
+(1 row)
+
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold')
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+-- No row count is below 0, so this forces the raw side of the branch.
+SET paradedb.visibility_threshold = 0;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold')
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+-- Well above the match estimate, so back to checking.
+SET paradedb.visibility_threshold = 1000000;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold')
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+-- 'threshold' leaves the pinned modes alone.
+SET paradedb.visibility_threshold = 0;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'transaction')
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+SET paradedb.visibility_threshold = 1000000;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+RESET paradedb.visibility_threshold;
+-- 'estimated' is an accepted spelling of 'threshold'.
+SET paradedb.visibility_threshold = 0;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'estimated')
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+RESET paradedb.visibility_threshold;
+--
+-- pdb.agg(): the legacy solve_mvcc spellings
+--
+-- The bool overload still resolves and still means what it did.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, true)
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, false)
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+-- The old string spellings are accepted as aliases.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'always')
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'never')
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'enabled')
+FROM vis_test WHERE description @@@ 'running';
+       agg        
+------------------
+ {"value": 900.0}
+(1 row)
+
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'disabled')
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+-- Parsing is case-insensitive and tolerates surrounding whitespace.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, '  RAW ')
+FROM vis_test WHERE description @@@ 'running';
+        agg        
+-------------------
+ {"value": 1000.0}
+(1 row)
+
+--
+-- pdb.agg(): errors
+--
+-- An unrecognized mode is an error rather than a silent fallback.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'nonsense')
+FROM vis_test WHERE description @@@ 'running';
+ERROR:  unrecognized visibility mode 'nonsense'. Valid values: 'transaction' (default), 'raw', 'threshold'.
+-- Two pdb.agg() calls in one query must agree.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'transaction'),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+ERROR:  pdb.agg() calls have contradicting visibility settings: 'transaction' and 'raw'. All pdb.agg() calls in a query must use the same visibility value, and omitting the argument selects 'transaction'.
+-- Including when one of them omits the argument: omitting selects
+-- 'transaction', which conflicts with an explicit 'raw'.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+ERROR:  pdb.agg() calls have contradicting visibility settings: 'transaction' and 'raw'. All pdb.agg() calls in a query must use the same visibility value, and omitting the argument selects 'transaction'.
+-- 'threshold' is a distinct mode, so it conflicts with a pinned one too.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold'),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+ERROR:  pdb.agg() calls have contradicting visibility settings: 'threshold' and 'raw'. All pdb.agg() calls in a query must use the same visibility value, and omitting the argument selects 'transaction'.
+-- Agreeing calls are fine, whatever they agree on.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw'),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+        agg        |         agg         
+-------------------+---------------------
+ {"value": 1000.0} | {"value": 500500.0}
+(1 row)
+
+--
+-- paradedb.aggregate(): the UDF
+--
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}'
+);
+          aggregate          
+-----------------------------
+ {"count": {"value": 900.0}}
+(1 row)
+
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    visibility => 'raw'
+);
+          aggregate           
+------------------------------
+ {"count": {"value": 1000.0}}
+(1 row)
+
+SET paradedb.visibility_threshold = 0;
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    visibility => 'threshold'
+);
+          aggregate           
+------------------------------
+ {"count": {"value": 1000.0}}
+(1 row)
+
+RESET paradedb.visibility_threshold;
+-- solve_mvcc still works, and now warns.
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    solve_mvcc => false
+);
+WARNING:  `solve_mvcc` is deprecated and will be removed in a future release. Use `visibility => 'raw'` instead.
+          aggregate           
+------------------------------
+ {"count": {"value": 1000.0}}
+(1 row)
+
+-- Positional calls written against the old signature still resolve, because
+-- `visibility` was appended after `bucket_limit` rather than replacing
+-- `solve_mvcc` in place.
+SELECT * FROM paradedb.aggregate(
+    'idx_vis_test',
+    paradedb.match('description', 'running'),
+    '{"count": {"value_count": {"field": "id"}}}',
+    false
+);
+WARNING:  `solve_mvcc` is deprecated and will be removed in a future release. Use `visibility => 'raw'` instead.
+          aggregate           
+------------------------------
+ {"count": {"value": 1000.0}}
+(1 row)
+
+-- Supplying both spellings is an error, not a precedence rule.
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    solve_mvcc => false,
+    visibility => 'raw'
+);
+ERROR:  cannot specify both `solve_mvcc` and `visibility`. `solve_mvcc` is deprecated: pass `visibility` alone.
+-- An unrecognized mode errors here too.
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    visibility => 'nonsense'
+);
+ERROR:  unrecognized visibility mode 'nonsense'. Valid values: 'transaction' (default), 'raw', 'threshold'.
+DROP TABLE vis_test;

--- a/pg_search/tests/pg_regress/expected/window_agg_normal_scan.out
+++ b/pg_search/tests/pg_regress/expected/window_agg_normal_scan.out
@@ -70,12 +70,12 @@ WHERE n.id @@@ pdb.parse('education', lenient => true)
   AND n.is_irs_active = true
 ORDER BY pdb.score(n.id) DESC
 LIMIT 5;
-                                                                                                                                       QUERY PLAN                                                                                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                    QUERY PLAN                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, legal_name, (pdb.score(id)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, legal_name, (pdb.score(id)), (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.nonprofits_test n
-         Output: id, legal_name, pdb.score(id), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, legal_name, pdb.score(id), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: nonprofits_test
          Index: nonprofits_test_idx
          Worker Selection: Per-segment
@@ -117,12 +117,12 @@ WHERE n.id @@@ pdb.parse('education', lenient => true)
   AND n.deleted_at IS NULL
   AND n.is_irs_active = true
 LIMIT 5;
-                                                                                                                               QUERY PLAN                                                                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: id, legal_name, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
+   Output: id, legal_name, (pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text))
    ->  Custom Scan (ParadeDB Base Scan) on public.nonprofits_test n
-         Output: id, legal_name, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Disabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
+         Output: id, legal_name, pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"terms":{"size":10,"field":"state"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Raw"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text)
          Table: nonprofits_test
          Index: nonprofits_test_idx
          Worker Selection: Row-capped

--- a/pg_search/tests/pg_regress/sql/aggregate-udf.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate-udf.sql
@@ -13,10 +13,10 @@ CREATE INDEX idxpr2625 ON pr2625 USING paradedb (id, k, v) WITH (key_field = 'id
 INSERT INTO pr2625(k, v) SELECT paradedb.random_words(1), x::float8 from generate_series(1, 1000) x;
 
 SET parallel_leader_participation = true;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>false);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'raw');
 SET parallel_leader_participation = false;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
 
 
 --
@@ -30,10 +30,10 @@ INSERT INTO pr2625(k, v) SELECT paradedb.random_words(1), x::float8 from generat
 INSERT INTO pr2625(k, v) SELECT paradedb.random_words(1), x::float8 from generate_series(1, 1000) x;
 
 SET parallel_leader_participation = true;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>false);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'raw');
 SET parallel_leader_participation = false;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
 
 
 --
@@ -41,7 +41,7 @@ SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=
 --
 SET parallel_leader_participation = false;
 SET max_parallel_workers = 0;
-SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
+SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', visibility=>'transaction');
 
 RESET parallel_leader_participation;
 RESET max_parallel_workers;

--- a/pg_search/tests/pg_regress/sql/json_agg.sql
+++ b/pg_search/tests/pg_regress/sql/json_agg.sql
@@ -89,7 +89,7 @@ SELECT * FROM paradedb.aggregate(
     index=>'json_test_idx',
     query=>paradedb.exists('metadata_json.value'),
     agg=>'{"buckets": { "terms": { "field": "metadata_json.value" }}}',
-    solve_mvcc=>true
+    visibility=>'transaction'
 ) ORDER BY 1;
 
 -- Test 5: JSON projection without filter (should still work)

--- a/pg_search/tests/pg_regress/sql/visibility.sql
+++ b/pg_search/tests/pg_regress/sql/visibility.sql
@@ -1,0 +1,197 @@
+-- Tests the `visibility` argument of pdb.agg() and paradedb.aggregate(): the
+-- 'transaction' / 'raw' / 'threshold' modes, the paradedb.visibility_threshold
+-- GUC, the legacy solve_mvcc spellings, and the errors for a conflicting or
+-- unrecognized setting.
+\echo 'Test: aggregate visibility modes'
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS vis_test;
+CREATE TABLE vis_test (
+    id serial8,
+    description text NOT NULL,
+    value int NOT NULL
+) WITH (autovacuum_enabled = off);
+
+INSERT INTO vis_test (description, value)
+SELECT 'shoes running test', x FROM generate_series(1, 1000) x;
+
+CREATE INDEX idx_vis_test ON vis_test
+USING bm25 (id, description, value)
+WITH (key_field = 'id', numeric_fields = '{"value": {"fast": true}}');
+
+-- Delete a tenth of the rows without vacuuming, so the index still holds
+-- entries for 1000 rows while only 900 are visible. Every assertion below turns
+-- on that gap: 900 means the visibility check ran, 1000 means it did not.
+DELETE FROM vis_test WHERE id % 10 = 0;
+
+--
+-- pdb.agg(): the three modes
+--
+
+-- Default: transaction visibility, so 900.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb)
+FROM vis_test WHERE description @@@ 'running';
+
+-- Explicit 'transaction' matches the default.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'transaction')
+FROM vis_test WHERE description @@@ 'running';
+
+-- 'raw' counts the dead index entries too, so 1000.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+
+-- An explicit ::text cast resolves to the same overload as the bare literal.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw'::text)
+FROM vis_test WHERE description @@@ 'running';
+
+--
+-- pdb.agg(): 'threshold' against the GUC
+--
+
+-- The GUC's default is 10000, comfortably above this query's ~1000 matching
+-- rows, so the checks run.
+SHOW paradedb.visibility_threshold;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold')
+FROM vis_test WHERE description @@@ 'running';
+
+-- No row count is below 0, so this forces the raw side of the branch.
+SET paradedb.visibility_threshold = 0;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold')
+FROM vis_test WHERE description @@@ 'running';
+
+-- Well above the match estimate, so back to checking.
+SET paradedb.visibility_threshold = 1000000;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold')
+FROM vis_test WHERE description @@@ 'running';
+
+-- 'threshold' leaves the pinned modes alone.
+SET paradedb.visibility_threshold = 0;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'transaction')
+FROM vis_test WHERE description @@@ 'running';
+SET paradedb.visibility_threshold = 1000000;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+RESET paradedb.visibility_threshold;
+
+-- 'estimated' is an accepted spelling of 'threshold'.
+SET paradedb.visibility_threshold = 0;
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'estimated')
+FROM vis_test WHERE description @@@ 'running';
+RESET paradedb.visibility_threshold;
+
+--
+-- pdb.agg(): the legacy solve_mvcc spellings
+--
+
+-- The bool overload still resolves and still means what it did.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, true)
+FROM vis_test WHERE description @@@ 'running';
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, false)
+FROM vis_test WHERE description @@@ 'running';
+
+-- The old string spellings are accepted as aliases.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'always')
+FROM vis_test WHERE description @@@ 'running';
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'never')
+FROM vis_test WHERE description @@@ 'running';
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'enabled')
+FROM vis_test WHERE description @@@ 'running';
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'disabled')
+FROM vis_test WHERE description @@@ 'running';
+
+-- Parsing is case-insensitive and tolerates surrounding whitespace.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, '  RAW ')
+FROM vis_test WHERE description @@@ 'running';
+
+--
+-- pdb.agg(): errors
+--
+
+-- An unrecognized mode is an error rather than a silent fallback.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'nonsense')
+FROM vis_test WHERE description @@@ 'running';
+
+-- Two pdb.agg() calls in one query must agree.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'transaction'),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+
+-- Including when one of them omits the argument: omitting selects
+-- 'transaction', which conflicts with an explicit 'raw'.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+
+-- 'threshold' is a distinct mode, so it conflicts with a pinned one too.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'threshold'),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+
+-- Agreeing calls are fine, whatever they agree on.
+SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb, 'raw'),
+       pdb.agg('{"sum": {"field": "value"}}'::jsonb, 'raw')
+FROM vis_test WHERE description @@@ 'running';
+
+--
+-- paradedb.aggregate(): the UDF
+--
+
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}'
+);
+
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    visibility => 'raw'
+);
+
+SET paradedb.visibility_threshold = 0;
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    visibility => 'threshold'
+);
+RESET paradedb.visibility_threshold;
+
+-- solve_mvcc still works, and now warns.
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    solve_mvcc => false
+);
+
+-- Positional calls written against the old signature still resolve, because
+-- `visibility` was appended after `bucket_limit` rather than replacing
+-- `solve_mvcc` in place.
+SELECT * FROM paradedb.aggregate(
+    'idx_vis_test',
+    paradedb.match('description', 'running'),
+    '{"count": {"value_count": {"field": "id"}}}',
+    false
+);
+
+-- Supplying both spellings is an error, not a precedence rule.
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    solve_mvcc => false,
+    visibility => 'raw'
+);
+
+-- An unrecognized mode errors here too.
+SELECT * FROM paradedb.aggregate(
+    index => 'idx_vis_test',
+    query => paradedb.match('description', 'running'),
+    agg => '{"count": {"value_count": {"field": "id"}}}',
+    visibility => 'nonsense'
+);
+
+DROP TABLE vis_test;


### PR DESCRIPTION
Part of #6074. Deliberately not using a closing keyword: `pdb.visibility_applied()`
and the EXPLAIN line are left for a follow-up, so the issue should stay open
after this merges. See "Deferred" below.

Renames the `solve_mvcc` aggregate parameter to `visibility`, turns it into a
three-way option, and adds the thresholded mode.

## The parameter

`visibility` takes one of three modes, in every user-facing position:

| Mode | Behavior |
| --- | --- |
| `'transaction'` | Check transaction visibility. Matches vanilla Postgres. The default. |
| `'raw'` | Skip the checks and aggregate raw index data. Faster, approximate. |
| `'threshold'` | Check only when the query's estimated matching row count is below `paradedb.visibility_threshold`. |

```sql
SELECT pdb.agg('{"value_count": {"field": "id"}}', 'threshold')
FROM items
WHERE description ||| 'running shoes';

SELECT * FROM paradedb.aggregate(
    index => 'items_search_idx',
    query => paradedb.match('description', 'running shoes'),
    agg => '{"avg_price": {"avg": {"field": "price"}}}',
    visibility => 'threshold'
);
```

`paradedb.visibility_threshold` is a new `Userset` integer GUC defaulting to
`10000`.

## Where the threshold decision is made

At execution time, in `execute_aggregate`, rather than at plan time.

`paradedb.aggregate()` is a UDF the planner never sees, so a plan-time decision
would have covered the aggregate custom scan and the `OVER ()` window path but
needed a second implementation for the UDF. Resolving in `execute_aggregate`
gives all three positions one code path and one meaning.

The estimate reuses the planner's own machinery: a new
`estimate_matching_rows` in `api/operator.rs` wraps the existing
`open_and_estimate_docs`, which is what `estimate_selectivity` already uses.
`'threshold'` therefore costs one extra single-segment index open; the two
pinned modes cost nothing.

Two cases fall back to `'transaction'` rather than guessing, because an unknown
row count must not silently downgrade accuracy:

- The index cannot be opened, or an expensive-to-estimate query (#4172) sits on
  a heap with no `reltuples`.
- The query carries heap filters or unsolved Postgres expressions. Building a
  Tantivy query for those shapes needs an `ExprContext`, which the estimate open
  does not have.

## Backwards compatibility

- `pdb.agg(jsonb, bool)` still exists and still means what it did. `true` is
  `'transaction'`, `false` is `'raw'`. No warning: the issue only asked for one
  on the UDF.
- A new `pdb.agg(jsonb, text)` overload carries the mode. Postgres resolves an
  untyped literal such as `'threshold'` to this overload rather than the boolean
  one, because it prefers the string category when disambiguating.
- The legacy strings `'always'`, `'never'`, `'enabled'` and `'disabled'` are
  accepted as aliases, as are the spellings Postgres itself accepts for a
  `boolean` input (`'t'`, `'yes'`, `'off'`, `'0'`, and so on), since this value
  used to be a boolean.
- `paradedb.aggregate()` keeps `solve_mvcc` as an optional argument defaulting
  to `NULL`. Supplying it emits a deprecation `WARNING` and maps onto
  `visibility`. Supplying both is an error rather than a precedence rule, since
  either choice of winner would silently ignore something the caller asked for.
- `visibility` is appended after `bucket_limit` rather than replacing
  `solve_mvcc` in place, so positional calls written against the old signature
  still resolve. There is a regression test for exactly that.

An unrecognized mode is an error. The pre-existing `MvccVisibility` string
parser warned and fell back to the accurate mode, but nothing could reach it:
SQL only ever exposed a boolean, so this changes no observable behavior.

## One visible side effect in EXPLAIN

`AggregateType` is serde-serialized into the `pdb.window_agg('...')` placeholder
argument, which appears verbatim in `EXPLAIN` output, so renaming the enum
variants changes query plans:

```
-"mvcc_visibility":"Enabled"     +"mvcc_visibility":"Transaction"
-"mvcc_visibility":"Disabled"    +"mvcc_visibility":"Raw"
```

That accounts for the expected-output churn in `agg-validate`,
`cardinality_mvcc`, `fn_wrapped_agg`, `topk-agg-facet`,
`window_agg_normal_scan`, `custom-agg` and `aggregate_edgecases`. It is
cosmetic, and the struct field keeps its `mvcc_visibility` name so the diff
stays limited to the variant spellings. Say the word if you would rather the
field were renamed too, or the serialized form pinned to the old spellings with
`#[serde(rename)]` to keep plans byte-identical.

## Validation

`resolve_mvcc_enabled` becomes `resolve_visibility` and returns the mode instead
of a boolean. The rule is unchanged in substance: every `pdb.agg()` call in a
query must agree, and an omitted argument is indistinguishable from an explicit
`'transaction'`, so omitting one alongside an explicit `'raw'` is still a
conflict. `'threshold'` is a distinct mode and conflicts with a pinned one. The
error message now names `visibility` and reports both offending values.

## A note on the shared decoder

`pdb.agg()`'s `Aggref` decoding was duplicated across `aggregate_type.rs`,
`window_agg.rs` and `hook.rs`, with a fourth rejection site in
`join_targetlist.rs` (the duplication is tracked in #3455). Adding a third
overload to four independent copies is how one of them goes stale, so the
argument decoding is now a single `visibility_from_agg_arg` in
`api/aggregate.rs` and the OID check a single `is_agg_funcoid` /
`agg_funcoids`. This is the minimum needed to add the overload safely, not a
wider cleanup of #3455; `hook.rs` keeps hoisting the OIDs out of its expression
walker, since that walker visits every node.

## Deferred

- **`pdb.visibility_applied()` and the `EXPLAIN (VERBOSE)` visibility line.**
  Left for a follow-up PR to keep this one reviewable. Happy to fold them in
  here instead if you would rather see the whole thing at once.
- **Client ORM SDKs**, as the issue already says.
- **The `paradedb.solve_mvcc_threshold` deprecated GUC alias.** Deliberately
  omitted. That GUC never shipped, so there is no setting to deprecate and
  nothing a user could have set. Happy to add it if you want the name reserved.

## Tests

- `pg_search/tests/pg_regress/sql/visibility.sql`, new: all three modes on both
  `pdb.agg()` and the UDF, `'threshold'` resolving on either side of the GUC,
  every legacy alias, the deprecation warning, the positional-call
  compatibility, and the errors for a conflicting or unrecognized mode.
- Unit tests for the parser in `api/aggregate.rs`. Parsing is split into a pure
  `try_from_sql_value` returning `Option`, with `from_sql_value` reporting the
  error, so the unit tests never reach `pgrx::error!`. Referencing it from a
  plain unit test pulls Postgres's `ereport` symbols into the lib test binary,
  which does not link on Linux. Every other file in `pg_search/src` carrying
  plain `#[test]` is likewise free of those macros. The split also makes the
  rejection path unit-testable.
- `aggregate-udf.sql` and `json_agg.sql` migrated from `solve_mvcc =>` to
  `visibility =>`. `issue_5944.sql` is untouched: it uses the `pdb.agg()`
  boolean overload, which is unchanged and does not warn.

## Release fragments

Rebased onto the fragment model from #6079, so the DDL now lives in
`pg_search/sql/unreleased/6099.rename_solve_mvcc_to_visibility.sql` rather than
in a versioned upgrade script. The two `paradedb.aggregate` statements are
SchemaBot's emitted text verbatim, which for a replaced function differs from
pgrx's generated form (named parameters, `pg_catalog.int8`, `CREATE OR
REPLACE`). A changelog fragment is included at
`docs/changelog/unreleased/6099.features.mdx`.

## Docs

`aggregates/overview.mdx` gains the mode table and a "Thresholded Visibility"
section covering the GUC and the bucketed-aggregation caveat from the issue.
`welcome/guarantees.mdx` updated. The ORM tabs in the `CodeGroup` are left
alone: their own kwargs are unchanged by this PR and still work.
