### PR TITLE
perf: defer aggregate string decode independently of visibility

### DIFF
--- a/docs/changelog/unreleased/6156.performance.mdx
+++ b/docs/changelog/unreleased/6156.performance.mdx
@@ -2,4 +2,4 @@
 header: performance
 ---
 
-Aggregate-on-join plans decode string columns after the join instead of in the scan, independently of whether the visibility check is deferred. Columns that a join key or a filter needs, and columns from the null-supplying side of an outer join, are still decoded in the scan. `EXPLAIN` lists the deferred columns in `decode=[...]` on the `TantivyLookupExec` above the join.
+Aggregate-on-join plans decode string columns after the join rather than in the scan, whether or not the visibility check is deferred. Join key and filter columns, and columns from the null-supplying side of an outer join, still decode in the scan. `EXPLAIN` lists the deferred columns under `decode=[...]` on the `TantivyLookupExec` above the join.

--- a/docs/changelog/unreleased/6156.performance.mdx
+++ b/docs/changelog/unreleased/6156.performance.mdx
@@ -1,0 +1,5 @@
+---
+header: performance
+---
+
+Aggregate-on-join plans decode string columns after the join instead of in the scan, independently of whether the visibility check is deferred. Columns that a join key or a filter needs, and columns from the null-supplying side of an outer join, are still decoded in the scan. `EXPLAIN` lists the deferred columns in `decode=[...]` on the `TantivyLookupExec` above the join.

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -598,37 +598,51 @@ async fn build_source_df(
     provider.set_expr_context(source_expr_context);
     provider.set_planstate(planstate);
 
-    // Deferring an aggregate source's visibility trades an in-scan check for a
-    // post-join one. On the current cost model that only pays for specific
-    // shapes, so it stays off until selective late materialization can pick
-    // them. With it off the source keeps eager, in-scan visibility.
-    if crate::gucs::enable_aggregate_late_materialization() {
-        let mut required_early: crate::api::HashSet<String> = Default::default();
-        for jk in plan.join_keys() {
-            if source.contains_rti(jk.outer_rti)
-                && let Some(col) = source.column_name(jk.outer_attno)
-            {
-                required_early.insert(col);
-            }
-            if source.contains_rti(jk.inner_rti)
-                && let Some(col) = source.column_name(jk.inner_attno)
-            {
-                required_early.insert(col);
-            }
+    // Join keys and join-filter inputs are read below any deferred decode, so
+    // they must leave the scan already materialized. Everything else that is a
+    // string can travel as a term ordinal and decode at its anchor, where the
+    // join has already dropped the rows that never needed the string.
+    let mut required_early: crate::api::HashSet<String> = Default::default();
+    for jk in plan.join_keys() {
+        if source.contains_rti(jk.outer_rti)
+            && let Some(col) = source.column_name(jk.outer_attno)
+        {
+            required_early.insert(col);
         }
-        for (rti, attno) in plan.filter_input_vars() {
-            if source.contains_rti(rti)
-                && let Some(col) = source.column_name(attno)
-            {
-                required_early.insert(col);
-            }
+        if source.contains_rti(jk.inner_rti)
+            && let Some(col) = source.column_name(jk.inner_attno)
+        {
+            required_early.insert(col);
         }
-
-        provider.configure_deferred_outputs(
-            &required_early,
-            crate::scan::VisibilityMode::Deferred { plan_position },
-        );
     }
+    for (rti, attno) in plan.filter_input_vars() {
+        if source.contains_rti(rti)
+            && let Some(col) = source.column_name(attno)
+        {
+            required_early.insert(col);
+        }
+    }
+
+    // A source an outer join can null-fill keeps every string materialized:
+    // the join's NULL cannot ride a union column, so a deferred decode would
+    // resurrect the value.
+    if plan.null_fillable_sources().contains(&plan_position) {
+        for f in &fields {
+            if let WhichFastField::Named(name, _) = f {
+                required_early.insert(name.clone());
+            }
+        }
+    }
+
+    // Deferring the visibility check is a separate decision from deferring
+    // string decode: it trades an in-scan check for a post-join one, which
+    // only pays for specific shapes, so it stays behind the GUC.
+    let visibility_mode = if crate::gucs::enable_aggregate_late_materialization() {
+        crate::scan::VisibilityMode::Deferred { plan_position }
+    } else {
+        crate::scan::VisibilityMode::Eager
+    };
+    provider.configure_deferred_outputs(&required_early, visibility_mode);
 
     let df = register_source_table(ctx, alias.as_str(), provider).await?;
 

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -1213,6 +1213,43 @@ impl RelNode {
         result
     }
 
+    /// Plan positions of sources an ancestor outer join can null-fill. A string
+    /// deferred past that join loses the null-fill: a union column has no
+    /// validity bitmap, so the decoded value resurrects a row's NULL.
+    pub fn null_fillable_sources(&self) -> crate::api::HashSet<usize> {
+        let mut acc = crate::api::HashSet::default();
+        self.collect_null_fillable(false, &mut acc);
+        acc
+    }
+
+    fn collect_null_fillable(&self, nullable: bool, acc: &mut crate::api::HashSet<usize>) {
+        match self {
+            RelNode::Scan(s) => {
+                if nullable {
+                    acc.insert(s.plan_position);
+                }
+            }
+            RelNode::Filter(f) => f.input.collect_null_fillable(nullable, acc),
+            RelNode::Join(j) => {
+                let (left_nullable, right_nullable) = match j.join_type {
+                    JoinType::Inner
+                    | JoinType::Semi
+                    | JoinType::Anti { .. }
+                    | JoinType::LeftMark
+                    | JoinType::RightSemi
+                    | JoinType::RightAnti
+                    | JoinType::RightMark => (false, false),
+                    JoinType::Left => (false, true),
+                    JoinType::Right => (true, false),
+                    JoinType::Full | JoinType::UniqueOuter | JoinType::UniqueInner => (true, true),
+                };
+                j.left.collect_null_fillable(nullable || left_nullable, acc);
+                j.right
+                    .collect_null_fillable(nullable || right_nullable, acc);
+            }
+        }
+    }
+
     /// Recursively collects all mutable base join sources from this tree.
     pub fn sources_mut(&mut self) -> Vec<&mut JoinSource> {
         let mut result = Vec::new();

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -56,8 +56,8 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                                 QUERY PLAN                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -66,9 +66,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
 (11 rows)
 
 SELECT COUNT(*)
@@ -86,8 +86,8 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                                 QUERY PLAN                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -96,9 +96,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0, sum(p_0.price) as agg_1, avg(p_0.rating) as agg_2]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[price@1, rating@2]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
 (11 rows)
 
 SELECT COUNT(*), SUM(p.price), AVG(p.rating)
@@ -116,8 +116,8 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                                 QUERY PLAN                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -126,9 +126,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[min(p_0.price) as agg_0, max(p_0.price) as agg_1]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[price@1]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
 (11 rows)
 
 SELECT MIN(p.price), MAX(p.price)
@@ -227,8 +227,8 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.category, (count(*))
    Sort Key: p.category
@@ -240,12 +240,13 @@ ORDER BY p.category;
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
-           :     CooperativeExec
-           :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(16 rows)
+           :   TantivyLookupExec: decode=[category]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
+           :       CooperativeExec
+           :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(17 rows)
 
 SELECT p.category, COUNT(*)
 FROM agg_join_products p
@@ -362,8 +363,8 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: p.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -373,12 +374,13 @@ ORDER BY p.category;
          Aggregates: COUNT(DISTINCT)(tag_name)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(DISTINCT t_1.tag_name) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-           :     CooperativeExec
-           :       PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(14 rows)
+           :   TantivyLookupExec: decode=[category, tag_name]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+           :       CooperativeExec
+           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT p.category, COUNT(DISTINCT t.tag_name)
 FROM agg_join_products p
@@ -418,8 +420,8 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: t.tag_name
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -429,12 +431,13 @@ ORDER BY t.tag_name;
          Aggregates: COUNT(DISTINCT)(category)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[tag_name@1 as tag_name], aggr=[count(DISTINCT p_0.category) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-           :     CooperativeExec
-           :       PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(14 rows)
+           :   TantivyLookupExec: decode=[category, tag_name]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+           :       CooperativeExec
+           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT t.tag_name, COUNT(DISTINCT p.category)
 FROM agg_join_products p
@@ -482,8 +485,8 @@ FROM agg_join_products p
 LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -491,12 +494,13 @@ GROUP BY p.category;
    Aggregates: COUNT(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(t_1.tag_name) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(12 rows)
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(13 rows)
 
 SELECT p.category, COUNT(t.tag_name)
 FROM agg_join_products p
@@ -549,8 +553,8 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: t.tag_name
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -560,12 +564,13 @@ ORDER BY t.tag_name;
          Aggregates: COUNT(category)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[tag_name@0 as tag_name], aggr=[count(p_1.category) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(product_id@0, id@0)], projection=[tag_name@1, category@3]
-           :     CooperativeExec
-           :       PgSearchScan: table=t, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"tag_name","query_string":"tech OR orphan_tag","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(14 rows)
+           :   TantivyLookupExec: decode=[tag_name]
+           :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(product_id@0, id@0)], projection=[tag_name@1, category@3]
+           :       CooperativeExec
+           :         PgSearchScan: table=t, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"tag_name","query_string":"tech OR orphan_tag","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT t.tag_name, COUNT(p.category)
 FROM agg_join_products p
@@ -626,8 +631,8 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
-                                                                                                               QUERY PLAN                                                                                                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                      QUERY PLAN                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: idx_comp_a (a), idx_comp_b (b)
@@ -636,9 +641,9 @@ WHERE a.description @@@ 'laptop OR shoes';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(x@0, x@0), (y@1, y@1)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=b, segments=1, visibility=eager, query="all"
+     :       PgSearchScan: table=b, segments=1, query="all"
      :     CooperativeExec
-     :       PgSearchScan: table=a, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=a, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
 (11 rows)
 
 SELECT COUNT(*)
@@ -1090,8 +1095,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -1099,12 +1104,13 @@ GROUP BY p.category;
    Aggregates: SUM(product_id)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[sum(DISTINCT t_1.product_id) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, product_id@2]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(12 rows)
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, product_id@2]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(13 rows)
 
 -- AVG(DISTINCT) should show AggregateScan (DataFusion supports DISTINCT)
 EXPLAIN (COSTS OFF)
@@ -1113,8 +1119,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -1122,12 +1128,13 @@ GROUP BY p.category;
    Aggregates: AVG(product_id)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[avg(DISTINCT t_1.product_id) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, product_id@2]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(12 rows)
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, product_id@2]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(13 rows)
 
 -- COUNT(DISTINCT) should still show AggregateScan (this still works)
 EXPLAIN (COSTS OFF)
@@ -1136,8 +1143,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -1145,12 +1152,13 @@ GROUP BY p.category;
    Aggregates: COUNT(DISTINCT)(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(DISTINCT t_1.tag_name) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(12 rows)
+     :   TantivyLookupExec: decode=[category, tag_name]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(13 rows)
 
 -- =====================================================================
 -- SECTION 13: Cross-table OR predicates (regression for generated_joins_small)
@@ -1213,8 +1221,8 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
-                                                                                                                                                     QUERY PLAN                                                                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                            QUERY PLAN                                                                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('SUM'::text)
    Backend: DataFusion
@@ -1224,9 +1232,9 @@ WHERE p.description @@@ 'laptop' AND p.price > 500;
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0, sum(p_0.price) as agg_1]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[price@1]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"price","lower_bound":{"excluded":500.0},"upper_bound":null}}]}}
+     :       PgSearchScan: table=p, segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"price","lower_bound":{"excluded":500.0},"upper_bound":null}}]}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 SELECT COUNT(*), SUM(p.price)
@@ -1343,8 +1351,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category;
-                                                                                                         QUERY PLAN                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (bool_and(p.in_stock))
    Backend: DataFusion
@@ -1353,12 +1361,13 @@ GROUP BY p.category;
    Aggregates: BOOL_AND(in_stock)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[bool_and(p_0.in_stock) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, in_stock@2]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR toy","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(13 rows)
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, in_stock@2]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR toy","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(14 rows)
 
 SELECT p.category, BOOL_AND(p.in_stock)
 FROM agg_join_products p
@@ -1394,8 +1403,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (string_agg(t.tag_name, ', '::text))
    Backend: DataFusion
