### PR TITLE
feat: Adds a separate Mintlify preview workflow for ParadeDB docs changes.

### DIFF
--- a/.github/workflows/preview-paradedb-docs.yml
+++ b/.github/workflows/preview-paradedb-docs.yml
@@ -1,0 +1,144 @@
+# workflows/preview-paradedb-docs.yml
+#
+# Preview ParadeDB (Docs)
+# Create or update a Mintlify preview deployment for docs changes without
+# affecting the live docs deployment.
+
+name: Preview ParadeDB (Docs)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/preview-paradedb-docs.yml"
+      - "docs/**"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to preview. Defaults to the workflow ref."
+        required: false
+        type: string
+
+concurrency:
+  group: preview-paradedb-docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  preview-paradedb-docs:
+    name: Create Mintlify Docs Preview
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+    steps:
+      - name: Trigger Mintlify Preview
+        uses: actions/github-script@v9
+        env:
+          MINTLIFY_PROJECT_ID: ${{ secrets.MINTLIFY_PROJECT_ID }}
+          MINTLIFY_API_KEY: ${{ secrets.MINTLIFY_API_KEY }}
+          REQUESTED_BRANCH: ${{ github.event.inputs.branch }}
+        with:
+          script: |
+            const projectId = process.env.MINTLIFY_PROJECT_ID;
+            const apiKey = process.env.MINTLIFY_API_KEY;
+            const requestedBranch = process.env.REQUESTED_BRANCH?.trim();
+            const refBranch = context.ref.replace(/^refs\/heads\//, "");
+            const branch = context.eventName === "pull_request_target"
+              ? context.payload.pull_request.head.ref
+              : requestedBranch || refBranch;
+
+            if (!projectId || !apiKey) {
+              core.setFailed("Missing MINTLIFY_PROJECT_ID or MINTLIFY_API_KEY secret.");
+              return;
+            }
+
+            if (!branch || branch.startsWith("refs/tags/")) {
+              core.setFailed("A branch name is required to create a Mintlify preview deployment.");
+              return;
+            }
+
+            const response = await fetch(
+              `https://api.mintlify.com/v1/project/preview/${encodeURIComponent(projectId)}`,
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${apiKey}`,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ branch }),
+              },
+            );
+
+            const responseBody = await response.text();
+            let parsedBody;
+            try {
+              parsedBody = JSON.parse(responseBody);
+            } catch {
+              parsedBody = {};
+            }
+
+            if (!response.ok) {
+              core.setFailed(`Mintlify preview failed with HTTP ${response.status}: ${responseBody}`);
+              return;
+            }
+
+            const previewUrl = parsedBody.previewUrl;
+            if (!previewUrl) {
+              core.setFailed(`Mintlify preview response did not include previewUrl: ${responseBody}`);
+              return;
+            }
+
+            core.setOutput("preview-url", previewUrl);
+            core.notice(`Mintlify docs preview: ${previewUrl}`);
+
+            await core.summary
+              .addHeading("Mintlify Docs Preview")
+              .addRaw(`Branch: \`${branch}\`\n\n`)
+              .addRaw(`Preview: ${previewUrl}\n`)
+              .write();
+
+            if (context.eventName !== "pull_request_target") {
+              return;
+            }
+
+            const marker = "<!-- paradedb-docs-mintlify-preview -->";
+            const body = [
+              marker,
+              "### Mintlify docs preview",
+              "",
+              previewUrl,
+              "",
+              `Branch: \`${branch}\``,
+            ].join("\n");
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previousComment = comments.find((comment) =>
+              comment.user.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,10 +19,14 @@ mint dev
 
 ## 😎 Publishing Changes
 
-Changes will be deployed to production automatically after pushing to the default
-branch.
+Production documentation updates are deployed manually through the
+`Publish ParadeDB (Docs)` GitHub Actions workflow. The workflow asks Mintlify to
+rebuild the configured production branch.
 
-You can also preview changes using PRs, which generates a preview link of the docs.
+Same-repository pull requests that change `docs/**` create or update a Mintlify
+preview deployment through the `Preview ParadeDB (Docs)` GitHub Actions
+workflow. Fork pull requests do not receive previews because Mintlify cannot
+preview fork-only branches from the ParadeDB repository.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This keeps the existing production docs process unchanged: production deploys still happen manually through `Publish ParadeDB (Docs)`. The new workflow only creates preview deployments for same-repository PRs that touch `docs/**`.

Tested as well as I can, but needs to be on main to confirm.