### PR TITLE
feat: combine multiple index bitmaps with BitmapAnd

### DIFF
--- a/docs/documentation/filtering/external-indexes.mdx
+++ b/docs/documentation/filtering/external-indexes.mdx
@@ -172,7 +172,6 @@ This is an optimization, so ParadeDB will fall back to regular row-by-row filter
 The most common reasons are:
 
 - The filter appears under `OR` or `NOT`. Only `AND` is currently supported.
-- More than one external index could help. ParadeDB currently chooses the best single external index instead of combining several.
 - The candidate set from the external index is expected to be too large, or the filter is not selective enough to justify the extra work.
 
 If your query still checks the filter row by row, please [open a GitHub issue](https://github.com/paradedb/paradedb/issues/new) with the query, index definitions, and `EXPLAIN` output.

--- a/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
+++ b/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
@@ -392,7 +392,7 @@ impl BitmapPlanner {
                     continue;
                 }
                 let Some(bm25_row_estimate) = self.bm25_row_estimate else {
-                    return Some((self.heap_path(ipath), self.bitmap_build_cost(ipath)));
+                    return Some((self.heap_path(ipath.cast()), self.bitmap_build_cost(ipath)));
                 };
                 let net = self.ledger(ipath, bm25_row_estimate);
                 pgrx::debug1!(
@@ -404,33 +404,31 @@ impl BitmapPlanner {
                     best = Some((ipath, net));
                 }
             }
-            best.map(|(ipath, _)| (self.heap_path(ipath), self.bitmap_build_cost(ipath)))
+            best.map(|(ipath, _)| (self.heap_path(ipath.cast()), self.bitmap_build_cost(ipath)))
         }
+    }
+
+    /// Estimated number of TIDs this index's bitmap holds.
+    unsafe fn bitmap_rows(&self, ipath: *mut pg_sys::IndexPath) -> f64 {
+        unsafe { selectivity(ipath) * (*self.rel).tuples.max(1.0) }
     }
 
     /// Cost of producing the probe-able set: the index scan that builds the
     /// TIDBitmap plus converting its entries.
     unsafe fn bitmap_build_cost(&self, ipath: *mut pg_sys::IndexPath) -> f64 {
         unsafe {
-            let bitmap_rows =
-                (*ipath).indexselectivity.clamp(0.0, 1.0) * (*self.rel).tuples.max(1.0);
             let cpu_operator_cost = *std::ptr::addr_of!(pg_sys::cpu_operator_cost);
-            (*ipath).indextotalcost + bitmap_rows * 0.1 * cpu_operator_cost
+            (*ipath).indextotalcost + self.bitmap_rows(ipath) * 0.1 * cpu_operator_cost
         }
     }
 
