### PR TITLE
feat: route vector queries with the stacked IVF router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7041,8 +7041,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superkmeans-rs"
-version = "0.1.0"
-source = "git+https://github.com/paradedb/superkmeans-rs?rev=b89e83196143acd518f1d8212ec1f53474e936d4#b89e83196143acd518f1d8212ec1f53474e936d4"
+version = "0.2.0"
+source = "git+https://github.com/paradedb/superkmeans-rs?rev=c06dc2b6e9bd15fb5c4a0627178bebbe1fb37a64#c06dc2b6e9bd15fb5c4a0627178bebbe1fb37a64"
 dependencies = [
  "matrixmultiply",
  "pkg-config",
@@ -7130,7 +7130,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7153,6 +7153,7 @@ dependencies = [
  "htmlescape",
  "itertools 0.14.0",
  "levenshtein_automata",
+ "libm",
  "log",
  "lru",
  "lz4_flex",
@@ -7167,6 +7168,7 @@ dependencies = [
  "serde_json",
  "sketches-ddsketch 0.4.1",
  "smallvec",
+ "superkmeans-rs",
  "tantivy-bitpacker",
  "tantivy-columnar",
  "tantivy-common",
@@ -7187,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "bitpacking",
 ]
@@ -7195,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7210,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7243,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7255,7 +7257,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7268,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7305,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=de9405aaadcd9378bdeeea7a4247c7f72e25bbd5#de9405aaadcd9378bdeeea7a4247c7f72e25bbd5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ overflow-checks = true
 [workspace.dependencies]
 pgrx = "=0.19.2"
 pgrx-tests = "=0.19.2"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "de9405aaadcd9378bdeeea7a4247c7f72e25bbd5", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "d40cd042967b355da33af8daa9f7f744dba9f7ae", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -78,7 +78,7 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "de9405aaadcd9378bdeeea7a4247c7f72e25bbd5" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "d40cd042967b355da33af8daa9f7f744dba9f7ae" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/docs/changelog/unreleased/6159.features.mdx
+++ b/docs/changelog/unreleased/6159.features.mdx
@@ -1,0 +1,5 @@
+---
+header: features
+---
+
+Vector indexes now route queries to clusters through a stacked IVF index over the centroids instead of a neighborhood graph. For vectors under 256 dimensions the router stops ranking clusters once the estimated recall reaches the new `paradedb.vector_router_recall` GUC (default `0.9`); higher-dimensional vectors, or a target of `1.0`, rank a fixed fraction of the routing index. The `training_samples_per_centroid` index option is replaced by `training_sample_ratio` (default `0.32`), the fraction of vectors sampled for clustering at build time.

--- a/docs/documentation/indexing/indexing-vectors.mdx
+++ b/docs/documentation/indexing/indexing-vectors.mdx
@@ -171,7 +171,7 @@ recall and latency, especially over large datasets. The following `WITH` options
 ```sql SQL
 CREATE INDEX search_idx ON mock_items
 USING paradedb (id, description, category, embedding vector_cosine_ops)
-WITH (key_field='id', centroid_ratio=0.01, training_samples_per_centroid=32, cluster_replication=1);
+WITH (key_field='id', centroid_ratio=0.01, training_sample_ratio=0.32, cluster_replication=1);
 ```
 
 ```ts Drizzle
@@ -182,7 +182,6 @@ import { indexing } from "@paradedb/drizzle-paradedb";
   indexing
     .paradedbIndex("search_idx", {
       centroidRatio: 0.01,
-      trainingSamplesPerCentroid: 32,
       clusterReplication: 1,
     })
     .on(
@@ -211,7 +210,6 @@ with connection.schema_editor() as schema_editor:
             key_field="id",
             name="search_idx",
             centroid_ratio=0.01,
-            training_samples_per_centroid=32,
             cluster_replication=1,
         ),
     )
@@ -232,7 +230,6 @@ idx = Index(
         "key_field": "id",
         **indexing.VectorIndexOptions(
             centroid_ratio=0.01,
-            training_samples_per_centroid=32,
             cluster_replication=1,
         ),
     },
@@ -255,7 +252,6 @@ ActiveRecord::Base.connection.add_paradedb_index(
   name: :search_idx,
   index_options: {
     centroid_ratio: 0.01,
-    training_samples_per_centroid: 32,
     cluster_replication: 1
   }
 )
@@ -268,7 +264,6 @@ modelBuilder.Entity<MockItem>()
     .HasField(e => e.Category)
     .HasField(e => e.Embedding, VectorMetric.Cosine)
     .HasCentroidRatio(0.01)
-    .HasTrainingSamplesPerCentroid(32)
     .HasClusterReplication(1);
 ```
 
@@ -282,14 +277,14 @@ modelBuilder.Entity<MockItem>()
   improving recall at the cost of a slower, more memory-intensive build. Must be
   between `0.000001` and `1.0`.
 </ParamField>
-<ParamField body="training_samples_per_centroid" default={32}>
-  The number of vectors sampled per centroid to train the k-means clustering at
+<ParamField body="training_sample_ratio" default={0.32}>
+  The fraction of indexed vectors sampled to train the k-means clustering at
   build time. Higher values yield better-quality centroids at the cost of a
-  slower build. Must be between `1` and `100000`.
+  slower, more memory-intensive build. Must be between `0.000001` and `1.0`,
+  where `1.0` trains on every vector. The default samples `0.32 * num_vectors`,
+  about 32 vectors per centroid at the default `centroid_ratio`.
 </ParamField>
 <ParamField body="cluster_replication" default={1}>
-  The number of clusters each vector is written into: its primary cluster plus
-  up to `cluster_replication - 1` next-nearest clusters. Higher values can
-  improve recall for filtered queries at the cost of a larger index. The default
-  of `1` disables replication.
+  Accepted for compatibility. Vectors are currently assigned to their single
+  nearest cluster regardless of this value.
 </ParamField>

--- a/docs/documentation/vector/tuning.mdx
+++ b/docs/documentation/vector/tuning.mdx
@@ -4,10 +4,11 @@ description: Trade recall against latency for vector search
 canonical: https://www.paradedb.com/docs/documentation/vector/tuning
 ---
 
-Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. One session-level setting controls this tradeoff:
+Vector search is approximate: it probes a subset of the index's vector clusters rather than scanning every vector. Probing more clusters improves recall (i.e. how often the true nearest neighbors are returned) at the cost of higher latency. Two session-level settings control this tradeoff:
 
 ```sql
 SET paradedb.vector_cluster_max_probe = 0.02;
+SET paradedb.vector_router_recall = 0.9;
 ```
 
 <ParamField body="paradedb.vector_cluster_max_probe" default={0.02}>
@@ -21,6 +22,15 @@ Within the ceiling, clusters that provably cannot improve the current top-K
 are skipped automatically using per-cluster bounds stored in the index; this
 skipping never reduces recall, so raising the ceiling only ever improves it.
 
+</ParamField>
+
+<ParamField body="paradedb.vector_router_recall" default={0.9}>
+  How thoroughly the query ranks clusters before probing them. Clusters are
+  themselves organized into a small routing index; below `1.0`, the router stops
+  scanning that index once the estimated chance that the best clusters have been
+  found reaches this target, and `1.0` scans a fixed fraction of it instead.
+  Must be between `0.000001` and `1.0`. Only applies to vectors of fewer than
+  256 dimensions; higher-dimensional vectors always use the fixed fraction.
 </ParamField>
 
 <Note>

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-Zg/gq7yZOcBIkqET80tIfa0RRDcZAA4eyx2+v+PiUxs=";
+  cargoHash = "sha256-YCwWZbDAEHUHPFlot9vvVtYjdDsIAXfOmloW3Kqqj3I=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -103,12 +103,12 @@ prost = "0.14.3"
 # SuperKMeans IVF clusterer (pure-Rust port). BLAS backend is target-specific:
 # Accelerate on macOS, OpenBLAS on Linux (already required by the build env).
 [target.'cfg(target_os = "macos")'.dependencies]
-superkmeans = { git = "https://github.com/paradedb/superkmeans-rs", package = "superkmeans-rs", rev = "b89e83196143acd518f1d8212ec1f53474e936d4", features = [
+superkmeans = { git = "https://github.com/paradedb/superkmeans-rs", package = "superkmeans-rs", rev = "c06dc2b6e9bd15fb5c4a0627178bebbe1fb37a64", features = [
   "accelerate",
 ] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-superkmeans = { git = "https://github.com/paradedb/superkmeans-rs", package = "superkmeans-rs", rev = "b89e83196143acd518f1d8212ec1f53474e936d4", features = [
+superkmeans = { git = "https://github.com/paradedb/superkmeans-rs", package = "superkmeans-rs", rev = "c06dc2b6e9bd15fb5c4a0627178bebbe1fb37a64", features = [
   "openblas",
 ] }
 

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -283,6 +283,19 @@ pub fn vector_fixed_probe_cost_rows() -> f64 {
     VECTOR_FIXED_PROBE_COST_ROWS.get()
 }
 
+/// Recall target for the stacked IVF router's centroid ranking. Below `1.0`
+/// the router stops scanning its centroid lists once the estimated recall
+/// of the top clusters reaches the target (adaptive partition scanning);
+/// `1.0` ranks with the fixed per-level nprobe fractions instead. Tantivy
+/// ignores the target and uses the nprobe path at or above
+/// `APS_MAX_DIM` (256) dimensions, where the estimate is unreliable.
+static VECTOR_ROUTER_RECALL: GucSetting<f64> =
+    GucSetting::<f64>::new(tantivy::vector::ivf::DEFAULT_ROUTER_RECALL as f64);
+
+pub fn vector_router_recall() -> f32 {
+    VECTOR_ROUTER_RECALL.get() as f32
+}
+
 /// Doc-count boundary at which a merged segment's vector storage switches
 /// from flat (exact scan) to IVF (clustered). Captured into the index's
 /// stored `IndexSettings` at CREATE INDEX time, so it applies to every merge
@@ -552,6 +565,17 @@ pub fn init() {
         &VECTOR_FIXED_PROBE_COST_ROWS,
         0.001,
         10_000.0,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_float_guc(
+        c"paradedb.vector_router_recall",
+        c"Recall target for the stacked IVF router's centroid ranking in vector ORDER BY queries",
+        c"Below 1.0 the stacked router stops scanning its centroid lists once the estimated recall of the ranked clusters reaches this target (adaptive partition scanning); 1.0 ranks with the fixed per-level nprobe fractions. Ignored, and treated as 1.0, for vectors of 256 or more dimensions where the recall estimate is unreliable.",
+        &VECTOR_ROUTER_RECALL,
+        0.000001,
+        1.0,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -29,8 +29,19 @@ pub use search::*;
 
 use crate::postgres::options::BM25IndexOptions;
 use crate::schema::SearchIndexSchema;
-use tantivy::IndexSettings;
 use tantivy::columnar::CodecType;
+use tantivy::directory::Directory;
+use tantivy::{Index, IndexSettings};
+
+/// Open the tantivy index behind `directory` the way every pg_search reader
+/// and writer must: with the IVF centroid router selected. Tantivy refuses
+/// to open an IVF segment for search, or to build one at merge time,
+/// without a configured router.
+pub fn open_index<D: Into<Box<dyn Directory>>>(directory: D) -> tantivy::Result<Index> {
+    let mut index = Index::open(directory)?;
+    crate::vector::clusterer::set_ivf_router(&mut index)?;
+    Ok(index)
+}
 
 /// The [`IndexSettings`] used for every tantivy index pg_search creates.
 ///
@@ -46,7 +57,6 @@ pub fn index_settings(
         docstore_compress_dedicated_thread: false,
         codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
         vector_clustering_threshold: crate::gucs::vector_clustering_threshold(),
-        vector_bounds_scope: options.bounds_scope(),
         ..IndexSettings::default()
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -501,7 +501,7 @@ impl SearchIndexReader {
         let cleanup_lock = Arc::new(MetaPage::open(index_relation).cleanup_lock_pinned());
 
         let directory = mvcc_style.directory(index_relation);
-        let mut index = Index::open(directory.clone())?;
+        let mut index = crate::index::open_index(directory.clone())?;
         let total_segment_count = directory
             .total_segment_count()
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -1247,6 +1247,7 @@ impl SearchIndexReader {
                     .order_by_similarity(tantivy_field, query_vector)
                     .with_adaptive_params(AdaptiveProbeParams {
                         max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
+                        router_recall_target: crate::gucs::vector_router_recall(),
                         ..Default::default()
                     });
 

--- a/pg_search/src/index/stats/pruning.rs
+++ b/pg_search/src/index/stats/pruning.rs
@@ -21,7 +21,6 @@
 use std::cmp::Ordering;
 use std::ops::Bound;
 
-use tantivy::Index;
 use tantivy::index::{SegmentId, SegmentReader};
 
 use super::SegmentStats;
@@ -44,7 +43,7 @@ pub(crate) fn persisted_split_points(
         return Ok(None);
     }
     let directory = MvccSatisfies::Snapshot.directory(indexrel);
-    let index = Index::open(directory.clone())?;
+    let index = crate::index::open_index(directory.clone())?;
     let Ok(field) = index.schema().get_field(partition_by) else {
         return Ok(None);
     };

--- a/pg_search/src/index/stats/tests.rs
+++ b/pg_search/src/index/stats/tests.rs
@@ -19,7 +19,6 @@ mod tests {
     use std::ops::Bound;
 
     use pgrx::prelude::*;
-    use tantivy::Index;
     use tantivy::index::SegmentId;
 
     use super::super::*;
@@ -40,7 +39,7 @@ mod tests {
     /// Every persisted segment's `.stats`, with the tantivy field for `field_name`.
     fn segment_stats(indexrel: &PgSearchRelation, field_name: &str) -> (Field, Vec<SegmentStats>) {
         let directory = MvccSatisfies::Snapshot.directory(indexrel);
-        let index = Index::open(directory.clone()).unwrap();
+        let index = crate::index::open_index(directory.clone()).unwrap();
         let field = index.schema().get_field(field_name).unwrap();
         let stats = index
             .searchable_segments()
@@ -84,7 +83,7 @@ mod tests {
         )
         .unwrap();
         let indexrel = open_index("stats_src_idx");
-        let index = Index::open(MvccSatisfies::Snapshot.directory(&indexrel)).unwrap();
+        let index = crate::index::open_index(MvccSatisfies::Snapshot.directory(&indexrel)).unwrap();
         let schema = index.schema();
         let (_, stats) = segment_stats(&indexrel, "id");
         let [stats] = stats.as_slice() else {

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -302,7 +302,7 @@ impl SerialIndexWriter {
         }
 
         let directory = mvcc_satisfies.directory(index_relation);
-        let mut index = Index::open(directory)?;
+        let mut index = crate::index::open_index(directory)?;
         stats::register(&mut index);
         if has_vector_field {
             set_ivf_clusterer(&mut index, index_relation.options());
@@ -341,6 +341,7 @@ impl SerialIndexWriter {
         // No stats plugin here: the segment is a throwaway materialization that nothing
         // reads statistics from, and it is rebuilt per reader.
         let mut index = Index::create(directory, tantivy_schema, settings)?;
+        crate::vector::clusterer::set_ivf_router(&mut index)?;
         if schema.has_vector_field() {
             set_ivf_clusterer(&mut index, index_relation.options());
         }
@@ -536,7 +537,7 @@ impl SearchIndexMerger {
     ) -> Result<SearchIndexMerger> {
         let directory = mvcc_satisfies.directory(indexrel);
         let schema = indexrel.schema()?;
-        let mut index = Index::open(directory.clone())?;
+        let mut index = crate::index::open_index(directory.clone())?;
         stats::register(&mut index);
         if schema.has_vector_field() {
             set_ivf_clusterer(&mut index, indexrel.options());

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -97,7 +97,6 @@ use crate::{FULL_RELATION_SELECTIVITY, UNASSIGNED_SELECTIVITY};
 
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use pgrx::{FromDatum, IntoDatum, PgList, PgMemoryContexts, pg_sys};
-use tantivy::Index;
 use tantivy::snippet::SnippetGenerator;
 
 #[derive(Default)]
@@ -781,7 +780,8 @@ impl CustomScan for BaseScan {
             let segment_count = {
                 let directory = MvccSatisfies::LargestSegment.directory(&bm25_index);
                 let segment_count = directory.total_segment_count(); // return value only valid after the index has been opened
-                Index::open(directory).expect("custom_scan: should be able to open index");
+                crate::index::open_index(directory)
+                    .expect("custom_scan: should be able to open index");
                 segment_count.load(Ordering::Relaxed)
             };
             let schema = bm25_index

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -165,7 +165,7 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     let mut new_metas = Vec::new();
 
     let directory = MvccSatisfies::Vacuum.directory(&index_relation);
-    let index = Index::open(directory.clone()).unwrap();
+    let index = crate::index::open_index(directory.clone()).unwrap();
     let searchable_segment_metas = index.searchable_segment_metas().unwrap();
     let mut did_delete = false;
 

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -33,7 +33,6 @@ use pgrx::pg_sys::AsPgCStr;
 use pgrx::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
-use tantivy::vector::BoundsScope;
 use tokenizers::manager::SearchTokenizerFilters;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
 /* ADDING OPTIONS
@@ -78,7 +77,8 @@ pub(crate) const DEFAULT_MUTABLE_SEGMENT_ROWS: usize = 1000;
 pub(crate) const MAX_MUTABLE_SEGMENT_ROWS: usize = 10000;
 
 pub(crate) const DEFAULT_CENTROID_RATIO: f64 = 0.01;
-pub(crate) const DEFAULT_TRAINING_SAMPLES_PER_CENTROID: usize = 32;
+/// Matches the old default sampling volume (`centroid_ratio * 32`).
+pub(crate) const DEFAULT_TRAINING_SAMPLE_RATIO: f64 = 0.32;
 pub(crate) const DEFAULT_CLUSTER_REPLICATION: i32 = 1;
 
 #[pg_guard]
@@ -189,9 +189,17 @@ extern "C-unwind" fn validate_search_tokenizer(value: *const std::os::raw::c_cha
 }
 
 /// The only legal `bounds_scope`: the merge folds centroid bounds over a
-/// cluster's NATIVE (primary-assignment) members. Captured into the stored
-/// tantivy `IndexSettings` at CREATE INDEX, like the clustering threshold.
+/// cluster's NATIVE (primary-assignment) members. Kept as a CREATE INDEX
+/// option for compatibility; Tantivy no longer stores a bounds-scope setting.
 pub(crate) const BOUNDS_SCOPE_NATIVE: &str = "native";
+
+/// Local mirror of the former Tantivy `BoundsScope`. Native is the only
+/// supported value; bounds folding always covers primary-assignment members.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub enum BoundsScope {
+    #[default]
+    Native,
+}
 
 #[pg_guard]
 extern "C-unwind" fn validate_bounds_scope(value: *const std::os::raw::c_char) {
@@ -365,10 +373,9 @@ pub unsafe extern "C-unwind" fn amoptions(
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
-            optname: "training_samples_per_centroid".as_pg_cstr(),
-            opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
-            offset: std::mem::offset_of!(BM25IndexOptionsData, training_samples_per_centroid)
-                as i32,
+            optname: "training_sample_ratio".as_pg_cstr(),
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_REAL,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, training_sample_ratio) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
@@ -483,8 +490,8 @@ impl BM25IndexOptions {
         self.options_data().bounds_scope()
     }
 
-    pub fn training_samples_per_centroid(&self) -> usize {
-        self.options_data().training_samples_per_centroid()
+    pub fn training_sample_ratio(&self) -> f32 {
+        self.options_data().training_sample_ratio()
     }
 
     pub fn cluster_replication(&self) -> usize {
@@ -839,7 +846,7 @@ struct BM25IndexOptionsData {
     sort_by_offset: i32,
     search_tokenizer_offset: i32,
     centroid_ratio: f64,
-    training_samples_per_centroid: i32,
+    training_sample_ratio: f64,
     cluster_replication: i32,
     partition_by_offset: i32,
     bounds_scope_offset: i32,
@@ -896,8 +903,8 @@ impl BM25IndexOptionsData {
         }
     }
 
-    pub fn training_samples_per_centroid(&self) -> usize {
-        self.training_samples_per_centroid.max(1) as usize
+    pub fn training_sample_ratio(&self) -> f32 {
+        self.training_sample_ratio as f32
     }
 
     /// Total cells a vector is written into (SPANN `ReplicaCount`): the primary
@@ -1161,13 +1168,13 @@ pub unsafe fn init() {
         1.0,
         pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
-    pg_sys::add_int_reloption(
+    pg_sys::add_real_reloption(
         RELOPT_KIND_PDB,
-        "training_samples_per_centroid".as_pg_cstr(),
-        "k-means training vectors sampled per IVF centroid at index build time".as_pg_cstr(),
-        DEFAULT_TRAINING_SAMPLES_PER_CENTROID as i32,
-        1,
-        100_000,
+        "training_sample_ratio".as_pg_cstr(),
+        "Fraction of vectors sampled for IVF clustering at index build time".as_pg_cstr(),
+        DEFAULT_TRAINING_SAMPLE_RATIO,
+        0.000001,
+        1.0,
         pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_int_reloption(

--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -30,7 +30,7 @@ use std::ops::Deref;
 use std::ptr::NonNull;
 use std::rc::Rc;
 use tantivy::TantivyError;
-use tantivy::index::{Index, Order};
+use tantivy::index::Order;
 
 type NeedClose = bool;
 
@@ -452,7 +452,7 @@ impl PgSearchRelation {
     /// exist.
     pub fn is_ctid_sorted_asc(&self) -> bool {
         let directory = MvccSatisfies::Snapshot.directory(self);
-        let Ok(underlying) = Index::open(directory) else {
+        let Ok(underlying) = crate::index::open_index(directory) else {
             return false;
         };
         matches!(

--- a/pg_search/src/vector/clusterer.rs
+++ b/pg_search/src/vector/clusterer.rs
@@ -20,13 +20,19 @@ use std::sync::{Arc, Mutex};
 use superkmeans::{HierarchicalSuperKMeans, HierarchicalSuperKMeansConfig};
 use tantivy::vector::{
     IvfCentroids, IvfClusterer, IvfMatrix, IvfMergeSettings, IvfTrainingVectors, IvfVectors,
-    Metric, VectorOptions,
+    Metric, RouterKind, VectorOptions,
 };
 use tantivy::{Index, TantivyError};
 
 use crate::postgres::options::BM25IndexOptions;
 
 const DEFAULT_ASSIGN_BATCH_SIZE: usize = 40_960;
+
+/// The IVF centroid router every pg_search index builds and opens: a stacked
+/// IVF over the trained centroids. Tantivy persists the router kind in each
+/// segment's `.centroids` file and refuses to open a segment under a
+/// different kind, so this is a build-time constant, not a GUC.
+pub const IVF_ROUTER: RouterKind = RouterKind::Stacked;
 
 /// A `HierarchicalSuperKMeans` built for assignment, tagged with the
 /// `(dim, angular)` it was constructed for. `assign` never reads the clusterer's
@@ -43,13 +49,8 @@ struct AssignClusterer {
 pub struct SuperKMeansIvfClusterer {
     config: HierarchicalSuperKMeansConfig,
     centroid_ratio: f32,
-    training_samples_per_centroid: usize,
+    training_sample_ratio: f32,
     assign_batch_size: usize,
-    /// Total cells a vector is written into (SPANN `ReplicaCount`). `1` (the
-    /// default) is primary-only Phase 1; `> 1` adds up to `replicas - 1`
-    /// next-nearest cells at merge time, selected by tantivy's centroid
-    /// selector (exact scan or `RelativeNeighborhoodGraph`).
-    replicas: usize,
     /// Lazily-built clusterer reused across `assign` batches.
     assign_cache: Arc<Mutex<Option<AssignClusterer>>>,
 }
@@ -59,12 +60,8 @@ impl std::fmt::Debug for SuperKMeansIvfClusterer {
         f.debug_struct("SuperKMeansIvfClusterer")
             .field("config", &self.config)
             .field("centroid_ratio", &self.centroid_ratio)
-            .field(
-                "training_samples_per_centroid",
-                &self.training_samples_per_centroid,
-            )
+            .field("training_sample_ratio", &self.training_sample_ratio)
             .field("assign_batch_size", &self.assign_batch_size)
-            .field("replicas", &self.replicas)
             .finish_non_exhaustive()
     }
 }
@@ -74,13 +71,11 @@ impl Default for SuperKMeansIvfClusterer {
         // Per-run knobs live on the nested `base` config in superkmeans-rs.
         let mut config = HierarchicalSuperKMeansConfig::default();
         config.base.suppress_warnings = true;
-        config.base.sampling_fraction = 1.0;
         Self {
             config,
             centroid_ratio: 0.01,
-            training_samples_per_centroid: 32,
+            training_sample_ratio: 0.32,
             assign_batch_size: DEFAULT_ASSIGN_BATCH_SIZE,
-            replicas: 1,
             assign_cache: Arc::new(Mutex::new(None)),
         }
     }
@@ -96,36 +91,32 @@ impl SuperKMeansIvfClusterer {
         self
     }
 
-    pub fn with_training_samples_per_centroid(
-        mut self,
-        training_samples_per_centroid: usize,
-    ) -> Self {
-        self.training_samples_per_centroid = training_samples_per_centroid;
+    pub fn with_training_sample_ratio(mut self, training_sample_ratio: f32) -> Self {
+        self.training_sample_ratio = training_sample_ratio;
         self
     }
 
-    pub fn with_replicas(mut self, replicas: usize) -> Self {
-        self.replicas = replicas.max(1);
-        self
+    /// Density-preserving leaf cap: a subsample of size
+    /// `training_sample_ratio * N` should still yield about
+    /// `centroid_ratio * N` leaves.
+    fn max_leaf_size(&self) -> usize {
+        let leaf = (self.training_sample_ratio / self.centroid_ratio).round() as usize;
+        leaf.max(1)
     }
 }
 
 impl IvfClusterer for SuperKMeansIvfClusterer {
-    fn centroid_ratio(&self) -> f32 {
-        self.centroid_ratio
-    }
-
-    fn training_samples_per_centroid(&self) -> usize {
-        self.training_samples_per_centroid
+    fn training_sample_ratio(&self) -> f32 {
+        self.training_sample_ratio
     }
 
     fn assign_batch_size(&self) -> usize {
         self.assign_batch_size
     }
 
-    fn merge_settings(&self, total_target_docs: usize) -> tantivy::Result<IvfMergeSettings> {
+    fn merge_settings(&self, _total_target_docs: usize) -> tantivy::Result<IvfMergeSettings> {
         let centroid_ratio = self.centroid_ratio;
-        let training_samples_per_centroid = self.training_samples_per_centroid;
+        let training_sample_ratio = self.training_sample_ratio;
         let assign_batch_size = self.assign_batch_size;
 
         assert!(
@@ -133,24 +124,14 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
             "centroid_ratio must be in (0, 1], got {centroid_ratio}"
         );
         assert!(
-            training_samples_per_centroid > 1,
-            "training_samples_per_centroid must be > 1, got {training_samples_per_centroid}"
+            training_sample_ratio > 0.0 && training_sample_ratio <= 1.0,
+            "training_sample_ratio must be in (0, 1], got {training_sample_ratio}"
         );
         assert!(assign_batch_size > 0, "assign_batch_size must be > 0");
 
-        let num_centroids =
-            ((total_target_docs as f64) * f64::from(centroid_ratio)).ceil() as usize;
-        let num_centroids = num_centroids.clamp(1, total_target_docs);
-
         Ok(IvfMergeSettings {
-            num_centroids,
-            training_samples_per_centroid,
+            training_sample_ratio,
             assign_batch_size,
-            // Replica cells (the `replicas - 1` non-primary cells per vector)
-            // are selected by tantivy in the field's raw metric —
-            // router-consistent with query-time `rank_centroids`. No angular
-            // assumption on this clusterer remains.
-            replicas: self.replicas.max(1),
         })
     }
 
@@ -158,7 +139,6 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
         &self,
         options: &VectorOptions,
         vectors: IvfTrainingVectors,
-        num_centroids: usize,
     ) -> tantivy::Result<IvfCentroids> {
         let IvfTrainingVectors::F32(vectors) = vectors;
         let dim = options.dim();
@@ -184,20 +164,27 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
         }
 
         let mut config = self.config.clone();
+        config.max_leaf_size = self.max_leaf_size();
         if matches!(options.metric(), Metric::Cosine | Metric::Dot) {
             config.base.angular = true;
         }
-        let mut clusterer = HierarchicalSuperKMeans::with_config(num_centroids, dim, config);
+        let mut clusterer = HierarchicalSuperKMeans::with_config(dim, config);
         let rows = vectors.matrix.rows;
         // Hand the buffer to superkmeans so it can rotate in place instead of
-        // keeping a second full-size copy alive through training.
+        // keeping a second full-size copy alive through training. Callers
+        // (tantivy merge) are responsible for sampling before this call.
         let centroids = clusterer.train_owned(vectors.matrix.values, rows);
-        if centroids.len() != num_centroids * dim {
+        if !centroids.len().is_multiple_of(dim) {
             return Err(TantivyError::InternalError(format!(
-                "SuperKMeans returned {} centroid floats, expected {}",
-                centroids.len(),
-                num_centroids * dim
+                "SuperKMeans returned {} centroid floats, not a multiple of dim {dim}",
+                centroids.len()
             )));
+        }
+        let num_centroids = centroids.len() / dim;
+        if num_centroids == 0 {
+            return Err(TantivyError::InternalError(
+                "SuperKMeans returned zero centroids".to_string(),
+            ));
         }
         Ok(IvfCentroids::F32(IvfMatrix {
             values: centroids,
@@ -274,11 +261,7 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
                 _ => {
                     let mut config = self.config.clone();
                     config.base.angular = angular;
-                    let clusterer = Arc::new(HierarchicalSuperKMeans::with_config(
-                        centroid_matrix.rows,
-                        dim,
-                        config,
-                    ));
+                    let clusterer = Arc::new(HierarchicalSuperKMeans::with_config(dim, config));
                     *cache = Some(AssignClusterer {
                         dim,
                         angular,
@@ -289,8 +272,7 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
             }
         };
         // Primary (nearest-centroid) assignment via superkmeans, angular-aware
-        // for cosine/dot. One cluster per vector — no replication. `n_centroids`
-        // is derived from the centroid slice length.
+        // for cosine/dot. One cluster per vector.
         let primaries = clusterer.assign(
             vector_matrix.values,
             centroid_matrix.values.as_slice(),
@@ -300,11 +282,17 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
     }
 }
 
+/// Select the IVF router on an opened index. Every `Index::open` in pg_search
+/// goes through this: tantivy requires a configured router both to build IVF
+/// segments at merge time and to open existing ones for search.
+pub fn set_ivf_router(index: &mut Index) -> tantivy::Result<()> {
+    index.set_ivf_router(IVF_ROUTER)
+}
+
 pub fn set_ivf_clusterer(index: &mut Index, options: &BM25IndexOptions) {
     let clusterer = SuperKMeansIvfClusterer::new()
         .with_centroid_ratio(options.centroid_ratio())
-        .with_training_samples_per_centroid(options.training_samples_per_centroid())
-        .with_replicas(options.cluster_replication());
+        .with_training_sample_ratio(options.training_sample_ratio());
     index.set_ivf_clusterer(Arc::new(clusterer));
 }
 
@@ -312,26 +300,38 @@ pub fn set_ivf_clusterer(index: &mut Index, options: &BM25IndexOptions) {
 mod tests {
     use super::*;
 
-    /// Replication is off by default (`replicas = 1`), and non-positive
-    /// configured values clamp to `1` rather than disabling clustering.
     #[test]
-    fn replicas_default_and_clamp() {
-        let total = 100_000;
+    fn max_leaf_size_is_density_preserving() {
+        let clusterer = SuperKMeansIvfClusterer::new()
+            .with_centroid_ratio(0.01)
+            .with_training_sample_ratio(0.32);
+        assert_eq!(clusterer.max_leaf_size(), 32);
+
+        let full = SuperKMeansIvfClusterer::new()
+            .with_centroid_ratio(0.01)
+            .with_training_sample_ratio(1.0);
+        assert_eq!(full.max_leaf_size(), 100);
+    }
+
+    #[test]
+    fn merge_settings_use_training_sample_ratio() {
         let settings = SuperKMeansIvfClusterer::new()
-            .merge_settings(total)
+            .with_training_sample_ratio(0.5)
+            .merge_settings(100_000)
             .unwrap();
-        assert_eq!(settings.replicas, 1, "primary-only by default");
+        assert_eq!(settings.training_sample_ratio, 0.5);
+        assert_eq!(settings.assign_batch_size, DEFAULT_ASSIGN_BATCH_SIZE);
+    }
 
-        let replicated = SuperKMeansIvfClusterer::new()
-            .with_replicas(4)
-            .merge_settings(total)
-            .unwrap();
-        assert_eq!(replicated.replicas, 4);
+    /// The router is fixed per index: setting it twice with the same kind is
+    /// idempotent, so opening the same `Index` through several paths is safe.
+    #[test]
+    fn set_ivf_router_is_idempotent() {
+        use tantivy::schema::Schema;
 
-        let clamped = SuperKMeansIvfClusterer::new()
-            .with_replicas(0)
-            .merge_settings(total)
-            .unwrap();
-        assert_eq!(clamped.replicas, 1, "non-positive clamps to primary-only");
+        let mut index = Index::create_in_ram(Schema::builder().build());
+        set_ivf_router(&mut index).expect("first set");
+        set_ivf_router(&mut index).expect("same kind again");
+        assert!(index.set_ivf_router(RouterKind::Rng).is_err());
     }
 }

--- a/pg_search/tests/pg_regress/expected/vector_merge.out
+++ b/pg_search/tests/pg_regress/expected/vector_merge.out
@@ -1,9 +1,13 @@
--- Merging an already-replicated IVF segment into a larger one (tantivy
--- c4582807: IVF count() returns distinct docs, not posting rows). At the
--- prior rev, a replicated segment's posting-row total was read where a doc
--- count was meant, tripping debug-build accounting asserts in tantivy's IVF
--- plugin when such a segment became a merge SOURCE. pgrx regress builds are
--- debug builds, so this test exercises those asserts for real.
+-- Merging an IVF segment into a larger one (tantivy c4582807: IVF count()
+-- returns distinct docs, not posting rows). At the prior rev, a segment's
+-- posting-row total was read where a doc count was meant, tripping
+-- debug-build accounting asserts in tantivy's IVF plugin when such a segment
+-- became a merge SOURCE. pgrx regress builds are debug builds, so this test
+-- exercises those asserts for real.
+--
+-- cluster_replication is accepted for compatibility but assignment is
+-- primary-only: every vector lands in exactly one cell, so per-cluster
+-- memberships sum to the distinct-doc count.
 --
 -- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
 -- NOTICE with nondeterministic millisecond values — keep it out of the
@@ -28,7 +32,7 @@ CREATE TABLE remerge (
 -- keeps every merge in the foreground, deterministic. Inserts flush ~1000-doc
 -- segments of ~70kb, and a 600kb layer closes its first candidate at
 -- >= 10000 docs — at or above tantivy's vector_clustering_threshold, so the
--- merge target is written IVF (clustered), with every vector in 3 cells.
+-- merge target is written IVF (clustered) under the stacked centroid router.
 CREATE INDEX remerge_idx ON remerge
     USING paradedb (id, vec vector_l2_ops)
     WITH (
@@ -52,8 +56,7 @@ FROM paradedb.vector_info('remerge_idx', 'vec');
  t
 (1 row)
 
--- ...whose reported vector count is distinct docs (= its doc count), not the
--- 3x posting-row total that replication writes...
+-- ...whose reported vector count is distinct docs (= its doc count)...
 SELECT bool_and(v.vector_num_vectors = i.num_docs) AS num_vectors_is_distinct_docs
 FROM paradedb.vector_info('remerge_idx', 'vec') v
 JOIN paradedb.index_info('remerge_idx') i USING (segno)
@@ -63,9 +66,9 @@ WHERE v.vector_format = 'ivf';
  t
 (1 row)
 
--- ...while the per-cluster sizes deliberately stay memberships: their total
--- strictly exceeds the distinct-doc count under replication.
-SELECT sum(vector_total_memberships) > sum(vector_num_vectors)
+-- ...and the per-cluster sizes are memberships, which under primary-only
+-- assignment total exactly the distinct-doc count.
+SELECT sum(vector_total_memberships) = sum(vector_num_vectors)
          AS cluster_sizes_are_memberships
 FROM paradedb.vector_info('remerge_idx', 'vec')
 WHERE vector_format = 'ivf';
@@ -74,7 +77,7 @@ WHERE vector_format = 'ivf';
  t
 (1 row)
 
--- Wave 2: make the replicated IVF segment a merge SOURCE. The layer must
+-- Wave 2: make the IVF segment a merge SOURCE. The layer must
 -- admit it (it is ~2.5-3.1mb; 3500kb leaves headroom) and the total corpus
 -- must overfill the extended layer, which the extra 35000 rows guarantee.
 ALTER INDEX remerge_idx SET (layer_sizes = '3500kb');
@@ -99,9 +102,8 @@ WHERE v.vector_format = 'ivf';
 
 -- Exhaustive probing: the ceiling clamps to each segment's cluster count,
 -- and LIMIT 60000 widens the candidate floor (4 x top_n) past the corpus so
--- the distance gate cannot stop early. The twice-merged replicated index
--- must return every distinct row exactly once — replicas deduped, nothing
--- lost, nothing doubled.
+-- the distance gate cannot stop early. The twice-merged index must return
+-- every distinct row exactly once — nothing lost, nothing doubled.
 SET paradedb.vector_cluster_max_probe = 1.0;
 SELECT count(*) AS returned, count(DISTINCT id) AS distinct_ids
 FROM (

--- a/pg_search/tests/pg_regress/sql/vector_merge.sql
+++ b/pg_search/tests/pg_regress/sql/vector_merge.sql
@@ -1,9 +1,13 @@
--- Merging an already-replicated IVF segment into a larger one (tantivy
--- c4582807: IVF count() returns distinct docs, not posting rows). At the
--- prior rev, a replicated segment's posting-row total was read where a doc
--- count was meant, tripping debug-build accounting asserts in tantivy's IVF
--- plugin when such a segment became a merge SOURCE. pgrx regress builds are
--- debug builds, so this test exercises those asserts for real.
+-- Merging an IVF segment into a larger one (tantivy c4582807: IVF count()
+-- returns distinct docs, not posting rows). At the prior rev, a segment's
+-- posting-row total was read where a doc count was meant, tripping
+-- debug-build accounting asserts in tantivy's IVF plugin when such a segment
+-- became a merge SOURCE. pgrx regress builds are debug builds, so this test
+-- exercises those asserts for real.
+--
+-- cluster_replication is accepted for compatibility but assignment is
+-- primary-only: every vector lands in exactly one cell, so per-cluster
+-- memberships sum to the distinct-doc count.
 --
 -- client_min_messages: the IVF merge emits a paradedb::ivf_build timings
 -- NOTICE with nondeterministic millisecond values — keep it out of the
@@ -25,7 +29,7 @@ CREATE TABLE remerge (
 -- keeps every merge in the foreground, deterministic. Inserts flush ~1000-doc
 -- segments of ~70kb, and a 600kb layer closes its first candidate at
 -- >= 10000 docs — at or above tantivy's vector_clustering_threshold, so the
--- merge target is written IVF (clustered), with every vector in 3 cells.
+-- merge target is written IVF (clustered) under the stacked centroid router.
 CREATE INDEX remerge_idx ON remerge
     USING paradedb (id, vec vector_l2_ops)
     WITH (
@@ -47,21 +51,20 @@ FROM generate_series(1, 15000) g;
 SELECT bool_or(vector_format = 'ivf') AS has_ivf
 FROM paradedb.vector_info('remerge_idx', 'vec');
 
--- ...whose reported vector count is distinct docs (= its doc count), not the
--- 3x posting-row total that replication writes...
+-- ...whose reported vector count is distinct docs (= its doc count)...
 SELECT bool_and(v.vector_num_vectors = i.num_docs) AS num_vectors_is_distinct_docs
 FROM paradedb.vector_info('remerge_idx', 'vec') v
 JOIN paradedb.index_info('remerge_idx') i USING (segno)
 WHERE v.vector_format = 'ivf';
 
--- ...while the per-cluster sizes deliberately stay memberships: their total
--- strictly exceeds the distinct-doc count under replication.
-SELECT sum(vector_total_memberships) > sum(vector_num_vectors)
+-- ...and the per-cluster sizes are memberships, which under primary-only
+-- assignment total exactly the distinct-doc count.
+SELECT sum(vector_total_memberships) = sum(vector_num_vectors)
          AS cluster_sizes_are_memberships
 FROM paradedb.vector_info('remerge_idx', 'vec')
 WHERE vector_format = 'ivf';
 
--- Wave 2: make the replicated IVF segment a merge SOURCE. The layer must
+-- Wave 2: make the IVF segment a merge SOURCE. The layer must
 -- admit it (it is ~2.5-3.1mb; 3500kb leaves headroom) and the total corpus
 -- must overfill the extended layer, which the extra 35000 rows guarantee.
 ALTER INDEX remerge_idx SET (layer_sizes = '3500kb');
@@ -79,9 +82,8 @@ WHERE v.vector_format = 'ivf';
 
 -- Exhaustive probing: the ceiling clamps to each segment's cluster count,
 -- and LIMIT 60000 widens the candidate floor (4 x top_n) past the corpus so
--- the distance gate cannot stop early. The twice-merged replicated index
--- must return every distinct row exactly once — replicas deduped, nothing
--- lost, nothing doubled.
+-- the distance gate cannot stop early. The twice-merged index must return
+-- every distinct row exactly once — nothing lost, nothing doubled.
 SET paradedb.vector_cluster_max_probe = 1.0;
 SELECT count(*) AS returned, count(DISTINCT id) AS distinct_ids
 FROM (


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Replaces the RNG centroid router with tantivy's stacked IVF router (paradedb/tantivy#223) and enables adaptive partition scanning (APS) for low-dimensional vectors.

- Bumps tantivy to `d40cd042` (brings paradedb/tantivy#199, #212, #216, #223) and superkmeans to `c06dc2b6`.
- Every `Index::open` goes through `crate::index::open_index`, which selects `RouterKind::Stacked`; tantivy persists the kind per segment and requires it at open. The parallel-build `Index::create` path sets it too.
- New GUC `paradedb.vector_router_recall` (default `0.9`, range `(0, 1]`), passed as `AdaptiveProbeParams::router_recall_target`. `paradedb.vector_cluster_max_probe` (2%) remains the L0 probe budget.
- `SuperKMeansIvfClusterer` ported to the post-#216 `IvfClusterer` trait: `training_sample_ratio` replaces `training_samples_per_centroid` (reloption renamed; real, default `0.32`), density-preserving `max_leaf_size`, `train` without `num_centroids`. The `build_router` / `paradedb.vector_router` GUC from the earlier revision are gone: a session GUC can't pick the router because the read path must match the persisted kind.
- `bounds_scope` is parsed locally (tantivy dropped `BoundsScope`); `cluster_replication` is still accepted but assignment is primary-only since tantivy #199.

## Why

The RNG router is being retired in favor of the stacked IVF. APS lets the router stop ranking clusters once the estimated recall of the top clusters reaches the target instead of always scanning a fixed nprobe fraction. APS is only reliable below 256 dimensions, so tantivy forces `recall = 1.0` (fixed nprobe, 25% per router level) at `dim >= 256`; Cohere-1024 exercises that path, SIFT/low-d exercises APS.

## How

Query path: L0 probe loop (`.vec` rows under `.centroids`, budget = `vector_cluster_max_probe`) -> `rank_clusters(RoutingParams { k, recall })` -> stacked router over the centroids (L1..Ln). `k` is `2 x ceil(work budget)` clusters; `recall` is the GUC, or `1.0` at `dim >= 256`.

## Tests

- `vector_merge`: replication assertion updated to primary-only (`memberships == distinct docs`); the rest of the test (IVF segment as merge source, exhaustive probe returns every row once) passes under the stacked router.
- `vector_delete_all_docs`, `vector_ingest`, `vector_mutable_segment`, `vector_search_pushdown`, `vector_unsupported_types` pass unchanged.
- `clusterer.rs` unit tests: `max_leaf_size`, `merge_settings`, `set_ivf_router` idempotence.
- tantivy side (#223): APS on an opened `LazyStackedIvf`, `dim >= 256` fallback, `RouterMetrics::Stacked { lists_scanned, members_scored, recall_target }`.