@@ -1404,12 +1413,13 @@ GROUP BY p.category;
    Aggregates: STRING_AGG(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[string_agg(t_1.tag_name, , ) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(13 rows)
+     :   TantivyLookupExec: decode=[category, tag_name]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(14 rows)
 
 SELECT p.category, STRING_AGG(t.tag_name, ', ')
 FROM agg_join_products p
@@ -1504,8 +1514,8 @@ SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
 FROM agg_join_products p
 FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('COUNT'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -1513,12 +1523,13 @@ WHERE p.description @@@ 'laptop OR shoes';
    Aggregates: COUNT(*), COUNT(category), COUNT(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0, count(p_0.category) as agg_1, count(t_1.tag_name) as agg_2]
-     :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(12 rows)
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(13 rows)
 
 SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
 FROM agg_join_products p
@@ -1583,8 +1594,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (string_agg(t.tag_name, ', '::text ORDER BY t.tag_name))
    Backend: DataFusion
@@ -1593,13 +1604,14 @@ GROUP BY p.category;
    Aggregates: STRING_AGG(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[string_agg(t_1.tag_name, , ) ORDER BY [t_1.tag_name ASC NULLS LAST] as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
-     :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(14 rows)
+     :   SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
+     :     TantivyLookupExec: decode=[category, tag_name]
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :         CooperativeExec
+     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         CooperativeExec
+     :           PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
 FROM agg_join_products p
@@ -1652,8 +1664,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (array_agg(t.tag_name ORDER BY t.tag_name))
    Backend: DataFusion
@@ -1662,13 +1674,14 @@ GROUP BY p.category;
    Aggregates: ARRAY_AGG(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[array_agg(t_1.tag_name) ORDER BY [t_1.tag_name ASC NULLS LAST] as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
-     :     SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
-     :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(14 rows)
+     :   SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
+     :     TantivyLookupExec: decode=[category, tag_name]
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :         CooperativeExec
+     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         CooperativeExec
+     :           PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
 FROM agg_join_products p
@@ -1761,12 +1774,13 @@ GROUP BY i.metadata->>'category';
    Aggregates: COUNT(*), SUM(qty)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[metadata.category@0 as metadata.category], aggr=[count(1) as agg_0, sum(o_1.qty) as agg_1]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, item_id@0)], projection=[metadata.category@1, qty@3]
-     :     CooperativeExec
-     :       PgSearchScan: table=i, segments=1, visibility=eager, query={"with_index":{"query":"all"}}
-     :     CooperativeExec
-     :       PgSearchScan: table=o, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(13 rows)
+     :   TantivyLookupExec: decode=[metadata.category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, item_id@0)], projection=[metadata.category@1, qty@3]
+     :       CooperativeExec
+     :         PgSearchScan: table=i, segments=1, query={"with_index":{"query":"all"}}
+     :       CooperativeExec
+     :         PgSearchScan: table=o, segments=1, dynamic_filters=1, query="all"
+(14 rows)
 
 -- Test 17.2: JSON sub-field GROUP BY results
 SELECT i.metadata->>'category' AS category, COUNT(*), SUM(o.qty)
@@ -1811,8 +1825,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                           QUERY PLAN                                                                                                           
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*)), (count(*) FILTER (WHERE (p.price > '100'::double precision)))
    Backend: DataFusion
@@ -1821,12 +1835,13 @@ GROUP BY p.category;
    Aggregates: COUNT(*), COUNT(*)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, count(1) FILTER (WHERE p_0.price > Float64(100)) as agg_1]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(13 rows)
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+(14 rows)
 
 -- Test 17.2: COUNT with FILTER — results
 SELECT p.category,
@@ -1920,9 +1935,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0], metrics=[output_rows=1, output_bytes=8.0 B, output_batches=1]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[], metrics=[output_rows=6, output_bytes=0.0 B, output_batches=1, build_mem_used=44.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=3, input_batches=2, input_rows=9, avg_fanout=100% (6/6), probe_hit_rate=66.67% (6/9)]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=24.0 B, output_batches=1]
+     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=24.0 B, output_batches=1]
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all", metrics=[output_rows=9, output_bytes=72.0 B, output_batches=2, rows_pruned=3, rows_scanned=12]
+     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all", metrics=[output_rows=9, output_bytes=72.0 B, output_batches=2, rows_pruned=3, rows_scanned=12]
 (11 rows)
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -56,8 +56,8 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -66,9 +66,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (11 rows)
 
 SELECT COUNT(*)
@@ -86,8 +86,8 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -96,9 +96,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0, sum(p_0.price) as agg_1, avg(p_0.rating) as agg_2]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[price@1, rating@2]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (11 rows)
 
 SELECT COUNT(*), SUM(p.price), AVG(p.rating)
@@ -116,8 +116,8 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -126,9 +126,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[min(p_0.price) as agg_0, max(p_0.price) as agg_1]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[price@1]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (11 rows)
 
 SELECT MIN(p.price), MAX(p.price)
@@ -227,8 +227,8 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                 QUERY PLAN                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.category, (count(*))
    Sort Key: p.category
@@ -243,9 +243,9 @@ ORDER BY p.category;
            :   TantivyLookupExec: decode=[category]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (17 rows)
 
 SELECT p.category, COUNT(*)
@@ -363,8 +363,8 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                 QUERY PLAN                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: p.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -377,9 +377,9 @@ ORDER BY p.category;
            :   TantivyLookupExec: decode=[category, tag_name]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT p.category, COUNT(DISTINCT t.tag_name)
@@ -420,8 +420,8 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-                                                                                                 QUERY PLAN                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: t.tag_name
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -434,9 +434,9 @@ ORDER BY t.tag_name;
            :   TantivyLookupExec: decode=[category, tag_name]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT t.tag_name, COUNT(DISTINCT p.category)
@@ -485,8 +485,8 @@ FROM agg_join_products p
 LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -497,9 +497,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (13 rows)
 
 SELECT p.category, COUNT(t.tag_name)
@@ -553,8 +553,8 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-                                                                                                 QUERY PLAN                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: t.tag_name
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -567,9 +567,9 @@ ORDER BY t.tag_name;
            :   TantivyLookupExec: decode=[tag_name]
            :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(product_id@0, id@0)], projection=[tag_name@1, category@3]
            :       CooperativeExec
-           :         PgSearchScan: table=t, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"tag_name","query_string":"tech OR orphan_tag","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=t, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"tag_name","query_string":"tech OR orphan_tag","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT t.tag_name, COUNT(p.category)
@@ -631,8 +631,8 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: idx_comp_a (a), idx_comp_b (b)
@@ -641,9 +641,9 @@ WHERE a.description @@@ 'laptop OR shoes';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(x@0, x@0), (y@1, y@1)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=b, segments=1, query="all"
+     :       PgSearchScan: table=b, segments=1, visibility=eager, query="all"
      :     CooperativeExec
-     :       PgSearchScan: table=a, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=a, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
 (11 rows)
 
 SELECT COUNT(*)
@@ -1095,8 +1095,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -1107,9 +1107,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, product_id@2]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (13 rows)
 
 -- AVG(DISTINCT) should show AggregateScan (DataFusion supports DISTINCT)
@@ -1119,8 +1119,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -1131,9 +1131,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, product_id@2]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (13 rows)
 
 -- COUNT(DISTINCT) should still show AggregateScan (this still works)
@@ -1143,8 +1143,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
@@ -1155,9 +1155,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category, tag_name]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (13 rows)
 
 -- =====================================================================
@@ -1221,8 +1221,8 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
-                                                                                                                                            QUERY PLAN                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                     QUERY PLAN                                                                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('SUM'::text)
    Backend: DataFusion
@@ -1232,9 +1232,9 @@ WHERE p.description @@@ 'laptop' AND p.price > 500;
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0, sum(p_0.price) as agg_1]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[price@1]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"price","lower_bound":{"excluded":500.0},"upper_bound":null}}]}}
+     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"price","lower_bound":{"excluded":500.0},"upper_bound":null}}]}}
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (12 rows)
 
 SELECT COUNT(*), SUM(p.price)
@@ -1351,8 +1351,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category;
-                                                                                                 QUERY PLAN                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (bool_and(p.in_stock))
    Backend: DataFusion
@@ -1364,9 +1364,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, in_stock@2]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR toy","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR toy","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (14 rows)
 
 SELECT p.category, BOOL_AND(p.in_stock)
@@ -1403,8 +1403,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (string_agg(t.tag_name, ', '::text))
    Backend: DataFusion
@@ -1416,9 +1416,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category, tag_name]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (14 rows)
 
 SELECT p.category, STRING_AGG(t.tag_name, ', ')
@@ -1514,8 +1514,8 @@ SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
 FROM agg_join_products p
 FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('COUNT'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -1526,9 +1526,9 @@ WHERE p.description @@@ 'laptop OR shoes';
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (13 rows)
 
 SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
@@ -1594,8 +1594,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                               QUERY PLAN                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (string_agg(t.tag_name, ', '::text ORDER BY t.tag_name))
    Backend: DataFusion
@@ -1608,9 +1608,9 @@ GROUP BY p.category;
      :     TantivyLookupExec: decode=[category, tag_name]
      :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
      :         CooperativeExec
-     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
@@ -1664,8 +1664,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                               QUERY PLAN                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (array_agg(t.tag_name ORDER BY t.tag_name))
    Backend: DataFusion
@@ -1678,9 +1678,9 @@ GROUP BY p.category;
      :     TantivyLookupExec: decode=[category, tag_name]
      :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
      :         CooperativeExec
-     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
@@ -1777,9 +1777,9 @@ GROUP BY i.metadata->>'category';
      :   TantivyLookupExec: decode=[metadata.category]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, item_id@0)], projection=[metadata.category@1, qty@3]
      :       CooperativeExec
-     :         PgSearchScan: table=i, segments=1, query={"with_index":{"query":"all"}}
+     :         PgSearchScan: table=i, segments=1, visibility=eager, query={"with_index":{"query":"all"}}
      :       CooperativeExec
-     :         PgSearchScan: table=o, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=o, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (14 rows)
 
 -- Test 17.2: JSON sub-field GROUP BY results
@@ -1825,8 +1825,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                   QUERY PLAN                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*)), (count(*) FILTER (WHERE (p.price > '100'::double precision)))
    Backend: DataFusion
@@ -1838,9 +1838,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (14 rows)
 
 -- Test 17.2: COUNT with FILTER — results
@@ -1935,9 +1935,9 @@ WHERE p.description @@@ 'laptop';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0], metrics=[output_rows=1, output_bytes=8.0 B, output_batches=1]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[], metrics=[output_rows=6, output_bytes=0.0 B, output_batches=1, build_mem_used=44.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=3, input_batches=2, input_rows=9, avg_fanout=100% (6/6), probe_hit_rate=66.67% (6/9)]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=24.0 B, output_batches=1]
+     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=24.0 B, output_batches=1]
      :     CooperativeExec
-     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, query="all", metrics=[output_rows=9, output_bytes=72.0 B, output_batches=2, rows_pruned=3, rows_scanned=12]
+     :       PgSearchScan: table=t, segments=2, dynamic_filters=1, visibility=eager, query="all", metrics=[output_rows=9, output_bytes=72.0 B, output_batches=2, rows_pruned=3, rows_scanned=12]
 (11 rows)
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
@@ -62,9 +62,9 @@ ORDER BY company_name;
            :   TantivyLookupExec: decode=[company_name_words]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
            :       CooperativeExec
-           :         PgSearchScan: table=cccf, segments=1, query="all"
+           :         PgSearchScan: table=cccf, segments=1, visibility=eager, query="all"
            :       CooperativeExec
-           :         PgSearchScan: table=ti, segments=1, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=ti, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT company_name, count(*)
@@ -112,9 +112,9 @@ JOIN repro_ti ti ON cccf.company_id = ti.company_id;
      :   TantivyLookupExec: decode=[company_name_words]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
      :       CooperativeExec
-     :         PgSearchScan: table=cccf, segments=1, query="all"
+     :         PgSearchScan: table=cccf, segments=1, visibility=eager, query="all"
      :       CooperativeExec
-     :         PgSearchScan: table=ti, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=ti, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (12 rows)
 
 SELECT count(DISTINCT company_name)
@@ -156,9 +156,9 @@ JOIN repro_ti ti ON cccf.company_id = ti.company_id;
      :     TantivyLookupExec: decode=[company_name_words]
      :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
      :         CooperativeExec
-     :           PgSearchScan: table=cccf, segments=1, query="all"
+     :           PgSearchScan: table=cccf, segments=1, visibility=eager, query="all"
      :         CooperativeExec
-     :           PgSearchScan: table=ti, segments=1, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=ti, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (13 rows)
 
 SELECT string_agg(company_name, ',' ORDER BY company_name)

--- a/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
@@ -48,8 +48,8 @@ FROM repro_cccf cccf
 JOIN repro_ti ti ON cccf.company_id = ti.company_id
 GROUP BY company_name
 ORDER BY company_name;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: cccf.company_name
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -59,12 +59,13 @@ ORDER BY company_name;
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[company_name_words@0 as company_name_words], aggr=[count(1) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
-           :     CooperativeExec
-           :       PgSearchScan: table=cccf, segments=1, visibility=eager, query="all"
-           :     CooperativeExec
-           :       PgSearchScan: table=ti, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(14 rows)
+           :   TantivyLookupExec: decode=[company_name_words]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
+           :       CooperativeExec
+           :         PgSearchScan: table=cccf, segments=1, query="all"
+           :       CooperativeExec
+           :         PgSearchScan: table=ti, segments=1, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT company_name, count(*)
 FROM repro_cccf cccf
@@ -100,20 +101,21 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT count(DISTINCT company_name)
 FROM repro_cccf cccf
 JOIN repro_ti ti ON cccf.company_id = ti.company_id;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: repro_cccf_idx (cccf), repro_ti_idx (ti)
    Aggregates: COUNT(DISTINCT)(company_name_words)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(DISTINCT cccf_0.company_name_words) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
-     :     CooperativeExec
-     :       PgSearchScan: table=cccf, segments=1, visibility=eager, query="all"
-     :     CooperativeExec
-     :       PgSearchScan: table=ti, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(11 rows)
+     :   TantivyLookupExec: decode=[company_name_words]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
+     :       CooperativeExec
+     :         PgSearchScan: table=cccf, segments=1, query="all"
+     :       CooperativeExec
+     :         PgSearchScan: table=ti, segments=1, dynamic_filters=1, query="all"
+(12 rows)
 
 SELECT count(DISTINCT company_name)
 FROM repro_cccf cccf
@@ -151,12 +153,13 @@ JOIN repro_ti ti ON cccf.company_id = ti.company_id;
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[string_agg(cccf_0.company_name_words, ,) ORDER BY [cccf_0.company_name_words ASC NULLS LAST] as agg_0]
      :   SortExec: expr=[company_name_words@0 ASC NULLS LAST], preserve_partitioning=[false]
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
-     :       CooperativeExec
-     :         PgSearchScan: table=cccf, segments=1, visibility=eager, query="all"
-     :       CooperativeExec
-     :         PgSearchScan: table=ti, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(12 rows)
+     :     TantivyLookupExec: decode=[company_name_words]
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@0, company_id@0)], projection=[company_name_words@1]
+     :         CooperativeExec
+     :           PgSearchScan: table=cccf, segments=1, query="all"
+     :         CooperativeExec
+     :           PgSearchScan: table=ti, segments=1, dynamic_filters=1, query="all"
+(13 rows)
 
 SELECT string_agg(company_name, ',' ORDER BY company_name)
 FROM repro_cccf cccf

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -80,8 +80,8 @@ SELECT COUNT(*)
 FROM ec_products p
 JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
-                                                                                                                     QUERY PLAN                                                                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -91,9 +91,9 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
 (12 rows)
 
 SELECT COUNT(*)
@@ -113,8 +113,8 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                                        QUERY PLAN                                                                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.category, (count(*)), (sum(r.rating)), (avg(r.rating))
    Sort Key: p.category
@@ -128,9 +128,9 @@ ORDER BY p.category;
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(r_1.rating) as agg_1, avg(r_1.rating) as agg_2]
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :     CooperativeExec
-           :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
-           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
+           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
 (16 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating), AVG(r.rating)
@@ -189,8 +189,8 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                    QUERY PLAN                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.category, (count(*)), (count(r.rating))
    Sort Key: p.category
