### PR TITLE
chore: Remove post-release bump.

### DIFF
--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -123,13 +123,14 @@ runs:
       shell: bash
       run: cargo pgrx init "--pg${{ inputs.pg_version }}=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
 
-    # Assemble unreleased fragments into an upgrade script so ALTER EXTENSION pg_search UPDATE
-    # can be tested, while preserving the fragment files on disk during the test.
+    # Assemble unreleased fragments into an upgrade script for a synthetic target version so
+    # ALTER EXTENSION pg_search UPDATE can be tested, while preserving the fragment files on disk during the test.
     - name: Assemble SQL Upgrade Scripts
       shell: bash
       run: |
-        VERSION=$(grep "^version" Cargo.toml | head -1 | awk -F '"' '{print $2}')
-        ./scripts/release.sh sql "$VERSION" --preserve-fragments
+        SYNTHETIC_VERSION="999.0.0"
+        ./scripts/release.sh set-version "$SYNTHETIC_VERSION" --skip-nix
+        ./scripts/release.sh sql "$SYNTHETIC_VERSION" --preserve-fragments
 
     - name: Compile & install pg_search
       working-directory: pg_search/

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -364,8 +364,7 @@ def update_version_snippet(repo_root, clean_ver):
     content = dedent(
         f"""\
         // This snippet exports the latest released version of ParadeDB for the documentation site.
-        // Do not edit manually during development: Cargo.toml tracks the unreleased development version,
-        // while this file is updated automatically by release.py upon release.
+        // Do not edit manually: this file is updated automatically by release.py upon release.
         export const version = "{clean_ver}";
         """
     )
@@ -440,17 +439,6 @@ def set_cargo_version(repo_root, version, skip_nix=False):
             subprocess.run(["bash", str(nix_script), "18"], cwd=repo_root, check=True)
 
 
-def compute_next_dev_version(version, branch, is_beta=False):
-    """Compute the next development version string."""
-    clean = clean_version(version)
-    if is_beta:
-        return clean
-    major, minor, patch = parse_semver(clean)
-    if branch == "main":
-        return f"{major}.{minor + 1}.0"
-    return f"{major}.{minor}.{patch + 1}"
-
-
 def check_is_latest(version, is_beta=False):
     """Determine whether a version should be marked as latest release."""
     if is_beta:
