### PR TITLE
fix(ci): limit stressgres benchmark concurrency

### DIFF
--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -45,6 +45,7 @@ jobs:
     name: Stressgres (${{ matrix.suite }})
     strategy:
       fail-fast: false
+      max-parallel: 4 # Avoid exhausting regional capacity for the large bare-metal benchmark runners
       matrix:
         suite:
           - background-merge.toml


### PR DESCRIPTION
## What\n\nLimit the stressgres benchmark matrix to four concurrent jobs.\n\n## Why\n\nAvoid exhausting regional capacity for the large bare-metal benchmark runners.\n\nThis ports the exact patch from paradedb-enterprise commit `12b167f4fc1bfb8d136e22f8b9af239a98a5d485` so it can flow back through the normal upstream sync process.