### PR TITLE
chore: Prepare `0.25.5`.

### DIFF
--- a/docs/changelog/0.25.5.mdx
+++ b/docs/changelog/0.25.5.mdx
@@ -1,0 +1,20 @@
+---
+title: 0.25.5
+noindex: true
+---
+
+## New Features 🎉
+
+- Predicates that cannot be answered by the ParadeDB index can now be evaluated by intersecting
+  with a bitmap scan over another PostgreSQL index (btree, GIN, or GiST), rather than checking
+  every matching row against the heap, reducing buffer reads by up to 20x for selective filters.
+- Replaced the `paradedb.check_aggregate_scan` and `paradedb.check_topk_scan` GUCs with a single
+  unified `paradedb.planner_warnings` GUC (`off`, `warning`, or `error`). When set to `error`,
+  queries that cannot use an optimized ParadeDB scan raise an error instead of logging a warning.
+
+## Performance Improvements 🚀
+
+- MPP search readers are now initialized only in the processes that execute them, avoiding
+  redundant index opens on the leader and opening fast fields lazily per segment.
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.25.5).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -38,7 +38,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.25.4-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.25.5-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/cloud-platforms/dokku.mdx
+++ b/docs/deploy/cloud-platforms/dokku.mdx
@@ -62,7 +62,7 @@ Point Dokku at the official ParadeDB image and rebuild the app:
 dokku git:from-image paradedb paradedb/paradedb:latest
 ```
 
-See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags. Pin a tag (for example `paradedb/paradedb:0.25.4-pg18`) instead of `latest` for reproducible deploys.
+See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags. Pin a tag (for example `paradedb/paradedb:0.25.5-pg18`) instead of `latest` for reproducible deploys.
 
 ## Connect to ParadeDB
 

--- a/docs/deploy/cloud-platforms/fly.mdx
+++ b/docs/deploy/cloud-platforms/fly.mdx
@@ -29,7 +29,7 @@ fly launch \
   --no-deploy
 ```
 
-`fly launch` prompts for an app name and a primary region, then writes a `fly.toml` in the current directory. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available `paradedb/paradedb` tags — pin one (for example `paradedb/paradedb:0.25.4-pg18`) instead of `latest` for reproducible deploys.
+`fly launch` prompts for an app name and a primary region, then writes a `fly.toml` in the current directory. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available `paradedb/paradedb` tags — pin one (for example `paradedb/paradedb:0.25.5-pg18`) instead of `latest` for reproducible deploys.
 
 ## Create a Persistent Volume
 

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -41,7 +41,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.25.4` with the `pg_search` version you wish to install and
+  You can replace `0.25.5` with the `pg_search` version you wish to install and
   `18` with the version of Postgres you are using.
 </Note>
 
@@ -49,49 +49,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 26.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-resolute_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-18-pg-search_0.25.5-1PARADEDB-resolute_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-18-pg-search_0.25.5-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-18-pg-search_0.25.5-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-18-pg-search_0.25.5-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/pg_search_18-0.25.4-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/pg_search_18-0.25.5-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/pg_search_18-0.25.4-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/pg_search_18-0.25.5-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 26 (Tahoe)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/pg_search@18--0.25.4.arm64_tahoe.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/pg_search@18--0.25.5.arm64_tahoe.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.4/pg_search@18--0.25.4.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.25.5/pg_search@18--0.25.5.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/self-hosted/kubernetes.mdx
+++ b/docs/deploy/self-hosted/kubernetes.mdx
@@ -136,7 +136,7 @@ spec:
     extensions:
       - name: pg_search
         image:
-          reference: docker.io/paradedb/paradedb-extension:0.25.4-18-trixie
+          reference: docker.io/paradedb/paradedb-extension:0.25.5-18-trixie
         extension_control_path:
           - /share
         dynamic_library_path:
@@ -157,11 +157,11 @@ spec:
     name: paradedb
   extensions:
     - name: pg_search
-      version: "0.25.4"
+      version: "0.25.5"
 ```
 
 The extension image tag format is `<paradedb-version>-<postgres-major>-trixie`.
-For example, use `0.25.4-18-trixie` for ParadeDB `0.25.4` on Postgres 18.
+For example, use `0.25.5-18-trixie` for ParadeDB `0.25.5` on Postgres 18.
 
 ## Connect to the Cluster
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -38,7 +38,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.25.4`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.25.5`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -80,10 +80,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.25.4
+docker pull paradedb/paradedb:0.25.5
 ```
 
-The latest version of the Docker image should be `0.25.4`.
+The latest version of the Docker image should be `0.25.5`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -100,7 +100,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.25.4';
+ALTER EXTENSION pg_search UPDATE TO '0.25.5';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.25.4",
+        "version": "v0.25.5",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -254,6 +254,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.25.5",
                   "changelog/0.25.4",
                   "changelog/0.25.3",
                   "changelog/0.25.2",


### PR DESCRIPTION
Changelog assumes #6088 is merged and cherry-picked onto `0.25.x` before release. Version bump, `Cargo.lock`, nix hash, and the `0.25.4--0.25.5` SQL script were already handled by #6061.