@@ -204,9 +204,9 @@ ORDER BY p.category;
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, count(r_1.rating) as agg_1]
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :     CooperativeExec
-           :       PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
-           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
+           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
 (16 rows)
 
 SELECT p.category, COUNT(*), COUNT(r.rating)
@@ -254,8 +254,8 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                                         QUERY PLAN                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: p.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -268,11 +268,11 @@ ORDER BY p.category;
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0), (category@1, category@0)], projection=[category@0, rating@2]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
+           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, visibility=eager, query="all"
+           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating)
@@ -318,8 +318,8 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                                              QUERY PLAN                                                                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: p.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -332,11 +332,11 @@ ORDER BY p.category;
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@1, supplier_name@3]
            :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
+           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, visibility=eager, query="all"
+           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT p.category, COUNT(*), COUNT(r.rating), COUNT(s.supplier_name)
@@ -419,8 +419,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel
 GROUP BY 1
 ORDER BY 1;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r)
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: ((p.metadata -> 'brand'::text))
    Sort Key: ((p.metadata -> 'brand'::text))
@@ -431,12 +431,13 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
          Group By: metadata.brand
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[metadata.brand@0 as metadata.brand], aggr=[]
-           :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(category@0, category@0)], projection=[metadata.brand@1]
-           :     CooperativeExec
-           :       PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(15 rows)
+           :   TantivyLookupExec: decode=[metadata.brand]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[metadata.brand@1]
+           :       CooperativeExec
+           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+(16 rows)
 
 SELECT p.metadata -> 'brand'
 FROM ec_products p
@@ -486,8 +487,8 @@ WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r, s)
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: ((p.metadata ->> 'brand'::text)), ((p.metadata -> 'brand'::text))
    Sort Key: ((p.metadata ->> 'brand'::text))
@@ -499,7 +500,7 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[metadata.brand@0 as metadata.brand], aggr=[]
            :   CooperativeExec
-           :     PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+           :     PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
 (12 rows)
 
 SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -80,8 +80,8 @@ SELECT COUNT(*)
 FROM ec_products p
 JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
-                                                                                                            QUERY PLAN                                                                                                             
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -91,9 +91,9 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (12 rows)
 
 SELECT COUNT(*)
@@ -113,8 +113,8 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                               QUERY PLAN                                                                                                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.category, (count(*)), (sum(r.rating)), (avg(r.rating))
    Sort Key: p.category
@@ -128,9 +128,9 @@ ORDER BY p.category;
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(r_1.rating) as agg_1, avg(r_1.rating) as agg_2]
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :     CooperativeExec
-           :       PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
-           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (16 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating), AVG(r.rating)
@@ -189,8 +189,8 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                                    QUERY PLAN                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.category, (count(*)), (count(r.rating))
    Sort Key: p.category
@@ -204,9 +204,9 @@ ORDER BY p.category;
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, count(r_1.rating) as agg_1]
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :     CooperativeExec
-           :       PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
-           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+           :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (16 rows)
 
 SELECT p.category, COUNT(*), COUNT(r.rating)
@@ -254,8 +254,8 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                                QUERY PLAN                                                                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: p.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -268,11 +268,11 @@ ORDER BY p.category;
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0), (category@1, category@0)], projection=[category@0, rating@2]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, query="all"
+           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (17 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating)
@@ -318,8 +318,8 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-                                                                                                                     QUERY PLAN                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: p.category
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -332,11 +332,11 @@ ORDER BY p.category;
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@1, supplier_name@3]
            :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, query="all"
+           :       PgSearchScan: table=s, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (17 rows)
 
 SELECT p.category, COUNT(*), COUNT(r.rating), COUNT(s.supplier_name)
@@ -419,8 +419,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel
 GROUP BY 1
 ORDER BY 1;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r)
-                                                                                                                     QUERY PLAN                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: ((p.metadata -> 'brand'::text))
    Sort Key: ((p.metadata -> 'brand'::text))
@@ -434,9 +434,9 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
            :   TantivyLookupExec: decode=[metadata.brand]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[metadata.brand@1]
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+           :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (16 rows)
 
 SELECT p.metadata -> 'brand'
@@ -487,8 +487,8 @@ WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r, s)
-                                                                                          QUERY PLAN                                                                                           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: ((p.metadata ->> 'brand'::text)), ((p.metadata -> 'brand'::text))
    Sort Key: ((p.metadata ->> 'brand'::text))
@@ -500,7 +500,7 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[metadata.brand@0 as metadata.brand], aggr=[]
            :   CooperativeExec
-           :     PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+           :     PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
 (12 rows)
 
 SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json

--- a/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
@@ -61,8 +61,8 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                                  QUERY PLAN                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -73,11 +73,11 @@ WHERE p.description @@@ 'laptop';
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
      :     CooperativeExec
-     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
 (15 rows)
 
 SELECT COUNT(*)
@@ -131,8 +131,8 @@ JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*)), (sum(r.rating)), (avg(r.rating)), (min(r.rating)), (max(r.rating))
    Backend: DataFusion
@@ -141,15 +141,16 @@ GROUP BY p.category;
    Aggregates: COUNT(*), SUM(rating), AVG(rating), MIN(rating), MAX(rating)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(r_2.rating) as agg_1, avg(r_2.rating) as agg_2, min(r_2.rating) as agg_3, max(r_2.rating) as agg_4]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0, category@1]
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0, category@1]
+     :         CooperativeExec
+     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :         CooperativeExec
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
-     :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-     :     CooperativeExec
-     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(16 rows)
+     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+(17 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating), AVG(r.rating), MIN(r.rating), MAX(r.rating)
 FROM fb_products p
@@ -201,8 +202,8 @@ LEFT JOIN fb_tags t ON p.id = t.product_id
 LEFT JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: fb_products_idx (p), fb_tags_idx (t), fb_reviews_idx (r)
@@ -210,15 +211,16 @@ GROUP BY p.category;
    Aggregates: COUNT(*), COUNT(rating)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, count(r_2.rating) as agg_1]
-     :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
-     :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[id@0, category@1]
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
+     :       HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[id@0, category@1]
+     :         CooperativeExec
+     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :         CooperativeExec
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
-     :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-     :     CooperativeExec
-     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(15 rows)
+     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+(16 rows)
 
 SELECT p.category, COUNT(*), COUNT(r.rating)
 FROM fb_products p
@@ -278,8 +280,8 @@ JOIN fb_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*))
    Backend: DataFusion
@@ -289,12 +291,13 @@ HAVING COUNT(*) > 0;
    DataFusion Physical Plan: 
      : FilterExec: agg_0@1 > 0
      :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
-     :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
-     :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(14 rows)
+     :     TantivyLookupExec: decode=[category]
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
+     :         CooperativeExec
+     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :         CooperativeExec
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT p.category, COUNT(*)
 FROM fb_products p

--- a/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
@@ -61,8 +61,8 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
-                                                                                         QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                  QUERY PLAN                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -73,11 +73,11 @@ WHERE p.description @@@ 'laptop';
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
      :     CooperativeExec
-     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT COUNT(*)
@@ -131,8 +131,8 @@ JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*)), (sum(r.rating)), (avg(r.rating)), (min(r.rating)), (max(r.rating))
    Backend: DataFusion
@@ -145,11 +145,11 @@ GROUP BY p.category;
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
      :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0, category@1]
      :         CooperativeExec
-     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
      :       CooperativeExec
-     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (17 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating), AVG(r.rating), MIN(r.rating), MAX(r.rating)
@@ -202,8 +202,8 @@ LEFT JOIN fb_tags t ON p.id = t.product_id
 LEFT JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: fb_products_idx (p), fb_tags_idx (t), fb_reviews_idx (r)
@@ -215,11 +215,11 @@ GROUP BY p.category;
      :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
      :       HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[id@0, category@1]
      :         CooperativeExec
-     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
      :       CooperativeExec
-     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (16 rows)
 
 SELECT p.category, COUNT(*), COUNT(r.rating)
@@ -280,8 +280,8 @@ JOIN fb_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*))
    Backend: DataFusion
@@ -294,9 +294,9 @@ HAVING COUNT(*) > 0;
      :     TantivyLookupExec: decode=[category]
      :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
      :         CooperativeExec
-     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (15 rows)
 
 SELECT p.category, COUNT(*)

--- a/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
@@ -85,8 +85,8 @@ JOIN mt_tags t ON p.id = t.product_id
 JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: mt_products_idx (p), mt_tags_idx (t), mt_reviews_idx (r)
@@ -98,11 +98,11 @@ GROUP BY p.category;
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
      :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0, category@1]
      :         CooperativeExec
-     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
      :       CooperativeExec
-     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (16 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating), AVG(r.rating)
@@ -148,8 +148,8 @@ JOIN mt_reviews r ON p.id = r.product_id
 JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                              QUERY PLAN                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: mt_products_idx (p), mt_tags_idx (t), mt_reviews_idx (r), mt_suppliers_idx (s)
@@ -160,15 +160,15 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(product_id@0, id@0), (product_id@0, product_id@2)], projection=[category@2, rating@4]
      :       CooperativeExec
-     :         PgSearchScan: table=s, segments=1, query="all"
+     :         PgSearchScan: table=s, segments=1, visibility=eager, query="all"
      :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0), (product_id@2, product_id@0)], projection=[id@0, category@1, product_id@2, rating@4]
      :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)]
      :           CooperativeExec
-     :             PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :             PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
      :           CooperativeExec
-     :             PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :             PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
      :         CooperativeExec
-     :           PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (19 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating)

--- a/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
@@ -85,8 +85,8 @@ JOIN mt_tags t ON p.id = t.product_id
 JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: mt_products_idx (p), mt_tags_idx (t), mt_reviews_idx (r)
@@ -94,15 +94,16 @@ GROUP BY p.category;
    Aggregates: COUNT(*), SUM(rating), AVG(rating)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(r_2.rating) as agg_1, avg(r_2.rating) as agg_2]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0, category@1]
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, rating@3]
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[id@0, category@1]
+     :         CooperativeExec
+     :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :         CooperativeExec
+     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
-     :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-     :     CooperativeExec
-     :       PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(15 rows)
+     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+(16 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating), AVG(r.rating)
 FROM mt_products p
@@ -147,8 +148,8 @@ JOIN mt_reviews r ON p.id = r.product_id
 JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-                                                                                                             QUERY PLAN                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: mt_products_idx (p), mt_tags_idx (t), mt_reviews_idx (r), mt_suppliers_idx (s)
@@ -156,18 +157,19 @@ GROUP BY p.category;
    Aggregates: COUNT(*), SUM(rating)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(r_2.rating) as agg_1]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(product_id@0, id@0), (product_id@0, product_id@2)], projection=[category@2, rating@4]
-     :     CooperativeExec
-     :       PgSearchScan: table=s, segments=1, visibility=eager, query="all"
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0), (product_id@2, product_id@0)], projection=[id@0, category@1, product_id@2, rating@4]
-     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)]
-     :         CooperativeExec
-     :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
-     :         CooperativeExec
-     :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(product_id@0, id@0), (product_id@0, product_id@2)], projection=[category@2, rating@4]
      :       CooperativeExec
-     :         PgSearchScan: table=r, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(18 rows)
+     :         PgSearchScan: table=s, segments=1, query="all"
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0), (product_id@2, product_id@0)], projection=[id@0, category@1, product_id@2, rating@4]
+     :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)]
+     :           CooperativeExec
+     :             PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+     :           CooperativeExec
+     :             PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :         CooperativeExec
+     :           PgSearchScan: table=r, segments=1, dynamic_filters=1, query="all"
+(19 rows)
 
 SELECT p.category, COUNT(*), SUM(r.rating)
 FROM mt_products p

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -71,8 +71,8 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-                                                                                                           QUERY PLAN                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                    QUERY PLAN                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, asa_cccf.job_title
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -85,9 +85,9 @@ ORDER BY doc_count DESC, job_title;
            :   TantivyLookupExec: decode=[job_title]
            :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
            :       CooperativeExec
-           :         PgSearchScan: table=asa_cccf, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=asa_cccf, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
 (15 rows)
 
 SELECT job_title, COUNT(*) AS doc_count
@@ -114,8 +114,8 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-                                                                                                     QUERY PLAN                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, c.job_title
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -129,11 +129,11 @@ ORDER BY doc_count DESC, job_title;
            :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
            :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)]
            :         CooperativeExec
-           :           PgSearchScan: table=c, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=c, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: table=cl, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=cl, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=cl, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=cl, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT job_title, COUNT(*) AS doc_count
@@ -166,8 +166,8 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-                                                                                                           QUERY PLAN                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                    QUERY PLAN                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, asa_cccf.job_title
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -181,11 +181,11 @@ ORDER BY doc_count DESC, job_title;
            :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
            :       HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)], null_aware
            :         CooperativeExec
-           :           PgSearchScan: table=asa_cccf, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=asa_cccf, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: table=asa_contact_list, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=asa_contact_list, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT job_title, COUNT(*) AS doc_count
@@ -392,8 +392,8 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-                                                                                                QUERY PLAN                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, asa_excl_outer.label
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -406,11 +406,11 @@ ORDER BY doc_count DESC, label;
            :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@0, id@0)], projection=[label@1]
            :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, eid@0)], null_aware
            :       CooperativeExec
-           :         PgSearchScan: table=asa_excl_outer, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"label","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=asa_excl_outer, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"label","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=asa_excl_inner, segments=1, query="all"
+           :         PgSearchScan: table=asa_excl_inner, segments=1, visibility=eager, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=asa_excl_include, segments=1, dynamic_filters=1, query="all"
+           :       PgSearchScan: table=asa_excl_include, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (17 rows)
 
 SELECT label, COUNT(*) AS doc_count
@@ -654,14 +654,14 @@ WHERE a.id NOT IN (
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, a_id@0)], filter=val@1 > threshold@0, projection=[val@3]
      :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, aid@0)], null_aware
      :       CooperativeExec
-     :         PgSearchScan: table=a, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"outermatch","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=a, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"outermatch","lenient":null,"conjunction_mode":null}}}}
      :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, y_id@1)], projection=[aid@0]
      :         CooperativeExec
-     :           PgSearchScan: table=y, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"block","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=y, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"block","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=x, segments=1, dynamic_filters=1, query="all"
+     :           PgSearchScan: table=x, segments=1, dynamic_filters=1, visibility=eager, query="all"
      :     CooperativeExec
