### PR TITLE
fix: use ParadeDB index terminology

### DIFF
--- a/docker/manifests/antithesis-paradedb.yaml
+++ b/docker/manifests/antithesis-paradedb.yaml
@@ -163,7 +163,7 @@ data:
         JOIN pg_am am ON am.oid = c.relam
         JOIN LATERAL paradedb.index_info(c.oid) AS info ON true
         WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-          AND am.amname = 'bm25'
+          AND am.amname = 'paradedb'
         GROUP BY n.nspname, c.relname, c.oid;
       target_databases: ["*"]
       predicate_query: "SELECT 1 FROM pg_extension WHERE extname = 'pg_search' AND extversion = '0.25.3';"

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -193,7 +193,7 @@ pub unsafe fn combined_layer_sizes(index: PgRelation) -> Vec<AnyNumeric> {
     sizes.into_iter().collect()
 }
 
-/// Returns the wall-clock time the given bm25 index was built, or NULL for indices created
+/// Returns the wall-clock time the given ParadeDB index was built, or NULL for indices created
 /// before build-time stamping was added.
 #[pg_extern]
 pub fn index_created_at(index: PgRelation) -> Option<pgrx::datum::TimestampWithTimeZone> {
@@ -203,7 +203,7 @@ pub fn index_created_at(index: PgRelation) -> Option<pgrx::datum::TimestampWithT
         .and_then(|ts| pgrx::datum::TimestampWithTimeZone::try_from(ts).ok())
 }
 