-    /// Net benefit of probing this index's bitmap ahead of the heap filters.
-    ///
-    /// Benefit: each ParadeDB-index row the bitmap rejects (the non-selected fraction)
-    /// skips its heap fetch and all heap filter evaluation.
-    ///
-    //  Cost: building the bitmap (`indextotalcost`) plus converting its entries into
-    // the probe-able set.
-    unsafe fn ledger(&self, ipath: *mut pg_sys::IndexPath, bm25_row_estimate: f64) -> f64 {
+    /// Cost avoided for every row a bitmap rejects: the heap fetch it skips plus each
+    /// heap filter it no longer evaluates. Independent of which index produced the
+    /// bitmap, so callers scoring several indexes hoist it out of their loop.
+    unsafe fn per_row_saved(&self) -> f64 {
         unsafe {
             let tuples = (*self.rel).tuples.max(1.0);
             let pages = (*self.rel).pages as f64;
-            let sel = (*ipath).indexselectivity.clamp(0.0, 1.0);
 
             let cpu_tuple_cost = *std::ptr::addr_of!(pg_sys::cpu_tuple_cost);
             let random_page_cost = *std::ptr::addr_of!(pg_sys::random_page_cost);
@@ -442,9 +440,20 @@ impl BitmapPlanner {
             }
             pg_sys::cost_qual_eval(&mut qual_cost, exprs.into_pg(), self.root);
 
-            let per_row_saved =
-                cpu_tuple_cost + qual_cost.per_tuple + (pages / tuples) * random_page_cost;
-            let benefit = bm25_row_estimate * (1.0 - sel) * per_row_saved;
+            cpu_tuple_cost + qual_cost.per_tuple + (pages / tuples) * random_page_cost
+        }
+    }
+
+    /// Net benefit of probing this index's bitmap ahead of the heap filters.
+    ///
+    /// Benefit: each ParadeDB-index row the bitmap rejects (the non-selected fraction)
+    /// skips its heap fetch and all heap filter evaluation.
+    ///
+    /// Cost: building the bitmap (`indextotalcost`) plus converting its entries into
+    /// the probe-able set.
+    unsafe fn ledger(&self, ipath: *mut pg_sys::IndexPath, bm25_row_estimate: f64) -> f64 {
+        unsafe {
+            let benefit = bm25_row_estimate * (1.0 - selectivity(ipath)) * self.per_row_saved();
             benefit - self.bitmap_build_cost(ipath)
         }
     }
@@ -453,19 +462,17 @@ impl BitmapPlanner {
     /// pages, which cannot reject anything.
     unsafe fn overflows_work_mem(&self, ipath: *mut pg_sys::IndexPath) -> bool {
         unsafe {
-            let bitmap_rows =
-                (*ipath).indexselectivity.clamp(0.0, 1.0) * (*self.rel).tuples.max(1.0);
             let work_mem_kb = *std::ptr::addr_of!(pg_sys::work_mem) as f64;
-            bitmap_rows * 8.0 > work_mem_kb * 1024.0
+            self.bitmap_rows(ipath) * 8.0 > work_mem_kb * 1024.0
         }
     }
 
-    unsafe fn heap_path(&self, ipath: *mut pg_sys::IndexPath) -> *mut pg_sys::BitmapHeapPath {
+    unsafe fn heap_path(&self, bitmapqual: *mut pg_sys::Path) -> *mut pg_sys::BitmapHeapPath {
         unsafe {
             pg_sys::create_bitmap_heap_path(
                 self.root,
                 self.rel,
-                ipath.cast(),
+                bitmapqual,
                 (*self.rel).lateral_relids,
                 1.0,
                 0,
@@ -747,6 +754,11 @@ impl IndexClause {
     fn into_pg(self) -> *mut pg_sys::IndexClause {
         self.0
     }
+}
+
+/// An index path's estimated selectivity, clamped to a usable fraction.
+unsafe fn selectivity(ipath: *mut pg_sys::IndexPath) -> f64 {
+    unsafe { (*ipath).indexselectivity.clamp(0.0, 1.0) }
 }
 
 unsafe fn strip_relabel(mut node: *mut pg_sys::Node) -> *mut pg_sys::Node {

--- a/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
+++ b/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
@@ -347,10 +347,9 @@ impl BitmapPlanner {
     }
 
     /// Build a `BitmapHeapPath` over the non-ParadeDB indexes whose bitmaps are worth
-    /// intersecting: every index with a key column matching a HeapExpr clause is scored
-    /// by [`Self::ledger`], and the positive-net ones are combined with a `BitmapAnd`
-    /// in descending net order while each addition still pays for itself. Without a
-    /// ParadeDB-side row estimate the first workable index is taken unscored.
+    /// intersecting: every index with a key column matching a HeapExpr clause becomes a
+    /// candidate, and [`Self::choose_bitmap_and`] decides which of them to combine.
+    /// Without a ParadeDB-side row estimate the first workable index is taken unscored.
     unsafe fn build_bitmap_path(&self) -> Option<(*mut pg_sys::BitmapHeapPath, f64)> {
         unsafe {
             let mut candidates = Vec::new();
@@ -366,58 +365,9 @@ impl BitmapPlanner {
                 candidates.push(candidate);
             }
             let bm25_row_estimate = self.bm25_row_estimate?;
-            if candidates.is_empty() {
-                return None;
-            }
-
-            // Constant across candidates, so it is evaluated once for the whole pass.
+            // Constant across candidates, so it is evaluated once for the whole search.
             let per_row_saved = self.per_row_saved();
-            let mut scored = Vec::with_capacity(candidates.len());
-            for candidate in candidates {
-                let net = self.ledger(&candidate, bm25_row_estimate, per_row_saved);
-                pgrx::debug1!(
-                    "[bitmap_intersection] index {}: net={net:.2} (bm25_row_estimate={bm25_row_estimate:.0} selectivity={:.6} indextotalcost={:.2})",
-                    candidate.index_name,
-                    candidate.selectivity,
-                    (*candidate.ipath).indextotalcost,
-                );
-                scored.push((candidate, net));
-            }
-
-            // Best net first, then keep adding while the next bitmap still pays for
-            // itself: it only sees the rows its predecessors kept, so its benefit
-            // shrinks by their combined selectivity while its build cost stays full
-            // price. Sorted descending, so the first non-paying one ends the run.
-            scored.sort_by(|(_, a), (_, b)| b.total_cmp(a));
-            let mut chosen: Vec<Candidate> = Vec::new();
-            let mut covered: Vec<usize> = Vec::new();
-            let mut reachable_rows = bm25_row_estimate;
-            for (candidate, _) in scored {
-                // Any shared clause disqualifies the candidate, as Postgres does
-                // with `bms_overlap` in `choose_bitmap_and`. The ledger multiplies
-                // selectivities as if the bitmaps were independent, so a clause both
-                // indexes answer is counted twice and makes the addition look like it
-                // rejects rows the first bitmap already rejected.
-                if candidate.covers.iter().any(|c| covered.contains(c)) {
-                    pgrx::debug1!(
-                        "[bitmap_intersection] index {}: shares a clause with the accepted set, skipping",
-                        candidate.index_name
-                    );
-                    continue;
-                }
-                let incremental = self.ledger(&candidate, reachable_rows, per_row_saved);
-                pgrx::debug1!(
-                    "[bitmap_intersection] index {}: incremental net={incremental:.2} against {} accepted bitmap(s) (reachable_rows={reachable_rows:.0})",
-                    candidate.index_name,
-                    chosen.len(),
-                );
-                if incremental <= 0.0 {
-                    break;
-                }
-                reachable_rows *= candidate.selectivity;
-                covered.extend(&candidate.covers);
-                chosen.push(candidate);
-            }
+            let chosen = self.choose_bitmap_and(candidates, bm25_row_estimate, per_row_saved)?;
 
             let (first, rest) = chosen.split_first()?;
             let build_cost = chosen.iter().map(|c| c.build_cost).sum();
@@ -432,6 +382,88 @@ impl BitmapPlanner {
             };
             Some((self.heap_path(bitmapqual), build_cost))
         }
+    }
+
+    /// Choose which candidate bitmaps to intersect, following Postgres'
+    /// `choose_bitmap_and`: order the candidates cheapest bitmap first, take each in
+    /// turn as the leader of an AND group, and offer every later candidate to that
+    /// group, keeping the ones that improve it. The best group across all leaders wins,
+    /// so O(N^2) groups are compared rather than every one of the O(2^N) subsets.
+    ///
+    /// A group's net is what it saves minus what it costs: the rows it keeps out of the
+    /// heap, priced at `per_row_saved`, less the build cost of every bitmap in it. It
+    /// has to come out positive to be used at all, so the intersection is dropped
+    /// entirely when no group pays for itself.
+    fn choose_bitmap_and(
+        &self,
+        mut candidates: Vec<Candidate>,
+        bm25_row_estimate: f64,
+        per_row_saved: f64,
+    ) -> Option<Vec<Candidate>> {
+        // Cheapest bitmap first, more selective breaking ties, mirroring Postgres'
+        // `path_usage_comparator`. Only candidates after the leader are offered to its
+        // group, so this ordering decides which groups exist to be compared at all.
+        candidates.sort_by(|a, b| {
+            a.build_cost
+                .total_cmp(&b.build_cost)
+                .then(a.selectivity.total_cmp(&b.selectivity))
+        });
+        let mut best: Option<(Vec<usize>, f64)> = None;
+        for (leader_pos, leader) in candidates.iter().enumerate() {
+            let mut group = vec![leader_pos];
+            let mut covered = leader.covers.clone();
+            let mut reachable_rows = bm25_row_estimate * leader.selectivity;
+            let mut net = self.ledger(leader, bm25_row_estimate, per_row_saved);
+            pgrx::debug1!(
+                "[bitmap_intersection] index {}: selectivity={:.6} build_cost={:.2} standalone net={net:.2} (bm25_row_estimate={bm25_row_estimate:.0})",
+                leader.index_name,
+                leader.selectivity,
+                leader.build_cost,
+            );
+
+            for (pos, candidate) in candidates.iter().enumerate().skip(leader_pos + 1) {
+                // Any shared clause disqualifies the candidate, as Postgres does with
+                // `bms_overlap`. The ledger multiplies selectivities as if the bitmaps
+                // were independent, so a clause both indexes answer is counted twice,
+                // making the addition look like it rejects rows the group already did.
+                if candidate.covers.iter().any(|c| covered.contains(c)) {
+                    continue;
+                }
+                // The bitmap only sees the rows its predecessors kept, so its benefit
+                // shrinks by their combined selectivity while its build cost stays full
+                // price. One that cannot pay for itself here may still pay under a
+                // later leader, so this drops the candidate, not the rest of the group.
+                let incremental = self.ledger(candidate, reachable_rows, per_row_saved);
+                if incremental <= 0.0 {
+                    continue;
+                }
+                net += incremental;
+                reachable_rows *= candidate.selectivity;
+                covered.extend(&candidate.covers);
+                group.push(pos);
+            }
+
+            pgrx::debug1!(
+                "[bitmap_intersection] group led by {}: {} bitmap(s), net={net:.2}",
+                leader.index_name,
+                group.len(),
+            );
+            if net > 0.0 && best.as_ref().is_none_or(|(_, best_net)| net > *best_net) {
+                best = Some((group, net));
+            }
+        }
+
+        // Groups collect their members in ascending position, so this preserves the
+        // order the leader loop accepted them in.
+        let (group, _) = best?;
+        Some(
+            candidates
+                .into_iter()
+                .enumerate()
+                .filter(|(pos, _)| group.contains(pos))
+                .map(|(_, candidate)| candidate)
+                .collect(),
+        )
     }
 
     /// Score one index as an intersection source. `None` when it cannot produce a

--- a/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
+++ b/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
@@ -393,12 +393,14 @@ impl BitmapPlanner {
             let mut covered: Vec<usize> = Vec::new();
             let mut reachable_rows = bm25_row_estimate;
             for (candidate, _) in scored {
-                // A multicolumn index and a single-column one over a shared key match
-                // the same clause. The second rejects nothing the first did not, and
-                // multiplying their selectivities would count that clause twice.
-                if candidate.covers.iter().all(|c| covered.contains(c)) {
+                // Any shared clause disqualifies the candidate, as Postgres does
+                // with `bms_overlap` in `choose_bitmap_and`. The ledger multiplies
+                // selectivities as if the bitmaps were independent, so a clause both
+                // indexes answer is counted twice and makes the addition look like it
+                // rejects rows the first bitmap already rejected.
+                if candidate.covers.iter().any(|c| covered.contains(c)) {
                     pgrx::debug1!(
-                        "[bitmap_intersection] index {}: covers nothing new, skipping",
+                        "[bitmap_intersection] index {}: shares a clause with the accepted set, skipping",
                         candidate.index_name
                     );
                     continue;

--- a/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
+++ b/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
@@ -44,6 +44,19 @@ struct HarvestedClause {
     matched_heap_expr: bool,
 }
 
+/// One index whose bitmap can feed the intersection, carrying what the combination
+/// step needs to score it and to tell it apart from a redundant one.
+struct Candidate {
+    ipath: *mut pg_sys::IndexPath,
+    index_name: String,
+    /// Cost of building this bitmap and converting it into the probe-able set.
+    build_cost: f64,
+    /// Fraction of the heap this index's quals select.
+    selectivity: f64,
+    /// Positions in `heap_exprs` this index's quals cover.
+    covers: Vec<usize>,
+}
+
 /// A successful harvest: the path to attach as a `custom_paths` child, plus the
 /// HeapExpr clauses its bitmap covers (with their planner-level lossiness).
 pub struct HarvestedBitmap {
@@ -333,78 +346,152 @@ impl BitmapPlanner {
         }
     }
 
-    /// Build a `BitmapHeapPath` over the non-ParadeDB index whose bitmap is worth
-    /// intersecting: every index with a key column matching a HeapExpr clause is
-    /// scored by [`Self::ledger`] and the best positive-net one wins. Without a
+    /// Build a `BitmapHeapPath` over the non-ParadeDB indexes whose bitmaps are worth
+    /// intersecting: every index with a key column matching a HeapExpr clause is scored
+    /// by [`Self::ledger`], and the positive-net ones are combined with a `BitmapAnd`
+    /// in descending net order while each addition still pays for itself. Without a
     /// ParadeDB-side row estimate the first workable index is taken unscored.
     unsafe fn build_bitmap_path(&self) -> Option<(*mut pg_sys::BitmapHeapPath, f64)> {
         unsafe {
-            // TODO: This currently returns the best index, but we can
-            // return all indexes that have a positive net benefit
-            let mut best: Option<(*mut pg_sys::IndexPath, f64)> = None;
+            let mut candidates = Vec::new();
             for ioi in PgList::<pg_sys::IndexOptInfo>::from_pg((*self.rel).indexlist).iter_ptr() {
-                if (*ioi).indexoid == self.bm25_oid || !(*ioi).amhasgetbitmap || (*ioi).hypothetical
-                {
+                let Some(candidate) = self.candidate(ioi) else {
                     continue;
+                };
+                // With no ParadeDB-side estimate there is nothing to score against, so
+                // the first workable index is taken unscored and uncombined.
+                if self.bm25_row_estimate.is_none() {
+                    return Some((self.heap_path(candidate.ipath.cast()), candidate.build_cost));
                 }
-                // Partial indexes need predicate-implication checks.
-                if !(*ioi).indpred.is_null() {
-                    continue;
-                }
+                candidates.push(candidate);
+            }
+            let bm25_row_estimate = self.bm25_row_estimate?;
+            if candidates.is_empty() {
+                return None;
+            }
 
-                let mut matched = Vec::new();
-                for ri in PgList::<pg_sys::RestrictInfo>::from_pg((*ioi).indrestrictinfo).iter_ptr()
-                {
-                    if self.matches_heap_expr((*ri).clause.cast())
-                        && let Some(iclause) = IndexClause::from_clause(self.root, ri, ioi)
-                    {
-                        matched.push(iclause);
-                    }
-                }
-                if matched.is_empty() {
-                    continue;
-                }
-                // `IndexPath.indexclauses` must be ordered by index column; the
-                // clauses above accumulate in `indrestrictinfo` order.
-                matched.sort_by_key(IndexClause::indexcol);
-                let mut iclauses = PgList::<pg_sys::IndexClause>::new();
-                for iclause in matched {
-                    iclauses.push(iclause.into_pg());
-                }
-                let ipath = pg_sys::create_index_path(
-                    self.root,
-                    ioi,
-                    iclauses.into_pg(),
-                    std::ptr::null_mut(),
-                    std::ptr::null_mut(),
-                    std::ptr::null_mut(),
-                    pg_sys::ScanDirection::ForwardScanDirection,
-                    false,
-                    std::ptr::null_mut(),
-                    1.0,
-                    false,
+            // Constant across candidates, so it is evaluated once for the whole pass.
+            let per_row_saved = self.per_row_saved();
+            let mut scored = Vec::with_capacity(candidates.len());
+            for candidate in candidates {
+                let net = self.ledger(&candidate, bm25_row_estimate, per_row_saved);
+                pgrx::debug1!(
+                    "[bitmap_intersection] index {}: net={net:.2} (bm25_row_estimate={bm25_row_estimate:.0} selectivity={:.6} indextotalcost={:.2})",
+                    candidate.index_name,
+                    candidate.selectivity,
+                    (*candidate.ipath).indextotalcost,
                 );
-                let index_name = PgSearchRelation::open((*ioi).indexoid).name().to_string();
-                if self.overflows_work_mem(ipath) {
+                scored.push((candidate, net));
+            }
+
+            // Best net first, then keep adding while the next bitmap still pays for
+            // itself: it only sees the rows its predecessors kept, so its benefit
+            // shrinks by their combined selectivity while its build cost stays full
+            // price. Sorted descending, so the first non-paying one ends the run.
+            scored.sort_by(|(_, a), (_, b)| b.total_cmp(a));
+            let mut chosen: Vec<Candidate> = Vec::new();
+            let mut covered: Vec<usize> = Vec::new();
+            let mut reachable_rows = bm25_row_estimate;
+            for (candidate, _) in scored {
+                // A multicolumn index and a single-column one over a shared key match
+                // the same clause. The second rejects nothing the first did not, and
+                // multiplying their selectivities would count that clause twice.
+                if candidate.covers.iter().all(|c| covered.contains(c)) {
                     pgrx::debug1!(
-                        "[bitmap_intersection] index {index_name}: bitmap would overflow work_mem, skipping"
+                        "[bitmap_intersection] index {}: covers nothing new, skipping",
+                        candidate.index_name
                     );
                     continue;
                 }
-                let Some(bm25_row_estimate) = self.bm25_row_estimate else {
-                    return Some((self.heap_path(ipath.cast()), self.bitmap_build_cost(ipath)));
-                };
-                let net = self.ledger(ipath, bm25_row_estimate);
+                let incremental = self.ledger(&candidate, reachable_rows, per_row_saved);
                 pgrx::debug1!(
-                    "[bitmap_intersection] index {index_name}: net={net:.2} (bm25_row_estimate={bm25_row_estimate:.0} selectivity={:.6} indextotalcost={:.2})",
-                    (*ipath).indexselectivity,
-                    (*ipath).indextotalcost,
+                    "[bitmap_intersection] index {}: incremental net={incremental:.2} against {} accepted bitmap(s) (reachable_rows={reachable_rows:.0})",
+                    candidate.index_name,
+                    chosen.len(),
                 );
-                if net > 0.0 && best.is_none_or(|(_, b)| net > b) {
-                    best = Some((ipath, net));
+                if incremental <= 0.0 {
+                    break;
+                }
+                reachable_rows *= candidate.selectivity;
+                covered.extend(&candidate.covers);
+                chosen.push(candidate);
+            }
+
+            let (first, rest) = chosen.split_first()?;
+            let build_cost = chosen.iter().map(|c| c.build_cost).sum();
+            let bitmapqual = if rest.is_empty() {
+                first.ipath.cast::<pg_sys::Path>()
+            } else {
+                let mut bitmapquals = PgList::<pg_sys::Path>::new();
+                for candidate in &chosen {
+                    bitmapquals.push(candidate.ipath.cast());
+                }
+                pg_sys::create_bitmap_and_path(self.root, self.rel, bitmapquals.into_pg()).cast()
+            };
+            Some((self.heap_path(bitmapqual), build_cost))
+        }
+    }
+
+    /// Score one index as an intersection source. `None` when it cannot produce a
+    /// usable bitmap, when none of its key columns matches a HeapExpr clause, or when
+    /// its bitmap would overflow `work_mem`.
+    unsafe fn candidate(&self, ioi: *mut pg_sys::IndexOptInfo) -> Option<Candidate> {
+        unsafe {
+            if (*ioi).indexoid == self.bm25_oid || !(*ioi).amhasgetbitmap || (*ioi).hypothetical {
+                return None;
+            }
+            // Partial indexes need predicate-implication checks.
+            if !(*ioi).indpred.is_null() {
+                return None;
+            }
+
+            let mut matched = Vec::new();
+            let mut covers = Vec::new();
+            for ri in PgList::<pg_sys::RestrictInfo>::from_pg((*ioi).indrestrictinfo).iter_ptr() {
+                if let Some(heap_expr) = self.heap_expr_index((*ri).clause.cast())
+                    && let Some(iclause) = IndexClause::from_clause(self.root, ri, ioi)
+                {
+                    matched.push(iclause);
+                    covers.push(heap_expr);
                 }
             }
-            best.map(|(ipath, _)| (self.heap_path(ipath.cast()), self.bitmap_build_cost(ipath)))
+            if matched.is_empty() {
+                return None;
+            }
+            // `IndexPath.indexclauses` must be ordered by index column; the
+            // clauses above accumulate in `indrestrictinfo` order.
+            matched.sort_by_key(IndexClause::indexcol);
+            let mut iclauses = PgList::<pg_sys::IndexClause>::new();
+            for iclause in matched {
+                iclauses.push(iclause.into_pg());
+            }
+            let ipath = pg_sys::create_index_path(
+                self.root,
+                ioi,
+                iclauses.into_pg(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                pg_sys::ScanDirection::ForwardScanDirection,
+                false,
+                std::ptr::null_mut(),
+                1.0,
+                false,
+            );
+            let index_name = PgSearchRelation::open((*ioi).indexoid).name().to_string();
+            if self.overflows_work_mem(ipath) {
+                pgrx::debug1!(
+                    "[bitmap_intersection] index {index_name}: bitmap would overflow work_mem, skipping"
+                );
+                return None;
+            }
+            Some(Candidate {
+                ipath,
+                index_name,
+                build_cost: self.bitmap_build_cost(ipath),
+                selectivity: selectivity(ipath),
+                covers,
+            })
         }
     }
 
@@ -444,18 +531,18 @@ impl BitmapPlanner {
         }
     }
 
-    /// Net benefit of probing this index's bitmap ahead of the heap filters.
+    /// Net benefit of probing this bitmap ahead of the heap filters.
     ///
-    /// Benefit: each ParadeDB-index row the bitmap rejects (the non-selected fraction)
-    /// skips its heap fetch and all heap filter evaluation.
+    /// Benefit: each row the bitmap rejects (the non-selected fraction of the
+    /// `reachable_rows` that still arrive at it) skips its heap fetch and all heap
+    /// filter evaluation. `reachable_rows` is the full ParadeDB-side estimate for the
+    /// first bitmap in an intersection, and the fraction its predecessors kept for
+    /// every bitmap after it.
     ///
     /// Cost: building the bitmap (`indextotalcost`) plus converting its entries into
-    /// the probe-able set.
-    unsafe fn ledger(&self, ipath: *mut pg_sys::IndexPath, bm25_row_estimate: f64) -> f64 {
-        unsafe {
-            let benefit = bm25_row_estimate * (1.0 - selectivity(ipath)) * self.per_row_saved();
-            benefit - self.bitmap_build_cost(ipath)
-        }
+    /// the probe-able set, which does not shrink as the intersection grows.
+    fn ledger(&self, candidate: &Candidate, reachable_rows: f64, per_row_saved: f64) -> f64 {
+        reachable_rows * (1.0 - candidate.selectivity) * per_row_saved - candidate.build_cost
     }
 
     /// A bitmap whose estimated TID count can't fit in `work_mem` degrades to lossy
@@ -480,12 +567,17 @@ impl BitmapPlanner {
         }
     }
 
-    unsafe fn matches_heap_expr(&self, clause: *mut pg_sys::Node) -> bool {
+    /// Position in [`Self::heap_exprs`] of the HeapExpr this clause is, if any.
+    unsafe fn heap_expr_index(&self, clause: *mut pg_sys::Node) -> Option<usize> {
         unsafe {
             self.heap_exprs
                 .iter()
-                .any(|expr| pg_sys::equal(clause.cast(), (*expr).cast()))
+                .position(|expr| pg_sys::equal(clause.cast(), (*expr).cast()))
         }
+    }
+
+    unsafe fn matches_heap_expr(&self, clause: *mut pg_sys::Node) -> bool {
+        unsafe { self.heap_expr_index(clause).is_some() }
     }
 }
 

--- a/pg_search/tests/pg_regress/expected/bitmap_intersection.out
+++ b/pg_search/tests/pg_regress/expected/bitmap_intersection.out
@@ -604,6 +604,54 @@ SELECT count(*) AS bitmap_and_count_no_bitmap FROM (
 (1 row)
 
 DROP TABLE wide_providers CASCADE;
+-- Overlapping clause sets: overlap_ab is the better single bitmap, and overlap_bc
+-- would still look like it pays for itself on top of it. Both answer cat_b, so the
+-- ledger would count that clause's selectivity twice and credit overlap_bc with
+-- rejecting rows overlap_ab already rejected. Sharing a clause disqualifies it.
+CREATE TABLE overlap_providers (
+    id BIGINT, description TEXT, cat_a TEXT, cat_b TEXT, cat_c TEXT, filler TEXT
+);
+ALTER TABLE overlap_providers ALTER COLUMN filler SET STORAGE PLAIN;
+INSERT INTO overlap_providers
+SELECT i, 'cardiology notes ' || i, 'a' || (i % 4), 'b' || ((i / 4) % 2),
+       'c' || ((i / 8) % 2), repeat('x', 1400)
+FROM generate_series(0, 4999) i;
+CREATE INDEX overlap_paradedb ON overlap_providers
+    USING bm25 (id, description) WITH (key_field = 'id');
+CREATE INDEX overlap_ab ON overlap_providers (cat_a, cat_b);
+CREATE INDEX overlap_bc ON overlap_providers (cat_b, cat_c);
+VACUUM ANALYZE overlap_providers;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM overlap_providers
+WHERE description === 'cardiology'
+  AND cat_a = 'a1' AND cat_b = 'b1' AND cat_c = 'c1'
+ORDER BY id LIMIT 5;
+                                                                                                                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on overlap_providers
+         Table: overlap_providers
+         Index: overlap_paradedb
+         Bitmap Intersection: overlap_ab
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id asc
+            TopK Limit: 5
+         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[],"recheck_filters":[{"heap_filter":"(cat_a = 'a1'::text)"}],"uses_tid_bitmap":true,"bitmap_consumer_id":0}},{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[],"recheck_filters":[{"heap_filter":"(cat_b = 'b1'::text)"}],"uses_tid_bitmap":true,"bitmap_consumer_id":1}},{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[{"heap_filter":"(cat_c = 'c1'::text)"}]}}]}}
+         ->  Bitmap Index Scan on overlap_ab
+               Index Cond: ((cat_a = 'a1'::text) AND (cat_b = 'b1'::text))
+(12 rows)
+
+SELECT count(*) AS overlap_clause_count FROM (
+    SELECT id FROM overlap_providers
+    WHERE description === 'cardiology'
+      AND cat_a = 'a1' AND cat_b = 'b1' AND cat_c = 'c1') q;
+ overlap_clause_count 
+----------------------
+                  312
+(1 row)
+
+DROP TABLE overlap_providers CASCADE;
 -- ============================================================================
 -- REJECTED SHAPES
 -- Correct refusals: no Bitmap Intersection, results identical to heap filtering.

--- a/pg_search/tests/pg_regress/expected/bitmap_intersection.out
+++ b/pg_search/tests/pg_regress/expected/bitmap_intersection.out
@@ -533,6 +533,77 @@ EXECUTE radius_search(0);
 
 DEALLOCATE radius_search;
 RESET plan_cache_mode;
+-- BitmapAnd: both predicates are indexable, so both bitmaps are intersected and
+-- both filters move to recheck. Wide rows make the heap fetch expensive enough
+-- that the second bitmap pays for itself.
+CREATE TABLE wide_providers (
+    id BIGINT, description TEXT, cat_a TEXT, cat_b TEXT, filler TEXT
+);
+ALTER TABLE wide_providers ALTER COLUMN filler SET STORAGE PLAIN;
+INSERT INTO wide_providers
+SELECT i, 'cardiology notes ' || i, 'a' || (i % 10), 'b' || (i % 10), repeat('x', 1400)
+FROM generate_series(0, 4999) i;
+CREATE INDEX wide_paradedb ON wide_providers
+    USING bm25 (id, description) WITH (key_field = 'id');
+CREATE INDEX wide_cat_a ON wide_providers (cat_a);
+CREATE INDEX wide_cat_b ON wide_providers (cat_b);
+VACUUM ANALYZE wide_providers;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM wide_providers
+WHERE description === 'cardiology' AND cat_a = 'a3' AND cat_b = 'b3'
+ORDER BY id LIMIT 5;
+                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on wide_providers
+         Table: wide_providers
+         Index: wide_paradedb
+         Bitmap Intersection: wide_cat_b, wide_cat_a
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id asc
+            TopK Limit: 5
+         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[],"recheck_filters":[{"heap_filter":"(cat_a = 'a3'::text)"}],"uses_tid_bitmap":true,"bitmap_consumer_id":0}},{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[],"recheck_filters":[{"heap_filter":"(cat_b = 'b3'::text)"}],"uses_tid_bitmap":true,"bitmap_consumer_id":1}}]}}
+         ->  BitmapAnd
+               ->  Bitmap Index Scan on wide_cat_b
+                     Index Cond: (cat_b = 'b3'::text)
+               ->  Bitmap Index Scan on wide_cat_a
+                     Index Cond: (cat_a = 'a3'::text)
+(15 rows)
+
+SELECT count(*) AS bitmap_and_count FROM (
+    SELECT id FROM wide_providers
+    WHERE description === 'cardiology' AND cat_a = 'a3' AND cat_b = 'b3') q;
+ bitmap_and_count 
+------------------
+              500
+(1 row)
+
+-- Rescan with a BitmapAnd child: freed and rebuilt per outer row, re-seeding
+-- through the BitmapAnd into its first leaf.
+SELECT v.k, s.n FROM (VALUES ('a3'), ('a7')) v(k)
+CROSS JOIN LATERAL (
+    SELECT count(*) AS n FROM wide_providers
+    WHERE description === 'cardiology' AND cat_a = v.k AND cat_b = 'b3') s
+ORDER BY v.k;
+ k  |  n  
+----+-----
+ a3 | 500
+ a7 |   0
+(2 rows)
+
+-- Parity with the same predicates and no bitmap source available.
+DROP INDEX wide_cat_a;
+DROP INDEX wide_cat_b;
+SELECT count(*) AS bitmap_and_count_no_bitmap FROM (
+    SELECT id FROM wide_providers
+    WHERE description === 'cardiology' AND cat_a = 'a3' AND cat_b = 'b3') q;
+ bitmap_and_count_no_bitmap 
+----------------------------
+                        500
+(1 row)
+
+DROP TABLE wide_providers CASCADE;
 -- ============================================================================
 -- REJECTED SHAPES
 -- Correct refusals: no Bitmap Intersection, results identical to heap filtering.
@@ -612,6 +683,31 @@ SELECT count(*) AS saop_all_count FROM (
 ----------------
             200
 (1 row)
+
+-- Cost gate: both indexes qualify, but the second bitmap only sees what the first
+-- one kept, and on this narrow table those rows are worth less than the index scan
+-- they cost. Only the best net bitmap is used.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM providers
+WHERE description === 'cardiology'
+  AND specialty LIKE 'specialty13%'
+  AND service_area && circle(point(50, 50), 1)
+ORDER BY id LIMIT 5;
+                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on providers
+         Table: providers
+         Index: providers_paradedb
+         Bitmap Intersection: providers_service_area
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id asc
+            TopK Limit: 5
+         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[{"heap_filter":"(specialty ~~ 'specialty13%'::text)"}]}},{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[],"recheck_filters":[{"heap_filter":"(service_area && '<(50,50),1>'::circle)"}],"uses_tid_bitmap":true,"bitmap_consumer_id":0}}]}}
+         ->  Bitmap Index Scan on providers_service_area
+               Index Cond: (service_area && '<(50,50),1>'::circle)
+(12 rows)
 
 -- Cost gate: an unselective bitmap is not worth building.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -790,29 +886,6 @@ ROLLBACK;
 -- UNSUPPORTED / TODO SHAPES
 -- Should harvest someday; these goldens flip when the feature lands.
 -- ============================================================================
