### PR TITLE
fix: don't reset the shared parallel work queue on rescan (#5024)

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/parallel.rs
+++ b/pg_search/src/postgres/customscan/basescan/parallel.rs
@@ -89,16 +89,6 @@ impl ParallelScanHandle {
             local.set_parallel_explain(explain_data);
         }
     }
-
-    /// Leader-only: reset the shared work queue for a rescan.
-    pub fn reset_work_queue(&self) {
-        debug_assert_eq!(self.role, ParallelRole::Leader);
-        unsafe {
-            let dsm = self.dsm.as_ptr();
-            let _mutex = (*dsm).acquire_mutex();
-            ParallelScanState::reset(&mut *dsm);
-        }
-    }
 }
 
 impl ParallelQueryCapable for BaseScan {
@@ -136,6 +126,13 @@ impl ParallelQueryCapable for BaseScan {
         _state: &mut CustomScanStateWrapper<Self>,
         coordinate: *mut c_void,
     ) {
+        // The one place the shared segment work queue is reset for a rescan.
+        // PostgreSQL guarantees this runs while no workers are attached (see
+        // nodeGather.c: "ReInitializeDSM should reset only shared state, ReScan
+        // should reset only local state"). Resetting the queue anywhere else —
+        // in particular from the leader's ReScan callback, which runs after
+        // LaunchParallelWorkers — races with workers' segment claims and makes
+        // already-claimed segments get scanned twice (#5024).
         let pscan_state = coordinate.cast::<ParallelScanState>();
         assert!(!pscan_state.is_null(), "coordinate is null");
         unsafe {

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -396,11 +396,12 @@ impl BaseScanState {
     }
 
     pub fn reset(&mut self) {
-        if let Some(parallel) = self.parallel
-            && parallel.is_leader()
-        {
-            parallel.reset_work_queue();
-        }
+        // Process-local state only. The shared parallel work queue must NOT be reset
+        // here: ReScan runs in the leader after parallel workers are launched, and a
+        // worker may have already claimed segments from the queue. Refilling it then
+        // hands those segments out a second time, duplicating rows (#5024). The
+        // shared queue is reset in `reinitialize_dsm_custom_scan`, which PostgreSQL
+        // runs before workers are launched.
         self.telemetry.reset();
         self.virtual_tuple_count = 0;
         if self.visibility_checker.is_some() {

--- a/tests/tests/parallel.rs
+++ b/tests/tests/parallel.rs
@@ -372,6 +372,138 @@ async fn test_parallel_hash_join_race_condition(database: Db) -> Result<()> {
     Ok(())
 }
 
+/// Regression test for https://github.com/paradedb/paradedb/issues/5024
+///
+/// A parallel-aware BaseScan under a Gather on the inner side of a Nested Loop is
+/// rescanned once per outer row. The shared segment work queue must be reset only in
+/// ReInitializeDSMCustomScan, which PostgreSQL runs before workers are launched. The
+/// leader's ReScan callback runs *after* LaunchParallelWorkers, so resetting the queue
+/// there races with segment claims from a freshly launched worker: an already-claimed
+/// segment goes back into the pool and gets scanned twice, duplicating every row in it
+/// (COUNT(*) returned exactly 2x).
+///
+/// The race is timing-dependent (the unfixed code failed ~65% of individual runs on a
+/// release build), so the query runs repeatedly and every result must match the plain
+/// PostgreSQL baseline.
+#[rstest]
+#[tokio::test]
+async fn test_parallel_rescan_does_not_double_scan(database: Db) -> Result<()> {
+    let mut conn = database.connection().await;
+
+    r#"CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
+
+    CREATE TABLE rescan_users (id BIGINT PRIMARY KEY, name TEXT, age INTEGER);
+    CREATE TABLE rescan_products (id BIGINT PRIMARY KEY, name TEXT, age INTEGER);
+    CREATE TABLE rescan_orders (id BIGINT PRIMARY KEY, name TEXT, age INTEGER);
+
+    CREATE INDEX idx_rescan_users ON rescan_users
+    USING paradedb (id, name, age)
+    WITH (
+        key_field = 'id',
+        text_fields = '{ "name": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+        numeric_fields = '{ "age": { "fast": true } }'
+    );
+    CREATE INDEX idx_rescan_products ON rescan_products
+    USING paradedb (id, name, age)
+    WITH (
+        key_field = 'id',
+        text_fields = '{ "name": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+        numeric_fields = '{ "age": { "fast": true } }'
+    );
+    CREATE INDEX idx_rescan_orders ON rescan_orders
+    USING paradedb (id, name, age)
+    WITH (
+        key_field = 'id',
+        text_fields = '{ "name": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+        numeric_fields = '{ "age": { "fast": true } }'
+    );
+
+    INSERT INTO rescan_users (id, name, age) VALUES
+        (1, 'bob', 20), (2, 'alice', 30), (3, 'cloe', 40), (4, 'anchovy', 50);
+    INSERT INTO rescan_products (id, name, age)
+        SELECT i, (ARRAY['red', 'green', 'blue'])[1 + i % 3], 10 + i FROM generate_series(1, 12) i;
+    INSERT INTO rescan_orders (id, name, age)
+        SELECT i, (ARRAY['red', 'green', 'blue'])[1 + i % 3], 10 + i FROM generate_series(1, 12) i;
+
+    ANALYZE rescan_users, rescan_products, rescan_orders;
+    "#
+    .execute(&mut conn);
+
+    // Ground truth from the plain PostgreSQL plan (no custom scan, `=` operators).
+    "SET paradedb.enable_custom_scan = false".execute(&mut conn);
+    let expected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM rescan_users CROSS JOIN rescan_products
+        JOIN rescan_orders ON rescan_products.name = rescan_orders.name
+        WHERE (rescan_users.name = 'bob')
+           OR ((rescan_users.id = 4) AND (rescan_orders.id = 4) AND (rescan_products.age = 20))
+        "#,
+    )
+    .fetch_one(&mut conn)
+    .await?;
+    assert!(expected > 0, "fixture should produce matching rows");
+
+    // The failing configuration from #5024: forced-parallel custom scans, so the
+    // inner side of the Nested Loop becomes a rescanned Gather over Parallel Custom
+    // Scans coordinating through the shared segment work queue.
+    r#"
+    SET paradedb.enable_custom_scan = true;
+    SET paradedb.enable_aggregate_custom_scan = false;
+    SET paradedb.enable_join_custom_scan = false;
+    SET paradedb.enable_filter_pushdown = false;
+    SET enable_seqscan = false;
+    SET enable_indexscan = true;
+    SET max_parallel_workers = 8;
+    "#
+    .execute(&mut conn);
+    // PG15: force_parallel_mode; PG16+: debug_parallel_query. On PG15 the basescan
+    // does not force a parallel worker for this plan, so the test degrades to a
+    // plain consistency check there.
+    let _ = "SET force_parallel_mode = on".execute_result(&mut conn);
+    let forced_parallel = "SET debug_parallel_query = on"
+        .execute_result(&mut conn)
+        .is_ok();
+
+    let query = r#"
+        SELECT COUNT(*)
+        FROM rescan_users CROSS JOIN rescan_products
+        JOIN rescan_orders ON rescan_products.name = rescan_orders.name
+        WHERE (rescan_users.name @@@ 'bob')
+           OR ((rescan_users.id @@@ '4') AND ((rescan_orders.id @@@ '4') AND (rescan_products.age @@@ '20')))
+    "#;
+
+    if forced_parallel {
+        // Confirm the plan has the shape that exercises the rescan path.
+        let explain_rows: Vec<(String,)> = format!("EXPLAIN (COSTS OFF) {query}").fetch(&mut conn);
+        let explain_text: String = explain_rows
+            .iter()
+            .map(|(s,)| s.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            explain_text.contains("Parallel Custom Scan (ParadeDB Base Scan)")
+                && explain_text.contains("Gather"),
+            "plan should use a parallel BaseScan under a Gather. EXPLAIN:\n{explain_text}"
+        );
+    }
+
+    // The unfixed race loses ~65% of individual runs, so 30 iterations detect a
+    // regression with near certainty; with the fix every run is deterministic.
+    let mut counts = Vec::new();
+    for _ in 0..30 {
+        let count: i64 = sqlx::query_scalar(query).fetch_one(&mut conn).await?;
+        counts.push(count);
+    }
+
+    assert!(
+        counts.iter().all(|&c| c == expected),
+        "parallel rescan duplicated rows: expected {expected} for every run, got {counts:?}"
+    );
+
+    Ok(())
+}
+
 /// Regression test for https://github.com/paradedb/paradedb/issues/4381
 ///
 /// In PG18 amestimateparallelscan sizes the DSM region based on target_segment_count. Concurrent


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5024

## What

`BaseScanState::reset()` — the leader's ReScan callback — reset the shared parallel segment work queue in DSM. This PR removes that reset and the now-unused `ParallelScanHandle::reset_work_queue`, leaving `ReInitializeDSMCustomScan` as the only place the queue is reset for a rescan, and documents that invariant. Adds a regression test.

## Why

Parallel-aware base scans partition work by lazily checking segments out of a shared pool; correctness requires each segment to be claimed exactly once per scan cycle.

On a parallel rescan, PostgreSQL defers the leader's ReScan of a parallel-aware child until the leader's first `ExecProcNode` call, which happens after `LaunchParallelWorkers`. Resetting the shared queue there races with segment claims from freshly launched workers: an already-claimed segment goes back into the pool, is claimed again, and every row in it is emitted twice. On the plan shape from #5024 (`debug_parallel_query=on`; a Gather over Parallel Custom Scans on the inner side of a Nested Loop, rescanned per outer row), `COUNT(*)` returned exactly 2× the correct value in ~65% of runs on a v0.25.4 release build.

nodeGather.c documents the contract: "ReInitializeDSM should reset only shared state, ReScan should reset only local state." `reinitialize_dsm_custom_scan` already performs the reset at the safe point, so the ReScan-side reset was redundant when it wasn't harmful. This is the custom-scan twin of the parallel index-scan race fixed in #3872.

## Tests

- New `test_parallel_rescan_does_not_double_scan` recreates the plan shape (asserted via EXPLAIN), computes the expected count from the plain PostgreSQL plan, and requires 30 consecutive runs of the `@@@` query to match. It fails 24/30 iterations against the unfixed v0.25.4 binary (`expected 49, got [50, 98, 97, …]`) and is deterministic with the fix.
- The issue's exact repro script: 100/100 runs correct with the fix; 65/100 returned 2× on v0.25.4.
- Causal check: a 200 ms delay injected before the old reset call (a timing-only change) made the unpatched build fail 30/30 runs at 4× (both Parallel Hash Join sides double-scanned); the same build with only the reset removed passed 100/100.
- Existing tests in `tests/tests/parallel.rs` (including the #3872 and #4381 races) and `generated_joins_small` pass; `cargo fmt` and `cargo clippy --all-targets -- -D warnings` are clean.

Maintainer note: this PR needs two labels external contributors cannot set — a cherry-pick decision (`Do Not Cherry Pick` or `cherry-pick/*`) to satisfy the label gate, and ideally `antithesis` to exercise the fix under the deterministic scheduler that found the bug.