-/// Returns the pg_search version that created the given bm25 index, or NULL for indices
+/// Returns the pg_search version that created the given ParadeDB index, or NULL for indices
 /// created before version stamping was added.
 #[pg_extern]
 pub fn index_created_by(index: PgRelation) -> Option<String> {
@@ -1105,7 +1105,7 @@ GRANT SELECT ON pdb.index_layer_info TO PUBLIC;
 pub mod pdb {
     use super::*;
 
-    /// Verify the integrity of a BM25 index, similar to PostgreSQL's amcheck extension.
+    /// Verify the integrity of a ParadeDB index, similar to PostgreSQL's amcheck extension.
     ///
     /// This function performs various verification checks on the index:
     /// - Schema validation: Ensures the index schema can be loaded
@@ -1115,7 +1115,7 @@ pub mod pdb {
     /// - Heap reference validation (optional): Verifies all indexed ctids exist in the heap table
     ///
     /// # Arguments
-    /// * `index` - The BM25 index to verify (name or OID)
+    /// * `index` - The ParadeDB index to verify (name or OID)
     /// * `heapallindexed` - If true, verify that all indexed ctids exist in the heap table.
     ///   This is expensive but thorough. Default: false
     /// * `sample_rate` - For large indexes, check only this fraction of documents (0.0-1.0).
@@ -1589,7 +1589,7 @@ pub mod pdb {
         Ok(TableIterator::new(results))
     }
 
-    /// List all segments in a BM25 index.
+    /// List all segments in a ParadeDB index.
     ///
     /// Returns information about each Tantivy segment in the index. This is useful for:
     /// - Understanding index structure and segment distribution
@@ -1598,7 +1598,7 @@ pub mod pdb {
     /// - Monitoring segment merging and index health
     ///
     /// # Arguments
-    /// * `index` - The BM25 index to inspect (name or OID)
+    /// * `index` - The ParadeDB index to inspect (name or OID)
     ///
     /// # Returns
     /// A table with columns:
@@ -1687,9 +1687,9 @@ pub mod pdb {
         Ok(TableIterator::new(results))
     }
 
-    /// List all BM25 indexes in the current database.
+    /// List all ParadeDB indexes in the current database.
     ///
-    /// Similar to pg_amcheck's index discovery, this function finds all BM25 indexes
+    /// Similar to pg_amcheck's index discovery, this function finds all ParadeDB indexes
     /// so they can be verified or inspected. Useful for automation and monitoring.
     ///
     /// # Returns
@@ -1703,7 +1703,7 @@ pub mod pdb {
     ///
     /// # Example
     /// ```sql
-    /// -- List all BM25 indexes
+    /// -- List all ParadeDB indexes
     /// SELECT * FROM pdb.indexes();
     ///
     /// -- Find large indexes (by document count)
@@ -1712,7 +1712,7 @@ pub mod pdb {
     /// -- Find indexes with many segments (may benefit from optimization)
     /// SELECT * FROM pdb.indexes() WHERE num_segments > 10;
     ///
-    /// -- Verify all BM25 indexes in a specific schema
+    /// -- Verify all ParadeDB indexes in a specific schema
     /// SELECT v.* FROM pdb.indexes() i
     /// CROSS JOIN LATERAL pdb.verify_index(i.indexrelid) v
     /// WHERE i.schemaname = 'public';
@@ -1734,7 +1734,7 @@ pub mod pdb {
     > {
         let mut results = Vec::new();
 
-        // Query pg_index joined with pg_class to find all BM25 indexes
+        // Query pg_index joined with pg_class to find all ParadeDB indexes
         let query = r#"
         SELECT
             n.nspname::text AS schemaname,
@@ -1799,10 +1799,10 @@ pub mod pdb {
         Ok(TableIterator::new(results))
     }
 
-    /// Verify all BM25 indexes in the current database.
+    /// Verify all ParadeDB indexes in the current database.
     ///
     /// Similar to pg_amcheck's `--all` option, this function discovers and verifies
-    /// all BM25 indexes in the database. Useful for scheduled health checks and
+    /// all ParadeDB indexes in the database. Useful for scheduled health checks and
     /// post-upgrade validation.
     ///
     /// # Arguments
@@ -1826,7 +1826,7 @@ pub mod pdb {
     ///
     /// # Example
     /// ```sql
-    /// -- Verify all BM25 indexes
+    /// -- Verify all ParadeDB indexes
     /// SELECT * FROM pdb.verify_all_indexes();
     ///
     /// -- Verify only indexes in 'public' schema with full heap check
@@ -1951,7 +1951,7 @@ pub mod pdb {
         let total_indexes = indexes.len();
         if report_progress {
             pgrx::notice!(
-                "verify_all_indexes: Found {} BM25 indexes to verify",
+                "verify_all_indexes: Found {} ParadeDB indexes to verify",
                 total_indexes
             );
         }

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -193,7 +193,7 @@ pub fn search_with_query_input(
             };
         }
 
-        // Reaching here means the planner could not use the BM25 index to satisfy this query, so we
+        // Reaching here means the planner could not use the ParadeDB index to satisfy this query, so we
         // materialize the match set and apply it as a per-row filter (the slow path).
         let index_oid = search_query_input.index_oid().unwrap_or_else(|| {
             panic!("pg_search: could not determine the index to use for this query")

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -428,7 +428,7 @@ pub(crate) mod test_support {
     /// Tests use it to prove reuse paths perform zero additional opens.
     pub(crate) static INDEX_COMPONENT_OPENS: AtomicUsize = AtomicUsize::new(0);
 
-    /// Test fixture shared by the reuse/laziness tests: a table + BM25 index laid out as
+    /// Test fixture shared by the reuse/laziness tests: a table + ParadeDB index laid out as
     /// `immutable_batches` frozen segments of 10 rows (batch 0's titles contain "silver dragon",
     /// later batches "quiet river"), plus an optional 5-row mutable segment. Returns the opened
     /// index relation and the heap relation's OID.

--- a/pg_search/src/postgres/composite.rs
+++ b/pg_search/src/postgres/composite.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Composite type handling for BM25 indexes
+//! Composite type handling for ParadeDB indexes
 //!
 //! This module provides functionality to:
 //! - Detect composite types in index definitions
@@ -52,12 +52,12 @@ pub struct CompositeFieldInfo {
 #[derive(Debug, thiserror::Error)]
 pub enum CompositeError {
     #[error(
-        "Anonymous ROW expressions are not supported for BM25 indexes. Create a named composite type: CREATE TYPE my_type AS (...); then use ROW(...)::my_type"
+        "Anonymous ROW expressions are not supported for ParadeDB indexes. Create a named composite type: CREATE TYPE my_type AS (...); then use ROW(...)::my_type"
     )]
     AnonymousRowNotSupported,
 
     #[error(
-        "Domain over composite type is not supported for BM25 indexes. Use the base composite type directly instead of the domain."
+        "Domain over composite type is not supported for ParadeDB indexes. Use the base composite type directly instead of the domain."
     )]
     DomainOverCompositeNotSupported,
 
@@ -67,7 +67,7 @@ pub enum CompositeError {
     #[error("Failed to lookup tuple descriptor for type OID {0}")]
     TupleDescLookupFailed(pg_sys::Oid),
 
-    #[error("Nested composite types are not supported for BM25 indexes.")]
+    #[error("Nested composite types are not supported for ParadeDB indexes.")]
     NestedCompositeNotSupported,
 }
 
@@ -189,7 +189,7 @@ pub unsafe fn has_nested_composite(type_oid: pg_sys::Oid) -> bool {
         .any(|f| is_composite_type(f.type_oid))
 }
 
-/// Get validated composite fields for use in BM25 index.
+/// Get validated composite fields for use in ParadeDB index.
 ///
 /// This is the main entry point called during index creation.
 /// Returns field info after validating for unsupported configurations.

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -86,13 +86,13 @@ pub struct JoinAggSource {
     /// [`JoinAggSource::column_name`] and the downstream
     /// [`JoinSource::column_name`] / `build_source_df` paths agree on the
     /// BM25-registered field name for every heap attno. Empty when the
-    /// relation has no BM25 index.
+    /// relation has no ParadeDB index.
     pub fields: Vec<FieldInfo>,
 }
 
 impl JoinAggSource {
     /// Resolve a heap attribute number to its DataFusion-facing column name
-    /// via the BM25 index.
+    /// via the ParadeDB index.
     ///
     /// Returns the BM25 field name (which may be an alias like
     /// `"company_name_words"`), **not** the heap attribute name. This keeps
@@ -114,7 +114,7 @@ impl JoinAggSource {
 }
 
 /// Walk every column in the heap tuple descriptor, resolving each through the
-/// given BM25 index. Returns an empty vec when `bm25_index` is `None`.
+/// given ParadeDB index. Returns an empty vec when `bm25_index` is `None`.
 unsafe fn collect_source_fields(
     relid: pg_sys::Oid,
     bm25_index: Option<&PgSearchRelation>,
@@ -137,7 +137,7 @@ unsafe fn collect_source_fields(
 }
 
 /// Extract all tables participating in the join from `input_rel.relids` and look up
-/// their RTE / BM25 index information.
+/// their RTE / ParadeDB index information.
 ///
 /// Delegates per-relation metadata lookup to the shared [`lookup_base_rel_info`]
 /// in `joinscan/build.rs`.
@@ -427,7 +427,7 @@ unsafe fn build_scan_node(
 
     let bm25_index = source.bm25_index.as_ref().ok_or_else(|| {
         format!(
-            "table at RTI {} ({}) has no BM25 index",
+            "table at RTI {} ({}) has no ParadeDB index",
             rti,
             source.alias.as_deref().unwrap_or("unknown")
         )
@@ -596,7 +596,7 @@ unsafe fn build_join_node(
 /// Extract equi-join keys from an expression tree (ON clause or WHERE clause).
 ///
 /// Looks for `OpExpr` nodes where the operator is `=` and the arguments are `Var`
-/// nodes referencing different tables that have BM25 indexes.
+/// nodes referencing different tables that have ParadeDB indexes.
 unsafe fn extract_equi_keys_from_expr(
     node: *mut pg_sys::Node,
     sources: &[JoinAggSource],
@@ -1311,12 +1311,12 @@ impl FilterExpr {
     }
 }
 
-/// Validate that at least one table in the join has a BM25 index.
+/// Validate that at least one table in the join has a ParadeDB index.
 pub fn has_any_bm25_index(sources: &[JoinAggSource]) -> bool {
     sources.iter().any(|s| s.bm25_index.is_some())
 }
 
-/// Validate that all tables in the join have a BM25 index.
+/// Validate that all tables in the join have a ParadeDB index.
 /// Required because DataFusion needs to scan all tables via `PgSearchTableProvider`.
 pub fn all_have_bm25_index(sources: &[JoinAggSource]) -> bool {
     sources.iter().all(|s| s.bm25_index.is_some())

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -181,7 +181,7 @@ pub struct AggOrderByEntry {
     /// 1-based attribute number in the source relation's tuple descriptor.
     /// Load-bearing for fast-field projection.
     pub attno: pg_sys::AttrNumber,
-    /// Resolved field name (from the BM25 index schema).
+    /// Resolved field name (from the ParadeDB index schema).
     pub field_name: String,
     /// Sort direction including NULLS FIRST/LAST.
     pub direction: crate::api::SortDirection,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -244,7 +244,7 @@ enum AggregateDeclineReason {
 impl AggregateDeclineReason {
     fn detail(&self) -> std::borrow::Cow<'static, str> {
         match self {
-            Self::NotAllBm25 => "all tables in the join must have BM25 indexes".into(),
+            Self::NotAllBm25 => "all tables in the join must have ParadeDB indexes".into(),
             Self::JoinPredicate(reason) => match reason {
                 datafusion_build::PathPredicateDeclineReason::ExternParam => {
                     "generic prepared-plan parameters in join predicates are not supported".into()
@@ -1346,7 +1346,7 @@ impl AggregateScan {
 
         let Some((_table, index)) = rel_get_bm25_index(heap_relid) else {
             if has_paradedb_agg {
-                pgrx::error!("Cannot execute pdb.agg: table must have a BM25 index");
+                pgrx::error!("Cannot execute pdb.agg: table must have a ParadeDB index");
             }
             return Vec::new();
         };
@@ -1465,7 +1465,7 @@ impl AggregateScan {
         let root = builder.args().root;
         let input_rel = builder.args().input_rel();
 
-        // Silent gates: no sources, or no BM25 index at all → not a candidate.
+        // Silent gates: no sources, or no ParadeDB index at all → not a candidate.
         let sources = unsafe { collect_join_agg_sources(root, input_rel) };
         if sources.is_empty() {
             return Err(AggregatePathDecline::Quiet);
@@ -1541,7 +1541,7 @@ impl AggregateScan {
             }
         }
 
-        // All tables must have BM25 indexes (DataFusion scans all via PgSearchTableProvider).
+        // All tables must have ParadeDB indexes (DataFusion scans all via PgSearchTableProvider).
         if !all_have_bm25_index(&sources) {
             return Err(warn(AggregateDeclineReason::NotAllBm25));
         }
@@ -2635,7 +2635,7 @@ unsafe fn get_aggregate_name(aggref: *mut pg_sys::Aggref) -> String {
 ///
 /// AggregateScan currently does not support extracting `RTE_SUBQUERY` nodes and will typically
 /// emit a WARNING when it encounters one. However, if a subquery is a TopK query (has a `LIMIT`
-/// and an `ORDER BY` on a BM25 index), we want to silently decline it instead. This is because
+/// and an `ORDER BY` on a ParadeDB index), we want to silently decline it instead. This is because
 /// `BaseScan` will natively optimize the subquery, meaning we can safely step aside without
 /// bothering the user with a planner warning.
 unsafe fn query_will_use_topk(parse: *mut pgrx::pg_sys::Query) -> bool {

--- a/pg_search/src/postgres/customscan/basescan/cost.rs
+++ b/pg_search/src/postgres/customscan/basescan/cost.rs
@@ -21,7 +21,7 @@
 //! [`WorkerPathPolicy`] ([`decide_scan_parallelism`]).
 //!
 //! A costable scan is costed by its work, emits both a serial and a partial path, and clears
-//! PostgreSQL's native paths -- otherwise the honest scan-work cost lets PostgreSQL's own BM25 index
+//! PostgreSQL's native paths -- otherwise the honest scan-work cost lets PostgreSQL's own ParadeDB index
 //! scan (correct, but without fast-field / Block-WAND execution) undercut us. PostgreSQL then costs
 //! the Gather and picks serial vs parallel, which it can only do once it sees the upper plan (a bulk
 //! `SELECT` ships every row; a `COUNT(*)` collapses rows in a Partial Aggregate first). pg_search

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -1116,7 +1116,7 @@ impl CustomScan for BaseScan {
                         // mechanism as TopK / score-snippet / `all()`), leaving only our serial and
                         // partial paths for PostgreSQL to choose between -- the honest scan-work cost
                         // would otherwise let PostgreSQL's own (correct, but fast-field/Block-WAND-
-                        // less) index scan over the BM25 index undercut us on cost (see module docs).
+                        // less) index scan over the ParadeDB index undercut us on cost (see module docs).
                         // Today the only multi-method emitter is Columnar: it emits unsorted first
                         // and the index-sort variant second, and the sorted variant exists only for
                         // an ORDER BY shape where it is the useful survivor. If another multi-method

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -395,14 +395,14 @@ unsafe fn can_handle_where_clause(parse: *mut pg_sys::Query) -> bool {
 /// Shared helper function to check if quals can be extracted from a Query's WHERE clause.
 ///
 /// This function encapsulates the common logic of:
-/// 1. Finding a relation with a BM25 index in the query's range table
+/// 1. Finding a relation with a ParadeDB index in the query's range table
 /// 2. Attempting to extract quals using Query context
 ///
 /// Used by `can_handle_where_clause` in the planner hook (to decide if we should replace window functions)
 ///
 /// Returns:
-/// - `true` if a BM25 index was found AND quals were successfully extracted
-/// - `false` if no BM25 index was found OR quals couldn't be extracted
+/// - `true` if a ParadeDB index was found AND quals were successfully extracted
+/// - `false` if no ParadeDB index was found OR quals couldn't be extracted
 pub unsafe fn try_extract_quals_from_query(
     parse: *mut pg_sys::Query,
     quals_node: *mut pg_sys::Node,
@@ -418,7 +418,7 @@ pub unsafe fn try_extract_quals_from_query(
         return false;
     }
 
-    // Find the first relation RTE with a BM25 index
+    // Find the first relation RTE with a ParadeDB index
     for (idx, rte_ptr) in rtable_list.iter_ptr().enumerate() {
         let rte = rte_ptr;
         if (*rte).rtekind != pg_sys::RTEKind::RTE_RELATION {
@@ -431,12 +431,12 @@ pub unsafe fn try_extract_quals_from_query(
             continue;
         }
 
-        // Check if this relation has a BM25 index
+        // Check if this relation has a ParadeDB index
         let Some((_, bm25_index)) = rel_get_bm25_index(relid) else {
             continue;
         };
 
-        // We found a relation with a BM25 index - try to extract quals
+        // We found a relation with a ParadeDB index - try to extract quals
         // Use Query context since we don't have PlannerInfo yet
         let rti = (idx + 1) as pg_sys::Index; // RTI is 1-indexed
         let mut state = QualExtractState::default();
@@ -463,7 +463,7 @@ pub unsafe fn try_extract_quals_from_query(
         return quals.is_some();
     }
 
-    // No BM25 index found
+    // No ParadeDB index found
     false
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -23,7 +23,7 @@ When a viable PostgreSQL parallel launch is available, JoinScan uses Massively P
 
 ### 1. Activation
 
-JoinScan fires when all conditions are met: LIMIT present, equi-join keys exist, all columns are fast fields, all tables have BM25 indexes, and at least one `@@@` predicate. See [`create_custom_path()`][activation] for the full checklist.
+JoinScan fires when all conditions are met: LIMIT present, equi-join keys exist, all columns are fast fields, all tables have ParadeDB indexes, and at least one `@@@` predicate. See [`create_custom_path()`][activation] for the full checklist.
 
 ### 2. Planning
 

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -302,7 +302,7 @@ impl JoinKeyPair {
 pub struct JoinLevelSearchPredicate {
     /// The RTI of the relation this predicate applies to (used for column resolution).
     pub rti: pg_sys::Index,
-    /// The OID of the BM25 index to use.
+    /// The OID of the ParadeDB index to use.
     pub indexrelid: pg_sys::Oid,
     /// The OID of the heap relation for visibility checks.
     pub heaprelid: pg_sys::Oid,
@@ -743,7 +743,7 @@ impl JoinNode {
     ///
     /// PG emits the right-oriented form (joinrels.c) when its hash-join cost
     /// model prefers to hash the preserved side -- a physical choice JoinScan
-    /// discards, since it joins BM25 indexes in DataFusion rather than via PG's
+    /// discards, since it joins ParadeDB indexes in DataFusion rather than via PG's
     /// hash table. A right-semi is just a left-semi with the inputs swapped
     /// (same rows, same key). The swap restores the `left == preserved side`
     /// invariant that [`RelNode::output_sources`], visibility filtering, and
@@ -1720,7 +1720,7 @@ pub unsafe fn try_extract_equi_key(
     })
 }
 
-/// Look up base-relation metadata for a given RTI: relid, alias, and BM25 index.
+/// Look up base-relation metadata for a given RTI: relid, alias, and ParadeDB index.
 ///
 /// Shared between JoinScan's `collect_join_sources_base_rel` and AggregateScan's
 /// `collect_join_agg_sources`. Returns `None` if the RTI doesn't point to a

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -48,7 +48,7 @@
 //!    - Future work will allow no-limit joins when both sides have search predicates.
 //!
 //! 4. **Search predicate**: At least one side must have:
-//!    - A BM25 index on the table
+//!    - A ParadeDB index on the table
 //!    - A `@@@` search predicate in the WHERE clause
 //!
 //! 5. **Multi-level Joins**: JoinScan supports multi-level joins (e.g., `(A JOIN B) JOIN C`).
@@ -56,7 +56,7 @@
 //!    multiple JoinScan operators.
 //!
 //! 6. **Fast-field columns**: All columns used in the join must be fast fields in their
-//!    respective BM25 indexes. This allows the join to be executed entirely within the index:
+//!    respective ParadeDB indexes. This allows the join to be executed entirely within the index:
 //!    - Equi-join keys (e.g., `a.id = b.id`) must be fast fields for join execution
 //!    - Multi-table predicates (e.g., `a.price > b.min_price`) must reference fast fields
 //!    - ORDER BY columns must be fast fields for efficient sorting
@@ -89,7 +89,7 @@
 //! WHERE p.description @@@ 'wireless'
 //! LIMIT 10;
 //!
-//! -- JoinScan IS proposed if price/min_price are fast fields in BM25 indexes
+//! -- JoinScan IS proposed if price/min_price are fast fields in ParadeDB indexes
 //! SELECT p.name, s.name
 //! FROM products p
 //! JOIN suppliers s ON p.supplier_id = s.id
@@ -575,7 +575,7 @@ impl JoinScan {
             .any(|s| s.scan_info.indexrelid == pg_sys::InvalidOid)
         {
             return Err(JoinDeclineReason::new(
-                "JoinScan not used: at least one relation lacks a BM25 index",
+                "JoinScan not used: at least one relation lacks a ParadeDB index",
             ));
         }
 

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -222,7 +222,7 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         side_info = side_info.with_alias(alias);
     }
 
-    // Subquery extraction is meaningful only when the base side has a BM25 index;
+    // Subquery extraction is meaningful only when the base side has a ParadeDB index;
     // otherwise the Semi/Anti/LeftMark wrapping has nothing useful to wrap.
     let mut classified = ClassifiedBaseRestrictInfo::empty();
 
@@ -408,7 +408,7 @@ pub unsafe fn wrap_with_semi_anti(
         let Some((inner_node, inner_keys)) = collect_join_sources(inner_root, inner_rel) else {
             pgrx::debug1!(
                 "agg-on-join: SubPlan plan_id={plan_id} declined; \
-                 inner relation cannot be pushed (no BM25 index, volatile, \
+                 inner relation cannot be pushed (no ParadeDB index, volatile, \
                  or un-pushdownable predicates)"
             );
             return Err("subquery cannot be pushed into the aggregate scan".into());
@@ -1433,7 +1433,7 @@ unsafe fn try_ensure_field(side: &mut JoinSource, attno: pg_sys::AttrNumber) -> 
 /// Ensures an expression-indexed fast field is projected from a `JoinSource`.
 ///
 /// Unlike `ensure_field` (which resolves plain columns via attno), this function
-/// looks up a search field by name in the BM25 index schema and adds the
+/// looks up a search field by name in the ParadeDB index schema and adds the
 /// corresponding `WhichFastField` directly.  Used for ORDER BY on indexed
 /// expressions like `upper(name)`, where the Tantivy field has no matching
 /// PostgreSQL column attno.
@@ -1526,7 +1526,7 @@ unsafe fn pathkey_is_outer_only(
 /// Check if all ORDER BY columns are fast fields.
 ///
 /// For JoinScan to be proposed, all columns used in ORDER BY must be fast fields
-/// in their respective BM25 indexes (or be paradedb.score() which is handled separately).
+/// in their respective ParadeDB indexes (or be paradedb.score() which is handled separately).
 /// Validate whether all ORDER BY clauses can be handled by JoinScan.
 ///
 /// Pathkeys that reference only relations outside this join subtree ("outer-only")
@@ -1774,7 +1774,7 @@ unsafe fn column_name_for_var(
     format!("rti {}, attno {}", varno, varattno)
 }
 
-/// Check if all DISTINCT columns are fast fields in their respective BM25 indexes.
+/// Check if all DISTINCT columns are fast fields in their respective ParadeDB indexes.
 ///
 /// DISTINCT requires all target columns to be available as fast fields so that
 /// deduplication can happen within DataFusion without heap access.

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -650,7 +650,7 @@ where
 /// 1. The query has both ORDER BY and LIMIT clauses.
 /// 2. There are not too many sort columns.
 /// 3. All sort columns belong to the same relation.
-/// 4. That relation has a BM25 index.
+/// 4. That relation has a ParadeDB index.
 /// 5. All sort columns are sortable in the index (fast fields).
 ///
 /// This function must be kept in sync with [`extract_pathkey_styles_with_sortability_check`]

--- a/pg_search/src/postgres/customscan/pullup.rs
+++ b/pg_search/src/postgres/customscan/pullup.rs
@@ -29,7 +29,7 @@ use pgrx::pg_sys;
 /// Resolves a PostgreSQL attribute number to a Tantivy fast field, if available.
 ///
 /// This checks if the column corresponding to `attno` in the heap relation is available
-/// as a fast field in the BM25 index. It handles:
+/// as a fast field in the ParadeDB index. It handles:
 ///
 /// - System columns (ctid, tableoid)
 /// - Regular columns (mapped via name)

--- a/pg_search/src/postgres/customscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pushdown.rs
@@ -58,7 +58,7 @@ unsafe fn is_ltree_descendant_operator(
     CStr::from_ptr(op_name).to_bytes() == b"<@"
 }
 
-/// Pushdown PostgreSQL ltree descendant operator `<@` to the BM25 index.
+/// Pushdown PostgreSQL ltree descendant operator `<@` to the ParadeDB index.
 ///
 /// Converts:
 ///
@@ -352,7 +352,7 @@ pub unsafe fn try_build_pushdown_qual(
     }
 }
 
-/// Pushdown JSONB `?` (exists) operator to BM25 index.
+/// Pushdown JSONB `?` (exists) operator to ParadeDB index.
 ///
 /// Converts `data ? 'key'` to equivalent of `id @@@ paradedb.exists('data.key')`.
 /// For nested paths like `data->'nested' ? 'key'`, produces `data.nested.key`.

--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -64,7 +64,7 @@ crate::impl_safe_drop!(HeapBufferPin, |self| {
 
 /// Helper to validate that a "ctid" is currently visible to a snapshot.
 ///
-/// When querying BM25 indexes, individual ctid entries may be stale. After an UPDATE,
+/// When querying ParadeDB indexes, individual ctid entries may be stale. After an UPDATE,
 /// the old tuple is marked dead and a new tuple is created at a new ctid, but the
 /// index still has the old ctid until VACUUM runs.
 ///

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -98,7 +98,7 @@ impl TryFrom<pg_sys::StrategyNumber> for ScanStrategy {
 CREATE FUNCTION bm25_handler(internal) RETURNS index_am_handler PARALLEL SAFE IMMUTABLE STRICT COST 0.0001 LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
 CREATE ACCESS METHOD paradedb TYPE INDEX HANDLER bm25_handler;
 CREATE ACCESS METHOD bm25 TYPE INDEX HANDLER bm25_handler;
-COMMENT ON ACCESS METHOD bm25 IS 'bm25 index access method';
+COMMENT ON ACCESS METHOD bm25 IS 'backwards-compatible alias for the paradedb index access method';
 ")]
 fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutine> {
     let mut amroutine =
@@ -143,8 +143,8 @@ fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRouti
 /// along with the heap relation. Returns [`None`] if there isn't one.
 ///
 /// Filters out indexes that aren't yet `indisvalid` (e.g. mid-`CREATE INDEX CONCURRENTLY`
-/// or a failed `REINDEX`). When more than one valid bm25 index exists on the relation
-/// (only possible via `CREATE INDEX CONCURRENTLY`, which bypasses the single-bm25-index
+/// or a failed `REINDEX`). When more than one valid ParadeDB index exists on the relation
+/// (only possible via `CREATE INDEX CONCURRENTLY`, which bypasses the single-ParadeDB-index
 /// check), the highest-OID one is chosen so that the index added most recently wins.
 pub fn rel_get_bm25_index(
     relid: pg_sys::Oid,

--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -103,7 +103,7 @@ pub enum SchemaError {
 impl Display for SchemaError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::RelationNotBM25Index => write!(f, "relation is not a BM25 index"),
+            Self::RelationNotBM25Index => write!(f, "relation is not a ParadeDB index"),
             Self::Other(e) => write!(f, "{e}"),
         }
     }

--- a/pg_search/src/scan/info.rs
+++ b/pg_search/src/scan/info.rs
@@ -198,7 +198,7 @@ pub struct ScanInfo {
     pub heap_rti: pg_sys::Index,
     /// The OID of the heap table.
     pub heaprelid: pg_sys::Oid,
-    /// The OID of the BM25 index (if this scan has one).
+    /// The OID of the ParadeDB index (if this scan has one).
     pub indexrelid: pg_sys::Oid,
     /// Whether this scan has a search predicate (uses @@@ operator).
     pub has_search_predicate: bool,
@@ -213,7 +213,7 @@ pub struct ScanInfo {
     /// The fields that need to be extracted from the index.
     /// Populated during planning via `collect_required_fields`.
     pub fields: Vec<FieldInfo>,
-    /// The partitioning configuration of the BM25 index, if it was created with `partition_by`.
+    /// The partitioning configuration of the ParadeDB index, if it was created with `partition_by`.
     pub partition_by: Vec<FieldName>,
     /// Estimated number of rows matching the query.
     /// Used to decide which table to partition in parallel joins.

--- a/pg_search/tests/pg_regress/expected/composite.out
+++ b/pg_search/tests/pg_regress/expected/composite.out
@@ -313,7 +313,7 @@ CREATE TABLE nested_test (
 -- This should fail: nested composite
 \set ON_ERROR_STOP off
 CREATE INDEX idx_nested_test ON nested_test USING paradedb (id, (ROW(field1, field2)::outer_composite)) WITH (key_field='id');
-ERROR:  Nested composite types are not supported for BM25 indexes.
+ERROR:  Nested composite types are not supported for ParadeDB indexes.
 \set ON_ERROR_STOP on
 DROP TABLE nested_test;
 DROP TYPE outer_composite;

--- a/pg_search/tests/pg_regress/expected/issue_2745.out
+++ b/pg_search/tests/pg_regress/expected/issue_2745.out
@@ -66,7 +66,7 @@ WHERE contact_id = ANY(ARRAY[17969,17970,17971,17973])
 AND NOT EXISTS (
     SELECT 1 FROM contact_list cl WHERE contact_id = cl.id
 );
-WARNING:  Aggregate Scan (DataFusion) not used: all tables in the join must have BM25 indexes (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: all tables in the join must have ParadeDB indexes (table: join)
  contact_id 
 ------------
       17969
@@ -81,7 +81,7 @@ WHERE contact_id = ANY(ARRAY[17969,17970,17971,17973])
 AND NOT EXISTS (
     SELECT 1 FROM contact_list cl WHERE contact_id = cl.id
 );
-WARNING:  Aggregate Scan (DataFusion) not used: all tables in the join must have BM25 indexes (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: all tables in the join must have ParadeDB indexes (table: join)
  contact_id 
 ------------
       17969


### PR DESCRIPTION
Updates current Rust documentation, planner diagnostics, user-facing errors, and admin notices from “BM25 index” to “ParadeDB index.” Required regression expectations are updated with the changed messages.

Also fixes the Antithesis monitoring query to select the `paradedb` access method and describes the legacy `bm25` access method as a backwards-compatible alias.

Deliberately unchanged: upgrade SQL, compatibility test inputs, changelogs, internal `bm25_*` identifiers, operator classes, and version-pinned benchmark fixtures.

Validation: all non-build commit hooks pass, including formatting, Markdown, YAML, and Prettier. Rust build hooks are locally blocked by the configured PostgreSQL SDK path `/Applications/Xcode.app/.../MacOSX26.5.sdk`, which does not exist on this machine; CI remains authoritative.