### PR TITLE
chore: Generate Dockerfiles for v0.25.5

### DIFF
--- a/docker/Dockerfile.official-15
+++ b/docker/Dockerfile.official-15
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="fd5a8cc339c21aba7c1b533f285b1f05235468c096f0ec5a3a62c3265166956a" ;; \
-        arm64) checksum="7bf4a4c74ec86e1846579dd368d4fe4b8ec5d4f5e24ec5a825bf4311bd787859" ;; \
+        amd64) checksum="8d6436d6b784a17c6c5b4175c620a6b025c060ce6b1f84e7dc304cf9f70731bf" ;; \
+        arm64) checksum="52076e1e5385636e501e423ad99e2fabe3e3bc36da10f4fcfa44a26b6a75e112" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-15-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-15-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.official-16
+++ b/docker/Dockerfile.official-16
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="a2d39d58cd15902deee76f814b32e220ecb820cab2b11de216e53ba3a4daab48" ;; \
-        arm64) checksum="9b3b8acfce50d97db94540018b232524780321c1c2f197b9f16ce7d3e8eec795" ;; \
+        amd64) checksum="c649bd3d29122903f150f6c92346e88894ac7084cb965ab765cceb3b49623384" ;; \
+        arm64) checksum="a73bb4a2fe1e90ffe199612300dc0bf683e2a6ddd0970ef50b2de7d74b295ce0" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-16-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-16-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.official-17
+++ b/docker/Dockerfile.official-17
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="ca49a0fdc625b2e3bdb631417f9b58dece81ca2f37f72a9e3ba1f03f48d8238d" ;; \
-        arm64) checksum="8b7f01985c8c060202a5dd32dd95f32dab674b682578a381a5b81893ccb185d2" ;; \
+        amd64) checksum="1163fdfa7fd7946e407c57c1c08b0d971314b7b8829d3b763347ad21eb6f21b2" ;; \
+        arm64) checksum="316208e8055abad6a924f02b0b64f35666dc0fdf79e158ea7a826559854fff12" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-17-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-17-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.official-18
+++ b/docker/Dockerfile.official-18
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="849cb8cd3e173c220a36a4d4e16e2d72f717a40122ea158e215494776bc9f8b6" ;; \
-        arm64) checksum="20d4fd631642112f2e0b66d683712bc0c61daac57e52194fc8fe7dd3771065c9" ;; \
+        amd64) checksum="2b090b54ad0ae83247832d8a5dd2b88bb18292aff29c0b75abd55a161c308df9" ;; \
+        arm64) checksum="be4cc5f2b2d661b25798d5d29a8c26bfef2a0fd6f7b279ffe1b70b95a76d0c00" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-18-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-15
+++ b/docker/Dockerfile.paradedb-15
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="fd5a8cc339c21aba7c1b533f285b1f05235468c096f0ec5a3a62c3265166956a" ;; \
-        arm64) checksum="7bf4a4c74ec86e1846579dd368d4fe4b8ec5d4f5e24ec5a825bf4311bd787859" ;; \
+        amd64) checksum="8d6436d6b784a17c6c5b4175c620a6b025c060ce6b1f84e7dc304cf9f70731bf" ;; \
+        arm64) checksum="52076e1e5385636e501e423ad99e2fabe3e3bc36da10f4fcfa44a26b6a75e112" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-15-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-15-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-16
+++ b/docker/Dockerfile.paradedb-16
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="a2d39d58cd15902deee76f814b32e220ecb820cab2b11de216e53ba3a4daab48" ;; \
-        arm64) checksum="9b3b8acfce50d97db94540018b232524780321c1c2f197b9f16ce7d3e8eec795" ;; \
+        amd64) checksum="c649bd3d29122903f150f6c92346e88894ac7084cb965ab765cceb3b49623384" ;; \
+        arm64) checksum="a73bb4a2fe1e90ffe199612300dc0bf683e2a6ddd0970ef50b2de7d74b295ce0" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-16-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-16-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-17
+++ b/docker/Dockerfile.paradedb-17
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="ca49a0fdc625b2e3bdb631417f9b58dece81ca2f37f72a9e3ba1f03f48d8238d" ;; \
-        arm64) checksum="8b7f01985c8c060202a5dd32dd95f32dab674b682578a381a5b81893ccb185d2" ;; \
+        amd64) checksum="1163fdfa7fd7946e407c57c1c08b0d971314b7b8829d3b763347ad21eb6f21b2" ;; \
+        arm64) checksum="316208e8055abad6a924f02b0b64f35666dc0fdf79e158ea7a826559854fff12" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-17-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-17-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \

--- a/docker/Dockerfile.paradedb-18
+++ b/docker/Dockerfile.paradedb-18
@@ -7,11 +7,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) checksum="849cb8cd3e173c220a36a4d4e16e2d72f717a40122ea158e215494776bc9f8b6" ;; \
-        arm64) checksum="20d4fd631642112f2e0b66d683712bc0c61daac57e52194fc8fe7dd3771065c9" ;; \
+        amd64) checksum="2b090b54ad0ae83247832d8a5dd2b88bb18292aff29c0b75abd55a161c308df9" ;; \
+        arm64) checksum="be4cc5f2b2d661b25798d5d29a8c26bfef2a0fd6f7b279ffe1b70b95a76d0c00" ;; \
         *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.4/postgresql-18-pg-search_0.25.4-1PARADEDB-trixie_${arch}.deb"; \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v0.25.5/postgresql-18-pg-search_0.25.5-1PARADEDB-trixie_${arch}.deb"; \
     echo "${checksum} */tmp/pg_search.deb" | sha256sum --strict --check -; \
     apt-get install -y --no-install-recommends /tmp/pg_search.deb; \
     apt-get purge -y --auto-remove curl; \


### PR DESCRIPTION
## What\n\nRegenerates the PG 15–18 ParadeDB and official Dockerfiles for v0.25.5 directly from the current main template.\n\nThis replaces the failed release-workflow cherry-pick from 0.25.x, which conflicted because the Dockerfile template has diverged on main.\n\n## Validation\n\n- Ran `docker/generate-dockerfiles.sh 0.25.5` twice against the published release assets\n- Verified `git diff --check`\n- Commit hooks passed\n\nFailure: https://github.com/paradedb/paradedb/actions/runs/33041883215