### PR TITLE
fix: minimize stressgres runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git/
-target/
 **/target/
 **/*.csv
 **/*.csv.gz

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git/
 target/
+**/target/
 **/*.csv
 **/*.csv.gz
 **/*.json

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -48,7 +48,7 @@ jobs:
           images: paradedb/stressgres
           tags: |
             type=raw,value=${{ github.sha }}
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -48,6 +48,7 @@ jobs:
           images: paradedb/stressgres
           tags: |
             type=raw,value=${{ github.sha }}
+            type=raw,value=latest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -11,13 +11,13 @@
 #       memory: "4Gi"
 #       cpu: "2000m"
 
-FROM rust:1.97-slim-trixie
+FROM rust:1.97-slim-trixie AS builder
 
 # pipefail for the piped build command below (hadolint DL4006).
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install build and runtime dependencies. Upgrade existing OS packages first so
-# we pick up the latest Debian security fixes regardless of the base layer's age.
+# Install build dependencies. None of these packages or the Rust toolchain are
+# copied into the runtime image below.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
     lld \
@@ -27,35 +27,15 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libpng-dev \
     libjpeg-dev \
     libfontconfig1-dev \
-    ca-certificates \
     curl \
     postgresql-client \
-    libpq5 \
-    util-linux \
     && rm -rf /var/lib/apt/lists/*
-
-# Create app user
-RUN useradd --create-home --shell /bin/bash app
-
-# Symbolization: Antithesis reads debug info from /symbols. The build step below symlinks the
-# (unstripped) binary in, so make it app-owned.
-RUN mkdir -p /symbols && chown app:app /symbols
 
 # Set working directory
 WORKDIR /home/app
 
-# Copy the entire paradedb/paradedb source code
-COPY --chown=app:app . .
-
-# Import Antithesis test drivers
-COPY stressgres/suites/antithesis/ /opt/antithesis/test/v1/paradedb/
-
-# Switch to app user
-USER app
-
-# Set environment variables
-ENV RUST_LOG=info
-ENV PGCLIENTENCODING=UTF8
+# Copy the source needed to compile Stressgres.
+COPY . .
 
 # Prefetch while online; the image runs air-gapped in Antithesis. Sancov flags are scoped to the
 # host triple (resolved here, not hardcoded, so it also builds on arm64 CI) via
@@ -67,6 +47,46 @@ RUN cargo fetch --manifest-path /home/app/Cargo.toml && \
     env "CARGO_TARGET_$(echo "$TARGET" | tr 'a-z-' 'A-Z_')_RUSTFLAGS=-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id" \
         cargo build --offline --profile dst --target "$TARGET" \
         --manifest-path /home/app/Cargo.toml -p stressgres --features dst && \
-    ln -sf "/home/app/target/$TARGET/dst/stressgres" /symbols/stressgres
+    cp "/home/app/target/$TARGET/dst/stressgres" /tmp/stressgres
+
+RUN cp "$(find /usr/lib/postgresql -path '*/bin/psql' -print -quit)" /tmp/psql
+
+# Keep compilers, development headers, Cargo sources, and build intermediates
+# out of the image that actually runs. Besides making the image much smaller,
+# this avoids reporting build-only packages such as linux-libc-dev as runtime
+# vulnerabilities.
+FROM debian:trixie-slim AS runtime
+
+# Upgrade the runtime packages so a rebuild picks up all available Debian
+# security fixes. psql is used by the Antithesis setup/verification scripts;
+# util-linux provides flock for the recovery-liveness script.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    libfontconfig1 \
+    libpq5 \
+    libreadline8t64 \
+    libssl3t64 \
+    util-linux \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash app
+
+WORKDIR /home/app
+
+# Preserve the paths used by the public Docker examples and Antithesis while
+# copying only runtime inputs. The unstripped binary under /symbols lets
+# Antithesis symbolize instrumented crashes.
+COPY --from=builder /tmp/stressgres /symbols/stressgres
+COPY --from=builder /tmp/psql /usr/local/bin/psql
+COPY --chown=app:app stressgres/suites/ stressgres/suites/
+COPY stressgres/suites/antithesis/ /opt/antithesis/test/v1/paradedb/
+
+RUN chown -R app:app /symbols
+
+USER app
+
+ENV RUST_LOG=info
+ENV PGCLIENTENCODING=UTF8
 
 CMD ["sleep", "infinity"]

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -47,9 +47,8 @@ RUN cargo fetch --manifest-path /home/app/Cargo.toml && \
     env "CARGO_TARGET_$(echo "$TARGET" | tr 'a-z-' 'A-Z_')_RUSTFLAGS=-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id" \
         cargo build --offline --profile dst --target "$TARGET" \
         --manifest-path /home/app/Cargo.toml -p stressgres --features dst && \