--- TODO BitmapAnd: both indexes qualify; today only the best-net bitmap is used.
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT id FROM providers
-WHERE description === 'cardiology'
-  AND specialty LIKE 'specialty13%'
-  AND service_area && circle(point(50, 50), 1)
-ORDER BY id LIMIT 5;
-                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit
-   ->  Custom Scan (ParadeDB Base Scan) on providers
-         Table: providers
-         Index: providers_paradedb
-         Bitmap Intersection: providers_service_area
-         Exec Method: TopKScanExecState
-         Scores: false
-            TopK Order By: id asc
-            TopK Limit: 5
-         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[{"heap_filter":"(specialty ~~ 'specialty13%'::text)"}]}},{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[],"recheck_filters":[{"heap_filter":"(service_area && '<(50,50),1>'::circle)"}],"uses_tid_bitmap":true,"bitmap_consumer_id":0}}]}}
-         ->  Bitmap Index Scan on providers_service_area
-               Index Cond: (service_area && '<(50,50),1>'::circle)
-(12 rows)
-
 -- TODO BitmapOr: a fully indexable disjunction; today it stays a heap filter.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM providers

--- a/pg_search/tests/pg_regress/sql/bitmap_intersection.sql
+++ b/pg_search/tests/pg_regress/sql/bitmap_intersection.sql
@@ -235,6 +235,44 @@ EXECUTE radius_search(0);
 DEALLOCATE radius_search;
 RESET plan_cache_mode;
 
