### PR TITLE
fix: estimate STABLE search expressions at plan time

### DIFF
--- a/docs/changelog/unreleased/6152.bugfix.mdx
+++ b/docs/changelog/unreleased/6152.bugfix.mdx
@@ -1,0 +1,5 @@
+---
+header: performance
+---
+
+Search predicates whose right-hand side is a `STABLE` expression, such as a row-level security policy's `id @@@ my_query_function()` or a `current_setting(...)` cast, are now folded with `estimate_expression_value()` at plan time for selectivity estimation, so the custom scan is chosen with a real row estimate instead of losing to a plain index scan whenever the query has additional predicates.

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -383,7 +383,22 @@ pub fn query_input_restrict(
                     estimate_selectivity(&indexrel, search_query_input)
                 }
                 pg_sys::NodeTag::T_Param => Some(PARAMETERIZED_SELECTIVITY),
-                _ => None,
+                _ => {
+                    // The RHS is neither a Const nor a Param: typically a STABLE function
+                    // call that is solved at execution time, such as an RLS policy's
+                    // `id @@@ acl.rls_query()` or `current_setting(...)::searchqueryinput`.
+                    // For estimation, fold it the way core's restriction estimators do in
+                    // `get_restriction_variable()`: `estimate_expression_value()` evaluates
+                    // STABLE functions at plan time for costing purposes only. An expression
+                    // that still does not fold keeps UNKNOWN_SELECTIVITY.
+                    let estimated = pg_sys::estimate_expression_value(info, rhs);
+                    let const_ = nodecast!(Const, T_Const, estimated)?;
+                    let (heaprelid, _, _) = find_var_relation(var, info);
+                    let indexrel = rel_get_bm25_index(heaprelid)?.1;
+                    let search_query_input =
+                        SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
+                    estimate_selectivity(&indexrel, search_query_input)
+                }
             }
         }
     }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -881,8 +881,21 @@ impl CustomScan for BaseScan {
                 // relation are visible) then we end up returning *everything* from _this_ relation
                 FULL_RELATION_SELECTIVITY
             } else if quals.contains_exprs() {
-                // if the query has expressions then it's parameterized and we have to guess something
-                PARAMETERIZED_SELECTIVITY
+                // The query contains expressions that are solved at execution time: a STABLE
+                // function call such as an RLS policy's `id @@@ acl.rls_query()`, or
+                // `current_setting(...)`. For estimation only, fold them the way core does for
+                // STABLE functions (`estimate_expression_value()`) and ask the index with the
+                // folded query. Anything that does not fold (a true runtime Param) keeps the
+                // parameterized guess. Execution still solves the original expressions at scan
+                // start, so a cached plan never carries a folded value.
+                match fold_postgres_expressions_for_estimation(root, &query) {
+                    Some(folded) => {
+                        let (sel, cost) = estimate_selectivity_and_cost(&bm25_index, folded);
+                        precomputed_query_cost = cost;
+                        sel.unwrap_or(PARAMETERIZED_SELECTIVITY)
+                    }
+                    None => PARAMETERIZED_SELECTIVITY,
+                }
             } else {
                 // Ask the index. This is the one branch that opens, so reuse that same
                 // open's cost for the TopK worker decision instead of opening twice.
@@ -3075,4 +3088,45 @@ unsafe fn where_clause_only_references_left(
 
     // If walker returns true, it found a reference to another relation
     !walker(quals, &rti as *const _ as *mut _)
+}
+
+/// A copy of `query` for selectivity estimation, with every `PostgresExpression` replaced by
+/// the value Postgres's `estimate_expression_value()` folds it to at plan time.
+///
+/// `estimate_expression_value()` evaluates STABLE functions (an RLS policy's query-returning
+/// function, `current_setting(...)`) for costing purposes only, the same way core's restriction
+/// estimators treat `col = stable_fn()`. Returns `None` if any expression does not fold to a
+/// non-null `Const`, or if the query carries a heap filter (which needs an executor expression
+/// context), in which case the caller keeps its parameterized guess. The returned query must
+/// never be used for execution: the original expressions are solved at scan start.
+unsafe fn fold_postgres_expressions_for_estimation(
+    root: *mut pg_sys::PlannerInfo,
+    query: &SearchQueryInput,
+) -> Option<SearchQueryInput> {
+    let mut folded = query.clone();
+    let mut all_folded = true;
+    folded.visit(&mut |sqi| {
+        if !all_folded {
+            return;
+        }
+        match sqi {
+            SearchQueryInput::PostgresExpression { expr } => {
+                let resolved = unsafe {
+                    let estimated = pg_sys::estimate_expression_value(root, expr.node());
+                    nodecast!(Const, T_Const, estimated).and_then(|const_| {
+                        SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)
+                    })
+                };
+                match resolved {
+                    Some(resolved) => *sqi = resolved,
+                    None => all_folded = false,
+                }
+            }
+            // A heap filter runs against heap tuples with an executor expression context,
+            // which the estimator does not have at plan time. Keep the parameterized guess.
+            SearchQueryInput::HeapFilter { .. } => all_folded = false,
+            _ => {}
+        }
+    });
+    all_folded.then_some(folded)
 }

