### PR TITLE
fix: preserve score placeholders through filtered Top-K plans

### DIFF
--- a/pg_search/src/postgres/customscan/projections.rs
+++ b/pg_search/src/postgres/customscan/projections.rs
@@ -287,16 +287,19 @@ unsafe fn make_placeholder_const_from_funcexpr(
 }
 
 /// Walker callback for [`expression_tree_walker`] that returns `true` (abort)
-/// when it encounters a join context.
+/// when it encounters a join or retained filter sublink context.
 #[pg_guard]
-unsafe extern "C-unwind" fn find_join_expr_walker(
+unsafe extern "C-unwind" fn find_join_or_sublink_walker(
     node: *mut pg_sys::Node,
     _context: *mut std::ffi::c_void,
 ) -> bool {
     if node.is_null() {
         return false;
     }
-    if (*node).type_ == pg_sys::NodeTag::T_JoinExpr {
+    if matches!(
+        (*node).type_,
+        pg_sys::NodeTag::T_JoinExpr | pg_sys::NodeTag::T_SubLink
+    ) {
         return true;
     }
     // Comma joins are a `FromExpr` with multiple fromlist entries and no
@@ -308,7 +311,7 @@ unsafe extern "C-unwind" fn find_join_expr_walker(
     {
         return true;
     }
-    expression_tree_walker(node, Some(find_join_expr_walker), _context)
+    expression_tree_walker(node, Some(find_join_or_sublink_walker), _context)
 }
 
 #[pg_extern(immutable, parallel_safe)]
@@ -317,6 +320,7 @@ pub unsafe fn placeholder_support(arg: Internal) -> ReturnedNodePointer {
     // node in a `PlaceHolderVar`. This ensures that Postgres won't lose the scores when they're
     // emitted by our custom scan from underneath:
     // - JOIN nodes (Hash Join, Merge Join, etc.)
+    // - SubPlan nodes (retained filter sublinks)
     // - Gather nodes (parallel aggregation)
     //
     // Without PlaceHolderVar, PostgreSQL may decide to re-evaluate the score function at a higher
@@ -334,17 +338,18 @@ pub unsafe fn placeholder_support(arg: Internal) -> ReturnedNodePointer {
         let root = (*srs).root;
         let has_aggs = !(*root).parse.is_null() && (*(*root).parse).hasAggs;
 
-        // We walk the jointree instead of checking hasJoinRTEs because
+        // We walk the jointree instead of checking hasJoinRTEs/hasSubLinks because
         // anti/semi-joins (from NOT EXISTS/EXISTS sublinks pulled up by
-        // pull_up_sublinks) create JoinExpr nodes without setting hasJoinRTEs.
-        let has_joins = !(*root).parse.is_null()
-            && find_join_expr_walker(
+        // pull_up_sublinks) create JoinExpr nodes without setting hasJoinRTEs,
+        // while retained filter sublinks remain as SubLink nodes in jointree quals.
+        let has_joins_or_sublinks = !(*root).parse.is_null()
+            && find_join_or_sublink_walker(
                 (*(*root).parse).jointree as *mut pg_sys::Node,
                 std::ptr::null_mut(),
             );
 
-        if !has_joins && !has_aggs {
-            // No joins and no aggregates - PlaceHolderVar provides no benefit
+        if !has_joins_or_sublinks && !has_aggs {
+            // No joins, sublinks, or aggregates - PlaceHolderVar provides no benefit
             return ReturnedNodePointer(None);
         }
 

--- a/pg_search/tests/pg_regress/expected/issue_6022.out
+++ b/pg_search/tests/pg_regress/expected/issue_6022.out
@@ -1,0 +1,193 @@
+-- Regression test for #6022: preserve paradedb.score() through filtered Top-K
+-- plans regardless of whether PostgreSQL uses a join, semi-join, or SubPlan.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS issue_6022_filters CASCADE;
+DROP TABLE IF EXISTS issue_6022_documents CASCADE;
+CREATE TABLE issue_6022_documents (
+    id bigint PRIMARY KEY,
+    body text NOT NULL
+);
+CREATE TABLE issue_6022_filters (
+    document_id bigint NOT NULL REFERENCES issue_6022_documents(id),
+    selected boolean NOT NULL
+);
+INSERT INTO issue_6022_documents (id, body) VALUES
+    (1, 'keyboard keyboard keyboard'),
+    (2, 'keyboard keyboard'),
+    (3, 'keyboard'),
+    (4, 'keyboard mouse'),
+    (5, 'keyboard monitor'),
+    (6, 'keyboard'),
+    (7, 'mouse only'),
+    (8, 'monitor only');
+INSERT INTO issue_6022_filters (document_id, selected)
+SELECT id, id BETWEEN 2 AND 6
+FROM issue_6022_documents;
+CREATE INDEX issue_6022_documents_bm25 ON issue_6022_documents
+USING paradedb (id, body) WITH (key_field = 'id');
+ANALYZE issue_6022_documents;
+ANALYZE issue_6022_filters;
+-- Single-relation control: the no-placeholder fast path remains valid.
+CREATE TEMP TABLE issue_6022_expected_scores AS
+SELECT id, paradedb.score(id) AS score
+FROM issue_6022_documents
+WHERE id @@@ paradedb.match('body', 'keyboard')
+ORDER BY paradedb.score(id) DESC, id
+LIMIT 6;
+SELECT array_agg(id ORDER BY score DESC, id) AS ids,
+       bool_and(score > 0) AS scores_computed
+FROM (
+    SELECT *
+    FROM issue_6022_expected_scores
+    ORDER BY score DESC, id
+    LIMIT 3
+) AS top_three;
+   ids   | scores_computed 
+---------+-----------------
+ {1,2,3} | t
+(1 row)
+
+-- Explicit derived INNER JOIN.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+INNER JOIN (
+    SELECT DISTINCT document_id
+    FROM issue_6022_filters
+    WHERE selected
+) AS f ON f.document_id = d.id
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+   ids   | scores_match 
+---------+--------------
+ {2,3,6} | t
+(1 row)
+
+DROP TABLE issue_6022_actual;
+-- Pull-up eligible IN filter.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND d.id IN (
+      SELECT document_id
+      FROM issue_6022_filters
+      WHERE selected
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+   ids   | scores_match 
+---------+--------------
+ {2,3,6} | t
+(1 row)
+
+DROP TABLE issue_6022_actual;
+-- LIMIT ALL keeps the equivalent IN filter as a sublink/subplan.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND d.id IN (
+      SELECT document_id
+      FROM issue_6022_filters
+      WHERE selected
+      LIMIT ALL
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+   ids   | scores_match 
+---------+--------------
+ {2,3,6} | t
+(1 row)
+
+DROP TABLE issue_6022_actual;
+-- Correlated EXISTS may be represented as a pulled-up semi-join.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND EXISTS (
+      SELECT 1
+      FROM issue_6022_filters AS f
+      WHERE f.document_id = d.id
+        AND f.selected
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+   ids   | scores_match 
+---------+--------------
+ {2,3,6} | t
+(1 row)
+
+DROP TABLE issue_6022_actual;
+-- Increase related-table cardinality without changing the qualifying document
+-- set, then repeat the vulnerable retained-sublink and semi-join forms.
+INSERT INTO issue_6022_filters (document_id, selected)
+SELECT d.id, true
+FROM issue_6022_documents AS d
+CROSS JOIN generate_series(1, 100)
+WHERE d.id BETWEEN 2 AND 6;
+ANALYZE issue_6022_filters;
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND d.id IN (
+      SELECT document_id
+      FROM issue_6022_filters
+      WHERE selected
+      LIMIT ALL
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+   ids   | scores_match 
+---------+--------------
+ {2,3,6} | t
+(1 row)
+
+DROP TABLE issue_6022_actual;
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND EXISTS (
+      SELECT 1
+      FROM issue_6022_filters AS f
+      WHERE f.document_id = d.id
+        AND f.selected
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+   ids   | scores_match 
+---------+--------------
+ {2,3,6} | t
+(1 row)
+
+DROP TABLE issue_6022_actual;
+DROP TABLE IF EXISTS issue_6022_filters CASCADE;
+DROP TABLE IF EXISTS issue_6022_documents CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_6022.sql
+++ b/pg_search/tests/pg_regress/sql/issue_6022.sql
@@ -1,0 +1,189 @@
+-- Regression test for #6022: preserve paradedb.score() through filtered Top-K
+-- plans regardless of whether PostgreSQL uses a join, semi-join, or SubPlan.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS issue_6022_filters CASCADE;
+DROP TABLE IF EXISTS issue_6022_documents CASCADE;
+
+CREATE TABLE issue_6022_documents (
+    id bigint PRIMARY KEY,
+    body text NOT NULL
+);
+
+CREATE TABLE issue_6022_filters (
+    document_id bigint NOT NULL REFERENCES issue_6022_documents(id),
+    selected boolean NOT NULL
+);
+
+INSERT INTO issue_6022_documents (id, body) VALUES
+    (1, 'keyboard keyboard keyboard'),
+    (2, 'keyboard keyboard'),
+    (3, 'keyboard'),
+    (4, 'keyboard mouse'),
+    (5, 'keyboard monitor'),
+    (6, 'keyboard'),
+    (7, 'mouse only'),
+    (8, 'monitor only');
+
+INSERT INTO issue_6022_filters (document_id, selected)
+SELECT id, id BETWEEN 2 AND 6
+FROM issue_6022_documents;
+
+CREATE INDEX issue_6022_documents_bm25 ON issue_6022_documents
+USING paradedb (id, body) WITH (key_field = 'id');
+
+ANALYZE issue_6022_documents;
+ANALYZE issue_6022_filters;
+
+-- Single-relation control: the no-placeholder fast path remains valid.
+CREATE TEMP TABLE issue_6022_expected_scores AS
+SELECT id, paradedb.score(id) AS score
+FROM issue_6022_documents
+WHERE id @@@ paradedb.match('body', 'keyboard')
+ORDER BY paradedb.score(id) DESC, id
+LIMIT 6;
+
+SELECT array_agg(id ORDER BY score DESC, id) AS ids,
+       bool_and(score > 0) AS scores_computed
+FROM (
+    SELECT *
+    FROM issue_6022_expected_scores
+    ORDER BY score DESC, id
+    LIMIT 3
+) AS top_three;
+
+-- Explicit derived INNER JOIN.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+INNER JOIN (
+    SELECT DISTINCT document_id
+    FROM issue_6022_filters
+    WHERE selected
+) AS f ON f.document_id = d.id
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+
+DROP TABLE issue_6022_actual;
+
+-- Pull-up eligible IN filter.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND d.id IN (
+      SELECT document_id
+      FROM issue_6022_filters
+      WHERE selected
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+
+DROP TABLE issue_6022_actual;
+
+-- LIMIT ALL keeps the equivalent IN filter as a sublink/subplan.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND d.id IN (
+      SELECT document_id
+      FROM issue_6022_filters
+      WHERE selected
+      LIMIT ALL
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+
+DROP TABLE issue_6022_actual;
+
+-- Correlated EXISTS may be represented as a pulled-up semi-join.
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND EXISTS (
+      SELECT 1
+      FROM issue_6022_filters AS f
+      WHERE f.document_id = d.id
+        AND f.selected
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+
+DROP TABLE issue_6022_actual;
+
+-- Increase related-table cardinality without changing the qualifying document
+-- set, then repeat the vulnerable retained-sublink and semi-join forms.
+INSERT INTO issue_6022_filters (document_id, selected)
+SELECT d.id, true
+FROM issue_6022_documents AS d
+CROSS JOIN generate_series(1, 100)
+WHERE d.id BETWEEN 2 AND 6;
+
+ANALYZE issue_6022_filters;
+
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND d.id IN (
+      SELECT document_id
+      FROM issue_6022_filters
+      WHERE selected
+      LIMIT ALL
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+
+DROP TABLE issue_6022_actual;
+
+CREATE TEMP TABLE issue_6022_actual AS
+SELECT d.id, paradedb.score(d.id) AS score
+FROM issue_6022_documents AS d
+WHERE d.id @@@ paradedb.match('body', 'keyboard')
+  AND EXISTS (
+      SELECT 1
+      FROM issue_6022_filters AS f
+      WHERE f.document_id = d.id
+        AND f.selected
+  )
+ORDER BY paradedb.score(d.id) DESC, d.id
+LIMIT 3;
+
+SELECT array_agg(a.id ORDER BY a.score DESC, a.id) AS ids,
+       bool_and(a.score = e.score) AS scores_match
+FROM issue_6022_actual AS a
+JOIN issue_6022_expected_scores AS e USING (id);
+
+DROP TABLE issue_6022_actual;
+
+DROP TABLE IF EXISTS issue_6022_filters CASCADE;
+DROP TABLE IF EXISTS issue_6022_documents CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6022

## What

Extend the existing query-shape detection in `projections.rs` so a score call used by a query containing a filter sublink receives the same `PlaceHolderVar` protection already applied for explicit joins, comma joins, and aggregates. Keep the placeholder anchored to the score argument's base relation so the ParadeDB base scan replaces it with the computed score and PostgreSQL carries that value through semi-join/subplan, sort, and limit nodes instead of re-invoking the SQL function. Preserve the no-wrapper fast path for genuinely single-relation queries with no aggregate, join, or sublink, and make the detection structural rather than matching the issue's SQL text or a particular planner node chosen at one cardinality.

A filtered BM25 Top-K query can allow `paradedb.score()` to survive past the ParadeDB custom scan and execute its intentional unsupported-shape fallback. The failure depends on whether PostgreSQL represents an equivalent related-table filter as an explicit join, a pulled-up semi-join, or a retained sublink/subplan, so cardinality and statistics can change whether otherwise identical application SQL succeeds. The shared `placeholder_support` hook currently protects joins and aggregates by wrapping score expressions in a `PlaceHolderVar`, but its query-shape walk does not explicitly classify retained sublinks as contexts that can evaluate the expression above the scan. The issue is open and unassigned, with no linked prior attempt or competing PR in the supplied bundle.

## Why

Extend the existing query-shape detection in `projections.rs` so a score call used by a query containing a filter sublink receives the same `PlaceHolderVar` protection already applied for explicit joins, comma joins, and aggregates. Keep the placeholder anchored to the score argument's base relation so the ParadeDB base scan replaces it with the computed score and PostgreSQL carries that value through semi-join/subplan, sort, and limit nodes instead of re-invoking the SQL function. Preserve the no-wrapper fast path for genuinely single-relation queries with no aggregate, join, or sublink, and make the detection structural rather than matching the issue's SQL text or a particular planner node chosen at one cardinality.

## How

Not applicable to this change.

## Tests

Run the filtered BM25 query through an explicit derived `INNER JOIN`; `paradedb.score()` is supplied by the custom scan, the query completes without the unsupported-shape error, and the expected Top-K IDs and scores are returned in deterministic order.
Run semantically equivalent `IN (subquery)` and `IN (subquery LIMIT ALL)` filters over the same related-table rows; both complete and return the same Top-K result set as the join form even when one filter remains a subplan.
Run the correlated `EXISTS` form and verify it returns the same ordered IDs and scores, covering the planner's semi-join representation.
Vary the related-table filter cardinality within the fixture and repeat the vulnerable forms; changing the selected plan must not change whether the score placeholder is replaced or alter the Top-K candidate set.
Retain a simple single-table score-ordered query in the regression as a control, confirming the existing no-join behavior and deterministic score ordering remain unchanged.

AI was used for assistance.