+-- BitmapAnd: both predicates are indexable, so both bitmaps are intersected and
+-- both filters move to recheck. Wide rows make the heap fetch expensive enough
+-- that the second bitmap pays for itself.
+CREATE TABLE wide_providers (
+    id BIGINT, description TEXT, cat_a TEXT, cat_b TEXT, filler TEXT
+);
+ALTER TABLE wide_providers ALTER COLUMN filler SET STORAGE PLAIN;
+INSERT INTO wide_providers
+SELECT i, 'cardiology notes ' || i, 'a' || (i % 10), 'b' || (i % 10), repeat('x', 1400)
+FROM generate_series(0, 4999) i;
+CREATE INDEX wide_paradedb ON wide_providers
+    USING bm25 (id, description) WITH (key_field = 'id');
+CREATE INDEX wide_cat_a ON wide_providers (cat_a);
+CREATE INDEX wide_cat_b ON wide_providers (cat_b);
+VACUUM ANALYZE wide_providers;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM wide_providers
+WHERE description === 'cardiology' AND cat_a = 'a3' AND cat_b = 'b3'
+ORDER BY id LIMIT 5;
+SELECT count(*) AS bitmap_and_count FROM (
+    SELECT id FROM wide_providers
+    WHERE description === 'cardiology' AND cat_a = 'a3' AND cat_b = 'b3') q;
+-- Rescan with a BitmapAnd child: freed and rebuilt per outer row, re-seeding
+-- through the BitmapAnd into its first leaf.
+SELECT v.k, s.n FROM (VALUES ('a3'), ('a7')) v(k)
+CROSS JOIN LATERAL (
+    SELECT count(*) AS n FROM wide_providers
+    WHERE description === 'cardiology' AND cat_a = v.k AND cat_b = 'b3') s
+ORDER BY v.k;
+
+-- Parity with the same predicates and no bitmap source available.
+DROP INDEX wide_cat_a;
+DROP INDEX wide_cat_b;
+SELECT count(*) AS bitmap_and_count_no_bitmap FROM (
+    SELECT id FROM wide_providers
+    WHERE description === 'cardiology' AND cat_a = 'a3' AND cat_b = 'b3') q;
+DROP TABLE wide_providers CASCADE;
+
 -- ============================================================================
 -- REJECTED SHAPES
 -- Correct refusals: no Bitmap Intersection, results identical to heap filtering.