-    cp "/home/app/target/$TARGET/dst/stressgres" /tmp/stressgres
-
-RUN cp "$(find /usr/lib/postgresql -path '*/bin/psql' -print -quit)" /tmp/psql
+    cp "/home/app/target/$TARGET/dst/stressgres" /tmp/stressgres && \
+    cp /usr/lib/postgresql/17/bin/psql /tmp/psql
 
 # Keep compilers, development headers, Cargo sources, and build intermediates
 # out of the image that actually runs. Besides making the image much smaller,
@@ -74,15 +73,14 @@ RUN useradd --create-home --shell /bin/bash app
 
 WORKDIR /home/app
 
-# Preserve the paths used by the public Docker examples and Antithesis while
-# copying only runtime inputs. The unstripped binary under /symbols lets
-# Antithesis symbolize instrumented crashes.
-COPY --from=builder /tmp/stressgres /symbols/stressgres
+# Preserve the paths used by the public Docker examples and Antithesis while copying only runtime
+# inputs. The unstripped binary under /symbols lets Antithesis symbolize instrumented crashes.
+COPY --chown=app:app --from=builder /tmp/stressgres /symbols/stressgres
+# Copy the native client without postgresql-client-common and its unused Perl runtime. Because the
+# Debian package database is not copied with it, package-based scanners may not inventory psql.
 COPY --from=builder /tmp/psql /usr/local/bin/psql
 COPY --chown=app:app stressgres/suites/ stressgres/suites/
 COPY stressgres/suites/antithesis/ /opt/antithesis/test/v1/paradedb/
-
-RUN chown -R app:app /symbols
 
 USER app
 

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -37,8 +37,8 @@ WORKDIR /home/app
 # Copy the source needed to compile Stressgres.
 COPY . .
 
-# Prefetch while online; the image runs air-gapped in Antithesis. Sancov flags are scoped to the
-# host triple (resolved here, not hardcoded, so it also builds on arm64 CI) via
+# Fetch dependencies before the offline Cargo build. Sancov flags are scoped to the host triple
+# (resolved here, not hardcoded, so it also builds on arm64 CI) via
 # CARGO_TARGET_<triple>_RUSTFLAGS + --target, keeping them off host build scripts. Coverage shim
 # comes from `--features dst`; its build script needs curl + a C toolchain.
 # See https://antithesis.com/docs/reference/sdk/rust/instrumentation

--- a/stressgres/suites/antithesis/helper_suite_setup.sh
+++ b/stressgres/suites/antithesis/helper_suite_setup.sh
@@ -7,7 +7,7 @@
 set -Eeuo pipefail
 
 SUITE_DIR=/home/app/stressgres/suites
-STRESSGRES=/home/app/target/x86_64-unknown-linux-gnu/dst/stressgres
+STRESSGRES=/symbols/stressgres
 PARADEDB_ADMIN_CONN="postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5"
 
 # The paired singleton_driver runs this symlink; each first_ repoints it at its own suite.


### PR DESCRIPTION
## What

- build Stressgres in a dedicated Rust builder stage and copy only runtime artifacts into a Debian slim image
- copy the native `psql` binary without the Perl-based `postgresql-client-common` runtime dependency
- use `/symbols/stressgres` as the architecture-neutral Antithesis binary path
- exclude nested Cargo `target` directories from Docker build contexts
- publish `latest` alongside the commit SHA tag

## Why

The existing single-stage image retained Rust, Cargo sources, the C toolchain, development headers, and build intermediates. Besides making each tag large, Docker scanners attributed build-only findings such as the `linux-libc-dev` kernel CVEs to the runtime image.

## Validation

- built `docker/Dockerfile.stressgres` successfully on arm64
- ran `/symbols/stressgres --version` in the final image
- ran `psql --version` and verified `flock`, suites, and Antithesis drivers
- Trivy critical/high scan: 3 critical and 12 high, down from 4 critical and 156 high in the Rust builder base; remaining critical findings are Debian slim `perl-base`
- `actionlint .github/workflows/publish-stressgres-docker.yml`
- `shellcheck stressgres/suites/antithesis/*.sh`
- repository pre-commit hooks