### PR TITLE
ci: configure Docker Scout policies

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -298,20 +298,22 @@ jobs:
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
       - name: Evaluate Docker Scout Policies (amd64)
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.24.0
         with:
           command: policy
           image: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/amd64
+          policy-config: docker/docker-scout-policy.json
 
       - name: Evaluate Docker Scout Policies (arm64)
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.24.0
         with:
           command: policy
           image: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/arm64
+          policy-config: docker/docker-scout-policy.json
 
   # Beta (`-rc.`) releases publish only the runnable PG 18 image, not the mountable extension image.
   publish-extension-image:
@@ -457,20 +459,22 @@ jobs:
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
       - name: Evaluate Docker Scout Policies (amd64)
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.24.0
         with:
           command: policy
           image: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/amd64
+          policy-config: docker/docker-scout-policy.json
 
       - name: Evaluate Docker Scout Policies (arm64)
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.24.0
         with:
           command: policy
           image: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/arm64
+          policy-config: docker/docker-scout-policy.json
 
   # Skip for beta (`-rc.`) releases, since we don't want to open Dockerfile-update PRs for prereleases
   open-dockerfile-prs:

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -108,20 +108,22 @@ jobs:
           cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
       - name: Evaluate Docker Scout Policies (amd64)
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.24.0
         with:
           command: policy
           image: index.docker.io/paradedb/stressgres@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/amd64
+          policy-config: docker/docker-scout-policy.json
 
       - name: Evaluate Docker Scout Policies (arm64)
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.24.0
         with:
           command: policy
           image: index.docker.io/paradedb/stressgres@${{ steps.build-push.outputs.digest }}
           organization: paradedb
           platform: linux/arm64
+          policy-config: docker/docker-scout-policy.json
 
       - name: Notify Slack on Failure
         if: failure()

--- a/docker/docker-scout-policy.json
+++ b/docker/docker-scout-policy.json
@@ -1,0 +1,45 @@
+{
+  "policies": [
+    {
+      "name": "fixable-vulnerabilities",
+      "enabled": true,
+      "config": {
+        "severities": ["CRITICAL", "HIGH"],
+        "fixable_only": true,
+        "package_types": [],
+        "grace_period_days": 0
+      }
+    },
+    {
+      "name": "high-profile-vulnerabilities",
+      "enabled": true,
+      "config": {
+        "ignored_cves": [],
+        "include_cisa_kev": true
+      }
+    },
+    {
+      "name": "copyleft-license",
+      "enabled": true,
+      "config": {
+        "ignored_packages": []
+      }
+    },
+    {
+      "name": "no-stale-base-images",
+      "enabled": true
+    },
+    {
+      "name": "supply-chain-attestations",
+      "enabled": true
+    },
+    {
+      "name": "approved-base-images",
+      "enabled": true,
+      "config": {
+        "allowed_base_images": ["*"],
+        "allowed_distros_only": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

- add a repository-owned Docker Scout policy configuration under `docker/`
- use that configuration for all published ParadeDB and Stressgres image policy evaluations
- pin `docker/scout-action` to v1.24.0

Policy evaluation remains informational and reports both linux/amd64 and linux/arm64 results in each publish workflow summary.

## Validation

- repository pre-commit hooks
- policy configuration evaluated successfully with Docker Scout CLI against `paradedb/stressgres:latest`
- docker/scout-action v1.24.0 tag verified against the official repository