-     :       PgSearchScan: table=b, segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=b, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (18 rows)
 
 SET paradedb.enable_aggregate_custom_scan TO on;

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -71,8 +71,8 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-                                                                                                                   QUERY PLAN                                                                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, asa_cccf.job_title
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -82,12 +82,13 @@ ORDER BY doc_count DESC, job_title;
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[job_title@0 as job_title], aggr=[count(1) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
-           :     CooperativeExec
-           :       PgSearchScan: table=asa_cccf, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
-(14 rows)
+           :   TantivyLookupExec: decode=[job_title]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
+           :       CooperativeExec
+           :         PgSearchScan: table=asa_cccf, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
+(15 rows)
 
 SELECT job_title, COUNT(*) AS doc_count
 FROM asa_cccf
@@ -113,8 +114,8 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, c.job_title
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -124,15 +125,16 @@ ORDER BY doc_count DESC, job_title;
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[job_title@0 as job_title], aggr=[count(1) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
-           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)]
+           :   TantivyLookupExec: decode=[job_title]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)]
+           :         CooperativeExec
+           :           PgSearchScan: table=c, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: table=cl, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=c, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
-           :       CooperativeExec
-           :         PgSearchScan: table=cl, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=cl, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
-(17 rows)
+           :         PgSearchScan: table=cl, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
 
 SELECT job_title, COUNT(*) AS doc_count
 FROM asa_cccf c
@@ -164,8 +166,8 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-                                                                                                                   QUERY PLAN                                                                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, asa_cccf.job_title
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -175,15 +177,16 @@ ORDER BY doc_count DESC, job_title;
          Aggregates: COUNT(*)
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[job_title@0 as job_title], aggr=[count(1) as agg_0]
-           :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
-           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)], null_aware
+           :   TantivyLookupExec: decode=[job_title]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)], null_aware
+           :         CooperativeExec
+           :           PgSearchScan: table=asa_cccf, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: table=asa_contact_list, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=asa_cccf, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
-           :       CooperativeExec
-           :         PgSearchScan: table=asa_contact_list, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-B","lenient":null,"conjunction_mode":null}}}}
-           :     CooperativeExec
-           :       PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
-(17 rows)
+           :         PgSearchScan: table=asa_contact_list, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"list_id","query_string":"list-A","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
 
 SELECT job_title, COUNT(*) AS doc_count
 FROM asa_cccf
@@ -389,8 +392,8 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (count(*)) DESC, asa_excl_outer.label
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -403,11 +406,11 @@ ORDER BY doc_count DESC, label;
            :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@0, id@0)], projection=[label@1]
            :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, eid@0)], null_aware
            :       CooperativeExec
-           :         PgSearchScan: table=asa_excl_outer, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"label","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=asa_excl_outer, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"label","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
-           :         PgSearchScan: table=asa_excl_inner, segments=1, visibility=eager, query="all"
+           :         PgSearchScan: table=asa_excl_inner, segments=1, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=asa_excl_include, segments=1, dynamic_filters=1, visibility=eager, query="all"
+           :       PgSearchScan: table=asa_excl_include, segments=1, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT label, COUNT(*) AS doc_count
@@ -651,14 +654,14 @@ WHERE a.id NOT IN (
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, a_id@0)], filter=val@1 > threshold@0, projection=[val@3]
      :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, aid@0)], null_aware
      :       CooperativeExec
-     :         PgSearchScan: table=a, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"outermatch","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=a, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"outermatch","lenient":null,"conjunction_mode":null}}}}
      :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, y_id@1)], projection=[aid@0]
      :         CooperativeExec
-     :           PgSearchScan: table=y, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"block","lenient":null,"conjunction_mode":null}}}}
+     :           PgSearchScan: table=y, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"block","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec
-     :           PgSearchScan: table=x, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :           PgSearchScan: table=x, segments=1, dynamic_filters=1, query="all"
      :     CooperativeExec
-     :       PgSearchScan: table=b, segments=1, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=b, segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SET paradedb.enable_aggregate_custom_scan TO on;

--- a/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
@@ -67,8 +67,8 @@ FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category;
-                                                                                                                              QUERY PLAN                                                                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                      QUERY PLAN                                                                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*))
    Backend: DataFusion
@@ -77,12 +77,13 @@ GROUP BY p.category;
    Aggregates: COUNT(*)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
-     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(13 rows)
+     :   TantivyLookupExec: decode=[category]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(14 rows)
 
 SELECT p.category, COUNT(*)
 FROM topk_products p
@@ -109,8 +110,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.category, (count(*))
    ->  Sort
@@ -125,12 +126,13 @@ LIMIT 3;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=3), expr=[agg_0@1 DESC], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
-                 :       CooperativeExec
-                 :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
-                 :       CooperativeExec
-                 :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(19 rows)
+                 :     TantivyLookupExec: decode=[category]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(20 rows)
 
 SELECT p.category, COUNT(*)
 FROM topk_products p
@@ -157,8 +159,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 2;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.category, (sum(p.price))
    ->  Sort
@@ -173,12 +175,13 @@ LIMIT 2;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=2), expr=[agg_0@1 DESC], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[sum(p_0.price) as agg_0]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
-                 :       CooperativeExec
-                 :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
-                 :       CooperativeExec
-                 :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(19 rows)
+                 :     TantivyLookupExec: decode=[category]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(20 rows)
 
 SELECT p.category, SUM(p.price)
 FROM topk_products p
@@ -284,8 +287,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 1;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.category, (count(*))
    ->  Sort
@@ -300,12 +303,13 @@ LIMIT 1;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=1), expr=[agg_0@1 DESC], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
-                 :       CooperativeExec
-                 :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
-                 :       CooperativeExec
-                 :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(19 rows)
+                 :     TantivyLookupExec: decode=[category]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(20 rows)
 
 SELECT p.category, COUNT(*)
 FROM topk_products p
@@ -459,8 +463,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
-                                                                                                                                              QUERY PLAN                                                                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: p.category
@@ -472,12 +476,13 @@ LIMIT 3;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=3), expr=[category@0 ASC NULLS LAST], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
-                 :       CooperativeExec
-                 :         PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
-                 :       CooperativeExec
-                 :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(16 rows)
+                 :     TantivyLookupExec: decode=[category]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=p, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(17 rows)
 
 SELECT p.category, COUNT(*)
 FROM topk_products p
@@ -561,8 +566,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (min(p.price))
@@ -574,12 +579,13 @@ LIMIT 3;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=3), expr=[agg_0@1 ASC NULLS LAST], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[min(p_0.price) as agg_0, max(p_0.price) as agg_1]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
-                 :       CooperativeExec
-                 :         PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
-                 :       CooperativeExec
-                 :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
-(16 rows)
+                 :     TantivyLookupExec: decode=[category]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+(17 rows)
 
 SELECT p.category, MIN(p.price), MAX(p.price)
 FROM topk_products p

--- a/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
@@ -67,8 +67,8 @@ FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category;
-                                                                                                                      QUERY PLAN                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                               QUERY PLAN                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (count(*))
    Backend: DataFusion
@@ -80,9 +80,9 @@ GROUP BY p.category;
      :   TantivyLookupExec: decode=[category]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (14 rows)
 
 SELECT p.category, COUNT(*)
@@ -110,8 +110,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.category, (count(*))
    ->  Sort
@@ -129,9 +129,9 @@ LIMIT 3;
                  :     TantivyLookupExec: decode=[category]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (20 rows)
 
 SELECT p.category, COUNT(*)
@@ -159,8 +159,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 2;
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.category, (sum(p.price))
    ->  Sort
@@ -178,9 +178,9 @@ LIMIT 2;
                  :     TantivyLookupExec: decode=[category]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (20 rows)
 
 SELECT p.category, SUM(p.price)
@@ -287,8 +287,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 1;
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.category, (count(*))
    ->  Sort
@@ -306,9 +306,9 @@ LIMIT 1;
                  :     TantivyLookupExec: decode=[category]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=p, segments=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (20 rows)
 
 SELECT p.category, COUNT(*)
@@ -463,8 +463,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
-                                                                                                                                      QUERY PLAN                                                                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                               QUERY PLAN                                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: p.category
@@ -479,9 +479,9 @@ LIMIT 3;
                  :     TantivyLookupExec: decode=[category]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (17 rows)
 
 SELECT p.category, COUNT(*)
@@ -566,8 +566,8 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (min(p.price))
@@ -582,9 +582,9 @@ LIMIT 3;
                  :     TantivyLookupExec: decode=[category]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=p, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, query="all"
+                 :           PgSearchScan: table=t, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (17 rows)
 
 SELECT p.category, MIN(p.price), MAX(p.price)

--- a/pg_search/tests/pg_regress/expected/alias_quoted_mixed_case.out
+++ b/pg_search/tests/pg_regress/expected/alias_quoted_mixed_case.out
@@ -62,8 +62,8 @@ FROM repro_5525_parent AS "Parent"
 JOIN repro_5525_child  AS "Child"
   ON "Parent"."child_id" = "Child"."id" AND "Child"."state" = 'active'
 WHERE "Parent"."owner" = 'user-1';
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: repro_5525_parent_idx (Parent), repro_5525_child_idx (Child)
@@ -72,9 +72,9 @@ WHERE "Parent"."owner" = 'user-1';
      : AggregateExec: mode=Single, gby=[], aggr=[count(parent_0.id) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, child_id@1)], projection=[id@1]
      :     CooperativeExec
-     :       PgSearchScan: table=Child, segments=1, visibility=eager, query={"term":{"field":"state","value":"active"}}
+     :       PgSearchScan: table=Child, segments=1, query={"term":{"field":"state","value":"active"}}
      :     CooperativeExec
-     :       PgSearchScan: table=Parent, segments=1, dynamic_filters=1, visibility=eager, query={"term":{"field":"owner","value":"user-1"}}
+     :       PgSearchScan: table=Parent, segments=1, dynamic_filters=1, query={"term":{"field":"owner","value":"user-1"}}
 (11 rows)
 
 SELECT count("Parent"."id")
@@ -126,8 +126,8 @@ WHERE "Parent"."owner" = 'user-1'
   AND "Child"."id" @@@ paradedb.term('state', 'active'::text)
 ORDER BY "Parent"."updated_at" DESC
 LIMIT 12;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: Child INNER Parent
@@ -141,9 +141,9 @@ LIMIT 12;
            :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, child_id@1)], projection=[ctid_0@0, ctid_1@2, updated_at@4]
            :           CooperativeExec
-           :             PgSearchScan: table=Child, segments=1, query={"with_index":{"query":{"term":{"field":"state","value":"active"}}}}
+           :             PgSearchScan: table=Child, segments=1, visibility=deferred, query={"with_index":{"query":{"term":{"field":"state","value":"active"}}}}
            :           CooperativeExec
-           :             PgSearchScan: table=Parent, segments=1, dynamic_filters=2, query={"term":{"field":"owner","value":"user-1"}}
+           :             PgSearchScan: table=Parent, segments=1, dynamic_filters=2, visibility=deferred, query={"term":{"field":"owner","value":"user-1"}}
 (16 rows)
 
 SELECT "Parent"."id"
@@ -256,8 +256,8 @@ JOIN repro_5525_child  AS "456"
 GROUP BY "123"."owner"
 ORDER BY "123"."owner"
 LIMIT 5;
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: "123".owner
@@ -269,12 +269,13 @@ LIMIT 5;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=5), expr=[owner@0 ASC NULLS LAST], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[owner@1 as owner], aggr=[count(_123_0.id) as agg_0]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, child_id@1)], projection=[id@1, owner@3]
-                 :       CooperativeExec
-                 :         PgSearchScan: table=456, segments=1, visibility=eager, query={"term":{"field":"state","value":"active"}}
-                 :       CooperativeExec
-                 :         PgSearchScan: table=123, segments=1, dynamic_filters=2, visibility=eager, query="all"
-(16 rows)
+                 :     TantivyLookupExec: decode=[owner]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, child_id@1)], projection=[id@1, owner@3]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=456, segments=1, query={"term":{"field":"state","value":"active"}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=123, segments=1, dynamic_filters=2, query="all"
+(17 rows)
 
 SELECT "123"."owner", count("123"."id")
 FROM repro_5525_parent AS "123"

--- a/pg_search/tests/pg_regress/expected/alias_quoted_mixed_case.out
+++ b/pg_search/tests/pg_regress/expected/alias_quoted_mixed_case.out
@@ -62,8 +62,8 @@ FROM repro_5525_parent AS "Parent"
 JOIN repro_5525_child  AS "Child"
   ON "Parent"."child_id" = "Child"."id" AND "Child"."state" = 'active'
 WHERE "Parent"."owner" = 'user-1';
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Backend: DataFusion
    Indexes: repro_5525_parent_idx (Parent), repro_5525_child_idx (Child)
@@ -72,9 +72,9 @@ WHERE "Parent"."owner" = 'user-1';
      : AggregateExec: mode=Single, gby=[], aggr=[count(parent_0.id) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, child_id@1)], projection=[id@1]
      :     CooperativeExec
-     :       PgSearchScan: table=Child, segments=1, query={"term":{"field":"state","value":"active"}}
+     :       PgSearchScan: table=Child, segments=1, visibility=eager, query={"term":{"field":"state","value":"active"}}
      :     CooperativeExec
-     :       PgSearchScan: table=Parent, segments=1, dynamic_filters=1, query={"term":{"field":"owner","value":"user-1"}}
+     :       PgSearchScan: table=Parent, segments=1, dynamic_filters=1, visibility=eager, query={"term":{"field":"owner","value":"user-1"}}
 (11 rows)
 
 SELECT count("Parent"."id")
@@ -126,8 +126,8 @@ WHERE "Parent"."owner" = 'user-1'
   AND "Child"."id" @@@ paradedb.term('state', 'active'::text)
 ORDER BY "Parent"."updated_at" DESC
 LIMIT 12;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: Child INNER Parent
@@ -141,9 +141,9 @@ LIMIT 12;
            :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, child_id@1)], projection=[ctid_0@0, ctid_1@2, updated_at@4]
            :           CooperativeExec