@@ -489,7 +477,6 @@ def generate_approval_body(
     sql_dir = repo_root / "pg_search" / "sql"
     prev_ver = resolve_prev_version(repo_root, sql_dir, clean_ver, prev_version)
     is_latest = check_is_latest(target_version, is_beta=False)
-    next_dev = compute_next_dev_version(target_version, branch, is_beta=False)
 
     if branch == "main":
         release_type = "Minor release"
@@ -515,7 +502,6 @@ def generate_approval_body(
         | **Is Latest Release** | {is_latest} |
         | **SQL Upgrade Script** | `pg_search/sql/pg_search--{prev_ver}--{clean_ver}.sql` |
         | **Changelog Document** | `docs/changelog/{clean_ver}.mdx` |
-        | **Post-Release Dev Version** | `{next_dev}` |
         | **Post-Release Action** | {branch_action} |
 
         ---
@@ -539,7 +525,6 @@ def generate_approval_body(
         branch=branch,
         prev_ver=prev_ver,
         is_latest="true" if is_latest else "false",
-        next_dev=next_dev,
         branch_action=branch_action,
         changelog_body=changelog_body,
     ).strip()
@@ -620,13 +605,6 @@ def handle_set_version_command(args, repo_root):
     """Handle set-version subcommand."""
     target_version = detect_target_version(repo_root, args.version)
     set_cargo_version(repo_root, target_version, skip_nix=args.skip_nix)
-
-
-def handle_next_dev_version_command(args, repo_root):
-    """Handle next-dev-version subcommand."""
-    target_version = detect_target_version(repo_root, args.version)
-    next_ver = compute_next_dev_version(target_version, args.branch, is_beta=args.beta)
-    print(next_ver)
 
 
 def handle_is_latest_command(args, repo_root):
@@ -737,22 +715,6 @@ def build_parser():
         help="Skip updating Nix cargo hash",
     )
 
-    next_dev_parser = subparsers.add_parser(
-        "next-dev-version",
-        help="Compute post-release development version",
-    )
-    add_common_args(next_dev_parser)
-    next_dev_parser.add_argument(
-        "--branch",
-        required=True,
-        help="Release branch name (e.g. main or 0.25.x)",
-    )
-    next_dev_parser.add_argument(
-        "--beta",
-        action="store_true",
-        help="Whether this was a beta release",
-    )
-
     is_latest_parser = subparsers.add_parser(
         "is-latest",
         help="Determine if version is latest release",
@@ -800,7 +762,6 @@ def main():
         "changelog": handle_changelog_command,
         "all": handle_all_command,
         "set-version": handle_set_version_command,
-        "next-dev-version": handle_next_dev_version_command,
         "is-latest": handle_is_latest_command,
         "approval-body": handle_approval_body_command,
     }

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -283,31 +283,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Post-Release Development Version Bump
-        if: github.repository == 'paradedb/paradedb' && github.event.inputs.beta != 'true'
-        run: |
-          REF_NAME="${{ github.ref_name }}"
-          if [[ "$REF_NAME" != "main" ]]; then
-            git checkout "$REF_NAME"
-          fi
-
-          NEXT_DEV_VERSION=$(./scripts/release.sh next-dev-version "${{ github.event.inputs.version }}" --branch "$REF_NAME")
-          COMMIT_MSG="chore: Start development of \`${NEXT_DEV_VERSION}\`."
-
-          echo "Bumping ${REF_NAME} to development version ${NEXT_DEV_VERSION}..."
-          ./scripts/release.sh set-version "$NEXT_DEV_VERSION"
-
-          git config user.name "paradedb-github-app[bot]"
-          git config user.email "282009505+paradedb-github-app[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock nix/pg_search.nix
-          if ! git diff --staged --quiet; then
-            git commit -m "$COMMIT_MSG"
-            git push origin HEAD:"$REF_NAME"
-            echo "✅ Successfully bumped ${REF_NAME} to ${NEXT_DEV_VERSION}."
-          else
-            echo "No development bump needed."
-          fi
-
       - name: Notify Slack on Failure
         if: failure()
         uses: paradedb/actions/slack-alert@v10

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -45,24 +45,22 @@ jobs:
         id: compute
         run: |
           set -euo pipefail
-          CURRENT=$(grep "^version" Cargo.toml | head -1 | awk -F '"' '{print $2}')
-          TAGS=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
-          SORTED=$(printf "%s\nv%s\n" "$TAGS" "$CURRENT" | sort -V -u)
-          PRIOR=$(echo "$SORTED" | awk -v cur="v$CURRENT" 'prev != "" && $0 == cur { print prev; exit } { prev = $0 }')
-          if [ -z "$PRIOR" ]; then
-            echo "Could not determine prior version for current=$CURRENT" >&2
+          TAGS=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
+          LATEST_TAG=$(echo "$TAGS" | tail -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "Could not determine latest tag" >&2
             exit 1
           fi
-          PRIOR_PGRX=$(git show "$PRIOR:Cargo.toml" | sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' | head -1)
-          if [ -z "$PRIOR_PGRX" ]; then
-            echo "Could not determine pgrx version at $PRIOR" >&2
+          LATEST_PGRX=$(git show "$LATEST_TAG:Cargo.toml" | sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' | head -1)
+          if [ -z "$LATEST_PGRX" ]; then
+            echo "Could not determine pgrx version at $LATEST_TAG" >&2
             exit 1
           fi
-          echo "Resolved prior=$PRIOR pgrx=$PRIOR_PGRX (current=$CURRENT)"
+          echo "Resolved latest tag=$LATEST_TAG pgrx=$LATEST_PGRX"
 
           # v0.21.0 is the first pg_search version with Postgres 18 support.
-          # Dedup in case the dynamic prior happens to also be v0.21.0.
-          MATRIX=$(jq -nc --arg p "$PRIOR" --arg pgrx "$PRIOR_PGRX" '[
+          # Dedup in case the latest tag happens to also be v0.21.0.
+          MATRIX=$(jq -nc --arg p "$LATEST_TAG" --arg pgrx "$LATEST_PGRX" '[
             { "pg_search_version": "v0.21.0", "pgrx_version": "0.16.1" },
             { "pg_search_version": $p, "pgrx_version": $pgrx }
           ] | unique_by(.pg_search_version)')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "benchmarks"
-version = "0.26.0"
+version = "0.25.6"
 dependencies = [
  "anyhow",
  "approx",
@@ -2753,7 +2753,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dst"
-version = "0.26.0"
+version = "0.25.6"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.26.0"
+version = "0.25.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.26.0"
+version = "0.25.6"
 dependencies = [
  "antithesis-instrumentation",
  "anyhow",
@@ -6944,7 +6944,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.26.0"
+version = "0.25.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -7342,7 +7342,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.26.0"
+version = "0.25.6"
 dependencies = [
  "anyhow",
  "approx",
@@ -7506,7 +7506,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.26.0"
+version = "0.25.6"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["pg_search", "tokenizers"]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.25.6"
 edition = "2024"
 license = "AGPL-3.0"
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,7 +55,6 @@ To publish a minor release from `main`:
    - Upon approval (by commenting `approved` on the issue), commit and push the release commit to `main`.
    - Create the Git tag `v<version>`, triggering downstream packaging and publishing workflows.
    - Create the stable branch `x.y.x` pointing at the release commit.
-   - Bump `main` to the next development version (e.g., `0.27.0`).
 
 ### Beta (RC) Releases
 
@@ -94,7 +93,7 @@ After executing the community release, executing an enterprise release involves:
 
 For a minor release (e.g. `0.22.0`):
 
-1. Manually trigger a rebase such that the community release commit (e.g. `chore: Prepare 0.22.0.`) has been synced to `origin/main`, but the post-release version bump commit has **not** been synced.
+1. Manually trigger a rebase or community sync such that the community release commit (e.g. `chore: Prepare 0.22.0.`) has been synced to `origin/main`.
 2. Trigger a release on `main` using the [**Publish GitHub Release** workflow](https://github.com/paradedb/paradedb/actions/workflows/publish-github-release.yml).
 3. The workflow will automatically:
    - Open a manual approval issue for `@pg_search-maintainers`.
@@ -110,12 +109,12 @@ Trigger the [**Publish GitHub Release** workflow](https://github.com/paradedb/pa
 
 For a patch release (e.g. `0.22.2`), stable branches should already exist in both `paradedb/paradedb` and `paradedb/paradedb-enterprise` with the same name (e.g. `0.22.x`).
 
-After executing the community release, you should "sync" all new commits on the community stable branch to the enterprise stable branch:
+After executing the community release, you should sync all new commits on the community stable branch to the enterprise stable branch:
 
 1. Create a sync branch from the enterprise stable branch:
    - Something like: `git checkout -b sync-0.22.2 origin/0.22.x` (where `origin` is your enterprise remote)
 2. Cherry-pick all new commits from the community stable branch into your sync branch:
-   - Something like `git cherry-pick abc0123...upstream/0.22.x` (where `upstream` is your community remote)
+   - Something like `git cherry-pick <prev_commit>...upstream/0.22.x` (where `upstream` is your community remote)
 3. Open a PR for your sync branch on enterprise, targeted at the stable branch, and get it reviewed.
 4. Land the PR with `Rebase and Merge`, then trigger a release on the stable branch using the [**Publish GitHub Release** workflow](https://github.com/paradedb/paradedb/actions/workflows/publish-github-release.yml).
 

--- a/docs/snippets/version.mdx
+++ b/docs/snippets/version.mdx
@@ -1,4 +1,3 @@
 // This snippet exports the latest released version of ParadeDB for the documentation site.
-// Do not edit manually during development: Cargo.toml tracks the unreleased development version,
-// while this file is updated automatically by release.py upon release.
+// Do not edit manually: this file is updated automatically by release.py upon release.
 export const version = "0.25.6";

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-Rtogp7WOnilNewKDV+aQmhdn+hOAlPOYXgepp+B7ipw=";
+  cargoHash = "sha256-1hb8BiWhG4iRKWYGKCsh9i8d8wKm2N4UawaN7O17aCE=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
The post-release bump of the version was an unnecessary artifact of using `Cargo.toml` to drive the upgrade script testing.

By using a synthetic version to test upgrades, we can remove one commit and a bunch of complexity from the process.