--- a/pg_search/tests/pg_regress/expected/issue_6151.out
+++ b/pg_search/tests/pg_regress/expected/issue_6151.out
@@ -1,0 +1,122 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- A STABLE expression on the right-hand side of @@@ (the shape a row-level
+-- security policy produces) is solved at execution time, but it must also be
+-- estimated at plan time, so that the custom scan competes on real numbers
+-- when the query has more than one qual. See issue #6151.
+CREATE TABLE issue_6151 (
+    id bigint PRIMARY KEY,
+    tenant text,
+    body text
+);
+INSERT INTO issue_6151
+SELECT g,
+       CASE WHEN g <= 100 THEN 'alpha' ELSE 'beta' END,
+       'lorem ipsum ' || g
+FROM generate_series(1, 10000) g;
+CREATE INDEX issue_6151_idx
+ON issue_6151 USING paradedb (id, ((tenant)::pdb.literal), body)
+WITH (key_field = 'id');
+ANALYZE issue_6151;
+-- The tenant filter arrives through a STABLE function reading session state,
+-- exactly as an RLS policy's USING clause would deliver it.
+CREATE FUNCTION issue_6151_tenant_query() RETURNS paradedb.searchqueryinput AS $$
+  SELECT paradedb.term('tenant', current_setting('issue_6151.tenant'))
+$$ LANGUAGE sql STABLE;
+CREATE FUNCTION issue_6151_plan_uses(q text, needle text) RETURNS boolean AS $$
+DECLARE r record;
+BEGIN
+  FOR r IN EXECUTE 'EXPLAIN (COSTS OFF) ' || q LOOP
+    IF r."QUERY PLAN" LIKE '%' || needle || '%' THEN RETURN true; END IF;
+  END LOOP;
+  RETURN false;
+END $$ LANGUAGE plpgsql;
+SET issue_6151.tenant = 'alpha';
+-- Two quals, one of them the STABLE expression: the estimator folds the
+-- expression, and the custom scan wins over the plain index scan.
+SELECT issue_6151_plan_uses(
+  $$SELECT id FROM issue_6151
+    WHERE id @@@ issue_6151_tenant_query() AND body @@@ 'lorem'$$,
+  'ParadeDB Base Scan') AS multi_qual_uses_custom_scan;
+ multi_qual_uses_custom_scan 
+-----------------------------
+ t
+(1 row)
+
+SELECT count(*) FROM issue_6151
+WHERE id @@@ issue_6151_tenant_query() AND body @@@ 'lorem';
+ count 
+-------
+   100
+(1 row)
+
+-- A single expression qual keeps the custom scan.
+SELECT issue_6151_plan_uses(
+  $$SELECT id FROM issue_6151 WHERE id @@@ issue_6151_tenant_query()$$,
+  'ParadeDB Base Scan') AS single_qual_uses_custom_scan;
+ single_qual_uses_custom_scan 
+------------------------------
+ t
+(1 row)
+
+-- The fold is for estimation only: nothing folded may be cached in a plan, so
+-- a prepared statement must follow the session state on every execution, also
+-- once a generic plan becomes possible after the fifth execution.
+PREPARE issue_6151_count AS
+SELECT count(*) FROM issue_6151
+WHERE id @@@ issue_6151_tenant_query() AND body @@@ 'lorem';
+EXECUTE issue_6151_count;
+ count 
+-------
+   100
+(1 row)
+
+EXECUTE issue_6151_count;
+ count 
+-------
+   100
+(1 row)
+
+EXECUTE issue_6151_count;
+ count 
+-------
+   100
+(1 row)
+
+EXECUTE issue_6151_count;
+ count 
+-------
+   100
+(1 row)
+
+EXECUTE issue_6151_count;
+ count 
+-------
+   100
+(1 row)
+
+EXECUTE issue_6151_count;
+ count 
+-------
+   100
+(1 row)
+
+SET issue_6151.tenant = 'beta';
+EXECUTE issue_6151_count;
+ count 
+-------
+  9900
+(1 row)
+
+DEALLOCATE issue_6151_count;
+-- An expression qual combined with a heap filter keeps the parameterized
+-- guess (a heap filter needs an executor expression context that does not
+-- exist at plan time) and must plan and run without error.
+SELECT count(*) FROM issue_6151
+WHERE id @@@ issue_6151_tenant_query() AND length(body) > 15;
+ count 
+-------
+  9001
+(1 row)
+
+DROP FUNCTION issue_6151_tenant_query(), issue_6151_plan_uses(text, text);
+DROP TABLE issue_6151;