-           :             PgSearchScan: table=Child, segments=1, visibility=deferred, query={"with_index":{"query":{"term":{"field":"state","value":"active"}}}}
+           :             PgSearchScan: table=Child, segments=1, query={"with_index":{"query":{"term":{"field":"state","value":"active"}}}}
            :           CooperativeExec
-           :             PgSearchScan: table=Parent, segments=1, dynamic_filters=2, visibility=deferred, query={"term":{"field":"owner","value":"user-1"}}
+           :             PgSearchScan: table=Parent, segments=1, dynamic_filters=2, query={"term":{"field":"owner","value":"user-1"}}
 (16 rows)
 
 SELECT "Parent"."id"
@@ -256,8 +256,8 @@ JOIN repro_5525_child  AS "456"
 GROUP BY "123"."owner"
 ORDER BY "123"."owner"
 LIMIT 5;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: "123".owner
@@ -272,9 +272,9 @@ LIMIT 5;
                  :     TantivyLookupExec: decode=[owner]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, child_id@1)], projection=[id@1, owner@3]
                  :         CooperativeExec
-                 :           PgSearchScan: table=456, segments=1, query={"term":{"field":"state","value":"active"}}
+                 :           PgSearchScan: table=456, segments=1, visibility=eager, query={"term":{"field":"state","value":"active"}}
                  :         CooperativeExec
-                 :           PgSearchScan: table=123, segments=1, dynamic_filters=2, query="all"
+                 :           PgSearchScan: table=123, segments=1, dynamic_filters=2, visibility=eager, query="all"
 (17 rows)
 
 SELECT "123"."owner", count("123"."id")

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -108,8 +108,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                      QUERY PLAN                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Unique
@@ -128,9 +128,9 @@ ORDER BY p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, query="all"
+                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
                  :           CooperativeExec
-                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 -- =============================================================================
@@ -149,8 +149,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY s.name
     LIMIT 20;
-                                                                                                        QUERY PLAN                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=10.00..11.00 rows=20 width=32)
    ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=20 width=32)
          Relation Tree: s INNER p
@@ -163,9 +163,9 @@ ORDER BY s.name
            :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3]
            :         CooperativeExec
-           :           PgSearchScan: table=s, segments=1, dynamic_filters=1, query="all"
+           :           PgSearchScan: table=s, segments=1, dynamic_filters=1, visibility=deferred, query="all"
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (15 rows)
 
 SELECT s.name AS supplier_name
@@ -249,8 +249,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY paradedb.score(p.id) DESC, p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                       QUERY PLAN                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, (paradedb.score(p.id))
    ->  Unique
@@ -269,10 +269,10 @@ ORDER BY paradedb.score(p.id) DESC, p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_0@0, score@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, query="all"
+                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
                  :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id, name@3 as name]
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (22 rows)
 
 SELECT DISTINCT p.name, paradedb.score(p.id) AS score
@@ -324,8 +324,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                       QUERY PLAN                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name, c.name
    ->  Unique
@@ -344,12 +344,12 @@ ORDER BY p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1, ctid_2]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@3)], projection=[ctid_0@3, name@4, ctid_1@0, name@2, ctid_2@5, name@7]
                  :           CooperativeExec
-                 :             PgSearchScan: table=c, segments=1, query="all"
+                 :             PgSearchScan: table=c, segments=1, visibility=deferred, query="all"
                  :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_2@3, category_id@5, name@6]
                  :             CooperativeExec
-                 :               PgSearchScan: table=s, segments=1, query="all"
+                 :               PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (24 rows)
 
 SELECT DISTINCT p.name AS product, s.name AS supplier, c.name AS category
@@ -427,8 +427,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY s.name
     LIMIT 10;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                      QUERY PLAN                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Unique
@@ -447,9 +447,9 @@ ORDER BY s.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, query="all"
+                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
                  :           CooperativeExec
-                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 -- =============================================================================
@@ -465,8 +465,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                        QUERY PLAN                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -481,9 +481,9 @@ ORDER BY p.name
            :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         CooperativeExec
-           :           PgSearchScan: table=s, segments=1, query="all"
+           :           PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- =============================================================================
@@ -499,8 +499,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless' AND s.name = 'TechCorp'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                        QUERY PLAN                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -515,9 +515,9 @@ ORDER BY p.name
            :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         CooperativeExec
-           :           PgSearchScan: table=s, segments=1, query={"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
+           :           PgSearchScan: table=s, segments=1, visibility=deferred, query={"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- =============================================================================
@@ -575,8 +575,8 @@ FROM dist_products p
          JOIN dist_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
     LIMIT 10;
-                                                                                                               QUERY PLAN                                                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                      QUERY PLAN                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: (pdb.agg_fn('COUNT(*)'::text))
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -588,9 +588,9 @@ WHERE p.description @@@ 'wireless'
            : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, supplier_id@0)], projection=[]
            :     CooperativeExec
-           :       PgSearchScan: table=s, segments=1, visibility=eager, query="all"
+           :       PgSearchScan: table=s, segments=1, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (14 rows)
 
 -- =============================================================================
@@ -623,8 +623,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, s)
-                                                                                                               QUERY PLAN                                                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.name, s.name
    Sort Key: p.name
@@ -635,12 +635,13 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
          Group By: name
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[name@0 as name, name@1 as name], aggr=[]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, supplier_id@1)], projection=[name@2, name@1]
-           :     CooperativeExec
-           :       PgSearchScan: table=s, segments=1, visibility=eager, query="all"
-           :     CooperativeExec
-           :       PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+           :   TantivyLookupExec: decode=[name, name]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, supplier_id@1)], projection=[name@2, name@1]
+           :       CooperativeExec
+           :         PgSearchScan: table=s, segments=1, query="all"
+           :       CooperativeExec
+           :         PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
 
 -- =============================================================================
 -- TEST 14: DISTINCT with search predicates on both sides
@@ -716,8 +717,8 @@ WHERE
 ORDER BY
     score DESC
 LIMIT 10;
-                                                                                                                                                                 QUERY PLAN                                                                                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, (paradedb.score(p.id))
    ->  Unique
@@ -737,10 +738,10 @@ LIMIT 10;
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], filter=__p_1_tag_0@1 OR __s_0_tag_0@0, projection=[ctid_0@0, score@3, ctid_1@4, id@6, name@7]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"USA","lenient":null,"conjunction_mode":null}}}}, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"USA","lenient":null,"conjunction_mode":null}}}}, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
                  :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id, name@4 as name, __p_1_tag_0@5 as __p_1_tag_0]
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
 (23 rows)
 
 SELECT DISTINCT
@@ -857,8 +858,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 3 OFFSET 2;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                      QUERY PLAN                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Unique
@@ -878,9 +879,9 @@ ORDER BY p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, query="all"
+                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
                  :           CooperativeExec
-                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (22 rows)
 
 -- Expected: Offset: 2 appears in the Custom Scan (ParadeDB Join Scan) node
@@ -928,12 +929,12 @@ LIMIT 50;
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(person_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, name@4]
                  :           CooperativeExec
-                 :             PgSearchScan: table=j, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=j, segments=1, visibility=deferred, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
                  :           HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@1, person_id@0)], null_aware
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, query="all"
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query="all"
                  :             CooperativeExec
-                 :               PgSearchScan: table=j2, segments=1, visibility=eager, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=j2, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 SELECT DISTINCT p.id, p.name
@@ -965,8 +966,8 @@ WHERE j.id @@@ paradedb.parse('title:developer')
   )
 ORDER BY p.id
 LIMIT 50;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: p.id
@@ -979,12 +980,12 @@ LIMIT 50;
                  :   AggregateExec: mode=Single, gby=[id@0 as id, name@1 as name], aggr=[]
                  :     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(person_id@0, id@0)]
                  :       CooperativeExec
-                 :         PgSearchScan: table=j, segments=1, visibility=eager, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
+                 :         PgSearchScan: table=j, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
                  :       HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, person_id@0)], null_aware
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=eager, query="all"
+                 :           PgSearchScan: table=p, segments=1, dynamic_filters=2, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: table=j2, segments=1, visibility=eager, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=j2, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT DISTINCT p.id, p.name
@@ -1037,8 +1038,8 @@ WHERE deleted_at IS NULL
   )
 ORDER BY profile_id
 LIMIT 50;
-                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Custom Scan (ParadeDB Join Scan)
@@ -1055,9 +1056,9 @@ LIMIT 50;
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0]
                  :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(profile_id@1, profile_id@0)]
                  :           CooperativeExec
-                 :             PgSearchScan: table=pp, segments=1, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
+                 :             PgSearchScan: table=pp, segments=1, visibility=deferred, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
                  :           CooperativeExec
-                 :             PgSearchScan: table=pp2, segments=1, dynamic_filters=1, visibility=eager, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
+                 :             PgSearchScan: table=pp2, segments=1, dynamic_filters=1, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
 (19 rows)
 
 SELECT DISTINCT profile_id

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -108,8 +108,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                      QUERY PLAN                                                                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Unique
@@ -128,9 +128,9 @@ ORDER BY p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
+                 :             PgSearchScan: table=s, segments=1, query="all"
                  :           CooperativeExec
-                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 -- =============================================================================
@@ -149,8 +149,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY s.name
     LIMIT 20;
-                                                                                                                  QUERY PLAN                                                                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=10.00..11.00 rows=20 width=32)
    ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=20 width=32)
          Relation Tree: s INNER p
@@ -163,9 +163,9 @@ ORDER BY s.name
            :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3]
            :         CooperativeExec
-           :           PgSearchScan: table=s, segments=1, dynamic_filters=1, visibility=deferred, query="all"
+           :           PgSearchScan: table=s, segments=1, dynamic_filters=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (15 rows)
 
 SELECT s.name AS supplier_name
@@ -249,8 +249,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY paradedb.score(p.id) DESC, p.name
     LIMIT 10;
-                                                                                                                       QUERY PLAN                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, (paradedb.score(p.id))
    ->  Unique
@@ -269,10 +269,10 @@ ORDER BY paradedb.score(p.id) DESC, p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_0@0, score@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
+                 :             PgSearchScan: table=s, segments=1, query="all"
                  :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id, name@3 as name]
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (22 rows)
 
 SELECT DISTINCT p.name, paradedb.score(p.id) AS score
@@ -324,8 +324,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                       QUERY PLAN                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name, c.name
    ->  Unique
@@ -344,12 +344,12 @@ ORDER BY p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1, ctid_2]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@3)], projection=[ctid_0@3, name@4, ctid_1@0, name@2, ctid_2@5, name@7]
                  :           CooperativeExec
-                 :             PgSearchScan: table=c, segments=1, visibility=deferred, query="all"
+                 :             PgSearchScan: table=c, segments=1, query="all"
                  :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_2@3, category_id@5, name@6]
                  :             CooperativeExec
-                 :               PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
+                 :               PgSearchScan: table=s, segments=1, query="all"
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (24 rows)
 
 SELECT DISTINCT p.name AS product, s.name AS supplier, c.name AS category
@@ -427,8 +427,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY s.name
     LIMIT 10;
-                                                                                                                      QUERY PLAN                                                                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Unique
@@ -447,9 +447,9 @@ ORDER BY s.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
+                 :             PgSearchScan: table=s, segments=1, query="all"
                  :           CooperativeExec
-                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 -- =============================================================================
@@ -465,8 +465,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                  QUERY PLAN                                                                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -481,9 +481,9 @@ ORDER BY p.name
            :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         CooperativeExec
-           :           PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
+           :           PgSearchScan: table=s, segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- =============================================================================
@@ -499,8 +499,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless' AND s.name = 'TechCorp'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                  QUERY PLAN                                                                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -515,9 +515,9 @@ ORDER BY p.name
            :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         CooperativeExec
-           :           PgSearchScan: table=s, segments=1, visibility=deferred, query={"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
+           :           PgSearchScan: table=s, segments=1, query={"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=p, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- =============================================================================
@@ -575,8 +575,8 @@ FROM dist_products p
          JOIN dist_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
     LIMIT 10;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: (pdb.agg_fn('COUNT(*)'::text))
    ->  Custom Scan (ParadeDB Aggregate Scan)
@@ -588,9 +588,9 @@ WHERE p.description @@@ 'wireless'
            : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, supplier_id@0)], projection=[]
            :     CooperativeExec
-           :       PgSearchScan: table=s, segments=1, query="all"
+           :       PgSearchScan: table=s, segments=1, visibility=eager, query="all"
            :     CooperativeExec
-           :       PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (14 rows)
 
 -- =============================================================================
@@ -623,8 +623,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, s)
-                                                                                                       QUERY PLAN                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                QUERY PLAN                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: p.name, s.name
    Sort Key: p.name
@@ -638,9 +638,9 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
            :   TantivyLookupExec: decode=[name, name]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, supplier_id@1)], projection=[name@2, name@1]
            :       CooperativeExec
-           :         PgSearchScan: table=s, segments=1, query="all"
+           :         PgSearchScan: table=s, segments=1, visibility=eager, query="all"
            :       CooperativeExec
-           :         PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (16 rows)
 
 -- =============================================================================
@@ -717,8 +717,8 @@ WHERE
 ORDER BY
     score DESC
 LIMIT 10;
-                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                 QUERY PLAN                                                                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, (paradedb.score(p.id))
    ->  Unique
@@ -738,10 +738,10 @@ LIMIT 10;
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], filter=__p_1_tag_0@1 OR __s_0_tag_0@0, projection=[ctid_0@0, score@3, ctid_1@4, id@6, name@7]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"USA","lenient":null,"conjunction_mode":null}}}}, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=s, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"USA","lenient":null,"conjunction_mode":null}}}}, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
                  :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id, name@4 as name, __p_1_tag_0@5 as __p_1_tag_0]
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Wireless","lenient":null,"conjunction_mode":null}}}}
 (23 rows)
 
 SELECT DISTINCT
@@ -858,8 +858,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 3 OFFSET 2;
-                                                                                                                      QUERY PLAN                                                                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Unique
@@ -879,9 +879,9 @@ ORDER BY p.name
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=s, segments=1, visibility=deferred, query="all"
+                 :             PgSearchScan: table=s, segments=1, query="all"
                  :           CooperativeExec
-                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (22 rows)
 
 -- Expected: Offset: 2 appears in the Custom Scan (ParadeDB Join Scan) node
@@ -929,12 +929,12 @@ LIMIT 50;
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0, ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(person_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, name@4]
                  :           CooperativeExec