@@ -269,6 +307,16 @@ ORDER BY id LIMIT 5;
 SELECT count(*) AS saop_all_count FROM (
     SELECT id FROM providers
     WHERE description === 'cardiology' AND specialty = ALL('{specialty13,specialty13}')) q;
+
+-- Cost gate: both indexes qualify, but the second bitmap only sees what the first
+-- one kept, and on this narrow table those rows are worth less than the index scan
+-- they cost. Only the best net bitmap is used.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM providers
+WHERE description === 'cardiology'
+  AND specialty LIKE 'specialty13%'
+  AND service_area && circle(point(50, 50), 1)
+ORDER BY id LIMIT 5;
 
 -- Cost gate: an unselective bitmap is not worth building.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -349,14 +397,6 @@ ROLLBACK;
 -- UNSUPPORTED / TODO SHAPES
 -- Should harvest someday; these goldens flip when the feature lands.
 -- ============================================================================
-
--- TODO BitmapAnd: both indexes qualify; today only the best-net bitmap is used.
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT id FROM providers
-WHERE description === 'cardiology'
-  AND specialty LIKE 'specialty13%'
-  AND service_area && circle(point(50, 50), 1)
-ORDER BY id LIMIT 5;
 
 -- TODO BitmapOr: a fully indexable disjunction; today it stays a heap filter.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/sql/bitmap_intersection.sql
