### PR TITLE
fix: convert NUMERIC heap keys with index schema in seqscan fallback (#6108)

### DIFF
--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 use super::keyset::KeySet;
 use super::{anyelement_query_input_opoid, request_simplify};
-use crate::api::operator::{estimate_selectivity, find_var_relation, ReturnedNodePointer};
+use crate::api::operator::{ReturnedNodePointer, estimate_selectivity, find_var_relation};
 use crate::api::version::Version;
 use crate::api::{HashMap, HashSet};
 use crate::gucs::per_tuple_cost;
@@ -29,14 +29,14 @@ use crate::postgres::types::TantivyValue;
 use crate::postgres::utils::scalar_datum_to_tantivy_value;
 use crate::query::SearchQueryInput;
 use crate::schema::SearchFieldType;
-use crate::{nodecast, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
+use crate::{PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY, nodecast};
 use pgrx::callconv::{Arg, ArgAbi};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
 };
 use pgrx::{
-    pg_extern, pg_func_extra, pg_getarg_datum_raw, pg_getarg_type, pg_sys, Internal, PgList, PgOid,
-    PgRelation,
+    Internal, PgList, PgOid, PgRelation, pg_extern, pg_func_extra, pg_getarg_datum_raw,
+    pg_getarg_type, pg_sys,
 };
 use std::ptr::NonNull;
 

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -16,7 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 use super::keyset::KeySet;
 use super::{anyelement_query_input_opoid, request_simplify};
-use crate::api::operator::{ReturnedNodePointer, estimate_selectivity, find_var_relation};
+use crate::api::operator::{estimate_selectivity, find_var_relation, ReturnedNodePointer};
+use crate::api::version::Version;
 use crate::api::{HashMap, HashSet};
 use crate::gucs::per_tuple_cost;
 use crate::index::mvcc::MvccSatisfies;
@@ -25,15 +26,17 @@ use crate::postgres::planner_warnings::{warn_filter_spilled, warn_sequential_sca
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::types::TantivyValue;
+use crate::postgres::utils::scalar_datum_to_tantivy_value;
 use crate::query::SearchQueryInput;
-use crate::{PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY, nodecast};
+use crate::schema::SearchFieldType;
+use crate::{nodecast, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
 use pgrx::callconv::{Arg, ArgAbi};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
 };
 use pgrx::{
-    Internal, PgList, PgOid, PgRelation, pg_extern, pg_func_extra, pg_getarg_datum_raw,
-    pg_getarg_type, pg_sys,
+    pg_extern, pg_func_extra, pg_getarg_datum_raw, pg_getarg_type, pg_sys, Internal, PgList, PgOid,
+    PgRelation,
 };
 use std::ptr::NonNull;
 
@@ -64,9 +67,29 @@ pub fn with_index(index: PgRelation, query: SearchQueryInput) -> SearchQueryInpu
 
 struct QueryCacheEntry {
     element_oid: PgOid,
+    /// Index key_field storage type, used to convert heap keys the same way as `collect_keyset()`.
+    key_field_type: Option<SearchFieldType>,
+    index_created_by_version: Option<Version>,
     matches: KeySet,
     /// Key-field values for rows where the indexed field is absent (SQL NULL semantics).
     missing_values: Option<KeySet>,
+}
+
+impl QueryCacheEntry {
+    fn heap_key(&self, datum: pg_sys::Datum) -> TantivyValue {
+        unsafe {
+            match self.key_field_type {
+                Some(field_type) => scalar_datum_to_tantivy_value(
+                    datum,
+                    field_type,
+                    self.element_oid,
+                    self.index_created_by_version,
+                ),
+                None => TantivyValue::try_from_datum(datum, self.element_oid),
+            }
+            .expect("no value present")
+        }
+    }
 }
 
 #[derive(Default)]
@@ -181,6 +204,8 @@ pub fn search_with_query_input(
         if search_query_input.is_match_all() {
             return QueryCacheEntry {
                 element_oid,
+                key_field_type: None,
+                index_created_by_version: None,
                 matches: KeySet::All,
                 missing_values: None,
             };
@@ -188,6 +213,8 @@ pub fn search_with_query_input(
         if matches!(&search_query_input, SearchQueryInput::Empty) {
             return QueryCacheEntry {
                 element_oid,
+                key_field_type: None,
+                index_created_by_version: None,
                 matches: KeySet::None,
                 missing_values: None,
             };
@@ -217,6 +244,8 @@ pub fn search_with_query_input(
         )
         .expect("search_with_query_input: should be able to open a SearchIndexReader");
         let schema = search_reader.schema();
+        let key_field_type = Some(schema.key_field_type());
+        let index_created_by_version = search_reader.index_created_by_version();
 
         // collect the matching key-field values into a memory-bounded set (spills to a temp file
         // past `work_mem`), reused for every row of the scan.
@@ -231,6 +260,8 @@ pub fn search_with_query_input(
             if !field_supports_null_preserving_guard(schema, &field) {
                 return QueryCacheEntry {
                     element_oid,
+                    key_field_type,
+                    index_created_by_version,
                     matches,
                     missing_values: None,
                 };
@@ -268,6 +299,8 @@ pub fn search_with_query_input(
 
         QueryCacheEntry {
             element_oid,
+            key_field_type,
+            index_created_by_version,
             matches,
             missing_values,
         }
@@ -285,8 +318,7 @@ pub fn search_with_query_input(
     // contained in the matches set
     let result = unsafe {
         let element = pg_getarg_datum_raw(fcinfo, 0);
-        let user_value = TantivyValue::try_from_datum(element, query_cache.element_oid)
-            .expect("no value present");
+        let user_value = query_cache.heap_key(element);
 
         if query_cache.matches.contains(&user_value) {
             Some(true)

--- a/pg_search/tests/pg_regress/expected/issue_6108.out
+++ b/pg_search/tests/pg_regress/expected/issue_6108.out
@@ -1,0 +1,100 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+-- Sequential-scan fallback must match NUMERIC key_field values using the
+-- index storage (Numeric64 I64 / NumericBytes), not try_from_datum's Str.
+SET paradedb.planner_warnings = 'off';
+CREATE FUNCTION explain_seqscan(query text) RETURNS SETOF text LANGUAGE plpgsql AS $$
+DECLARE
+    line text;
+BEGIN
+    FOR line IN EXECUTE 'EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) ' || query LOOP
+        RETURN NEXT regexp_replace(line, '"oid":\d+', '"oid":N');
+    END LOOP;
+END;
+$$;
+CREATE TABLE issue_6108_bytes (
+    id numeric(30,2) PRIMARY KEY,
+    body text
+);
+INSERT INTO issue_6108_bytes
+VALUES (-49999, 'alpha'), (-49990, 'alpha'), (7, 'beta');
+CREATE INDEX issue_6108_bytes_idx
+ON issue_6108_bytes
+USING paradedb (id, body)
+WITH (key_field = 'id');
+CREATE TABLE issue_6108_i64 (
+    id numeric(10,2) PRIMARY KEY,
+    body text
+);
+INSERT INTO issue_6108_i64
+VALUES (-49999, 'alpha'), (-49990, 'alpha'), (7, 'beta');
+CREATE INDEX issue_6108_i64_idx
+ON issue_6108_i64
+USING paradedb (id, body)
+WITH (key_field = 'id');
+SELECT id
+FROM issue_6108_bytes
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+    id     
+-----------
+ -49999.00
+ -49990.00
+(2 rows)
+
+SELECT id
+FROM issue_6108_i64
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+    id     
+-----------
+ -49999.00
+ -49990.00
+(2 rows)
+
+SET paradedb.enable_custom_scan = off;
+SET enable_bitmapscan = off;
+SELECT bool_or(line LIKE '%Seq Scan%') AS used_seqscan
+FROM explain_seqscan($$SELECT id FROM issue_6108_bytes WHERE body @@@ pdb.term('alpha') ORDER BY id$$) AS line;
+ used_seqscan 
+--------------
+ t
+(1 row)
+
+SELECT id
+FROM issue_6108_bytes
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+    id     
+-----------
+ -49999.00
+ -49990.00
+(2 rows)
+
+SELECT bool_or(line LIKE '%Seq Scan%') AS used_seqscan
+FROM explain_seqscan($$SELECT id FROM issue_6108_i64 WHERE body @@@ pdb.term('alpha') ORDER BY id$$) AS line;
+ used_seqscan 
+--------------
+ t
+(1 row)
+
+SELECT id
+FROM issue_6108_i64
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+    id     
+-----------
+ -49999.00
+ -49990.00
+(2 rows)
+
+DROP TABLE issue_6108_bytes CASCADE;
+DROP TABLE issue_6108_i64 CASCADE;
+DROP FUNCTION explain_seqscan(text);
+RESET paradedb.enable_custom_scan;
+RESET enable_bitmapscan;
+RESET paradedb.planner_warnings;

--- a/pg_search/tests/pg_regress/expected/issue_6108.out
+++ b/pg_search/tests/pg_regress/expected/issue_6108.out
@@ -69,6 +69,8 @@ SELECT id
 FROM issue_6108_bytes
 WHERE body @@@ pdb.term('alpha')
 ORDER BY id;
+WARNING:  the table is being sequentially scanned for this query, so performance may be slow
+if you are not sure why, please file an issue: https://github.com/paradedb/paradedb/issues/new/choose
     id     
 -----------
  -49999.00
@@ -86,6 +88,8 @@ SELECT id
 FROM issue_6108_i64
 WHERE body @@@ pdb.term('alpha')
 ORDER BY id;
+WARNING:  the table is being sequentially scanned for this query, so performance may be slow
+if you are not sure why, please file an issue: https://github.com/paradedb/paradedb/issues/new/choose
     id     
 -----------
  -49999.00

--- a/pg_search/tests/pg_regress/sql/issue_6108.sql
+++ b/pg_search/tests/pg_regress/sql/issue_6108.sql
@@ -1,0 +1,79 @@
+\i common/common_setup.sql
+
+-- Sequential-scan fallback must match NUMERIC key_field values using the
+-- index storage (Numeric64 I64 / NumericBytes), not try_from_datum's Str.
+
+SET paradedb.planner_warnings = 'off';
+
+CREATE FUNCTION explain_seqscan(query text) RETURNS SETOF text LANGUAGE plpgsql AS $$
+DECLARE
+    line text;
+BEGIN
+    FOR line IN EXECUTE 'EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) ' || query LOOP
+        RETURN NEXT regexp_replace(line, '"oid":\d+', '"oid":N');
+    END LOOP;
+END;
+$$;
+
+CREATE TABLE issue_6108_bytes (
+    id numeric(30,2) PRIMARY KEY,
+    body text
+);
+
+INSERT INTO issue_6108_bytes
+VALUES (-49999, 'alpha'), (-49990, 'alpha'), (7, 'beta');
+
+CREATE INDEX issue_6108_bytes_idx
+ON issue_6108_bytes
+USING paradedb (id, body)
+WITH (key_field = 'id');
+
+CREATE TABLE issue_6108_i64 (
+    id numeric(10,2) PRIMARY KEY,
+    body text
+);
+
+INSERT INTO issue_6108_i64
+VALUES (-49999, 'alpha'), (-49990, 'alpha'), (7, 'beta');
+
+CREATE INDEX issue_6108_i64_idx
+ON issue_6108_i64
+USING paradedb (id, body)
+WITH (key_field = 'id');
+
+SELECT id
+FROM issue_6108_bytes
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+
+SELECT id
+FROM issue_6108_i64
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+
+SET paradedb.enable_custom_scan = off;
+SET enable_bitmapscan = off;
+
+SELECT bool_or(line LIKE '%Seq Scan%') AS used_seqscan
+FROM explain_seqscan($$SELECT id FROM issue_6108_bytes WHERE body @@@ pdb.term('alpha') ORDER BY id$$) AS line;
+
+SELECT id
+FROM issue_6108_bytes
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+
+SELECT bool_or(line LIKE '%Seq Scan%') AS used_seqscan
+FROM explain_seqscan($$SELECT id FROM issue_6108_i64 WHERE body @@@ pdb.term('alpha') ORDER BY id$$) AS line;
+
+SELECT id
+FROM issue_6108_i64
+WHERE body @@@ pdb.term('alpha')
+ORDER BY id;
+
+DROP TABLE issue_6108_bytes CASCADE;
+DROP TABLE issue_6108_i64 CASCADE;
+DROP FUNCTION explain_seqscan(text);
+
+RESET paradedb.enable_custom_scan;
+RESET enable_bitmapscan;
+RESET paradedb.planner_warnings;


### PR DESCRIPTION
The sequential-scan fallback materializes matching keys from the index as Numeric64→I64 or NumericBytes→Bytes. Heap keys were converted with TantivyValue::try_from_datum(NUMERICOID), which stores NUMERIC as Str. KeySet equality is exact, so the filter returned no rows.

Heap keys now go through scalar_datum_to_tantivy_value using the index key_field type and format version, the same conversion used at index time.

pg_regress issue_6108 covers numeric(10,2) (Numeric64) and numeric(30,2) (NumericBytes) under seqscan fallback, including the issue repro values.

Fixes #6108