-                 :             PgSearchScan: table=j, segments=1, visibility=deferred, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: table=j, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
                  :           HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@1, person_id@0)], null_aware
                  :             CooperativeExec
-                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=deferred, query="all"
+                 :               PgSearchScan: table=p, segments=1, dynamic_filters=1, query="all"
                  :             CooperativeExec
-                 :               PgSearchScan: table=j2, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
+                 :               PgSearchScan: table=j2, segments=1, visibility=eager, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 SELECT DISTINCT p.id, p.name
@@ -966,8 +966,8 @@ WHERE j.id @@@ paradedb.parse('title:developer')
   )
 ORDER BY p.id
 LIMIT 50;
-                                                                                     QUERY PLAN                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: p.id
@@ -980,12 +980,12 @@ LIMIT 50;
                  :   AggregateExec: mode=Single, gby=[id@0 as id, name@1 as name], aggr=[]
                  :     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(person_id@0, id@0)]
                  :       CooperativeExec
-                 :         PgSearchScan: table=j, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
+                 :         PgSearchScan: table=j, segments=1, visibility=eager, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
                  :       HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, person_id@0)], null_aware
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=1, dynamic_filters=2, query="all"
+                 :           PgSearchScan: table=p, segments=1, dynamic_filters=2, visibility=eager, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: table=j2, segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=j2, segments=1, visibility=eager, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT DISTINCT p.id, p.name
@@ -1038,8 +1038,8 @@ WHERE deleted_at IS NULL
   )
 ORDER BY profile_id
 LIMIT 50;
-                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Custom Scan (ParadeDB Join Scan)
@@ -1056,9 +1056,9 @@ LIMIT 50;
                  :       TantivyLookupExec: decode=[], fetch=[ctid_0]
                  :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(profile_id@1, profile_id@0)]
                  :           CooperativeExec
-                 :             PgSearchScan: table=pp, segments=1, visibility=deferred, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
+                 :             PgSearchScan: table=pp, segments=1, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
                  :           CooperativeExec
-                 :             PgSearchScan: table=pp2, segments=1, dynamic_filters=1, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
+                 :             PgSearchScan: table=pp2, segments=1, dynamic_filters=1, visibility=eager, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"deleted_at"}}]}},{"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(group_id = 'c624233d-2c2c-43ab-976e-0847bfd58387'::text)"}]}}]}}
 (19 rows)
 
 SELECT DISTINCT profile_id

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -74,8 +74,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                       QUERY PLAN                                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -85,9 +85,9 @@ WHERE f.content @@@ 'Section';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :       PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (12 rows)
 
 SELECT COUNT(*)
@@ -106,8 +106,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                        QUERY PLAN                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -125,9 +125,9 @@ LIMIT 5;
                  :     TantivyLookupExec: decode=[title]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :         CooperativeExec
-                 :           PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+                 :           PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (20 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
@@ -153,8 +153,8 @@ SELECT DISTINCT f.title
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f, p)
-                                                                                        QUERY PLAN                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: f.title
    Backend: DataFusion
@@ -165,9 +165,9 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f,
      :   TantivyLookupExec: decode=[title]
      :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1]
      :       CooperativeExec
-     :         PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :         PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :         PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
 (13 rows)
 
 SELECT COUNT(*) FROM (
@@ -210,8 +210,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -230,14 +230,14 @@ WHERE f.content @@@ 'Section';
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       DistributedLeafExec:
-     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=2, partitions=4
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
-     :     │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :     │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
 (27 rows)
 
@@ -256,8 +256,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                           QUERY PLAN                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                    QUERY PLAN                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -288,14 +288,14 @@ LIMIT 5;
                  :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
                  :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │           DistributedLeafExec:
-                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=2, partitions=4
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
-                 :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
 (39 rows)
 
@@ -321,8 +321,8 @@ SELECT DISTINCT f.title
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f, p)
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: f.title
    Backend: DataFusion
@@ -346,14 +346,14 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f,
      :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
      :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :     │           DistributedLeafExec:
-     :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-     :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
      :     └──────────────────────────────────────────────────
      :       ┌───── Stage 1 ── tasks=2, partitions=4
      :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :       │   DistributedLeafExec:
-     :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :       └──────────────────────────────────────────────────
 (32 rows)
 

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -74,8 +74,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                                QUERY PLAN                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -85,9 +85,9 @@ WHERE f.content @@@ 'Section';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :       PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 SELECT COUNT(*)
@@ -106,8 +106,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                QUERY PLAN                                                                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -122,12 +122,13 @@ LIMIT 5;
                DataFusion Physical Plan: 
                  : SortExec: TopK(fetch=5), expr=[title@0 ASC NULLS LAST], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
-                 :       CooperativeExec
-                 :         PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :       CooperativeExec
-                 :         PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(19 rows)
+                 :     TantivyLookupExec: decode=[title]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+(20 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
@@ -152,8 +153,8 @@ SELECT DISTINCT f.title
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f, p)
-                                                                                                QUERY PLAN                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: f.title
    Backend: DataFusion
@@ -161,12 +162,13 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f,
    Group By: title
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[title@0 as title], aggr=[]
-     :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@0, file_id@0)], projection=[title@1]
-     :     CooperativeExec
-     :       PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :     CooperativeExec
-     :       PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-(12 rows)
+     :   TantivyLookupExec: decode=[title]
+     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1]
+     :       CooperativeExec
+     :         PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       CooperativeExec
+     :         PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+(13 rows)
 
 SELECT COUNT(*) FROM (
     SELECT DISTINCT f.title
@@ -208,8 +210,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -228,14 +230,14 @@ WHERE f.content @@@ 'Section';
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       DistributedLeafExec:
-     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=2, partitions=4
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
-     :     │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :     │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
 (27 rows)
 
@@ -254,8 +256,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                    QUERY PLAN                                                                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -280,21 +282,22 @@ LIMIT 5;
                  :     ┌───── Stage 2 ── tasks=2, partitions=6
                  :     │ RepartitionExec: partitioning=Hash([title@0], 6), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-                 :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
-                 :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         DistributedLeafExec:
-                 :     │           t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-                 :     │           t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     │     TantivyLookupExec: decode=[title]
+                 :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
+                 :     │         CoalescePartitionsExec
+                 :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+                 :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :     │           DistributedLeafExec:
+                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=2, partitions=4
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
-                 :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
-(38 rows)
+(39 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
@@ -318,8 +321,8 @@ SELECT DISTINCT f.title
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f, p)
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: f.title
    Backend: DataFusion
@@ -328,33 +331,31 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: f,
    DataFusion Physical Plan: 
      : ┌───── DistributedExec
      : │ CoalescePartitionsExec
-     : │   [Stage 4] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+     : │   [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 4 ── tasks=2, partitions=3
+     :   ┌───── Stage 3 ── tasks=2, partitions=3
      :   │ AggregateExec: mode=FinalPartitioned, gby=[title@0 as title], aggr=[]
-     :   │   [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+     :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 3 ── tasks=2, partitions=6
+     :     ┌───── Stage 2 ── tasks=2, partitions=6
      :     │ RepartitionExec: partitioning=Hash([title@0], 6), input_partitions=3
      :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[]
-     :     │     HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(id@0, file_id@0)], projection=[title@1]
-     :     │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=2
-     :     │       [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+     :     │     TantivyLookupExec: decode=[title]
+     :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1]
+     :     │         CoalescePartitionsExec
+     :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+     :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+     :     │           DistributedLeafExec:
+     :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
      :     └──────────────────────────────────────────────────
-     :       ┌───── Stage 1 ── tasks=2, partitions=6
-     :       │ RepartitionExec: partitioning=Hash([id@0], 6), input_partitions=1
+     :       ┌───── Stage 1 ── tasks=2, partitions=4
+     :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :       │   DistributedLeafExec:
-     :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :       └──────────────────────────────────────────────────
-     :       ┌───── Stage 2 ── tasks=2, partitions=6
-     :       │ RepartitionExec: partitioning=Hash([file_id@0], 6), input_partitions=3
-     :       │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :       │     DistributedLeafExec:
-     :       │       t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-     :       │       t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-     :       └──────────────────────────────────────────────────
-(34 rows)
+(32 rows)
 
 SELECT COUNT(*) FROM (
     SELECT DISTINCT f.title

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
@@ -119,8 +119,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                                 QUERY PLAN                                                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -145,17 +145,18 @@ LIMIT 5;
                  :     ┌───── Stage 1 ── tasks=3, partitions=9
                  :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=1
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-                 :     │     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
-                 :     │       DistributedLeafExec:
-                 :     │         t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │         t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │         t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │       DistributedLeafExec:
-                 :     │         t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=eager, query="all"
-                 :     │         t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=eager, query="all"
-                 :     │         t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=eager, query="all"
+                 :     │     TantivyLookupExec: decode=[title]
+                 :     │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
+                 :     │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
+                 :     │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-(34 rows)
+(35 rows)
 
 SELECT COUNT(*)
 FROM mpp_agg_pb_files f JOIN mpp_agg_pb_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_partition_by.out
@@ -119,8 +119,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                         QUERY PLAN                                                                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -148,13 +148,13 @@ LIMIT 5;
                  :     │     TantivyLookupExec: decode=[title]
                  :     │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :     │         DistributedLeafExec:
-                 :     │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :     │         DistributedLeafExec:
-                 :     │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
-                 :     │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
-                 :     │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
+                 :     │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=eager, query="all"
+                 :     │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=eager, query="all"
+                 :     │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=eager, query="all"
                  :     └──────────────────────────────────────────────────
 (35 rows)
 

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -103,8 +103,8 @@ FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 GROUP BY f.category
 ORDER BY f.category;
-                                                                                               QUERY PLAN                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
    Sort Key: f.category
@@ -132,14 +132,14 @@ ORDER BY f.category;
            :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
            :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :     │           DistributedLeafExec:
-           :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-           :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+           :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+           :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
            :     └──────────────────────────────────────────────────
            :       ┌───── Stage 1 ── tasks=2, partitions=4
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
-           :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
 (36 rows)
 
@@ -193,8 +193,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.category, f.title
 ORDER BY f.category, f.title
 LIMIT 10;
-                                                                                                  QUERY PLAN                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, f.title, (count(*))
    ->  Sort
@@ -224,14 +224,14 @@ LIMIT 10;
                  :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
                  :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │           DistributedLeafExec:
-                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=2, partitions=4
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
-                 :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
 (38 rows)
 
@@ -282,8 +282,8 @@ GROUP BY f.category
 HAVING COUNT(*) > 100
 ORDER BY s DESC
 LIMIT 3;
-                                                                                                  QUERY PLAN                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -315,14 +315,14 @@ LIMIT 3;
                  :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
                  :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │           DistributedLeafExec:
-                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=2, partitions=4
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
-                 :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
 (40 rows)
 
@@ -360,8 +360,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -380,14 +380,14 @@ WHERE f.content @@@ 'Section';
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       DistributedLeafExec:
-     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=2, partitions=4
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
-     :     │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :     │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
 (27 rows)
 
@@ -454,8 +454,8 @@ JOIN mpp_postagg_categories c ON f.category = c.name
 WHERE f.content @@@ 'Section'
 GROUP BY c.name
 ORDER BY c.name;
-                                                                                                        QUERY PLAN                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: c.name, (count(*)), (sum(p.size_bytes))
    Sort Key: c.name
@@ -485,20 +485,20 @@ ORDER BY c.name;
            :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
            :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :     │           DistributedLeafExec:
-           :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
-           :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+           :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+           :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
            :     └──────────────────────────────────────────────────
            :       ┌───── Stage 1 ── tasks=2, partitions=4
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
-           :       │     t0: PgSearchScan: table=c, segments=2, query="all"
-           :       │     t1: PgSearchScan: table=c, segments=2, query="all"
+           :       │     t0: PgSearchScan: table=c, segments=2, visibility=eager, query="all"
+           :       │     t1: PgSearchScan: table=c, segments=2, visibility=eager, query="all"
            :       └──────────────────────────────────────────────────
            :       ┌───── Stage 2 ── tasks=2, partitions=4
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
-           :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
 (44 rows)
 

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -103,8 +103,8 @@ FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 GROUP BY f.category
 ORDER BY f.category;
-                                                                                                        QUERY PLAN                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
    Sort Key: f.category
@@ -126,21 +126,22 @@ ORDER BY f.category;
            :     ┌───── Stage 2 ── tasks=2, partitions=6
            :     │ RepartitionExec: partitioning=Hash([category@0], 6), input_partitions=3
            :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1, min(p_1.size_bytes) as agg_2, max(p_1.size_bytes) as agg_3]
-           :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
-           :     │       CoalescePartitionsExec
-           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
-           :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :     │         DistributedLeafExec:
-           :     │           t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-           :     │           t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+           :     │     TantivyLookupExec: decode=[category]
+           :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
+           :     │         CoalescePartitionsExec
+           :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+           :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :     │           DistributedLeafExec:
+           :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+           :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
            :       ┌───── Stage 1 ── tasks=2, partitions=4
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
-           :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
-(35 rows)
+(36 rows)
 
 SELECT f.category,
        COUNT(*) AS row_count,
@@ -192,8 +193,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.category, f.title
 ORDER BY f.category, f.title
 LIMIT 10;
-                                                                                                           QUERY PLAN                                                                                                           
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, f.title, (count(*))
    ->  Sort
@@ -217,21 +218,22 @@ LIMIT 10;
                  :     ┌───── Stage 2 ── tasks=2, partitions=6
                  :     │ RepartitionExec: partitioning=Hash([category@0, title@1], 6), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[category@1 as category, title@0 as title], aggr=[count(1) as agg_0]
-                 :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, category@2]
-                 :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         DistributedLeafExec:
-                 :     │           t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-                 :     │           t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     │     TantivyLookupExec: decode=[title, category]
+                 :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, category@2]
+                 :     │         CoalescePartitionsExec
+                 :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+                 :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :     │           DistributedLeafExec:
+                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=2, partitions=4
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
-                 :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
-(37 rows)
+(38 rows)
 
 SELECT f.category, f.title, COUNT(*) AS pages_per_file
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -280,8 +282,8 @@ GROUP BY f.category
 HAVING COUNT(*) > 100
 ORDER BY s DESC
 LIMIT 3;
-                                                                                                           QUERY PLAN                                                                                                           
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -307,21 +309,22 @@ LIMIT 3;
                  :     ┌───── Stage 2 ── tasks=2, partitions=6
                  :     │ RepartitionExec: partitioning=Hash([category@0], 6), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-                 :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