+++ b/pg_search/tests/pg_regress/sql/bitmap_intersection.sql
@@ -273,6 +273,34 @@ SELECT count(*) AS bitmap_and_count_no_bitmap FROM (
     WHERE description === 'cardiology' AND cat_a = 'a3' AND cat_b = 'b3') q;
 DROP TABLE wide_providers CASCADE;
 
+-- Overlapping clause sets: overlap_ab is the better single bitmap, and overlap_bc
+-- would still look like it pays for itself on top of it. Both answer cat_b, so the
+-- ledger would count that clause's selectivity twice and credit overlap_bc with
+-- rejecting rows overlap_ab already rejected. Sharing a clause disqualifies it.
+CREATE TABLE overlap_providers (
+    id BIGINT, description TEXT, cat_a TEXT, cat_b TEXT, cat_c TEXT, filler TEXT
+);
+ALTER TABLE overlap_providers ALTER COLUMN filler SET STORAGE PLAIN;
+INSERT INTO overlap_providers
+SELECT i, 'cardiology notes ' || i, 'a' || (i % 4), 'b' || ((i / 4) % 2),
+       'c' || ((i / 8) % 2), repeat('x', 1400)
+FROM generate_series(0, 4999) i;
+CREATE INDEX overlap_paradedb ON overlap_providers
+    USING bm25 (id, description) WITH (key_field = 'id');
+CREATE INDEX overlap_ab ON overlap_providers (cat_a, cat_b);
+CREATE INDEX overlap_bc ON overlap_providers (cat_b, cat_c);
+VACUUM ANALYZE overlap_providers;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM overlap_providers
+WHERE description === 'cardiology'
+  AND cat_a = 'a1' AND cat_b = 'b1' AND cat_c = 'c1'
+ORDER BY id LIMIT 5;
+SELECT count(*) AS overlap_clause_count FROM (
+    SELECT id FROM overlap_providers
+    WHERE description === 'cardiology'
+      AND cat_a = 'a1' AND cat_b = 'b1' AND cat_c = 'c1') q;
+DROP TABLE overlap_providers CASCADE;
+
 -- ============================================================================
 -- REJECTED SHAPES
 -- Correct refusals: no Bitmap Intersection, results identical to heap filtering.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6089

