### PR TITLE
perf: sort doc ids before a deferred fast-field fetch

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -480,10 +480,15 @@ where
         let (seg_ord, doc_id) = unpack_doc_address(packed);
         by_seg[seg_ord as usize].push((row_idx, doc_id));
     }
-    for (seg_ord, rows) in by_seg.into_iter().enumerate() {
+    for (seg_ord, mut rows) in by_seg.into_iter().enumerate() {
         if rows.is_empty() {
             continue;
         }
+
+        // A fast-field column reads fastest in DocId order. Rows reach here in whatever
+        // order the plan produced them, which a join above the scan no longer keeps, so
+        // sort before the fetch. Callers map results back by their row index.
+        rows.sort_unstable_by_key(|(_, doc_id)| *doc_id);
 
         process(seg_ord as SegmentOrdinal, rows)?;
     }


### PR DESCRIPTION
This PR sorts doc ids before a deferred fast-field fetch.

Stacked on #6140. It came out of Stu's point that our deferred paths have two phases, and that the first one wants DocId order.

## Why

`for_each_segment` groups rows by segment before a fast-field read, but it keeps them in plan order inside each segment. A join above the scan does not keep that order, so both deferred fetches read their column scrambled:

- the ctid fetch in `materialize_deferred_ctid`
- the term-ordinal fetch in `resolve_doc_addresses_to_term_ords`

The heap side already handles this: `VisibilityChecker::check_batch` sorts the ctids and holds one buffer per run of same-block ctids. The column side had no equivalent.

Both callers map results back by row index, so the order inside a segment is free to change.

The wider point for the selective late-materialization work: this lowers the cost of the randomization that deferral pays for, so it shifts where the break-even is.

## CI benchmarks

The SO Queries benchmark against #6140 shows the same pattern at CI scale ([run](https://github.com/paradedb/paradedb/actions/runs/33297341043) vs [base run](https://github.com/paradedb/paradedb/actions/runs/33297326565); medians of 10 warm runs):

| query | #6140 | this PR | |
|-|-|-|-|
| `join_distinct_parent_sort` (2 alts) | 3956 / 4144 ms | 3383 / 3416 ms | 0.86x / 0.82x |
| `join_permissioned_search` | 435.9 ms | 382.8 ms | 0.88x |
| `join_disjunctive_score_sort` (2 alts) | 1942 / 2319 ms | 1831 / 2193 ms | 0.94x / 0.95x |
| `join_disjunctive_local_sort` (2 alts) | 1833 / 2188 ms | 1726 / 2079 ms | 0.94x / 0.95x |
| `join_foreign_filter_local_sort` (2 alts) | 85.2 / 86.9 ms | 81.6 / 82.9 ms | 0.96x / 0.95x |
| `top_k-score-desc-tiebreaker` | 10.6 ms | 10.2 ms | 0.96x |

No real regressions. 

## Tests

Existing tests.
