### PR TITLE
ci: evaluate policies for published Docker images

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -297,13 +297,21 @@ jobs:
             }' > provenance.json
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
-      - name: Evaluate Docker Scout Policies
+      - name: Evaluate Docker Scout Policies (amd64)
         uses: docker/scout-action@v1
         with:
           command: policy
           image: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/amd64
+
+      - name: Evaluate Docker Scout Policies (arm64)
+        uses: docker/scout-action@v1
+        with:
+          command: policy
+          image: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
+          organization: paradedb
+          platform: linux/arm64
 
   # Beta (`-rc.`) releases publish only the runnable PG 18 image, not the mountable extension image.
   publish-extension-image:
@@ -448,13 +456,21 @@ jobs:
             }' > provenance.json
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
-      - name: Evaluate Docker Scout Policies
+      - name: Evaluate Docker Scout Policies (amd64)
         uses: docker/scout-action@v1
         with:
           command: policy
           image: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/amd64
+
+      - name: Evaluate Docker Scout Policies (arm64)
+        uses: docker/scout-action@v1
+        with:
+          command: policy
+          image: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
+          organization: paradedb
+          platform: linux/arm64
 
   # Skip for beta (`-rc.`) releases, since we don't want to open Dockerfile-update PRs for prereleases
   open-dockerfile-prs:

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -297,6 +297,14 @@ jobs:
             }' > provenance.json
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
+      - name: Evaluate Docker Scout Policies
+        uses: docker/scout-action@v1
+        with:
+          command: policy
+          image: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
+          organization: paradedb
+          platform: linux/amd64
+
   # Beta (`-rc.`) releases publish only the runnable PG 18 image, not the mountable extension image.
   publish-extension-image:
     name: Publish ParadeDB Extension Image for PostgreSQL ${{ matrix.pg_version }}
@@ -439,6 +447,14 @@ jobs:
               materials: [{ uri: $uri, digest: { sha1: $sha } }]
             }' > provenance.json
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
+
+      - name: Evaluate Docker Scout Policies
+        uses: docker/scout-action@v1
+        with:
+          command: policy
+          image: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
+          organization: paradedb
+          platform: linux/amd64
 
   # Skip for beta (`-rc.`) releases, since we don't want to open Dockerfile-update PRs for prereleases
   open-dockerfile-prs:

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -107,6 +107,16 @@ jobs:
             }' > provenance.json
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
+      # Docker Scout's dashboard policy evaluator is deprecated. Evaluate the pushed,
+      # attested image in CI and publish the results to the workflow run summary instead.
+      - name: Evaluate Docker Scout Policies
+        uses: docker/scout-action@v1
+        with:
+          command: policy
+          image: index.docker.io/paradedb/stressgres@${{ steps.build-push.outputs.digest }}
+          organization: paradedb
+          platform: linux/amd64
+
       - name: Notify Slack on Failure
         if: failure()
         uses: paradedb/actions/slack-alert@v10

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -107,13 +107,21 @@ jobs:
             }' > provenance.json
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
-      - name: Evaluate Docker Scout Policies
+      - name: Evaluate Docker Scout Policies (amd64)
         uses: docker/scout-action@v1
         with:
           command: policy
           image: index.docker.io/paradedb/stressgres@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/amd64
+
+      - name: Evaluate Docker Scout Policies (arm64)
+        uses: docker/scout-action@v1
+        with:
+          command: policy
+          image: index.docker.io/paradedb/stressgres@${{ steps.build-push.outputs.digest }}
+          organization: paradedb
+          platform: linux/arm64
 
       - name: Notify Slack on Failure
         if: failure()

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -107,8 +107,6 @@ jobs:
             }' > provenance.json
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
-      # Docker Scout's dashboard policy evaluator is deprecated. Evaluate the pushed,
-      # attested image in CI and publish the results to the workflow run summary instead.
       - name: Evaluate Docker Scout Policies
         uses: docker/scout-action@v1
         with:


### PR DESCRIPTION
## What

- evaluate Docker Scout policies for immutable image digests after publishing and attestation
- cover `paradedb/stressgres`, the `paradedb/paradedb` PostgreSQL matrix, and `paradedb/paradedb-extension`
- publish each policy report in the GitHub Actions workflow summary
- evaluate both linux/amd64 and linux/arm64 platform manifests

## Why

Docker Scout image, package, and vulnerability analysis remains available in the dashboard, but its dashboard policy evaluator retires on September 1, 2026. Running `docker scout policy` in CI preserves a visible policy report alongside each publish run.

The checks are informational: they do not set `exit-code`, so existing policy findings will not block publishing.

## Validation

- repository pre-commit hooks for both modified workflows
- YAML and GitHub Actions workflow validation