--- a/pg_search/tests/pg_regress/sql/issue_6151.sql
+++ b/pg_search/tests/pg_regress/sql/issue_6151.sql
@@ -1,0 +1,79 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- A STABLE expression on the right-hand side of @@@ (the shape a row-level
+-- security policy produces) is solved at execution time, but it must also be
+-- estimated at plan time, so that the custom scan competes on real numbers
+-- when the query has more than one qual. See issue #6151.
+
+CREATE TABLE issue_6151 (
+    id bigint PRIMARY KEY,
+    tenant text,
+    body text
+);
+INSERT INTO issue_6151
+SELECT g,
+       CASE WHEN g <= 100 THEN 'alpha' ELSE 'beta' END,
+       'lorem ipsum ' || g
+FROM generate_series(1, 10000) g;
+
+CREATE INDEX issue_6151_idx
+ON issue_6151 USING paradedb (id, ((tenant)::pdb.literal), body)
+WITH (key_field = 'id');
+ANALYZE issue_6151;
+
+-- The tenant filter arrives through a STABLE function reading session state,
+-- exactly as an RLS policy's USING clause would deliver it.
+CREATE FUNCTION issue_6151_tenant_query() RETURNS paradedb.searchqueryinput AS $$
+  SELECT paradedb.term('tenant', current_setting('issue_6151.tenant'))
+$$ LANGUAGE sql STABLE;
+
+CREATE FUNCTION issue_6151_plan_uses(q text, needle text) RETURNS boolean AS $$
+DECLARE r record;
+BEGIN
+  FOR r IN EXECUTE 'EXPLAIN (COSTS OFF) ' || q LOOP
+    IF r."QUERY PLAN" LIKE '%' || needle || '%' THEN RETURN true; END IF;
+  END LOOP;
+  RETURN false;
+END $$ LANGUAGE plpgsql;
+
+SET issue_6151.tenant = 'alpha';
+
+-- Two quals, one of them the STABLE expression: the estimator folds the
+-- expression, and the custom scan wins over the plain index scan.
+SELECT issue_6151_plan_uses(
+  $$SELECT id FROM issue_6151
+    WHERE id @@@ issue_6151_tenant_query() AND body @@@ 'lorem'$$,
+  'ParadeDB Base Scan') AS multi_qual_uses_custom_scan;
+
+SELECT count(*) FROM issue_6151
+WHERE id @@@ issue_6151_tenant_query() AND body @@@ 'lorem';
+
+-- A single expression qual keeps the custom scan.
+SELECT issue_6151_plan_uses(
+  $$SELECT id FROM issue_6151 WHERE id @@@ issue_6151_tenant_query()$$,
+  'ParadeDB Base Scan') AS single_qual_uses_custom_scan;
+
+-- The fold is for estimation only: nothing folded may be cached in a plan, so
+-- a prepared statement must follow the session state on every execution, also
+-- once a generic plan becomes possible after the fifth execution.
+PREPARE issue_6151_count AS
+SELECT count(*) FROM issue_6151
+WHERE id @@@ issue_6151_tenant_query() AND body @@@ 'lorem';
+EXECUTE issue_6151_count;
+EXECUTE issue_6151_count;
+EXECUTE issue_6151_count;
+EXECUTE issue_6151_count;
+EXECUTE issue_6151_count;
+EXECUTE issue_6151_count;
+SET issue_6151.tenant = 'beta';
+EXECUTE issue_6151_count;
+DEALLOCATE issue_6151_count;
+
+-- An expression qual combined with a heap filter keeps the parameterized
+-- guess (a heap filter needs an executor expression context that does not
+-- exist at plan time) and must plan and run without error.
+SELECT count(*) FROM issue_6151
+WHERE id @@@ issue_6151_tenant_query() AND length(body) > 15;
+
+DROP FUNCTION issue_6151_tenant_query(), issue_6151_plan_uses(text, text);
+DROP TABLE issue_6151;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6151

