### PR TITLE
docs: Order Fly.io before DigitalOcean in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ ParadeDB integrates with the tools you already use, with more on the way.
 
 - [Railway](https://www.paradedb.com/docs/deploy/cloud-platforms/railway)
 - [Render](https://www.paradedb.com/docs/deploy/cloud-platforms/render)
-- [DigitalOcean](https://www.paradedb.com/docs/deploy/cloud-platforms/digitalocean)
 - [Fly.io](https://www.paradedb.com/docs/deploy/cloud-platforms/fly)
+- [DigitalOcean](https://www.paradedb.com/docs/deploy/cloud-platforms/digitalocean)
 - [Dokku](https://www.paradedb.com/docs/deploy/cloud-platforms/dokku)
 - More coming (Heroku, and others)
 

--- a/docs/deploy/overview.mdx
+++ b/docs/deploy/overview.mdx
@@ -12,7 +12,7 @@ canonical: https://www.paradedb.com/docs/deploy/overview
 
 There are three ways to deploy ParadeDB today:
 
-- **[Cloud Platforms](#cloud-platforms)** — deploy a ParadeDB container to Railway, Render, Fly.io, or DigitalOcean with minimal setup
+- **[Cloud Platforms](#cloud-platforms)** — deploy a ParadeDB container to Railway, Render, Fly.io, DigitalOcean, or Dokku with minimal setup
 - **[Self-Hosted](#self-hosted-paradedb)** — run ParadeDB inside Kubernetes or as an extension in your existing Postgres
 - **[ParadeDB BYOC](#paradedb-byoc)** — a managed deployment of ParadeDB Enterprise inside your own AWS or GCP account
 
@@ -26,6 +26,7 @@ ParadeDB Community is supported by several cloud platforms. These all use Docker
 - [Render](/deploy/cloud-platforms/render) — One-click deploy to Render
 - [Fly.io](/deploy/cloud-platforms/fly) — Deploy on Fly.io
 - [DigitalOcean](/deploy/cloud-platforms/digitalocean) — Deploy on a DigitalOcean Droplet
+- [Dokku](/deploy/cloud-platforms/dokku) — Deploy with Dokku
 
 ## Self-Hosted ParadeDB
 

--- a/docs/deploy/overview.mdx
+++ b/docs/deploy/overview.mdx
@@ -12,7 +12,7 @@ canonical: https://www.paradedb.com/docs/deploy/overview
 
 There are three ways to deploy ParadeDB today:
 
-- **[Cloud Platforms](#cloud-platforms)** — deploy a ParadeDB container to Railway, Render, or DigitalOcean with minimal setup
+- **[Cloud Platforms](#cloud-platforms)** — deploy a ParadeDB container to Railway, Render, Fly.io, or DigitalOcean with minimal setup
 - **[Self-Hosted](#self-hosted-paradedb)** — run ParadeDB inside Kubernetes or as an extension in your existing Postgres
 - **[ParadeDB BYOC](#paradedb-byoc)** — a managed deployment of ParadeDB Enterprise inside your own AWS or GCP account
 
@@ -24,6 +24,7 @@ ParadeDB Community is supported by several cloud platforms. These all use Docker
 
 - [Railway](/deploy/cloud-platforms/railway) — One-click deploy to Railway
 - [Render](/deploy/cloud-platforms/render) — One-click deploy to Render
+- [Fly.io](/deploy/cloud-platforms/fly) — Deploy on Fly.io
 - [DigitalOcean](/deploy/cloud-platforms/digitalocean) — Deploy on a DigitalOcean Droplet
 
 ## Self-Hosted ParadeDB

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -318,8 +318,8 @@
                     "pages": [
                       "deploy/cloud-platforms/railway",
                       "deploy/cloud-platforms/render",
-                      "deploy/cloud-platforms/digitalocean",
                       "deploy/cloud-platforms/fly",
+                      "deploy/cloud-platforms/digitalocean",
                       "deploy/cloud-platforms/dokku"
                     ]
                   },

--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -23,7 +23,7 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 
 - **ORMs**. Official support for more ORMs, like Prisma and others, is coming. [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Django](https://github.com/paradedb/django-paradedb), [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) are already available.
 - **AI Frameworks**. Official support for LangChain, LlamaIndex, CrewAI, and others is coming.
-- **PaaS Providers**. Official tutorials for hosting ParadeDB on more platform-as-a-service providers like Heroku and others are coming. [Railway](/deploy/cloud-platforms/railway), [Render](/deploy/cloud-platforms/render), [DigitalOcean](/deploy/cloud-platforms/digitalocean), [Fly.io](/deploy/cloud-platforms/fly), and [Dokku](/deploy/cloud-platforms/dokku) are already available.
+- **PaaS Providers**. Official tutorials for hosting ParadeDB on more platform-as-a-service providers like Heroku and others are coming. [Railway](/deploy/cloud-platforms/railway), [Render](/deploy/cloud-platforms/render), [Fly.io](/deploy/cloud-platforms/fly), [DigitalOcean](/deploy/cloud-platforms/digitalocean), and [Dokku](/deploy/cloud-platforms/dokku) are already available.
 
 ### Managed Cloud
 


### PR DESCRIPTION
## Summary
- list Fly.io before DigitalOcean in the README
- align the docs navigation, deployment overview, and roadmap ordering
- include the existing Fly.io guide in the deployment overview

## Testing
- mint validate
- commit hooks (prettier, markdownlint, JSON validation)