## What

`build_bitmap_path` kept only the best net candidate, so a predicate covered by a second index stayed a heap filter. It now scores every candidate, sorts by descending net, and keeps adding while the next bitmap's incremental net stays positive, then combines them with `create_bitmap_and_path`.

## Why

Follow-up to #6088. A second bitmap only rejects rows the first one kept, so when it still pays for itself the scan skips those heap fetches and their filter evaluation.

## How

`ledger` takes the rows that reach a bitmap, so one function scores both the standalone case and the incremental one. An index covering no clause the accepted set already covers is skipped, since a multicolumn index and a single column one over a shared key match the same clause and multiplying their selectivities would count it twice.

`accept()`, the query rewrite, `MultiExecProcNode` and `index_names()` already handled a BitmapAnd child, so this is planner only.

## Tests

New supported case: two indexable predicates on a wide row table. EXPLAIN shows BitmapAnd over both leaves, both filters move to recheck, and results match the same query with the indexes dropped. A lateral rescan covers freeing and re-seeding the bitmap per outer row.

The `TODO BitmapAnd` shape does not flip. Both its predicates take the 0.005 default selectivity and `providers` is narrow, so the first bitmap is modeled as cutting 1000 rows to 5 and the second one's incremental net is -5.84. That is the cost gate working rather than missing coverage, so it moved to the rejected section.

`cargo pgrx regress pg18` 332/332.