-                 :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         DistributedLeafExec:
-                 :     │           t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-                 :     │           t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     │     TantivyLookupExec: decode=[category]
+                 :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
+                 :     │         CoalescePartitionsExec
+                 :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+                 :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :     │           DistributedLeafExec:
+                 :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+                 :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=2, partitions=4
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
                  :       │   DistributedLeafExec:
-                 :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
-(39 rows)
+(40 rows)
 
 SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -357,8 +360,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -377,14 +380,14 @@ WHERE f.content @@@ 'Section';
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       DistributedLeafExec:
-     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :   │         t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+     :   │         t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=2, partitions=4
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
-     :     │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :     │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t0: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t1: PgSearchScan: table=f, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
 (27 rows)
 
@@ -451,8 +454,8 @@ JOIN mpp_postagg_categories c ON f.category = c.name
 WHERE f.content @@@ 'Section'
 GROUP BY c.name
 ORDER BY c.name;
-                                                                                                                 QUERY PLAN                                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: c.name, (count(*)), (sum(p.size_bytes))
    Sort Key: c.name
@@ -482,20 +485,20 @@ ORDER BY c.name;
            :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
            :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :     │           DistributedLeafExec:
-           :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
-           :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+           :     │             t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
+           :     │             t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
            :       ┌───── Stage 1 ── tasks=2, partitions=4
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
-           :       │     t0: PgSearchScan: table=c, segments=2, visibility=eager, query="all"
-           :       │     t1: PgSearchScan: table=c, segments=2, visibility=eager, query="all"
+           :       │     t0: PgSearchScan: table=c, segments=2, query="all"
+           :       │     t1: PgSearchScan: table=c, segments=2, query="all"
            :       └──────────────────────────────────────────────────
            :       ┌───── Stage 2 ── tasks=2, partitions=4
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
            :       │   DistributedLeafExec:
-           :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t0: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t1: PgSearchScan: table=f, segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
 (44 rows)
 

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -86,8 +86,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                      QUERY PLAN                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -102,9 +102,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: table=f, segments=3, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=f, segments=3, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, query="all"
+           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, visibility=deferred, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes
@@ -138,8 +138,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                           QUERY PLAN                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                      QUERY PLAN                                                                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -160,13 +160,13 @@ LIMIT 10;
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
-           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
-           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
+           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=deferred, query="all"
+           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=deferred, query="all"
+           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=deferred, query="all"
            :   └──────────────────────────────────────────────────
 (28 rows)
 
@@ -263,8 +263,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                                       QUERY PLAN                                                                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -285,13 +285,13 @@ LIMIT 10;
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
-           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
-           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
+           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=deferred, query="all"
+           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=deferred, query="all"
+           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=deferred, query="all"
            :   └──────────────────────────────────────────────────
 (28 rows)
 
@@ -328,8 +328,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                        QUERY PLAN                                                                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                  QUERY PLAN                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -344,9 +344,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: table=f, segments=3, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :           PgSearchScan: table=f, segments=3, visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, query="all"
+           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, visibility=deferred, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes
@@ -382,8 +382,8 @@ FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                         QUERY PLAN                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                    QUERY PLAN                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -409,17 +409,17 @@ LIMIT 10;
            :     ┌───── Stage 1 ── tasks=3, partitions=12
            :     │ RepartitionExec: partitioning=Hash([id@1], 12), input_partitions=1
            :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t1: PgSearchScan: table=f, segments=3, partition=id[68..134), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t1: PgSearchScan: table=f, segments=3, partition=id[68..134), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
            :     ┌───── Stage 2 ── tasks=3, partitions=12
            :     │ RepartitionExec: partitioning=Hash([file_id@1], 12), input_partitions=4
            :     │   RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
            :     │     DistributedLeafExec:
-           :     │       t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=eager, query="all"
-           :     │       t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=eager, query="all"
-           :     │       t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=eager, query="all"
+           :     │       t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
+           :     │       t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
+           :     │       t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
 (37 rows)
 
@@ -475,8 +475,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                                 QUERY PLAN                                                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -501,17 +501,18 @@ LIMIT 5;
                  :     ┌───── Stage 1 ── tasks=3, partitions=9
                  :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=1
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-                 :     │     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
-                 :     │       DistributedLeafExec:
-                 :     │         t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │         t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │         t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │       DistributedLeafExec:
-                 :     │         t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=eager, query="all"
-                 :     │         t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=eager, query="all"
-                 :     │         t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=eager, query="all"
+                 :     │     TantivyLookupExec: decode=[title]
+                 :     │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
+                 :     │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
+                 :     │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-(34 rows)
+(35 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -918,8 +919,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -934,9 +935,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: table=f, segments=3, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=f, segments=3, partition_by=id, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=3, partition_by=file_id, dynamic_filters=1, query="all"
+           :           PgSearchScan: table=p, segments=3, partition_by=file_id, dynamic_filters=1, visibility=deferred, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -86,8 +86,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -102,9 +102,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: table=f, segments=3, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=f, segments=3, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, visibility=deferred, query="all"
+           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes
@@ -138,8 +138,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                      QUERY PLAN                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -160,13 +160,13 @@ LIMIT 10;
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=deferred, query="all"
-           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=deferred, query="all"
-           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=deferred, query="all"
+           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
+           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
+           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
 (28 rows)
 
@@ -263,8 +263,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -285,13 +285,13 @@ LIMIT 10;
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :   │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :   │         DistributedLeafExec:
-           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=deferred, query="all"
-           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=deferred, query="all"
-           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=deferred, query="all"
+           :   │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
+           :   │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
+           :   │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
 (28 rows)
 
@@ -328,8 +328,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                                  QUERY PLAN                                                                                                                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                        QUERY PLAN                                                                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -344,9 +344,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: table=f, segments=3, visibility=deferred, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :           PgSearchScan: table=f, segments=3, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, visibility=deferred, query="all"
+           :           PgSearchScan: table=p, segments=3, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes
@@ -382,8 +382,8 @@ FROM mpp_join_files f LEFT JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                    QUERY PLAN                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -409,17 +409,17 @@ LIMIT 10;
            :     ┌───── Stage 1 ── tasks=3, partitions=12
            :     │ RepartitionExec: partitioning=Hash([id@1], 12), input_partitions=1
            :     │   DistributedLeafExec:
-           :     │     t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t1: PgSearchScan: table=f, segments=3, partition=id[68..134), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :     │     t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t1: PgSearchScan: table=f, segments=3, partition=id[68..134), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
            :     ┌───── Stage 2 ── tasks=3, partitions=12
            :     │ RepartitionExec: partitioning=Hash([file_id@1], 12), input_partitions=4
            :     │   RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
            :     │     DistributedLeafExec:
-           :     │       t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
-           :     │       t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
-           :     │       t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
+           :     │       t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=eager, query="all"
+           :     │       t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=eager, query="all"
+           :     │       t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=eager, query="all"
            :     └──────────────────────────────────────────────────
 (37 rows)
 
@@ -475,8 +475,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                                         QUERY PLAN                                                                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -504,13 +504,13 @@ LIMIT 5;
                  :     │     TantivyLookupExec: decode=[title]
                  :     │       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :     │         DistributedLeafExec:
-                 :     │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :     │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t0: PgSearchScan: table=f, segments=3, partition=id[-∞..68), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t1: PgSearchScan: table=f, segments=3, partition=id[68..134), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     │           t2: PgSearchScan: table=f, segments=3, partition=id[134..∞), dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :     │         DistributedLeafExec:
-                 :     │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, query="all"
-                 :     │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, query="all"
-                 :     │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, query="all"
+                 :     │           t0: PgSearchScan: table=p, segments=3, partition=file_id[-∞..68), dynamic_filters=1, visibility=eager, query="all"
+                 :     │           t1: PgSearchScan: table=p, segments=3, partition=file_id[68..134), dynamic_filters=1, visibility=eager, query="all"
+                 :     │           t2: PgSearchScan: table=p, segments=3, partition=file_id[134..∞), dynamic_filters=1, visibility=eager, query="all"
                  :     └──────────────────────────────────────────────────
 (35 rows)
 
@@ -919,8 +919,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                               QUERY PLAN                                                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -935,9 +935,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: table=f, segments=3, partition_by=id, visibility=deferred, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: table=f, segments=3, partition_by=id, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: table=p, segments=3, partition_by=file_id, dynamic_filters=1, visibility=deferred, query="all"
+           :           PgSearchScan: table=p, segments=3, partition_by=file_id, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes

--- a/pg_search/tests/pg_regress/expected/numeric_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/numeric_aggregate.out
@@ -44,8 +44,8 @@ ANALYZE numagg;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                                  QUERY PLAN                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -54,7 +54,7 @@ SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg 
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric64_avg(numagg_0.price, 2) as agg_1, min(numagg_0.price) as agg_2, max(numagg_0.price) as agg_3, count(numagg_0.price) as agg_4]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -77,8 +77,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                                  QUERY PLAN                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -87,7 +87,7 @@ SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM nu
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[numeric_bytes_sum(numagg_0.weight) as agg_0, numeric_bytes_avg(numagg_0.weight) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.weight) as agg_3, count(numagg_0.weight) as agg_4]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -109,8 +109,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                                  QUERY PLAN                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -119,7 +119,7 @@ SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM nu
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.amount) as agg_2, max(numagg_0.amount) as agg_3, count(numagg_0.amount) as agg_4]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -170,8 +170,8 @@ SET max_parallel_workers_per_gather = 2;
 -- COUNT on an unbounded NUMERIC column still pushes down
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                                  QUERY PLAN                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -180,7 +180,7 @@ SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(numagg_0.free) as agg_0]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -194,8 +194,8 @@ SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description ||| 'apple OR basket OR crate' GROUP BY category ORDER BY category;
-                                                                                                                                     QUERY PLAN                                                                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                            QUERY PLAN                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: category, (sum(price)), (avg(amount)), (min(weight)), (max(price))
    Sort Key: numagg.category
@@ -208,7 +208,7 @@ SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WH
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.price) as agg_3]
            :   CooperativeExec
-           :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (13 rows)
 
 SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description ||| 'apple OR basket OR crate' GROUP BY category ORDER BY category;
@@ -232,8 +232,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY price ORDER BY price;
-                                                                                                                                 QUERY PLAN                                                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: price, (count(*))
    Sort Key: numagg.price
@@ -246,7 +246,7 @@ SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[price@0 as price], aggr=[count(1) as agg_0]
            :   CooperativeExec
-           :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (13 rows)
 
 SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY price ORDER BY price;
@@ -260,8 +260,8 @@ SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY amount ORDER BY amount;
-                                                                                                                                 QUERY PLAN                                                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: amount, (count(*))
    Sort Key: numagg.amount
@@ -274,7 +274,7 @@ SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROU
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[amount@0 as amount], aggr=[count(1) as agg_0]
            :   CooperativeExec
-           :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (13 rows)
 
 SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY amount ORDER BY amount;
@@ -292,8 +292,8 @@ SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROU
 -- SUM sorts natively: decimal-bytes ordering matches numeric ordering
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                            QUERY PLAN                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(amount))
    ->  Sort
@@ -309,7 +309,7 @@ SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR baske
                  : SortExec: TopK(fetch=1), expr=[agg_0@1 DESC], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0]
                  :     CooperativeExec
-                 :       PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :       PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (16 rows)
 
 SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
@@ -329,8 +329,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- Numeric64 SUM sorts the same way
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                            QUERY PLAN                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(price))
    ->  Sort
@@ -346,7 +346,7 @@ SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket
                  : SortExec: TopK(fetch=1), expr=[agg_0@1 ASC NULLS LAST], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
                  :     CooperativeExec
-                 :       PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :       PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (16 rows)
 
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
@@ -366,8 +366,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- AVG blobs do not sort; TopK is skipped and Postgres sorts above the scan
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
-                                                                                                                                    QUERY PLAN                                                                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                           QUERY PLAN                                                                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (avg(price))
    ->  Sort
@@ -382,7 +382,7 @@ SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket
                DataFusion Physical Plan: 
                  : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_avg(numagg_0.price, 2) as agg_0]
                  :   CooperativeExec
-                 :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (15 rows)
 
 SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
@@ -407,8 +407,8 @@ INSERT INTO numagg (description, category, price, weight, amount) VALUES
 ANALYZE numagg;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description ||| 'durian OR basket';
-                                                                                                                                  QUERY PLAN                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
    Backend: DataFusion
@@ -423,8 +423,8 @@ SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description ||| 'dur
      :   ┌───── Stage 1 ── tasks=2, partitions=2
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, min(numagg_0.price) as agg_1, max(numagg_0.price) as agg_2]
      :   │   DistributedLeafExec:
-     :   │     t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │     t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
 (17 rows)
 
@@ -469,8 +469,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- TopK over a group whose SUM is NaN: NaN sorts highest, matching Postgres
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
-                                                                                                                                               QUERY PLAN                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(price))
    ->  Sort
@@ -496,8 +496,8 @@ SELECT category, SUM(price) s FROM numagg WHERE description ||| 'durian OR baske
                  :     │ RepartitionExec: partitioning=Hash([category@0], 4), input_partitions=1
                  :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
                  :     │     DistributedLeafExec:
-                 :     │       t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-                 :     │       t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :     │       t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :     │       t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
                  :     └──────────────────────────────────────────────────
 (28 rows)
 
@@ -520,8 +520,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description ||| 'nonexistent';
-                                                                                                                                QUERY PLAN                                                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                       QUERY PLAN                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -536,8 +536,8 @@ SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description ||| 'non
      :   ┌───── Stage 1 ── tasks=2, partitions=2
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, count(1) as agg_2]
      :   │   DistributedLeafExec:
-     :   │     t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │     t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
 (17 rows)
 
@@ -549,8 +549,8 @@ SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description ||| 'non
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE description ||| 'apple OR basket';
-                                                                                                                                  QUERY PLAN                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                         QUERY PLAN                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text)
    Backend: DataFusion
@@ -565,8 +565,8 @@ SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE descript
      :   ┌───── Stage 1 ── tasks=2, partitions=2
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) FILTER (WHERE numagg_0.category = Utf8View("grocery")) as agg_0]
      :   │   DistributedLeafExec:
-     :   │     t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │     t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
 (17 rows)
 
@@ -689,8 +689,8 @@ CREATE INDEX numagg_lines_idx ON numagg_lines USING paradedb (
 ANALYZE numagg_lines;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description ||| 'apple OR basket';
-                                                                                                                                          QUERY PLAN                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('SUM'::text), pdb.agg_fn('MIN'::text)
    Backend: DataFusion
@@ -704,19 +704,20 @@ SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_line
      : └──────────────────────────────────────────────────
      :   ┌───── Stage 2 ── tasks=2, partitions=2
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(n_0.price, 2) as agg_0, numeric_bytes_sum(n_0.amount) as agg_1, min(n_0.weight) as agg_2]
-     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(numagg_id@0, id@0)], projection=[price@2, weight@3, amount@4]
-     :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=1
-     :   │     DistributedLeafExec:
-     :   │       t0: PgSearchScan: table=n, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │       t1: PgSearchScan: table=n, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │   TantivyLookupExec: decode=[weight, amount]
+     :   │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(numagg_id@0, id@0)], projection=[price@2, weight@3, amount@4]
+     :   │       CoalescePartitionsExec
+     :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=1
+     :   │       DistributedLeafExec:
+     :   │         t0: PgSearchScan: table=n, segments=2, dynamic_filters=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │         t1: PgSearchScan: table=n, segments=2, dynamic_filters=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=1, partitions=2
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
-     :     │     t0: PgSearchScan: table=l, segments=1, visibility=eager, query="all"
+     :     │     t0: PgSearchScan: table=l, segments=1, query="all"
      :     └──────────────────────────────────────────────────
-(25 rows)
+(26 rows)
 
 SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description ||| 'apple OR basket';
    sum   |                                      sum                                       |     min     

--- a/pg_search/tests/pg_regress/expected/numeric_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/numeric_aggregate.out
@@ -44,8 +44,8 @@ ANALYZE numagg;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                         QUERY PLAN                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -54,7 +54,7 @@ SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg 
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric64_avg(numagg_0.price, 2) as agg_1, min(numagg_0.price) as agg_2, max(numagg_0.price) as agg_3, count(numagg_0.price) as agg_4]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT SUM(price), AVG(price), MIN(price), MAX(price), COUNT(price) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -77,8 +77,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                         QUERY PLAN                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -87,7 +87,7 @@ SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM nu
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[numeric_bytes_sum(numagg_0.weight) as agg_0, numeric_bytes_avg(numagg_0.weight) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.weight) as agg_3, count(numagg_0.weight) as agg_4]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT SUM(weight), AVG(weight), MIN(weight), MAX(weight), COUNT(weight) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -109,8 +109,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                         QUERY PLAN                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text), pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -119,7 +119,7 @@ SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM nu
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.amount) as agg_2, max(numagg_0.amount) as agg_3, count(numagg_0.amount) as agg_4]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT SUM(amount), AVG(amount), MIN(amount), MAX(amount), COUNT(amount) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -170,8 +170,8 @@ SET max_parallel_workers_per_gather = 2;
 -- COUNT on an unbounded NUMERIC column still pushes down
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
-                                                                                                                         QUERY PLAN                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -180,7 +180,7 @@ SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(numagg_0.free) as agg_0]
      :   CooperativeExec
-     :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (9 rows)
 
 SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
@@ -194,8 +194,8 @@ SELECT COUNT(free) FROM numagg WHERE description ||| 'apple OR basket OR crate';
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description ||| 'apple OR basket OR crate' GROUP BY category ORDER BY category;
-                                                                                                                            QUERY PLAN                                                                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                     QUERY PLAN                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: category, (sum(price)), (avg(amount)), (min(weight)), (max(price))
    Sort Key: numagg.category
@@ -208,7 +208,7 @@ SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WH
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, min(numagg_0.weight) as agg_2, max(numagg_0.price) as agg_3]
            :   CooperativeExec
-           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+           :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket OR crate","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (13 rows)
 
 SELECT category, SUM(price), AVG(amount), MIN(weight), MAX(price) FROM numagg WHERE description ||| 'apple OR basket OR crate' GROUP BY category ORDER BY category;
@@ -232,8 +232,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY price ORDER BY price;
-                                                                                                                        QUERY PLAN                                                                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                 QUERY PLAN                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: price, (count(*))
    Sort Key: numagg.price
@@ -246,7 +246,7 @@ SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[price@0 as price], aggr=[count(1) as agg_0]
            :   CooperativeExec
-           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+           :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (13 rows)
 
 SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY price ORDER BY price;
@@ -260,8 +260,8 @@ SELECT price, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY amount ORDER BY amount;
-                                                                                                                        QUERY PLAN                                                                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                 QUERY PLAN                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: amount, (count(*))
    Sort Key: numagg.amount
@@ -274,7 +274,7 @@ SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROU
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[amount@0 as amount], aggr=[count(1) as agg_0]
            :   CooperativeExec
-           :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+           :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (13 rows)
 
 SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROUP BY amount ORDER BY amount;
@@ -292,8 +292,8 @@ SELECT amount, COUNT(*) FROM numagg WHERE description ||| 'apple OR basket' GROU
 -- SUM sorts natively: decimal-bytes ordering matches numeric ordering
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
-                                                                                                                            QUERY PLAN                                                                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                     QUERY PLAN                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(amount))
    ->  Sort
@@ -309,7 +309,7 @@ SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR baske
                  : SortExec: TopK(fetch=1), expr=[agg_0@1 DESC], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0]
                  :     CooperativeExec
-                 :       PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :       PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (16 rows)
 
 SELECT category, SUM(amount) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s DESC LIMIT 1;
@@ -329,8 +329,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- Numeric64 SUM sorts the same way
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
-                                                                                                                            QUERY PLAN                                                                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                     QUERY PLAN                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(price))
    ->  Sort
@@ -346,7 +346,7 @@ SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket
                  : SortExec: TopK(fetch=1), expr=[agg_0@1 ASC NULLS LAST], preserve_partitioning=[false]
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
                  :     CooperativeExec
-                 :       PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :       PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (16 rows)
 
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY s ASC LIMIT 1;
@@ -366,8 +366,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- AVG blobs do not sort; TopK is skipped and Postgres sorts above the scan
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
-                                                                                                                           QUERY PLAN                                                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                    QUERY PLAN                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (avg(price))
    ->  Sort
@@ -382,7 +382,7 @@ SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket
                DataFusion Physical Plan: 
                  : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[numeric64_avg(numagg_0.price, 2) as agg_0]
                  :   CooperativeExec
-                 :     PgSearchScan: table=numagg, segments=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :     PgSearchScan: table=numagg, segments=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (15 rows)
 
 SELECT category, AVG(price) a FROM numagg WHERE description ||| 'apple OR basket' GROUP BY category ORDER BY a ASC LIMIT 1;
@@ -407,8 +407,8 @@ INSERT INTO numagg (description, category, price, weight, amount) VALUES
 ANALYZE numagg;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description ||| 'durian OR basket';
-                                                                                                                         QUERY PLAN                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
    Backend: DataFusion
@@ -423,8 +423,8 @@ SELECT SUM(price), MIN(price), MAX(price) FROM numagg WHERE description ||| 'dur
      :   ┌───── Stage 1 ── tasks=2, partitions=2
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0, min(numagg_0.price) as agg_1, max(numagg_0.price) as agg_2]
      :   │   DistributedLeafExec:
-     :   │     t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │     t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
 (17 rows)
 
@@ -469,8 +469,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- TopK over a group whose SUM is NaN: NaN sorts highest, matching Postgres
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT category, SUM(price) s FROM numagg WHERE description ||| 'durian OR basket OR apple' GROUP BY category ORDER BY s DESC LIMIT 1;
-                                                                                                                                      QUERY PLAN                                                                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                               QUERY PLAN                                                                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: category, (sum(price))
    ->  Sort
@@ -496,8 +496,8 @@ SELECT category, SUM(price) s FROM numagg WHERE description ||| 'durian OR baske
                  :     │ RepartitionExec: partitioning=Hash([category@0], 4), input_partitions=1
                  :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[numeric64_sum(numagg_0.price, 2) as agg_0]
                  :     │     DistributedLeafExec:
-                 :     │       t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-                 :     │       t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :     │       t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :     │       t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"durian OR basket OR apple","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
                  :     └──────────────────────────────────────────────────
 (28 rows)
 
@@ -520,8 +520,8 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 -- ============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description ||| 'nonexistent';
-                                                                                                                       QUERY PLAN                                                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                QUERY PLAN                                                                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -536,8 +536,8 @@ SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description ||| 'non
      :   ┌───── Stage 1 ── tasks=2, partitions=2
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric_bytes_sum(numagg_0.amount) as agg_0, numeric_bytes_avg(numagg_0.amount) as agg_1, count(1) as agg_2]
      :   │   DistributedLeafExec:
-     :   │     t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │     t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"nonexistent","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
 (17 rows)
 
@@ -549,8 +549,8 @@ SELECT SUM(amount), AVG(amount), COUNT(*) FROM numagg WHERE description ||| 'non
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE description ||| 'apple OR basket';
-                                                                                                                         QUERY PLAN                                                                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text)
    Backend: DataFusion
@@ -565,8 +565,8 @@ SELECT SUM(price) FILTER (WHERE category = 'grocery') FROM numagg WHERE descript
      :   ┌───── Stage 1 ── tasks=2, partitions=2
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[numeric64_sum(numagg_0.price, 2) FILTER (WHERE numagg_0.category = Utf8View("grocery")) as agg_0]
      :   │   DistributedLeafExec:
-     :   │     t0: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │     t1: PgSearchScan: table=numagg, segments=2, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t0: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │     t1: PgSearchScan: table=numagg, segments=2, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
 (17 rows)
 
@@ -689,8 +689,8 @@ CREATE INDEX numagg_lines_idx ON numagg_lines USING paradedb (
 ANALYZE numagg_lines;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_lines l ON l.numagg_id = n.id WHERE n.description ||| 'apple OR basket';
-                                                                                                                                  QUERY PLAN                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('SUM'::text), pdb.agg_fn('SUM'::text), pdb.agg_fn('MIN'::text)
    Backend: DataFusion
@@ -709,13 +709,13 @@ SELECT SUM(n.price), SUM(n.amount), MIN(n.weight) FROM numagg n JOIN numagg_line
      :   │       CoalescePartitionsExec
      :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=1
      :   │       DistributedLeafExec:
-     :   │         t0: PgSearchScan: table=n, segments=2, dynamic_filters=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-     :   │         t1: PgSearchScan: table=n, segments=2, dynamic_filters=1, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │         t0: PgSearchScan: table=n, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+     :   │         t1: PgSearchScan: table=n, segments=2, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"match":{"field":"description","value":"apple OR basket","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=1, partitions=2
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
      :     │   DistributedLeafExec:
-     :     │     t0: PgSearchScan: table=l, segments=1, query="all"
+     :     │     t0: PgSearchScan: table=l, segments=1, visibility=eager, query="all"
      :     └──────────────────────────────────────────────────
 (26 rows)
 


### PR DESCRIPTION
This PR deferred aggregate string decode independently of the visibility check. Closed as a negative result: the CI benchmarks confirmed the loss that the local measurement had shown.

## Idea

Ord-to-string decode looked like random access wherever it runs, so running it after the join should cost the same per row and touch fewer rows.

## What the local measurement showed

The per-row claim does not hold, and neither does the row count. An aggregate-on-join like `posts JOIN comments` fans out: eager decode reads `p.title` once per matching post (~60k), a post-join decode runs once per join output row (~700k). In a dylib-swap A/B run as a fix/base/fix sandwich under identical load, the deferred build measured 1.6x slower on a `GROUP BY owner_display_name` and 4.4x slower on a `GROUP BY id, title` (1233 ms to ~5400 ms) at 1M.

An earlier A/B on the same queries showed the opposite because the machine drifts between fast and slow modes across hours; only the interleaved sandwich pairing is trustworthy.

## CI benchmarks

[Run 33719923207](https://github.com/paradedb/paradedb/actions/runs/33719923207) on `4bd0c6306` against `main`. No query improved by 10% at any scale. Every regression is an aggregate-on-join that groups or projects a decoded string column across a fan-out join:

| query | 100k | 1m | 20m |
|---|---|---|---|
| `join_aggregate_sort` alt 1 (`GROUP BY p.id, p.title`) | 1.80 | 5.08 | 9.49 (2.0 s to 18.8 s) |
| `join_aggregate_sort` alt 2 | 1.77 | 2.77 | 9.10 (2.3 s to 20.6 s) |
| `join_distinct_parent_sort` (`DISTINCT u.id, display_name, about_me`) | 1.17 | 2.29 | 3.99 (2.2 s to 8.8 s) |
| `join_aggregate_topk_count` alt 1 (`GROUP BY owner_display_name`) | 1.41 | 1.38 | 1.91 |
| `join_aggregate_topk_count` alt 2 | 1.36 | 1.16 | 1.57 |

The `EXPLAIN ANALYZE` in the job log shows the mechanism. At 20m, `join_aggregate_sort` alt 1 has `TantivyLookupExec: decode=[title]` above the `HashJoinExec`, decoding 3.01M rows per partition (24M in total, once per join output row) at about 5.7 s of compute per partition, while the aggregate emits about 0.99M groups per partition. Two effects compound. The fan-out multiplies the decode count about 3x. The join also destroys locality: in the scan, a batch is one segment's docs and the ordinal sort sweeps a small dictionary range, while above a hash-partitioned join every batch mixes random docs from all segments and walks the whole dictionary. That is why the ratio grows with the dataset, from 1.8x at 100k to 9.5x at 20m.

## Conclusion

Deferring decode pays only when the operators above preserve or reduce the deferred side's rows. Deciding that per source at plan time is the estimate problem #6155 already hit. The null-fill guard in the second commit only matters together with the decoupling, so nothing here is worth landing on its own.

## A hazard for whoever picks this up

With eager visibility plus deferred strings, a string from the null-supplying side of an outer join crosses the join as a union column, which has no validity bitmap, so the decode resurrects the join's NULL (`COUNT(s.supplier_name)` counted a phantom row in `aggregate_join`). The second commit guards this by keeping such sources' strings materialized. The GUC-on path does not reach the hole (the rules decline those plans), so the guard only matters together with the decoupling.