## What

Give search quals whose right-hand side is a STABLE expression (the shape an RLS policy's `USING (id @@@ acl.rls_query())` produces, or `current_setting(...)` casts) a real selectivity estimate, so the custom scan competes on real numbers instead of losing to the plain index scan whenever the query has more than one qual.

## Why

Execution already handles these expressions well: they are solved once at scan start as a `postgres_expression` node. Planning did not: `query_input_restrict` returned `UNKNOWN_SELECTIVITY` (1e-5) for any RHS that is neither `Const` nor `Param`, and the base scan's custom path fell back to `PARAMETERIZED_SELECTIVITY` (10 percent) as soon as `restrict_info.len() > 1` and the quals contained an expression. The index scan then won on cost (estimating one row against the custom scan's 10 percent of the table), and the query lost columnar execution, Top-K, aggregate and join pushdown, and bitmap intersection. With only the expression qual the custom scan was chosen, but with the 1e-5 guess, which misleads join planning. Details and reproduction in #6151.

## How

Fold the expression with PostgreSQL's `estimate_expression_value()`, which evaluates STABLE functions at plan time for costing purposes only; core's restriction estimators give the non-Var side of a clause the same treatment in `get_restriction_variable()`.

- `query_input_restrict` (`api/operator/searchqueryinput.rs`): for an RHS that is neither `Const` nor `Param`, fold it; when it folds to a `Const`, estimate the selectivity by opening the index, exactly as for a literal. Otherwise keep returning `UNKNOWN_SELECTIVITY`.
- Base scan custom path (`customscan/basescan/mod.rs`): in the `contains_exprs()` branch, ask the index with an estimation-only copy of the `SearchQueryInput` in which every `PostgresExpression` is replaced by its folded value. When any expression does not fold (a true runtime `Param`), or when the query carries a `HeapFilter` (it needs an executor expression context that does not exist at plan time), keep `PARAMETERIZED_SELECTIVITY`.

The folded copy is never executed: `custom_private` still receives the original query, so the scan solves the expressions at scan start as before. Nothing folded is stored in any plan, so prepared statements keep following session-state changes.

## Tests

New pg_regress test `issue_6151`:

- asserts the custom scan is chosen for `id @@@ stable_fn() AND body @@@ 'term'` (fails on `main`, where this plans as an index scan) and for the single-qual shape;
- runs a named prepared statement seven times across a change of the session setting the STABLE function reads, asserting the row counts follow the setting (guards against anything folded leaking into a cached plan, including a generic plan after the fifth execution);
- covers the expression-plus-heap-filter shape, which must keep the parameterized guess and run without error.

Also verified out-of-tree on a 487k-row dataset with an actual RLS policy (`FORCE ROW LEVEL SECURITY`, non-owner role): the policy qual plus a user qual now plans as `Custom Scan (ParadeDB Base Scan)` with the folded estimate (1,718 estimated vs 1,581 actual for the policy alone, previously 3), and the existing `issue_5751` regression test still passes against the patched build.
