### PR TITLE
fix: Expand cross-table filters in proptests

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -29,9 +29,8 @@ use crate::api::operator::anyelement_query_input_opoid;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::builders::custom_path::RestrictInfoType;
 use crate::postgres::customscan::joinscan::build::{
-    FilterNode, JoinKeyPair, JoinLevelExpr, JoinLevelSearchPredicate, JoinNode, JoinSource,
-    JoinSourceCandidate, JoinType, MultiTablePredicateInfo, PlannerRootId, RelNode,
-    lookup_base_rel_info, try_extract_equi_key,
+    FilterNode, JoinKeyPair, JoinLevelExpr, JoinNode, JoinSource, JoinSourceCandidate, JoinType,
+    PlannerRootId, RelNode, lookup_base_rel_info, try_extract_equi_key,
 };
 use crate::postgres::customscan::joinscan::planning::{
     ClassifiedBaseRestrictInfo, classify_base_restrictinfo, transparent_path_subpath,
@@ -55,23 +54,11 @@ use crate::query::SearchQueryInput;
 use crate::scan::info::FieldInfo;
 use pgrx::{PgList, pg_sys};
 
-/// Result type for `extract_join_tree_from_parse`: the plan tree, search
-/// predicates, multi-table predicate info, and raw PG Expr clause pointers.
-type JoinTreeResult = (
-    RelNode,
-    Vec<JoinLevelSearchPredicate>,
-    Vec<MultiTablePredicateInfo>,
-    Vec<*mut pg_sys::Expr>,
-);
+/// Result type for `extract_join_tree_from_parse`: the plan tree and raw PG Expr clause pointers.
+type JoinTreeResult = (RelNode, Vec<*mut pg_sys::Expr>);
 
-/// Result type for `build_search_filter`: the filter expression, search
-/// predicates, multi-table predicate info, and raw PG Expr clause pointers.
-type SearchFilterResult = (
-    JoinLevelExpr,
-    Vec<JoinLevelSearchPredicate>,
-    Vec<MultiTablePredicateInfo>,
-    Vec<*mut pg_sys::Expr>,
-);
+/// Result type for `build_search_filter`: the filter expression and raw PG Expr clause pointers.
+type SearchFilterResult = (JoinLevelExpr, Vec<*mut pg_sys::Expr>);
 
 /// Metadata about a table participating in the join, collected during parse-tree walk.
 #[derive(Debug)]
@@ -225,8 +212,6 @@ pub unsafe fn extract_join_tree_from_parse(
     //
     // The earlier coverage check guarantees an opaque path cannot reach the
     // FromExpr.quals fallback below.
-    let mut join_level_predicates = Vec::new();
-    let mut multi_table_predicates = Vec::new();
     let mut multi_table_clauses: Vec<*mut pg_sys::Expr> = Vec::new();
 
     // Each call below fails closed if `build_search_filter` returns `None` -
@@ -246,15 +231,13 @@ pub unsafe fn extract_join_tree_from_parse(
         "path joinrestrictinfo",
         "cross-table predicate cannot be pushed into the aggregate scan",
         &mut plan,
-        &mut join_level_predicates,
-        &mut multi_table_predicates,
         &mut multi_table_clauses,
     )?;
 
     // 2. Fallback: parse-tree `(*jointree).quals` - PG sometimes leaves
     // cross-table predicates here that `joinrestrictinfo` didn't surface.
-    if join_level_predicates.is_empty()
-        && multi_table_predicates.is_empty()
+    if !plan.has_search_predicate()
+        && multi_table_clauses.is_empty()
         && !(*jointree).quals.is_null()
     {
         let mut parse_clauses = Vec::new();
@@ -266,30 +249,23 @@ pub unsafe fn extract_join_tree_from_parse(
             "jointree.quals",
             "cross-table predicate in WHERE clause cannot be pushed into the aggregate scan",
             &mut plan,
-            &mut join_level_predicates,
-            &mut multi_table_predicates,
             &mut multi_table_clauses,
         )?;
     }
+    let predicates = plan.search_predicates();
     crate::postgres::customscan::joinscan::build::assign_tagged_queries(
         plan.sources_mut(),
-        &join_level_predicates,
+        &predicates,
     );
 
-    Ok((
-        plan,
-        join_level_predicates,
-        multi_table_predicates,
-        multi_table_clauses,
-    ))
+    Ok((plan, multi_table_clauses))
 }
 
 /// Try translating `clauses` into a cross-table search filter and, on
 /// success, wrap `plan` in a `FilterNode` and collect the resulting
 /// predicate metadata. If `build_search_filter` returns `None` we decline
 /// the agg-on-join path: silently dropping a cross-table predicate
-/// computes wrong rows. A no-op when `clauses` is empty.
-#[allow(clippy::too_many_arguments)]
+/// computes wrong rows.
 unsafe fn apply_search_filter_or_decline(
     root: *mut pg_sys::PlannerInfo,
     sources: &[JoinAggSource],
@@ -297,8 +273,6 @@ unsafe fn apply_search_filter_or_decline(
     source_label: &str,
     err_msg: &str,
     plan: &mut RelNode,
-    join_level_predicates: &mut Vec<JoinLevelSearchPredicate>,
-    multi_table_predicates: &mut Vec<MultiTablePredicateInfo>,
     multi_table_clauses: &mut Vec<*mut pg_sys::Expr>,
 ) -> Result<(), String> {
     if clauses.is_empty() {
@@ -315,9 +289,7 @@ unsafe fn apply_search_filter_or_decline(
         );
     }
 
-    let Some((filter_expr, predicates, mt_predicates, mt_clauses)) =
-        build_search_filter(root, clauses, sources, plan)
-    else {
+    let Some((filter_expr, mt_clauses)) = build_search_filter(root, clauses, sources, plan) else {
         pgrx::debug1!(
             "agg-on-join: declining; {} {} predicate(s) untranslatable",
             clauses.len(),
@@ -325,8 +297,6 @@ unsafe fn apply_search_filter_or_decline(
         );
         return Err(err_msg.into());
     };
-    *join_level_predicates = predicates;
-    *multi_table_predicates = mt_predicates;
     *multi_table_clauses = mt_clauses;
     let prev = std::mem::take(plan);
     *plan = RelNode::Filter(Box::new(FilterNode {
@@ -1558,7 +1528,6 @@ unsafe fn build_search_filter(
     _sources: &[JoinAggSource],
     plan: &RelNode,
 ) -> Option<SearchFilterResult> {
-    use crate::postgres::customscan::joinscan::build::JoinCSClause;
     use crate::postgres::customscan::joinscan::predicate::transform_to_search_expr;
 
     // Predicate clauses are outer-query expressions.  Use only output-visible
@@ -1584,7 +1553,6 @@ unsafe fn build_search_filter(
         }
     }
 
-    let mut temp_clause = JoinCSClause::new(plan.clone());
     let mut multi_table_clauses: Vec<*mut pg_sys::Expr> = Vec::new();
     let mut expr_trees: Vec<JoinLevelExpr> = Vec::new();
 
@@ -1592,13 +1560,7 @@ unsafe fn build_search_filter(
         // If any clause can't be fully transformed, bail out.
         // Returning None causes the caller to decline the DataFusion path;
         // silently omitting any one clause would compute incorrect rows.
-        let expr = transform_to_search_expr(
-            root,
-            clause,
-            &sources,
-            &mut temp_clause,
-            &mut multi_table_clauses,
-        )?;
+        let expr = transform_to_search_expr(root, clause, &sources, &mut multi_table_clauses)?;
         expr_trees.push(expr);
     }
 
@@ -1612,12 +1574,7 @@ unsafe fn build_search_filter(
         JoinLevelExpr::And(expr_trees)
     };
 
-    Some((
-        final_expr,
-        temp_clause.join_level_predicates,
-        temp_clause.multi_table_predicates,
-        multi_table_clauses,
-    ))
+    Some((final_expr, multi_table_clauses))
 }
 
 /// Walk a parse-tree expression (typically `FromExpr.quals`) and collect

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -38,9 +38,7 @@ use crate::postgres::customscan::datafusion::translator::{
     ColumnMapper, PredicateTranslator, apply_join_level_filter, build_join_df, make_col,
     make_source_col,
 };
-use crate::postgres::customscan::joinscan::build::{
-    JoinLevelSearchPredicate, JoinSource, RelNode, RelationAlias,
-};
+use crate::postgres::customscan::joinscan::build::{JoinSource, RelNode, RelationAlias};
 use crate::postgres::customscan::joinscan::scan_state::{
     SessionContextProfile, create_datafusion_session_context, register_source_table,
 };
@@ -78,7 +76,6 @@ pub async fn build_join_aggregate_plan(
     plan: &RelNode,
     targetlist: &JoinAggregateTargetList,
     topk: Option<&DataFusionTopK>,
-    join_level_predicates: &[JoinLevelSearchPredicate],
     custom_exprs: *mut pg_sys::List,
     custom_scan_tlist: *mut pg_sys::List,
     having_filter: Option<&FilterExpr>,
@@ -91,7 +88,6 @@ pub async fn build_join_aggregate_plan(
     let df = build_relnode_df(
         ctx,
         plan,
-        join_level_predicates,
         custom_exprs,
         custom_scan_tlist,
         expr_context,
@@ -284,7 +280,6 @@ pub async fn build_join_aggregate_plan(
 fn build_relnode_df<'a>(
     ctx: &'a SessionContext,
     node: &'a RelNode,
-    join_level_predicates: &'a [JoinLevelSearchPredicate],
     custom_exprs: *mut pg_sys::List,
     custom_scan_tlist: *mut pg_sys::List,
     expr_context: Option<*mut pg_sys::ExprContext>,
@@ -312,7 +307,6 @@ fn build_relnode_df<'a>(
                 let left_df = build_relnode_df(
                     ctx,
                     &join.left,
-                    join_level_predicates,
                     custom_exprs,
                     custom_scan_tlist,
                     expr_context,
@@ -323,7 +317,6 @@ fn build_relnode_df<'a>(
                 let right_df = build_relnode_df(
                     ctx,
                     &join.right,
-                    join_level_predicates,
                     custom_exprs,
                     custom_scan_tlist,
                     expr_context,
@@ -338,7 +331,6 @@ fn build_relnode_df<'a>(
                 let df = build_relnode_df(
                     ctx,
                     &filter.input,
-                    join_level_predicates,
                     custom_exprs,
                     custom_scan_tlist,
                     expr_context,
@@ -346,13 +338,6 @@ fn build_relnode_df<'a>(
                     mpp_manifests,
                 )
                 .await?;
-
-                let has_predicates = !join_level_predicates.is_empty() || !custom_exprs.is_null();
-
-                if !has_predicates {
-                    // No predicates to apply — pass through
-                    return Ok(df);
-                }
 
                 let sources = filter.input.output_sources();
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -693,8 +693,6 @@ impl CustomScan for AggregateScan {
                 plan,
                 targetlist,
                 topk,
-                join_level_predicates,
-                multi_table_predicates,
                 having_filter,
                 ..
             } => {
@@ -706,12 +704,10 @@ impl CustomScan for AggregateScan {
                     ((*cscan).custom_exprs, (*cscan).custom_scan_tlist)
                 };
                 builder.custom_state().datafusion_state = Some(scan_state::DataFusionAggState {
+                    base_plan: Some(plan.clone()),
                     plan,
                     targetlist,
                     topk,
-                    base_join_level_predicates: Some(join_level_predicates.clone()),
-                    join_level_predicates,
-                    multi_table_predicates,
                     custom_exprs,
                     custom_scan_tlist,
                     having_filter,
@@ -784,12 +780,10 @@ impl CustomScan for AggregateScan {
                 }
 
                 // Show multi-table predicates (non-@@@ cross-table filters)
-                if !df_state.multi_table_predicates.is_empty() {
-                    let preds: Vec<String> = df_state
-                        .multi_table_predicates
-                        .iter()
-                        .map(|p| p.description.clone())
-                        .collect();
+                let mt_predicates = df_state.plan.multi_table_predicates();
+                if !mt_predicates.is_empty() {
+                    let preds: Vec<String> =
+                        mt_predicates.into_iter().map(|p| p.description).collect();
                     explainer.add_text("Multi-Table Filter", preds.join(" AND "));
                 }
 
@@ -1195,7 +1189,6 @@ impl AggregateScan {
                 &df_state.plan,
                 &df_state.targetlist,
                 df_state.topk.as_ref(),
-                &df_state.join_level_predicates,
                 custom_exprs,
                 custom_scan_tlist,
                 df_state.having_filter.as_ref(),
@@ -1271,7 +1264,6 @@ impl AggregateScan {
                         &df_state.plan,
                         &df_state.targetlist,
                         df_state.topk.as_ref(),
-                        &df_state.join_level_predicates,
                         custom_exprs,
                         custom_scan_tlist,
                         df_state.having_filter.as_ref(),
@@ -1564,7 +1556,7 @@ impl AggregateScan {
         };
 
         // Extract the join tree from the parse tree
-        let (mut plan, join_level_predicates, multi_table_predicates, multi_table_clauses) =
+        let (mut plan, multi_table_clauses) =
             unsafe { extract_join_tree_from_parse(root, &sources, path_info) }
                 .map_err(|e| warn(AggregateDeclineReason::Other(e)))?;
 
@@ -1660,8 +1652,6 @@ impl AggregateScan {
             plan,
             targetlist,
             topk,
-            join_level_predicates,
-            multi_table_predicates,
             multi_table_clause_count,
             having_filter,
         });

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -18,9 +18,7 @@
 use crate::api::AsCStr;
 use crate::customscan::aggregatescan::build::AggregateCSClause;
 use crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList;
-use crate::postgres::customscan::joinscan::build::{
-    JoinLevelSearchPredicate, MultiTablePredicateInfo, RelNode, RelationAlias,
-};
+use crate::postgres::customscan::joinscan::build::{RelNode, RelationAlias};
 use pgrx::PgList;
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::prelude::*;
@@ -175,15 +173,6 @@ pub enum PrivateData {
         targetlist: JoinAggregateTargetList,
         /// Optional TopK sort+limit pushed down from Postgres.
         topk: Option<DataFusionTopK>,
-        /// Cross-table search predicates extracted from WHERE quals.
-        /// These are @@@ predicates that reference multiple tables and cannot
-        /// be pushed to individual table scans.
-        #[serde(default)]
-        join_level_predicates: Vec<JoinLevelSearchPredicate>,
-        /// Non-@@@ cross-table predicates (like `b.id > 5`) that reference
-        /// fast fields and can be evaluated by DataFusion at join time.
-        #[serde(default)]
-        multi_table_predicates: Vec<MultiTablePredicateInfo>,
         /// Number of raw PG Expr pointers stored in custom_private after the
         /// serialized PrivateData. These are moved to custom_exprs during
         /// plan_custom_path so setrefs transforms their Var nodes.

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -23,9 +23,7 @@ use crate::postgres::customscan::CustomScanState;
 use crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList;
 use crate::postgres::customscan::aggregatescan::privdat::{DataFusionTopK, FilterExpr};
 use crate::postgres::customscan::bitmap_intersection::BitmapExec;
-use crate::postgres::customscan::joinscan::build::{
-    JoinLevelSearchPredicate, MultiTablePredicateInfo, RelNode,
-};
+use crate::postgres::customscan::joinscan::build::RelNode;
 use crate::postgres::customscan::mpp::glue::MppLaunchTiming;
 use crate::postgres::customscan::mpp::launch::MppLifecycle;
 use crate::postgres::customscan::solve_expr::SolvePostgresExpressions;
@@ -49,16 +47,12 @@ pub enum ExecutionState {
 pub struct DataFusionAggState {
     /// The join tree.
     pub plan: RelNode,
+    /// Original plan preserved for rescans.
+    pub base_plan: Option<RelNode>,
     /// GROUP BY columns and aggregate functions.
     pub targetlist: JoinAggregateTargetList,
     /// Optional TopK sort+limit pushed down from Postgres.
     pub topk: Option<DataFusionTopK>,
-    /// Cross-table search predicates for join-level filtering.
-    pub join_level_predicates: Vec<JoinLevelSearchPredicate>,
-    /// Original predicates preserved for rescans.
-    pub base_join_level_predicates: Option<Vec<JoinLevelSearchPredicate>>,
-    /// Non-@@@ cross-table predicates (descriptions for EXPLAIN).
-    pub multi_table_predicates: Vec<MultiTablePredicateInfo>,
     /// Raw PG Expr pointers from custom_exprs (after setrefs transforms
     /// Var nodes to INDEX_VAR references). Used to translate non-@@@
     /// cross-table predicates at execution time.
@@ -196,13 +190,16 @@ impl SolvePostgresExpressions for AggregateScanState {
         // Check both the Tantivy-path search queries and DataFusion-path
         // join-level predicates for unresolved PostgresExpression nodes
         // (prepared statement parameters like $1).
-        if let Some(ref mut df) = self.datafusion_state
-            && df
-                .join_level_predicates
-                .iter_mut()
-                .any(|p| p.query.has_postgres_expressions())
-        {
-            return true;
+        if let Some(ref mut df) = self.datafusion_state {
+            let mut has = false;
+            df.plan.visit_queries(&mut |q| {
+                if q.has_postgres_expressions() {
+                    has = true;
+                }
+            });
+            if has {
+                return true;
+            }
         }
         self.aggregate_clause.query_mut().has_postgres_expressions()
             || self
@@ -212,13 +209,16 @@ impl SolvePostgresExpressions for AggregateScanState {
     }
 
     fn has_parameters(&mut self) -> bool {
-        if let Some(ref mut df) = self.datafusion_state
-            && df
-                .join_level_predicates
-                .iter_mut()
-                .any(|p| p.query.has_parameters())
-        {
-            return true;
+        if let Some(ref mut df) = self.datafusion_state {
+            let mut has = false;
+            df.plan.visit_queries(&mut |q| {
+                if q.has_parameters() {
+                    has = true;
+                }
+            });
+            if has {
+                return true;
+            }
         }
         self.aggregate_clause.query_mut().has_parameters()
             || self
@@ -232,9 +232,9 @@ impl SolvePostgresExpressions for AggregateScanState {
             self.aggregate_clause = base.clone();
         }
         if let Some(ref mut df) = self.datafusion_state
-            && let Some(base) = &df.base_join_level_predicates
+            && let Some(base) = &df.base_plan
         {
-            df.join_level_predicates = base.clone();
+            df.plan = base.clone();
         }
     }
 
@@ -258,9 +258,9 @@ impl SolvePostgresExpressions for AggregateScanState {
 
     fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) {
         if let Some(ref mut df) = self.datafusion_state {
-            for pred in &mut df.join_level_predicates {
-                pred.query.init_postgres_expressions(planstate);
-            }
+            df.plan.visit_queries_mut(&mut |q| {
+                q.init_postgres_expressions(planstate);
+            });
         }
         self.aggregate_clause
             .query_mut()
@@ -272,9 +272,9 @@ impl SolvePostgresExpressions for AggregateScanState {
 
     fn solve_postgres_expressions(&mut self, expr_context: *mut pg_sys::ExprContext) {
         if let Some(ref mut df) = self.datafusion_state {
-            for pred in &mut df.join_level_predicates {
-                pred.query.solve_postgres_expressions(expr_context);
-            }
+            df.plan.visit_queries_mut(&mut |q| {
+                q.solve_postgres_expressions(expr_context);
+            });
         }
         if !self.is_datafusion_backend() {
             self.aggregate_clause

--- a/pg_search/src/postgres/customscan/datafusion/explain.rs
+++ b/pg_search/src/postgres/customscan/datafusion/explain.rs
@@ -73,7 +73,7 @@ pub fn format_join_level_expr(expr: &JoinLevelExpr, join_clause: &JoinCSClause) 
     match expr {
         JoinLevelExpr::SingleTablePredicate {
             plan_position,
-            predicate_idx,
+            predicate,
         } => {
             let label = join_clause
                 .plan
@@ -85,18 +85,10 @@ pub fn format_join_level_expr(expr: &JoinLevelExpr, join_clause: &JoinCSClause) 
                         .display(source.plan_position)
                 })
                 .unwrap_or_else(|| RelationAlias::new(None).display(*plan_position));
-            if let Some(pred) = join_clause.join_level_predicates.get(*predicate_idx) {
-                format!("{}:{}", label, pred.query.explain_format())
-            } else {
-                format!("{}:?", label)
-            }
+            format!("{}:{}", label, predicate.query.explain_format())
         }
-        JoinLevelExpr::MultiTablePredicate { predicate_idx } => {
-            if let Some(cond) = join_clause.multi_table_predicates.get(*predicate_idx) {
-                format!("heap:{}", cond.description)
-            } else {
-                "heap:?".to_string()
-            }
+        JoinLevelExpr::MultiTablePredicate { predicate } => {
+            format!("heap:{}", predicate.description)
         }
         JoinLevelExpr::And(children) => {
             let parts: Vec<_> = children

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -123,36 +123,48 @@ impl<'a> PredicateTranslator<'a> {
     pub unsafe fn translate_join_level_expr(
         expr: &JoinLevelExpr,
         custom_exprs: &[Expr],
+        custom_expr_idx: &mut usize,
         sources: &[&JoinSource],
     ) -> Option<Expr> {
         match expr {
             JoinLevelExpr::SingleTablePredicate {
                 plan_position,
-                predicate_idx,
+                predicate,
             } => {
                 let source = sources.iter().find(|s| s.plan_position == *plan_position)?;
                 let tag_name = match &source.scan_info.mode {
                     crate::scan::ScanMode::Tagged { local_queries, .. } => {
                         &local_queries
                             .iter()
-                            .find(|tq| tq.predicate_idx.0 == *predicate_idx)?
+                            .find(|tq| tq.query.as_ref() == &predicate.query)?
                             .tag_name
                     }
                     crate::scan::ScanMode::Standard { .. } => return None,
                 };
                 Some(col(tag_name))
             }
-            JoinLevelExpr::MultiTablePredicate { predicate_idx } => {
-                custom_exprs.get(*predicate_idx).cloned()
+            JoinLevelExpr::MultiTablePredicate { .. } => {
+                let expr = custom_exprs.get(*custom_expr_idx).cloned();
+                *custom_expr_idx += 1;
+                expr
             }
             JoinLevelExpr::And(children) => {
                 if children.is_empty() {
                     return None;
                 }
-                let mut result =
-                    Self::translate_join_level_expr(&children[0], custom_exprs, sources)?;
+                let mut result = Self::translate_join_level_expr(
+                    &children[0],
+                    custom_exprs,
+                    custom_expr_idx,
+                    sources,
+                )?;
                 for child in &children[1..] {
-                    let right = Self::translate_join_level_expr(child, custom_exprs, sources)?;
+                    let right = Self::translate_join_level_expr(
+                        child,
+                        custom_exprs,
+                        custom_expr_idx,
+                        sources,
+                    )?;
                     result = Expr::BinaryExpr(BinaryExpr::new(
                         Box::new(result),
                         Operator::And,
@@ -165,10 +177,19 @@ impl<'a> PredicateTranslator<'a> {
                 if children.is_empty() {
                     return None;
                 }
-                let mut result =
-                    Self::translate_join_level_expr(&children[0], custom_exprs, sources)?;
+                let mut result = Self::translate_join_level_expr(
+                    &children[0],
+                    custom_exprs,
+                    custom_expr_idx,
+                    sources,
+                )?;
                 for child in &children[1..] {
-                    let right = Self::translate_join_level_expr(child, custom_exprs, sources)?;
+                    let right = Self::translate_join_level_expr(
+                        child,
+                        custom_exprs,
+                        custom_expr_idx,
+                        sources,
+                    )?;
                     result = Expr::BinaryExpr(BinaryExpr::new(
                         Box::new(result),
                         Operator::Or,
@@ -178,7 +199,8 @@ impl<'a> PredicateTranslator<'a> {
                 Some(result)
             }
             JoinLevelExpr::Not(child) => {
-                let inner = Self::translate_join_level_expr(child, custom_exprs, sources)?;
+                let inner =
+                    Self::translate_join_level_expr(child, custom_exprs, custom_expr_idx, sources)?;
                 Some(Expr::Not(Box::new(inner)))
             }
             JoinLevelExpr::MarkOrNull {
@@ -323,8 +345,14 @@ pub fn apply_join_level_filter(
     sources: &[&JoinSource],
     handle_mark: bool,
 ) -> Result<DataFrame> {
+    let mut custom_expr_idx = 0;
     let filter_expr = unsafe {
-        PredicateTranslator::translate_join_level_expr(predicate, translated_exprs, sources)
+        PredicateTranslator::translate_join_level_expr(
+            predicate,
+            translated_exprs,
+            &mut custom_expr_idx,
+            sources,
+        )
     }
     .ok_or_else(|| {
         DataFusionError::Internal(format!(

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -628,8 +628,6 @@ impl TryFrom<JoinSourceCandidate> for JoinSource {
 pub struct MultiTablePredicateInfo {
     /// Human-readable description for EXPLAIN output.
     pub description: String,
-    /// Index of this condition in the restrictlist (for runtime extraction).
-    pub restrictinfo_index: usize,
 }
 
 /// A boolean expression tree for join-level conditions.
@@ -639,13 +637,12 @@ pub enum JoinLevelExpr {
     SingleTablePredicate {
         /// Plan position of the source (in the order yielded by `RelNode::sources()`) this predicate references.
         plan_position: usize,
-        /// Index into the `join_level_predicates` vector.
-        predicate_idx: usize,
+        /// The search predicate to evaluate against Tantivy.
+        predicate: Box<JoinLevelSearchPredicate>,
     },
     /// Leaf: multi-table predicate, evaluate at runtime against the joined row pair.
     MultiTablePredicate {
-        /// Index into the `multi_table_predicates` vector.
-        predicate_idx: usize,
+        predicate: Box<MultiTablePredicateInfo>,
     },
     /// Logical AND of child expressions.
     And(Vec<JoinLevelExpr>),
@@ -699,6 +696,18 @@ impl JoinLevelExpr {
         }
     }
 
+    pub fn has_multi_table_predicate(&self) -> bool {
+        match self {
+            Self::SingleTablePredicate { .. } => false,
+            Self::MultiTablePredicate { .. } => true,
+            Self::And(children) | Self::Or(children) => {
+                children.iter().any(|c| c.has_multi_table_predicate())
+            }
+            Self::Not(inner) => inner.has_multi_table_predicate(),
+            Self::MarkOrNull { .. } | Self::PgExpression { .. } => false,
+        }
+    }
+
     pub fn offset_plan_positions(&mut self, offset: usize) {
         if offset == 0 {
             return;
@@ -718,41 +727,76 @@ impl JoinLevelExpr {
         }
     }
 
-    pub fn offset_predicate_indices(&mut self, offset: usize) {
-        if offset == 0 {
-            return;
-        }
+    pub fn collect_search_predicates<'a>(
+        &'a self,
+        acc: &mut Vec<(usize, &'a JoinLevelSearchPredicate)>,
+    ) {
         match self {
-            Self::SingleTablePredicate { predicate_idx, .. } => {
-                *predicate_idx += offset;
+            Self::SingleTablePredicate {
+                plan_position,
+                predicate,
+            } => {
+                acc.push((*plan_position, predicate.as_ref()));
             }
-            Self::MultiTablePredicate { .. } => {}
             Self::And(children) | Self::Or(children) => {
                 for c in children {
-                    c.offset_predicate_indices(offset);
+                    c.collect_search_predicates(acc);
                 }
             }
-            Self::Not(inner) => inner.offset_predicate_indices(offset),
-            Self::MarkOrNull { .. } | Self::PgExpression { .. } => {}
+            Self::Not(inner) => inner.collect_search_predicates(acc),
+            Self::MultiTablePredicate { .. }
+            | Self::MarkOrNull { .. }
+            | Self::PgExpression { .. } => {}
         }
     }
 
-    pub fn offset_multi_table_predicate_indices(&mut self, offset: usize) {
-        if offset == 0 {
-            return;
-        }
+    pub fn visit_queries_mut(&mut self, f: &mut impl FnMut(&mut SearchQueryInput)) {
         match self {
-            Self::SingleTablePredicate { .. } => {}
-            Self::MultiTablePredicate { predicate_idx } => {
-                *predicate_idx += offset;
+            Self::SingleTablePredicate { predicate, .. } => f(&mut predicate.query),
+            Self::And(children) | Self::Or(children) => {
+                for c in children {
+                    c.visit_queries_mut(f);
+                }
+            }
+            Self::Not(inner) => inner.visit_queries_mut(f),
+            Self::MultiTablePredicate { .. }
+            | Self::MarkOrNull { .. }
+            | Self::PgExpression { .. } => {}
+        }
+    }
+
+    pub fn visit_queries(&self, f: &mut impl FnMut(&SearchQueryInput)) {
+        match self {
+            Self::SingleTablePredicate { predicate, .. } => f(&predicate.query),
+            Self::And(children) | Self::Or(children) => {
+                for c in children {
+                    c.visit_queries(f);
+                }
+            }
+            Self::Not(inner) => inner.visit_queries(f),
+            Self::MultiTablePredicate { .. }
+            | Self::MarkOrNull { .. }
+            | Self::PgExpression { .. } => {}
+        }
+    }
+
+    pub fn collect_multi_table_predicates<'a>(
+        &'a self,
+        acc: &mut Vec<&'a MultiTablePredicateInfo>,
+    ) {
+        match self {
+            Self::MultiTablePredicate { predicate } => {
+                acc.push(predicate.as_ref());
             }
             Self::And(children) | Self::Or(children) => {
                 for c in children {
-                    c.offset_multi_table_predicate_indices(offset);
+                    c.collect_multi_table_predicates(acc);
                 }
             }
-            Self::Not(inner) => inner.offset_multi_table_predicate_indices(offset),
-            Self::MarkOrNull { .. } | Self::PgExpression { .. } => {}
+            Self::Not(inner) => inner.collect_multi_table_predicates(acc),
+            Self::SingleTablePredicate { .. }
+            | Self::MarkOrNull { .. }
+            | Self::PgExpression { .. } => {}
         }
     }
 }
@@ -906,6 +950,56 @@ impl RelNode {
         .unwrap_or(false)
     }
 
+    /// Returns true if this node or any subtree contains a multi-table predicate.
+    pub fn has_multi_table_predicates(&self) -> bool {
+        self.exists(|node| {
+            let has = match node {
+                Self::Filter(f) => f.predicate.has_multi_table_predicate(),
+                Self::Join(j) => j
+                    .filter
+                    .as_ref()
+                    .is_some_and(|f| f.has_multi_table_predicate()),
+                Self::Scan(_) => false,
+            };
+            Ok(has)
+        })
+        .unwrap_or(false)
+    }
+
+    /// Recursively collects all search predicates in this tree.
+    pub fn search_predicates(&self) -> Vec<JoinLevelSearchPredicate> {
+        let mut predicates = Vec::new();
+        let _ = self.apply(|node| {
+            if let Self::Filter(f) = node {
+                f.predicate.collect_search_predicates(&mut predicates);
+            }
+            if let Self::Join(j) = node
+                && let Some(ref f) = j.filter
+            {
+                f.collect_search_predicates(&mut predicates);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
+        predicates.into_iter().map(|(_, p)| p.clone()).collect()
+    }
+
+    /// Recursively collects all multi-table predicates in this tree.
+    pub fn multi_table_predicates(&self) -> Vec<MultiTablePredicateInfo> {
+        let mut predicates = Vec::new();
+        let _ = self.apply(|node| {
+            if let Self::Filter(f) = node {
+                f.predicate.collect_multi_table_predicates(&mut predicates);
+            }
+            if let Self::Join(j) = node
+                && let Some(ref f) = j.filter
+            {
+                f.collect_multi_table_predicates(&mut predicates);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
+        predicates.into_iter().cloned().collect()
+    }
+
     /// Offset plan_position on all SingleTablePredicate expressions in this tree.
     pub fn offset_plan_positions(self, offset: usize) -> Self {
         if offset == 0 {
@@ -918,48 +1012,6 @@ impl RelNode {
                 Self::Join(j) => {
                     if let Some(ref mut filter) = j.filter {
                         filter.offset_plan_positions(offset);
-                    }
-                }
-            }
-            Ok(Transformed::yes(node))
-        })
-        .expect("infallible tree transformation")
-        .data
-    }
-
-    /// Offset predicate_idx on all SingleTablePredicate expressions in this tree.
-    pub fn offset_predicate_indices(self, offset: usize) -> Self {
-        if offset == 0 {
-            return self;
-        }
-        self.transform_down(|mut node| {
-            match &mut node {
-                Self::Scan(_) => {}
-                Self::Filter(f) => f.predicate.offset_predicate_indices(offset),
-                Self::Join(j) => {
-                    if let Some(ref mut filter) = j.filter {
-                        filter.offset_predicate_indices(offset);
-                    }
-                }
-            }
-            Ok(Transformed::yes(node))
-        })
-        .expect("infallible tree transformation")
-        .data
-    }
-
-    /// Offset predicate_idx on all MultiTablePredicate expressions in this tree.
-    pub fn offset_multi_table_predicate_indices(self, offset: usize) -> Self {
-        if offset == 0 {
-            return self;
-        }
-        self.transform_down(|mut node| {
-            match &mut node {
-                Self::Scan(_) => {}
-                Self::Filter(f) => f.predicate.offset_multi_table_predicate_indices(offset),
-                Self::Join(j) => {
-                    if let Some(ref mut filter) = j.filter {
-                        filter.offset_multi_table_predicate_indices(offset);
                     }
                 }
             }
@@ -1444,8 +1496,14 @@ impl RelNode {
             RelNode::Join(j) => {
                 j.left.visit_queries_mut(f);
                 j.right.visit_queries_mut(f);
+                if let Some(ref mut filter) = j.filter {
+                    filter.visit_queries_mut(f);
+                }
             }
-            RelNode::Filter(filt) => filt.input.visit_queries_mut(f),
+            RelNode::Filter(filt) => {
+                filt.input.visit_queries_mut(f);
+                filt.predicate.visit_queries_mut(f);
+            }
         }
     }
 
@@ -1469,8 +1527,14 @@ impl RelNode {
             RelNode::Join(j) => {
                 j.left.visit_queries(f);
                 j.right.visit_queries(f);
+                if let Some(ref filter) = j.filter {
+                    filter.visit_queries(f);
+                }
             }
-            RelNode::Filter(filt) => filt.input.visit_queries(f),
+            RelNode::Filter(filt) => {
+                filt.input.visit_queries(f);
+                filt.predicate.visit_queries(f);
+            }
         }
     }
 }
@@ -1563,10 +1627,6 @@ pub struct JoinCSClause {
     /// `LimitOffset` form so parameterized values are resolved at execution
     /// time rather than dropped at planning time.
     pub limit_offset: Option<LimitOffset>,
-    /// Join-level search predicates (Tantivy queries to execute).
-    pub join_level_predicates: Vec<JoinLevelSearchPredicate>,
-    /// Heap conditions (PostgreSQL expressions referencing both sides).
-    pub multi_table_predicates: Vec<MultiTablePredicateInfo>,
     /// ORDER BY clause to be applied to the DataFusion plan.
     pub order_by: Vec<OrderByInfo>,
     /// Projection of output columns for this join.
@@ -1580,8 +1640,6 @@ impl JoinCSClause {
         let mut clause = Self {
             plan,
             limit_offset: None,
-            join_level_predicates: Vec::new(),
-            multi_table_predicates: Vec::new(),
             order_by: Vec::new(),
             output_projection: None,
             has_distinct: false,
@@ -1612,41 +1670,9 @@ impl JoinCSClause {
         self
     }
 
-    /// Add a join-level predicate and return its index.
-    pub fn add_join_level_predicate(
-        &mut self,
-        rti: pg_sys::Index,
-        indexrelid: pg_sys::Oid,
-        heaprelid: pg_sys::Oid,
-        query: SearchQueryInput,
-    ) -> usize {
-        let idx = self.join_level_predicates.len();
-        self.join_level_predicates.push(JoinLevelSearchPredicate {
-            rti,
-            indexrelid,
-            heaprelid,
-            query,
-        });
-        idx
-    }
-
-    /// Add a heap condition and return its index.
-    pub fn add_multi_table_predicate(
-        &mut self,
-        description: String,
-        restrictinfo_index: usize,
-    ) -> usize {
-        let idx = self.multi_table_predicates.len();
-        self.multi_table_predicates.push(MultiTablePredicateInfo {
-            description,
-            restrictinfo_index,
-        });
-        idx
-    }
-
     /// Returns true if there are heap conditions to evaluate.
     pub fn has_multi_table_predicates(&self) -> bool {
-        !self.multi_table_predicates.is_empty()
+        self.plan.has_multi_table_predicates()
     }
 
     /// Set the join-level expression tree by wrapping the current plan in a FilterNode.
@@ -1706,13 +1732,9 @@ impl JoinCSClause {
             None
         }
     }
-    /// Visit every `SearchQueryInput` in this clause: both inside `Scan` nodes
-    /// (via `plan`) and inside `join_level_predicates`.
+    /// Visit every `SearchQueryInput` in this clause via `plan`.
     pub fn visit_queries_mut(&mut self, f: &mut impl FnMut(&mut SearchQueryInput)) {
         self.plan.visit_queries_mut(f);
-        for pred in &mut self.join_level_predicates {
-            f(&mut pred.query);
-        }
     }
 
     /// Read-only counterpart of `visit_queries_mut`, for callers (e.g. EXPLAIN) that only
@@ -1720,9 +1742,6 @@ impl JoinCSClause {
     /// to satisfy a `&mut` receiver.
     pub fn visit_queries(&self, f: &mut impl FnMut(&SearchQueryInput)) {
         self.plan.visit_queries(f);
-        for pred in &self.join_level_predicates {
-            f(&pred.query);
-        }
     }
 
     pub fn has_postgres_expressions(&self) -> bool {
@@ -1770,9 +1789,10 @@ impl JoinCSClause {
         });
     }
 
-    /// Configures `ScanMode::Tagged` on each join source that participates in `join_level_predicates`.
+    /// Configures `ScanMode::Tagged` on each join source that participates in search predicates.
     pub fn assign_tagged_queries(&mut self) {
-        assign_tagged_queries(self.plan.sources_mut(), &self.join_level_predicates);
+        let predicates = self.plan.search_predicates();
+        assign_tagged_queries(self.plan.sources_mut(), &predicates);
     }
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -30,6 +30,7 @@ use crate::postgres::utils::ExprContextGuard;
 use crate::query::SearchQueryInput;
 pub use crate::scan::ScanInfo;
 use anyhow::anyhow;
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use pgrx::{PgList, pg_sys};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -685,6 +686,77 @@ pub enum JoinLevelExpr {
     },
 }
 
+impl JoinLevelExpr {
+    pub fn has_search_predicate(&self) -> bool {
+        match self {
+            Self::SingleTablePredicate { .. } => true,
+            Self::MultiTablePredicate { .. } => false,
+            Self::And(children) | Self::Or(children) => {
+                children.iter().any(|c| c.has_search_predicate())
+            }
+            Self::Not(inner) => inner.has_search_predicate(),
+            Self::MarkOrNull { .. } | Self::PgExpression { .. } => false,
+        }
+    }
+
+    pub fn offset_plan_positions(&mut self, offset: usize) {
+        if offset == 0 {
+            return;
+        }
+        match self {
+            Self::SingleTablePredicate { plan_position, .. } => {
+                *plan_position += offset;
+            }
+            Self::MultiTablePredicate { .. } => {}
+            Self::And(children) | Self::Or(children) => {
+                for c in children {
+                    c.offset_plan_positions(offset);
+                }
+            }
+            Self::Not(inner) => inner.offset_plan_positions(offset),
+            Self::MarkOrNull { .. } | Self::PgExpression { .. } => {}
+        }
+    }
+
+    pub fn offset_predicate_indices(&mut self, offset: usize) {
+        if offset == 0 {
+            return;
+        }
+        match self {
+            Self::SingleTablePredicate { predicate_idx, .. } => {
+                *predicate_idx += offset;
+            }
+            Self::MultiTablePredicate { .. } => {}
+            Self::And(children) | Self::Or(children) => {
+                for c in children {
+                    c.offset_predicate_indices(offset);
+                }
+            }
+            Self::Not(inner) => inner.offset_predicate_indices(offset),
+            Self::MarkOrNull { .. } | Self::PgExpression { .. } => {}
+        }
+    }
+
+    pub fn offset_multi_table_predicate_indices(&mut self, offset: usize) {
+        if offset == 0 {
+            return;
+        }
+        match self {
+            Self::SingleTablePredicate { .. } => {}
+            Self::MultiTablePredicate { predicate_idx } => {
+                *predicate_idx += offset;
+            }
+            Self::And(children) | Self::Or(children) => {
+                for c in children {
+                    c.offset_multi_table_predicate_indices(offset);
+                }
+            }
+            Self::Not(inner) => inner.offset_multi_table_predicate_indices(offset),
+            Self::MarkOrNull { .. } | Self::PgExpression { .. } => {}
+        }
+    }
+}
+
 /// A node in the intermediate relational plan tree.
 ///
 /// `RelNode` serves as the Intermediate Representation (IR) between PostgreSQL's C-based
@@ -774,17 +846,150 @@ pub struct FilterNode {
 
 type JoinKeySide<'a> = (&'a JoinSource, pg_sys::AttrNumber);
 
-// TODO: Implement `datafusion::common::tree_node::TreeNode` for `RelNode`.
-// This trait will likely be implemented in a future patch to enable functional, boilerplate-free
-// tree rewrites (using `.transform_up()` and `.transform_down()`). This is specifically
-// useful for hoisting PostgreSQL subqueries (like `InitPlan`s temporarily stored inside
-// expressions) into relational `SemiJoin` or `AntiJoin` nodes in the IR tree.
+// `RelNode` implements DataFusion's `TreeNode` trait to enable functional, boilerplate-free
+// tree walks and rewrites (`.apply()`, `.exists()`, `.transform_up()`, `.transform_down()`).
+//
+// TODO: Consider migrating additional manual tree-walking operations (such as
+// `rewrite_pruned_join_keys`, `output_sources`, or subquery lifting) to use `TreeNode`
+// methods.
+impl TreeNode for RelNode {
+    fn apply_children<'n, F: FnMut(&'n Self) -> datafusion::common::Result<TreeNodeRecursion>>(
+        &'n self,
+        mut f: F,
+    ) -> datafusion::common::Result<TreeNodeRecursion> {
+        match self {
+            Self::Scan(_) => Ok(TreeNodeRecursion::Continue),
+            Self::Filter(filter) => f(&filter.input),
+            Self::Join(join) => f(&join.left)?.visit_sibling(|| f(&join.right)),
+        }
+    }
+
+    fn map_children<F: FnMut(Self) -> datafusion::common::Result<Transformed<Self>>>(
+        self,
+        mut f: F,
+    ) -> datafusion::common::Result<Transformed<Self>> {
+        match self {
+            Self::Scan(_) => Ok(Transformed::no(self)),
+            Self::Filter(filter) => {
+                let FilterNode { input, predicate } = *filter;
+                let input = f(input)?;
+                Ok(input
+                    .update_data(|input| Self::Filter(Box::new(FilterNode { input, predicate }))))
+            }
+            Self::Join(mut join) => {
+                let left = f(join.left)?;
+                let right = f(join.right)?;
+                let transformed = left.transformed || right.transformed;
+                let tnr = left.tnr.visit_sibling(|| Ok(right.tnr))?;
+                join.left = left.data;
+                join.right = right.data;
+                Ok(Transformed::new(Self::Join(join), transformed, tnr))
+            }
+        }
+    }
+}
 
 impl RelNode {
+    /// Returns true if this node or any subtree contains a search predicate.
+    pub fn has_search_predicate(&self) -> bool {
+        self.exists(|node| {
+            let has = match node {
+                Self::Scan(s) => s.has_search_predicate(),
+                Self::Filter(f) => f.predicate.has_search_predicate(),
+                Self::Join(j) => {
+                    !j.absorbed_search_clauses.is_empty()
+                        || j.filter.as_ref().is_some_and(|f| f.has_search_predicate())
+                }
+            };
+            Ok(has)
+        })
+        .unwrap_or(false)
+    }
+
+    /// Offset plan_position on all SingleTablePredicate expressions in this tree.
+    pub fn offset_plan_positions(self, offset: usize) -> Self {
+        if offset == 0 {
+            return self;
+        }
+        self.transform_down(|mut node| {
+            match &mut node {
+                Self::Scan(_) => {}
+                Self::Filter(f) => f.predicate.offset_plan_positions(offset),
+                Self::Join(j) => {
+                    if let Some(ref mut filter) = j.filter {
+                        filter.offset_plan_positions(offset);
+                    }
+                }
+            }
+            Ok(Transformed::yes(node))
+        })
+        .expect("infallible tree transformation")
+        .data
+    }
+
+    /// Offset predicate_idx on all SingleTablePredicate expressions in this tree.
+    pub fn offset_predicate_indices(self, offset: usize) -> Self {
+        if offset == 0 {
+            return self;
+        }
+        self.transform_down(|mut node| {
+            match &mut node {
+                Self::Scan(_) => {}
+                Self::Filter(f) => f.predicate.offset_predicate_indices(offset),
+                Self::Join(j) => {
+                    if let Some(ref mut filter) = j.filter {
+                        filter.offset_predicate_indices(offset);
+                    }
+                }
+            }
+            Ok(Transformed::yes(node))
+        })
+        .expect("infallible tree transformation")
+        .data
+    }
+
+    /// Offset predicate_idx on all MultiTablePredicate expressions in this tree.
+    pub fn offset_multi_table_predicate_indices(self, offset: usize) -> Self {
+        if offset == 0 {
+            return self;
+        }
+        self.transform_down(|mut node| {
+            match &mut node {
+                Self::Scan(_) => {}
+                Self::Filter(f) => f.predicate.offset_multi_table_predicate_indices(offset),
+                Self::Join(j) => {
+                    if let Some(ref mut filter) = j.filter {
+                        filter.offset_multi_table_predicate_indices(offset);
+                    }
+                }
+            }
+            Ok(Transformed::yes(node))
+        })
+        .expect("infallible tree transformation")
+        .data
+    }
+
     /// Recursively collects all unsupported join types found in the tree.
     pub fn unsupported_join_types(&self) -> Vec<JoinType> {
         let mut unsupported = Vec::new();
-        self.collect_unsupported_join_types(&mut unsupported);
+        let _ = self.apply(|node| {
+            if let Self::Join(j) = node
+                && !matches!(
+                    j.join_type,
+                    JoinType::Inner
+                        | JoinType::Left
+                        | JoinType::Right
+                        | JoinType::Full
+                        | JoinType::Semi
+                        | JoinType::Anti { .. }
+                        | JoinType::LeftMark
+                        | JoinType::RightMark
+                )
+            {
+                unsupported.push(j.join_type);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
         unsupported.sort_by_key(|t| t.to_string());
         unsupported.dedup_by_key(|t| t.to_string());
         unsupported
@@ -866,52 +1071,25 @@ impl RelNode {
 
     /// Returns true if the query tree contains a SEMI or ANTI join at any level.
     pub fn has_semi_or_anti(&self) -> bool {
-        match self {
-            RelNode::Scan(_) => false,
-            RelNode::Join(j) => {
-                matches!(
-                    j.join_type,
-                    JoinType::Semi
-                        | JoinType::Anti { .. }
-                        | JoinType::LeftMark
-                        | JoinType::RightMark
-                ) || j.left.has_semi_or_anti()
-                    || j.right.has_semi_or_anti()
-            }
-            RelNode::Filter(f) => f.input.has_semi_or_anti(),
-        }
-    }
-
-    fn collect_unsupported_join_types(&self, acc: &mut Vec<JoinType>) {
-        match self {
-            RelNode::Scan(_) => {}
-            RelNode::Join(j) => {
-                if !matches!(
-                    j.join_type,
-                    JoinType::Inner
-                        | JoinType::Left
-                        | JoinType::Right
-                        | JoinType::Full
-                        | JoinType::Semi
-                        | JoinType::Anti { .. }
-                        | JoinType::LeftMark
-                        | JoinType::RightMark
-                ) {
-                    acc.push(j.join_type);
-                }
-                j.left.collect_unsupported_join_types(acc);
-                j.right.collect_unsupported_join_types(acc);
-            }
-            RelNode::Filter(f) => f.input.collect_unsupported_join_types(acc),
-        }
+        self.exists(|node| {
+            Ok(matches!(
+                node,
+                RelNode::Join(j)
+                    if matches!(
+                        j.join_type,
+                        JoinType::Semi
+                            | JoinType::Anti { .. }
+                            | JoinType::LeftMark
+                            | JoinType::RightMark
+                    )
+            ))
+        })
+        .unwrap_or(false)
     }
 
     pub fn contains_rti(&self, rti: pg_sys::Index) -> bool {
-        match self {
-            RelNode::Scan(s) => s.scan_info.heap_rti == rti,
-            RelNode::Join(j) => j.left.contains_rti(rti) || j.right.contains_rti(rti),
-            RelNode::Filter(f) => f.input.contains_rti(rti),
-        }
+        self.exists(|node| Ok(matches!(node, RelNode::Scan(s) if s.scan_info.heap_rti == rti)))
+            .unwrap_or(false)
     }
 
     pub fn source_for_rti_in_subtree(&self, rti: pg_sys::Index) -> Option<&JoinSource> {
@@ -971,19 +1149,13 @@ impl RelNode {
     /// Recursively collects all base join sources from this tree.
     pub fn sources(&self) -> Vec<&JoinSource> {
         let mut result = Vec::new();
-        self.collect_sources(&mut result);
-        result
-    }
-
-    fn collect_sources<'a>(&'a self, acc: &mut Vec<&'a JoinSource>) {
-        match self {
-            RelNode::Scan(s) => acc.push(&**s),
-            RelNode::Join(j) => {
-                j.left.collect_sources(acc);
-                j.right.collect_sources(acc);
+        let _ = self.apply(|node| {
+            if let RelNode::Scan(s) = node {
+                result.push(&**s);
             }
-            RelNode::Filter(f) => f.input.collect_sources(acc),
-        }
+            Ok(TreeNodeRecursion::Continue)
+        });
+        result
     }
 
     /// Recursively collects all mutable base join sources from this tree.

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -2077,14 +2077,9 @@ impl JoinScan {
         let inner_collected = collect_join_sources(root, innerrel).ok_or(JoinPathDecline::Quiet)?;
 
         let left_sources_count = outer_collected.plan.sources().len();
-        let search_pred_offset = outer_collected.join_level_predicates.len();
-        let multi_table_offset = outer_collected.multi_table_predicates.len();
-
         let inner_node = inner_collected
             .plan
-            .offset_plan_positions(left_sources_count)
-            .offset_predicate_indices(search_pred_offset)
-            .offset_multi_table_predicate_indices(multi_table_offset);
+            .offset_plan_positions(left_sources_count);
 
         let mut join_keys = outer_collected.join_keys;
         join_keys.extend(inner_collected.join_keys);
@@ -2290,16 +2285,6 @@ impl JoinScan {
         let (mut join_clause, limit_offset) =
             Self::validate_and_build_clause(root, &plan, &join_keys, has_distinct).map_err(warn)?;
 
-        join_clause.join_level_predicates = outer_collected.join_level_predicates;
-        join_clause
-            .join_level_predicates
-            .extend(inner_collected.join_level_predicates);
-
-        join_clause.multi_table_predicates = outer_collected.multi_table_predicates;
-        join_clause
-            .multi_table_predicates
-            .extend(inner_collected.multi_table_predicates);
-
         let mut multi_table_clauses = outer_collected.multi_table_clauses;
         multi_table_clauses.extend(inner_collected.multi_table_clauses);
 
@@ -2327,16 +2312,10 @@ impl JoinScan {
         join_clause = join_clause_updated;
         multi_table_clauses.extend(new_multi_table_clauses);
 
-        // Post-extraction check: need at least one side predicate OR join-level predicates OR plan search predicate.
+        // Post-extraction check: need at least one search predicate in the plan.
         // This is a silent gate — the join is no longer interesting once predicates have
         // been pulled out.
-        let current_sources_after_cond = join_clause.plan.sources();
-        let has_side_predicate = current_sources_after_cond
-            .iter()
-            .any(|s| s.has_search_predicate());
-        let has_join_level_predicates = !join_clause.join_level_predicates.is_empty();
-        let plan_has_search_predicate = join_clause.plan.has_search_predicate();
-        if !has_side_predicate && !has_join_level_predicates && !plan_has_search_predicate {
+        if !join_clause.plan.has_search_predicate() {
             return Err(JoinPathDecline::Quiet);
         }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -512,10 +512,12 @@ pub unsafe fn try_create_subplan_join_paths(
     }
 
     // Try to extract SubPlan-based joins from baserestrictinfo.
-    let (plan, join_keys) = match collect_join_sources_base_rel(root, rel, rti) {
+    let collected = match collect_join_sources_base_rel(root, rel, rti) {
         Some(res) => res,
         None => return Vec::new(),
     };
+    let plan = collected.plan;
+    let join_keys = collected.join_keys;
 
     // Only proceed if the plan actually contains a join (from SubPlan extraction).
     if !plan.has_semi_or_anti() {
@@ -1072,22 +1074,31 @@ impl CustomScan for JoinScan {
             // join condition evaluation manually during execution using the original Var
             // references.
 
-            // Extract the column mappings from the UPDATED targetlist (before we add restrictlist
-            // Vars). The updated targetlist has the SELECT's output columns plus any missing
-            // search operators, which is what ps_ResultTupleSlot is based on. We store this
-            // mapping in PrivateData so build_result_tuple can use it during execution.
-            let mut private_data = PrivateData::from(node.custom_private);
-
-            private_data.output_columns =
-                compute_output_columns(&private_data.join_clause, tlist_ptr, root);
-
-            let updated_entries = PgList::<pg_sys::TargetEntry>::from_pg(tlist_ptr);
-            build_output_projection(&mut private_data, &updated_entries, root);
-
             // Add heap condition clauses to custom_exprs so they get transformed by
             // set_customscan_references. The Vars in these expressions will be converted to
             // INDEX_VAR references into custom_scan_tlist.
             node.custom_exprs = splice_path_private_into_list(node.custom_exprs, best_path);
+
+            // Ensure all Vars referenced in custom_exprs (heap condition clauses)
+            // are present in custom_scan_tlist so setrefs can create INDEX_VAR references.
+            let path_private_full = PgList::<pg_sys::Node>::from_pg((*best_path).custom_private);
+            let mut scan_tlist = PgList::<pg_sys::TargetEntry>::from_pg(node.custom_scan_tlist);
+            for i in 1..path_private_full.len() {
+                if let Some(node_ptr) = path_private_full.get_ptr(i) {
+                    crate::postgres::utils::add_vars_to_tlist(node_ptr, &mut scan_tlist);
+                }
+            }
+            node.custom_scan_tlist = scan_tlist.into_pg();
+
+            // Extract the column mappings from custom_scan_tlist (including any added
+            // custom_exprs Vars) so INDEX_VAR references can be resolved.
+            let mut private_data = PrivateData::from(node.custom_private);
+
+            private_data.output_columns =
+                compute_output_columns(&private_data.join_clause, node.custom_scan_tlist, root);
+
+            let updated_entries = PgList::<pg_sys::TargetEntry>::from_pg(tlist_ptr);
+            build_output_projection(&mut private_data, &updated_entries, root);
             // Snapshot custom_exprs before setrefs rewrites it, for MPP re-baking.
             // Needed for any of: maybe_solve_and_rebake (resolves Param/PostgresExpression
             // nodes) or rebake_for_mpp_fallback (serial replan on a short-launch decline,
@@ -2062,11 +2073,23 @@ impl JoinScan {
         }
 
         // Silent gates: collect outer/inner sources or bail without a warning.
-        let (outer_node, mut join_keys) =
-            collect_join_sources(root, outerrel).ok_or(JoinPathDecline::Quiet)?;
-        let (inner_node, inner_keys) =
-            collect_join_sources(root, innerrel).ok_or(JoinPathDecline::Quiet)?;
-        join_keys.extend(inner_keys);
+        let outer_collected = collect_join_sources(root, outerrel).ok_or(JoinPathDecline::Quiet)?;
+        let inner_collected = collect_join_sources(root, innerrel).ok_or(JoinPathDecline::Quiet)?;
+
+        let left_sources_count = outer_collected.plan.sources().len();
+        let search_pred_offset = outer_collected.join_level_predicates.len();
+        let multi_table_offset = outer_collected.multi_table_predicates.len();
+
+        let inner_node = inner_collected
+            .plan
+            .offset_plan_positions(left_sources_count)
+            .offset_predicate_indices(search_pred_offset)
+            .offset_multi_table_predicate_indices(multi_table_offset);
+
+        let mut join_keys = outer_collected.join_keys;
+        join_keys.extend(inner_collected.join_keys);
+
+        let outer_node = outer_collected.plan;
 
         let aliases: Vec<String> = {
             let mut all_sources = outer_node.sources();
@@ -2087,12 +2110,14 @@ impl JoinScan {
         };
 
         // The minimum requirement for considering the join scan is that a
-        // search predicate is used — either in a source or in a join-level
+        // search predicate is used — either in a source, a sub-join plan, or in a join-level
         // condition. Below this gate, every Err carries a planner warning.
         {
             let mut all_sources = outer_node.sources();
             all_sources.extend(inner_node.sources());
             if !all_sources.iter().any(|s| s.scan_info.has_search_predicate)
+                && !outer_node.has_search_predicate()
+                && !inner_node.has_search_predicate()
                 && !join_conditions.has_search_predicate
             {
                 return Err(JoinPathDecline::Quiet);
@@ -2265,6 +2290,19 @@ impl JoinScan {
         let (mut join_clause, limit_offset) =
             Self::validate_and_build_clause(root, &plan, &join_keys, has_distinct).map_err(warn)?;
 
+        join_clause.join_level_predicates = outer_collected.join_level_predicates;
+        join_clause
+            .join_level_predicates
+            .extend(inner_collected.join_level_predicates);
+
+        join_clause.multi_table_predicates = outer_collected.multi_table_predicates;
+        join_clause
+            .multi_table_predicates
+            .extend(inner_collected.multi_table_predicates);
+
+        let mut multi_table_clauses = outer_collected.multi_table_clauses;
+        multi_table_clauses.extend(inner_collected.multi_table_clauses);
+
         // --- Join-level predicate extraction (join-hook specific) ---
         // This builds an expression tree that can reference:
         // - Predicate nodes: Tantivy search queries
@@ -2274,7 +2312,7 @@ impl JoinScan {
         // `JoinNode.filter` (above) are filtered out of `remaining_other_conditions`
         // so they are not re-processed here as MultiTablePredicates.
         let current_sources = join_clause.plan.sources();
-        let (join_clause_updated, multi_table_clauses) = extract_join_level_conditions(
+        let (join_clause_updated, new_multi_table_clauses) = extract_join_level_conditions(
             root,
             extra,
             &current_sources,
@@ -2287,8 +2325,9 @@ impl JoinScan {
             ))
         })?;
         join_clause = join_clause_updated;
+        multi_table_clauses.extend(new_multi_table_clauses);
 
-        // Post-extraction check: need at least one side predicate OR join-level predicates.
+        // Post-extraction check: need at least one side predicate OR join-level predicates OR plan search predicate.
         // This is a silent gate — the join is no longer interesting once predicates have
         // been pulled out.
         let current_sources_after_cond = join_clause.plan.sources();
@@ -2296,7 +2335,8 @@ impl JoinScan {
             .iter()
             .any(|s| s.has_search_predicate());
         let has_join_level_predicates = !join_clause.join_level_predicates.is_empty();
-        if !has_side_predicate && !has_join_level_predicates {
+        let plan_has_search_predicate = join_clause.plan.has_search_predicate();
+        if !has_side_predicate && !has_join_level_predicates && !plan_has_search_predicate {
             return Err(JoinPathDecline::Quiet);
         }
 

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -25,8 +25,9 @@
 
 use super::JoinDeclineReason;
 use super::build::{
-    self as build, FilterNode, InputVarInfo, JoinCSClause, JoinKeyPair, JoinLevelExpr, JoinNode,
-    JoinSource, JoinSourceCandidate, JoinType, RelNode,
+    self as build, FilterNode, InputVarInfo, JoinCSClause, JoinKeyPair, JoinLevelExpr,
+    JoinLevelSearchPredicate, JoinNode, JoinSource, JoinSourceCandidate, JoinType,
+    MultiTablePredicateInfo, RelNode,
 };
 use super::predicate::find_base_info_recursive;
 use super::privdat::{OutputColumnInfo, PrivateData};
@@ -166,6 +167,27 @@ unsafe fn get_type_info(type_oid: pg_sys::Oid) -> (i16, bool) {
     (typlen, typbyval)
 }
 
+/// Collected information about a relation tree during join source collection.
+pub(super) struct CollectedJoinRel {
+    pub plan: RelNode,
+    pub join_keys: Vec<JoinKeyPair>,
+    pub join_level_predicates: Vec<JoinLevelSearchPredicate>,
+    pub multi_table_predicates: Vec<MultiTablePredicateInfo>,
+    pub multi_table_clauses: Vec<*mut pg_sys::Expr>,
+}
+
+impl CollectedJoinRel {
+    pub fn new(plan: RelNode, join_keys: Vec<JoinKeyPair>) -> Self {
+        Self {
+            plan,
+            join_keys,
+            join_level_predicates: Vec::new(),
+            multi_table_predicates: Vec::new(),
+            multi_table_clauses: Vec::new(),
+        }
+    }
+}
+
 /// Main entry point for constructing a DataFusion relational query tree (`RelNode`) from
 /// a PostgreSQL planner `RelOptInfo` structure.
 ///
@@ -179,11 +201,11 @@ unsafe fn get_type_info(type_oid: pg_sys::Oid) -> (i16, bool) {
 ///    equi-join conditions.
 ///
 /// Returns an intermediate `RelNode` tree capturing the execution plan structure, as well as a list
-/// of all extracted equi-join keys.
+/// of all extracted equi-join keys and predicates.
 pub(super) unsafe fn collect_join_sources(
     root: *mut pg_sys::PlannerInfo,
     rel: *mut pg_sys::RelOptInfo,
-) -> Option<(RelNode, Vec<JoinKeyPair>)> {
+) -> Option<CollectedJoinRel> {
     if rel.is_null() {
         return None;
     }
@@ -214,7 +236,7 @@ pub(super) unsafe fn collect_join_sources_base_rel(
     root: *mut pg_sys::PlannerInfo,
     rel: *mut pg_sys::RelOptInfo,
     rti: pg_sys::Index,
-) -> Option<(RelNode, Vec<JoinKeyPair>)> {
+) -> Option<CollectedJoinRel> {
     let (relid, alias, _bm25_opt) = build::lookup_base_rel_info(root, rti)?;
 
     let mut side_info = JoinSourceCandidate::new(root.into(), rti).with_heaprelid(relid);
@@ -277,7 +299,7 @@ pub(super) unsafe fn collect_join_sources_base_rel(
     current_node = node;
     current_node = wrap_with_mark_filter(current_node, classified.or_subplans, &mut all_keys);
 
-    Some((current_node, all_keys))
+    Some(CollectedJoinRel::new(current_node, all_keys))
 }
 
 /// Buckets that [`classify_base_restrictinfo`] sorts a relation's
@@ -405,7 +427,7 @@ pub unsafe fn wrap_with_semi_anti(
             return Err("subquery cannot be pushed into the aggregate scan".into());
         }
 
-        let Some((inner_node, inner_keys)) = collect_join_sources(inner_root, inner_rel) else {
+        let Some(inner_collected) = collect_join_sources(inner_root, inner_rel) else {
             pgrx::debug1!(
                 "agg-on-join: SubPlan plan_id={plan_id} declined; \
                  inner relation cannot be pushed (no ParadeDB index, volatile, \
@@ -413,6 +435,8 @@ pub unsafe fn wrap_with_semi_anti(
             );
             return Err("subquery cannot be pushed into the aggregate scan".into());
         };
+        let inner_node = inner_collected.plan;
+        let inner_keys = inner_collected.join_keys;
 
         // Recursively collect join sources for the inner subquery
         all_keys.extend(inner_keys);
@@ -482,10 +506,11 @@ unsafe fn wrap_with_mark_filter(
             continue;
         }
 
-        let Some((inner_node, inner_keys)) = collect_join_sources(or_ext.inner_root, inner_rel)
-        else {
+        let Some(inner_collected) = collect_join_sources(or_ext.inner_root, inner_rel) else {
             continue;
         };
+        let inner_node = inner_collected.plan;
+        let inner_keys = inner_collected.join_keys;
 
         all_keys.extend(inner_keys);
 
@@ -540,7 +565,7 @@ unsafe fn wrap_with_mark_filter(
 unsafe fn collect_join_sources_join_rel(
     root: *mut pg_sys::PlannerInfo,
     rel: *mut pg_sys::RelOptInfo,
-) -> Option<(RelNode, Vec<JoinKeyPair>)> {
+) -> Option<CollectedJoinRel> {
     // We only inspect the cheapest path chosen by PostgreSQL.
     let raw_path = (*rel).cheapest_total_path;
     if raw_path.is_null() {
@@ -566,10 +591,22 @@ unsafe fn collect_join_sources_join_rel(
                 let private_list = PgList::<pg_sys::Node>::from_pg((*custom_path).custom_private);
                 if !private_list.is_empty() {
                     let private_data = PrivateData::from((*custom_path).custom_private);
-                    // Return the plan from the existing JoinScan
+                    // Return the plan and predicates from the existing JoinScan
                     let plan = private_data.join_clause.plan.clone();
                     let join_keys = plan.join_keys();
-                    return Some((plan, join_keys));
+                    let mut multi_table_clauses = Vec::new();
+                    for i in 1..private_list.len() {
+                        if let Some(node_ptr) = private_list.get_ptr(i) {
+                            multi_table_clauses.push(node_ptr.cast());
+                        }
+                    }
+                    return Some(CollectedJoinRel {
+                        plan,
+                        join_keys,
+                        join_level_predicates: private_data.join_clause.join_level_predicates,
+                        multi_table_predicates: private_data.join_clause.multi_table_predicates,
+                        multi_table_clauses,
+                    });
                 }
             }
         }
@@ -585,9 +622,32 @@ unsafe fn collect_join_sources_join_rel(
         let outer_rel = (*outer_path).parent;
         let inner_rel = (*inner_path).parent;
 
-        let (outer_node, mut keys) = collect_join_sources(root, outer_rel)?;
-        let (inner_node, inner_keys) = collect_join_sources(root, inner_rel)?;
-        keys.extend(inner_keys);
+        let outer_collected = collect_join_sources(root, outer_rel)?;
+        let inner_collected = collect_join_sources(root, inner_rel)?;
+
+        let left_sources_count = outer_collected.plan.sources().len();
+        let search_pred_offset = outer_collected.join_level_predicates.len();
+        let multi_table_offset = outer_collected.multi_table_predicates.len();
+
+        let inner_node = inner_collected
+            .plan
+            .offset_plan_positions(left_sources_count)
+            .offset_predicate_indices(search_pred_offset)
+            .offset_multi_table_predicate_indices(multi_table_offset);
+
+        let mut keys = outer_collected.join_keys;
+        keys.extend(inner_collected.join_keys);
+
+        let mut join_level_predicates = outer_collected.join_level_predicates;
+        join_level_predicates.extend(inner_collected.join_level_predicates);
+
+        let mut multi_table_predicates = outer_collected.multi_table_predicates;
+        multi_table_predicates.extend(inner_collected.multi_table_predicates);
+
+        let mut multi_table_clauses = outer_collected.multi_table_clauses;
+        multi_table_clauses.extend(inner_collected.multi_table_clauses);
+
+        let outer_node = outer_collected.plan;
 
         let mut all_sources = outer_node.sources();
         all_sources.extend(inner_node.sources());
@@ -710,8 +770,8 @@ unsafe fn collect_join_sources_join_rel(
             }
         };
 
-        // Inner is the only join type where wrapping the reconstructed join in
-        // a `RelNode::Filter` is semantically equivalent. Outer joins
+        // Absorbed search clauses must lower to `RelNode::Filter` sitting
+        // immediately above the absorbing `JoinNode`. Outer joins
         // (Left/Right/Full) would drop outer-fill rows the post-Filter
         // shouldn't see; pruned-side joins (Semi/Anti/Mark, both directions)
         // would leave Vars unresolved against the pruned schema;
@@ -742,7 +802,13 @@ unsafe fn collect_join_sources_join_rel(
         // there would only add a duplicate path.
         join_node.canonicalize_orientation();
 
-        return Some((RelNode::Join(Box::new(join_node)), keys));
+        return Some(CollectedJoinRel {
+            plan: RelNode::Join(Box::new(join_node)),
+            join_keys: keys,
+            join_level_predicates,
+            multi_table_predicates,
+            multi_table_clauses,
+        });
     }
 
     None

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -25,9 +25,8 @@
 
 use super::JoinDeclineReason;
 use super::build::{
-    self as build, FilterNode, InputVarInfo, JoinCSClause, JoinKeyPair, JoinLevelExpr,
-    JoinLevelSearchPredicate, JoinNode, JoinSource, JoinSourceCandidate, JoinType,
-    MultiTablePredicateInfo, RelNode,
+    self as build, FilterNode, InputVarInfo, JoinCSClause, JoinKeyPair, JoinLevelExpr, JoinNode,
+    JoinSource, JoinSourceCandidate, JoinType, RelNode,
 };
 use super::predicate::find_base_info_recursive;
 use super::privdat::{OutputColumnInfo, PrivateData};
@@ -171,8 +170,6 @@ unsafe fn get_type_info(type_oid: pg_sys::Oid) -> (i16, bool) {
 pub(super) struct CollectedJoinRel {
     pub plan: RelNode,
     pub join_keys: Vec<JoinKeyPair>,
-    pub join_level_predicates: Vec<JoinLevelSearchPredicate>,
-    pub multi_table_predicates: Vec<MultiTablePredicateInfo>,
     pub multi_table_clauses: Vec<*mut pg_sys::Expr>,
 }
 
@@ -181,8 +178,6 @@ impl CollectedJoinRel {
         Self {
             plan,
             join_keys,
-            join_level_predicates: Vec::new(),
-            multi_table_predicates: Vec::new(),
             multi_table_clauses: Vec::new(),
         }
     }
@@ -603,8 +598,6 @@ unsafe fn collect_join_sources_join_rel(
                     return Some(CollectedJoinRel {
                         plan,
                         join_keys,
-                        join_level_predicates: private_data.join_clause.join_level_predicates,
-                        multi_table_predicates: private_data.join_clause.multi_table_predicates,
                         multi_table_clauses,
                     });
                 }
@@ -626,23 +619,12 @@ unsafe fn collect_join_sources_join_rel(
         let inner_collected = collect_join_sources(root, inner_rel)?;
 
         let left_sources_count = outer_collected.plan.sources().len();
-        let search_pred_offset = outer_collected.join_level_predicates.len();
-        let multi_table_offset = outer_collected.multi_table_predicates.len();
-
         let inner_node = inner_collected
             .plan
-            .offset_plan_positions(left_sources_count)
-            .offset_predicate_indices(search_pred_offset)
-            .offset_multi_table_predicate_indices(multi_table_offset);
+            .offset_plan_positions(left_sources_count);
 
         let mut keys = outer_collected.join_keys;
         keys.extend(inner_collected.join_keys);
-
-        let mut join_level_predicates = outer_collected.join_level_predicates;
-        join_level_predicates.extend(inner_collected.join_level_predicates);
-
-        let mut multi_table_predicates = outer_collected.multi_table_predicates;
-        multi_table_predicates.extend(inner_collected.multi_table_predicates);
 
         let mut multi_table_clauses = outer_collected.multi_table_clauses;
         multi_table_clauses.extend(inner_collected.multi_table_clauses);
@@ -805,8 +787,6 @@ unsafe fn collect_join_sources_join_rel(
         return Some(CollectedJoinRel {
             plan: RelNode::Join(Box::new(join_node)),
             join_keys: keys,
-            join_level_predicates,
-            multi_table_predicates,
             multi_table_clauses,
         });
     }

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -79,17 +79,18 @@ pub unsafe fn extract_join_level_conditions(
     let new_plan = lower_absorbed_search_clauses(
         root,
         std::mem::take(&mut join_clause.plan),
-        &mut join_clause,
         &mut multi_table_predicate_clauses,
     )?;
     join_clause.plan = new_plan;
 
     if extra.is_null() {
+        join_clause.assign_tagged_queries();
         return Ok((join_clause, multi_table_predicate_clauses));
     }
 
     let restrictlist = (*extra).restrictlist;
     if restrictlist.is_null() {
+        join_clause.assign_tagged_queries();
         return Ok((join_clause, multi_table_predicate_clauses));
     }
 
@@ -116,7 +117,6 @@ pub unsafe fn extract_join_level_conditions(
                 root,
                 clause.cast(),
                 sources,
-                &mut join_clause,
                 &mut multi_table_predicate_clauses,
             ) {
                 expr_trees.push(expr);
@@ -146,10 +146,14 @@ pub unsafe fn extract_join_level_conditions(
 
             // Create a MultiTablePredicate leaf node
             let description = format_expr_for_explain(clause.cast());
-            let predicate_idx = join_clause
-                .add_multi_table_predicate(description, multi_table_predicate_clauses.len());
             multi_table_predicate_clauses.push(clause);
-            expr_trees.push(JoinLevelExpr::MultiTablePredicate { predicate_idx });
+            expr_trees.push(JoinLevelExpr::MultiTablePredicate {
+                predicate: Box::new(
+                    crate::postgres::customscan::joinscan::build::MultiTablePredicateInfo {
+                        description,
+                    },
+                ),
+            });
         }
     }
 
@@ -168,20 +172,17 @@ pub unsafe fn extract_join_level_conditions(
     Ok((join_clause, multi_table_predicate_clauses))
 }
 
-/// Recursively transform a PostgreSQL expression with search predicates into a JoinLevelExpr.
+/// Recursively transform a PostgreSQL expression tree into a `JoinLevelExpr`.
 ///
-/// - For single-table sub-trees with search predicates: extract as a Predicate leaf
-/// - For cross-relation sub-trees without search predicates: extract as a MultiTablePredicate leaf
-/// - For BoolExpr (AND/OR/NOT): recursively transform children
-///
-/// Also collects heap condition clause pointers into `multi_table_predicate_clauses` for adding
-/// to custom_exprs during plan_custom_path.
-#[allow(clippy::too_many_arguments)]
+/// Handles:
+/// - Single-table search predicates: extracted into a single Tantivy query (preserving NOT/AND/OR)
+/// - Cross-relation sub-trees without search predicates: extracted as a MultiTablePredicate leaf
+///   (in the same order as multi_table_predicates in the clause) for adding to custom_exprs
+/// - Cross-relation boolean expressions (AND/OR/NOT): recursively preserved in the `JoinLevelExpr` tree
 pub unsafe fn transform_to_search_expr(
     root: *mut pg_sys::PlannerInfo,
     node: *mut pg_sys::Node,
     sources: &[&JoinSource],
-    join_clause: &mut JoinCSClause,
     multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
 ) -> Option<JoinLevelExpr> {
     if node.is_null() {
@@ -197,13 +198,8 @@ pub unsafe fn transform_to_search_expr(
         let list = PgList::<pg_sys::Node>::from_pg(node as *mut pg_sys::List);
         let mut children = Vec::new();
         for item in list.iter_ptr() {
-            let child_expr = transform_to_search_expr(
-                root,
-                item,
-                sources,
-                join_clause,
-                multi_table_predicate_clauses,
-            )?;
+            let child_expr =
+                transform_to_search_expr(root, item, sources, multi_table_predicate_clauses)?;
             children.push(child_expr);
         }
         return if children.is_empty() {
@@ -238,12 +234,11 @@ pub unsafe fn transform_to_search_expr(
 
         // Extract the Tantivy query for this expression
         if let Some(base_info) = find_base_info_recursive(source, rti)
-            && let Some(predicate_idx) =
-                extract_single_table_predicate(root, rti, &base_info, node, join_clause)
+            && let Some(pred) = extract_single_table_predicate(root, rti, &base_info, node)
         {
             return Some(JoinLevelExpr::SingleTablePredicate {
                 plan_position,
-                predicate_idx,
+                predicate: Box::new(pred),
             });
         }
         return None;
@@ -259,10 +254,14 @@ pub unsafe fn transform_to_search_expr(
         translator.translate(node)?;
 
         let description = format_expr_for_explain(node);
-        let predicate_idx =
-            join_clause.add_multi_table_predicate(description, multi_table_predicate_clauses.len());
         multi_table_predicate_clauses.push(node as *mut pg_sys::Expr);
-        return Some(JoinLevelExpr::MultiTablePredicate { predicate_idx });
+        return Some(JoinLevelExpr::MultiTablePredicate {
+            predicate: Box::new(
+                crate::postgres::customscan::joinscan::build::MultiTablePredicateInfo {
+                    description,
+                },
+            ),
+        });
     }
 
     // If this is a cross-table BoolExpr, preserve its boolean structure (AND, OR, NOT)
@@ -280,7 +279,6 @@ pub unsafe fn transform_to_search_expr(
                         root,
                         arg,
                         sources,
-                        join_clause,
                         multi_table_predicate_clauses,
                     )?;
                     children.push(child_expr);
@@ -297,13 +295,8 @@ pub unsafe fn transform_to_search_expr(
             }
             pg_sys::BoolExprType::NOT_EXPR => {
                 if let Some(arg) = args.iter_ptr().next()
-                    && let Some(child_expr) = transform_to_search_expr(
-                        root,
-                        arg,
-                        sources,
-                        join_clause,
-                        multi_table_predicate_clauses,
-                    )
+                    && let Some(child_expr) =
+                        transform_to_search_expr(root, arg, sources, multi_table_predicate_clauses)
                 {
                     return Some(JoinLevelExpr::Not(Box::new(child_expr)));
                 }
@@ -327,15 +320,13 @@ pub unsafe fn find_base_info_recursive(
     }
 }
 
-/// Extract a single-table predicate and add it to the join clause.
-/// Returns the index of the predicate in join_level_predicates, or None if extraction fails.
+/// Extract a single-table predicate from an expression.
 pub unsafe fn extract_single_table_predicate(
     root: *mut pg_sys::PlannerInfo,
     rti: pg_sys::Index,
     side: &ScanInfo,
     expr: *mut pg_sys::Node,
-    join_clause: &mut JoinCSClause,
-) -> Option<usize> {
+) -> Option<crate::postgres::customscan::joinscan::build::JoinLevelSearchPredicate> {
     let indexrelid = side.indexrelid;
     let heaprelid = side.heaprelid;
     let (_, bm25_idx) = rel_get_bm25_index(heaprelid)?;
@@ -363,8 +354,14 @@ pub unsafe fn extract_single_table_predicate(
     )?;
 
     let query = SearchQueryInput::from(&qual);
-    let idx = join_clause.add_join_level_predicate(rti, indexrelid, heaprelid, query);
-    Some(idx)
+    Some(
+        crate::postgres::customscan::joinscan::build::JoinLevelSearchPredicate {
+            rti,
+            indexrelid,
+            heaprelid,
+            query,
+        },
+    )
 }
 
 /// Sub-join reconstruction stashes `@@@` `RestrictInfo`s onto
@@ -375,19 +372,13 @@ pub unsafe fn extract_single_table_predicate(
 pub(super) unsafe fn lower_absorbed_search_clauses(
     root: *mut pg_sys::PlannerInfo,
     node: RelNode,
-    join_clause: &mut JoinCSClause,
     multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
 ) -> Result<RelNode, String> {
     match node {
         RelNode::Scan(s) => Ok(RelNode::Scan(s)),
         RelNode::Filter(f) => {
             let FilterNode { input, predicate } = *f;
-            let input = lower_absorbed_search_clauses(
-                root,
-                input,
-                join_clause,
-                multi_table_predicate_clauses,
-            )?;
+            let input = lower_absorbed_search_clauses(root, input, multi_table_predicate_clauses)?;
             Ok(RelNode::Filter(Box::new(FilterNode { input, predicate })))
         }
         RelNode::Join(j) => {
@@ -400,18 +391,8 @@ pub(super) unsafe fn lower_absorbed_search_clauses(
                 subplan_id,
                 absorbed_search_clauses,
             } = *j;
-            let left = lower_absorbed_search_clauses(
-                root,
-                left,
-                join_clause,
-                multi_table_predicate_clauses,
-            )?;
-            let right = lower_absorbed_search_clauses(
-                root,
-                right,
-                join_clause,
-                multi_table_predicate_clauses,
-            )?;
+            let left = lower_absorbed_search_clauses(root, left, multi_table_predicate_clauses)?;
+            let right = lower_absorbed_search_clauses(root, right, multi_table_predicate_clauses)?;
 
             if absorbed_search_clauses.is_empty() {
                 return Ok(RelNode::Join(Box::new(JoinNode {
@@ -434,7 +415,6 @@ pub(super) unsafe fn lower_absorbed_search_clauses(
                 root,
                 &sub_sources,
                 &absorbed_search_clauses,
-                join_clause,
                 multi_table_predicate_clauses,
             )?;
             Ok(RelNode::Filter(Box::new(FilterNode {
@@ -461,7 +441,6 @@ unsafe fn build_absorbed_filter(
     root: *mut pg_sys::PlannerInfo,
     sub_sources: &[&JoinSource],
     absorbed: &[*mut pg_sys::RestrictInfo],
-    join_clause: &mut JoinCSClause,
     multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
 ) -> Result<JoinLevelExpr, String> {
     let expr_trees: Vec<JoinLevelExpr> = absorbed
@@ -479,7 +458,6 @@ unsafe fn build_absorbed_filter(
                 root,
                 clause.cast(),
                 sub_sources,
-                join_clause,
                 multi_table_predicate_clauses,
             )
             .ok_or_else(|| {

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -1774,8 +1774,20 @@ impl From<anyhow::Error> for QueryError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 struct PostgresPointer(*mut std::os::raw::c_void);
+
+impl PartialEq for PostgresPointer {
+    fn eq(&self, other: &Self) -> bool {
+        if self.0 == other.0 {
+            return true;
+        }
+        if self.0.is_null() || other.0.is_null() {
+            return false;
+        }
+        unsafe { pg_sys::equal(self.0.cast(), other.0.cast()) }
+    }
+}
 
 // SAFETY: PostgresPointer is only used within PostgreSQL's single-threaded context
 // during query execution. The PostgresPointer serialization/deserialization handles

--- a/pg_search/tests/pg_regress/expected/nested_loop.out
+++ b/pg_search/tests/pg_regress/expected/nested_loop.out
@@ -1,10 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
--- This test demonstrates an extremely expensive nested-loop join plan
--- as described in https://github.com/paradedb/paradedb/issues/2733.
--- TODO: The test cannot be scaled up to 10k rows per-table as shown
--- in the original repro because the nested-loop plan runs in exponential time.
--- We keep a minimal amount of data to reproduce the plan structure.
+-- This test verifies that complex multi-table disjunctions in join queries
+-- are planned using ParadeDB Join Scan rather than falling back to
+-- nested-loop join plans.
 DROP TABLE IF EXISTS users CASCADE;
 CREATE TABLE users (id SERIAL8 PRIMARY KEY, name TEXT, color VARCHAR, age VARCHAR);
 CREATE INDEX idxusers ON users USING paradedb (id, name, color, age) WITH (key_field = 'id', text_fields = '{ "name": { "tokenizer": { "type": "keyword" }, "fast": true }, "color": { "tokenizer": { "type": "keyword" }, "fast": true } }');

--- a/pg_search/tests/pg_regress/sql/nested_loop.sql
+++ b/pg_search/tests/pg_regress/sql/nested_loop.sql
@@ -1,11 +1,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 
--- This test demonstrates an extremely expensive nested-loop join plan
--- as described in https://github.com/paradedb/paradedb/issues/2733.
--- TODO: The test cannot be scaled up to 10k rows per-table as shown
--- in the original repro because the nested-loop plan runs in exponential time.
--- We keep a minimal amount of data to reproduce the plan structure.
+-- This test verifies that complex multi-table disjunctions in join queries
+-- are planned using ParadeDB Join Scan rather than falling back to
+-- nested-loop join plans.
 
 DROP TABLE IF EXISTS users CASCADE;
 CREATE TABLE users (id SERIAL8 PRIMARY KEY, name TEXT, color VARCHAR, age VARCHAR);

--- a/tests/antithesis/singleton_driver_property-tests.sh
+++ b/tests/antithesis/singleton_driver_property-tests.sh
@@ -14,7 +14,7 @@ set -Eeuo pipefail
 
 export DATABASE_URL="postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"
 export PARADEDB_FORCE_PARALLEL=1
-# Hang detector for pathologically slow generated queries (issue #2733), not a fault-tolerance knob.
+# Hang detector for pathologically slow generated queries, not a fault-tolerance knob.
 export PARADEDB_QGEN_STATEMENT_TIMEOUT_MS="${PARADEDB_QGEN_STATEMENT_TIMEOUT_MS:-60000}"
 export PROPTEST_CASES="${PROPTEST_CASES:-128}"
 # Disable proptest's source-relative regression file persistence: the qgen

--- a/tests/src/fixtures/querygen/crossrelgen.rs
+++ b/tests/src/fixtures/querygen/crossrelgen.rs
@@ -15,11 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Generator for cross-relation predicates (HeapConditions).
+//! Generator for cross-relation predicates.
 //!
-//! These are predicates that compare columns from different tables,
-//! such as `a.price > b.price`, which cannot be pushed down to Tantivy
-//! and must be evaluated at join time.
+//! These are predicates that compare columns from different tables
+//! (e.g., `a.age > b.age`), which cannot be pushed down to individual Tantivy
+//! scan nodes and must be evaluated as post-join filters.
 
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -66,38 +66,51 @@ impl CrossRelExpr {
     }
 }
 
-/// Generate arbitrary cross-relation predicate expressions.
+/// Generate arbitrary cross-relation predicate expressions comparing columns between two tables
+/// chosen from the given set of tables.
 ///
 /// Creates predicates comparing numeric columns between two tables,
-/// such as `left_table.col > right_table.col`.
+/// such as `table_a.col > table_b.col`.
 ///
 /// # Arguments
-/// * `left_table` - Name of the left table in the comparison
-/// * `right_table` - Name of the right table in the comparison
+/// * `tables` - List of table names to select pairs from (requires at least 2 tables)
 /// * `numeric_columns` - List of numeric column names that can be compared
-pub fn arb_cross_rel_expr(
-    left_table: impl AsRef<str>,
-    right_table: impl AsRef<str>,
-    numeric_columns: Vec<impl AsRef<str>>,
-) -> impl Strategy<Value = CrossRelExpr> {
-    let left_table = left_table.as_ref().to_string();
-    let right_table = right_table.as_ref().to_string();
+pub fn arb_cross_rel_expr<S: AsRef<str>, C: AsRef<str>>(
+    tables: Vec<S>,
+    numeric_columns: Vec<C>,
+) -> impl Strategy<Value = CrossRelExpr> + use<S, C> {
+    let tables: Vec<String> = tables.into_iter().map(|t| t.as_ref().to_string()).collect();
     let columns: Vec<String> = numeric_columns
         .into_iter()
         .map(|c| c.as_ref().to_string())
         .collect();
 
+    assert!(
+        tables.len() >= 2,
+        "arb_cross_rel_expr requires at least 2 tables, got {}",
+        tables.len()
+    );
+
     (
         any::<CrossRelOp>(),
+        proptest::sample::subsequence(tables, 2),
+        proptest::bool::ANY,
         proptest::sample::select(columns.clone()),
         proptest::sample::select(columns),
     )
-        .prop_map(move |(op, left_col, right_col)| CrossRelExpr {
-            left_table: left_table.clone(),
-            left_col,
-            op,
-            right_table: right_table.clone(),
-            right_col,
+        .prop_map(move |(op, pair, swap, left_col, right_col)| {
+            let (left_table, right_table) = if swap {
+                (pair[1].clone(), pair[0].clone())
+            } else {
+                (pair[0].clone(), pair[1].clone())
+            };
+            CrossRelExpr {
+                left_table,
+                left_col,
+                op,
+                right_table,
+                right_col,
+            }
         })
 }
 

--- a/tests/src/fixtures/querygen/mod.rs
+++ b/tests/src/fixtures/querygen/mod.rs
@@ -38,6 +38,7 @@ use sqlx::{Connection, PgConnection};
 use crate::fixtures::ConnExt;
 use crate::fixtures::db::Query;
 use crate::fixtures::fault_grace::{TransientKind, classify_transient};
+use crossrelgen::CrossRelExpr;
 use joingen::{JoinExpr, JoinType};
 use opexprgen::{ArrayQuantifier, Operator};
 use wheregen::Expr;
@@ -385,13 +386,14 @@ ANALYZE {tname};
 }
 
 ///
-/// Generates arbitrary joins and where clauses for the given tables and columns.
+/// Generates arbitrary joins, where clauses, and optional cross-relation predicates
+/// for the given tables and columns.
 ///
 pub fn arb_joins_and_wheres<J, S>(
     join_types: J,
     tables: Vec<S>,
     columns: &[Column],
-) -> impl Strategy<Value = (JoinExpr, Expr)> + use<J, S>
+) -> impl Strategy<Value = (JoinExpr, Expr, Option<CrossRelExpr>)> + use<J, S>
 where
     J: Strategy<Value = JoinType> + Clone,
     S: AsRef<str>,
@@ -402,15 +404,30 @@ where
         .collect::<Vec<_>>();
 
     let columns = columns.to_vec();
+    let numeric_columns: Vec<String> = columns
+        .iter()
+        .filter(|c| c.sql_type == "INTEGER" && c.is_whereable)
+        .map(|c| c.name.to_string())
+        .collect();
 
-    // Choose how many tables will be joined.
+    // Choose how many tables will be joined (at least 2).
     (2..=table_names.len())
         .prop_flat_map(move |join_size| {
             // Then choose tables for that join size.
             proptest::sample::subsequence(table_names.clone(), join_size)
         })
         .prop_flat_map(move |tables| {
-            // Finally, choose the joins and where clauses for those tables.
+            let cross_rel_strategy = if numeric_columns.is_empty() {
+                proptest::strategy::Just(None).boxed()
+            } else {
+                proptest::option::of(crossrelgen::arb_cross_rel_expr(
+                    tables.clone(),
+                    numeric_columns.clone(),
+                ))
+                .boxed()
+            };
+
+            // Finally, choose the joins, where clauses, and optional cross-relation predicate for those tables.
             (
                 joingen::arb_joins(
                     join_types.clone(),
@@ -418,6 +435,7 @@ where
                     columns.iter().map(|c| c.name.to_owned()).collect(),
                 ),
                 wheregen::arb_wheres(tables.clone(), &columns.to_vec()),
+                cross_rel_strategy,
             )
         })
 }

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use tests::fixtures::querygen::crossrelgen::arb_cross_rel_expr;
 use tests::fixtures::querygen::groupbygen::arb_group_by;
 use tests::fixtures::querygen::joingen::{JoinType, arb_joins, arb_semi_joins};
 use tests::fixtures::querygen::numericgen::arb_numeric_expr;
@@ -47,6 +46,7 @@ fn qgen_proptest_config() -> proptest::test_runner::Config {
         // No shrinking: Antithesis controls the entropy stream and fault schedule, so a replay
         // sees a different history and the minimized input is meaningless.
         config.max_shrink_iters = 0;
+        config.source_file = Some("tests/tests/qgen.rs");
     }
     config
 }
@@ -259,7 +259,7 @@ async fn generated_joins_small(database: Db) {
     let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
     proptest!(qgen_proptest_config(), |(
-        (join, where_expr) in arb_joins_and_wheres(
+        (join, where_expr, cross_rel) in arb_joins_and_wheres(
             any::<JoinType>(),
             tables,
             &columns_named(vec!["id", "name", "color", "age"]),
@@ -270,72 +270,22 @@ async fn generated_joins_small(database: Db) {
 
         let from = format!("SELECT COUNT(*) {join_clause} ");
 
+        let (where_pg, where_bm25) = match &cross_rel {
+            Some(cr) => (
+                format!("({}) AND ({})", where_expr.to_sql(" = "), cr.to_sql()),
+                format!("({}) AND ({})", where_expr.to_sql("@@@"), cr.to_sql()),
+            ),
+            None => (where_expr.to_sql(" = "), where_expr.to_sql("@@@")),
+        };
+
         qgen_oracle!("qgen: generated_joins_small - ParadeDB result matches PostgreSQL", compare_outcome_retrying(
-            &format!("{from} WHERE {}", where_expr.to_sql(" = ")),
-            &format!("{from} WHERE {}", where_expr.to_sql("@@@")),
+            &format!("{from} WHERE {where_pg}"),
+            &format!("{from} WHERE {where_bm25}"),
             &gucs,
             &pool,
             &setup_sql,
             |query, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
         ))?;
-    });
-}
-
-///
-/// Tests only the smallest JoinType against larger tables, with a target list, and a limit.
-///
-/// TODO: This test is currently ignored because the generator can still produce nested loop join
-/// plans that blow up combinatorially and make the run take exponential time:
-/// https://github.com/paradedb/paradedb/issues/2733
-///
-#[ignore]
-#[rstest]
-#[tokio::test]
-async fn generated_joins_large_limit(database: Db) {
-    let pool = MutexObjectPool::<PgConnection>::new(
-        move || block_on(async { database.connection().await }),
-        |_| {},
-    );
-
-    let tables_and_sizes = [("users", 10000), ("products", 10000), ("orders", 10000)];
-    let tables = tables_and_sizes
-        .iter()
-        .map(|(table, _)| table)
-        .collect::<Vec<_>>();
-    let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
-
-    proptest!(qgen_proptest_config(), |(
-        (join, where_expr) in arb_joins_and_wheres(
-            Just(JoinType::Inner),
-            tables,
-            &columns_named(vec!["id", "name", "color", "age"]),
-        ),
-        target_list in proptest::sample::subsequence(vec!["id", "name", "color", "age"], 1..=4),
-        gucs in any::<PgGucs>(),
-    )| {
-        let join_clause = join.to_sql();
-        let used_tables = join.used_tables();
-
-        let target_list =
-            target_list
-                .into_iter()
-                .map(|column| format!("{}.{column}", used_tables[0]))
-                .collect::<Vec<_>>()
-                .join(", ");
-
-        let from = format!("SELECT {target_list} {join_clause} ");
-
-        // This test is #[ignore]d, so it never runs. Emit no Antithesis property for it: a cataloged
-        // `Always` that is never reached would otherwise show as a permanently-failing property.
-        compare_outcome_retrying(
-            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql(" = ")),
-            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql("@@@")),
-            &gucs,
-            &pool,
-            &setup_sql,
-            |query, conn| Ok(query.fetch_dynamic_result(conn)?.len()),
-        )
-        .into_test_result()?;
     });
 }
 
@@ -628,9 +578,8 @@ async fn generated_subquery(database: Db) {
 /// 3. A LIMIT clause
 ///
 /// This test randomly combines:
-/// - 2 or 3 table joins
-/// - BM25 predicates on outer table only, or on both outer and inner tables
-/// - Optional HeapConditions (cross-relation predicates like a.price > b.price)
+/// - 2 or 3 table joins and arbitrary boolean WHERE trees (AND, OR, NOT) across tables
+/// - Optional cross-relation predicates (like a.age > b.age)
 /// - Optional DISTINCT keyword (deduplication of result rows)
 /// - Score-based ordering vs regular column ordering (currently skipped, see prop_assume!)
 ///
@@ -649,27 +598,15 @@ async fn generated_joinscan(database: Db) {
     let all_tables: Vec<&str> = tables_and_sizes.iter().map(|(table, _)| *table).collect();
     let setup_sql = generated_queries_setup(&pool, &tables_and_sizes, COLUMNS);
 
-    // Text columns for BM25 WHERE clauses
-    let text_columns = columns_named(vec!["name"]);
-    // Numeric columns for join keys and cross-relation predicates
-    let join_key_columns = vec!["id", "age", "uuid"];
-    // Columns for cross relation expressions.
-    // Note: NUMERIC columns (price, big_numeric) are excluded because cross-type
-    // comparisons (e.g., NUMERIC < INT) require type coercion that the JoinScan
-    // cannot evaluate correctly in DataFusion (different underlying scales/representations).
-    // NumericBytes fast field projection is tested separately in fast_fields.rs.
-    let numeric_columns = ["age"];
+    // Columns for join keys and WHERE clauses
+    let where_and_join_columns = columns_named(vec!["id", "name", "color", "age", "uuid"]);
 
     proptest!(qgen_proptest_config(), |(
-        num_tables in 2..=3usize,
-        // Outer table BM25 predicate (always present)
-        outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
-        // Inner table BM25 predicate (optional)
-        include_inner_bm25 in proptest::bool::ANY,
-        inner_bm25 in arb_wheres(vec![all_tables[1]], &text_columns),
-        // HeapCondition (cross-relation predicate)
-        include_heap_condition in proptest::bool::ANY,
-        heap_condition in arb_cross_rel_expr(all_tables[0], all_tables[1], numeric_columns.to_vec()),
+        (join_expr, where_expr, heap_condition) in arb_joins_and_wheres(
+            Just(JoinType::Inner),
+            all_tables.clone(),
+            &where_and_join_columns,
+        ),
         // Optional DISTINCT keyword
         include_distinct in proptest::bool::ANY,
         // Indexed expression ORDER BY (e.g. ORDER BY upper(category))
@@ -682,40 +619,11 @@ async fn generated_joinscan(database: Db) {
         // which JoinScan doesn't support yet. Skip this combination.
         prop_assume!(!(include_distinct && include_expr_ordering));
 
-        // Build join with selected number of tables
-        let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
-
-        // Generate join expression
-        let join = arb_joins(
-            Just(JoinType::Inner),
-            tables_for_join.clone(),
-            join_key_columns.clone(),
-        );
-
-        // We need to sample from the strategy - use a fixed seed approach
-        let join_expr = {
-            use proptest::strategy::ValueTree;
-            use proptest::test_runner::TestRunner;
-            let mut runner = TestRunner::new(qgen_proptest_config());
-            join.new_tree(&mut runner).unwrap().current()
-        };
-
         let join_clause = join_expr.to_sql();
         let used_tables = join_expr.used_tables();
 
         // Select columns from the first table
-        // When HeapCondition is used, include the referenced columns in target list
-        // (JoinScan requires columns to be projected to evaluate HeapConditions)
-        let mut target_cols = if include_heap_condition {
-            format!(
-                "{}.id, {}.name, {}.{}, {}.{}",
-                used_tables[0], used_tables[0],
-                used_tables[0], heap_condition.left_col,
-                used_tables[1], heap_condition.right_col
-            )
-        } else {
-            format!("{}.id, {}.name", used_tables[0], used_tables[0])
-        };
+        let mut target_cols = format!("{}.id, {}.name", used_tables[0], used_tables[0]);
 
         if include_distinct {
             for table in &used_tables[1..] {
@@ -730,18 +638,12 @@ async fn generated_joinscan(database: Db) {
         let from = format!("SELECT {distinct_kw}{target_cols} {join_clause}");
 
         // Build WHERE clause parts for BM25 query
-        let mut bm25_where_parts = vec![outer_bm25.to_sql("@@@")];
-        let mut pg_where_parts = vec![outer_bm25.to_sql(" = ")];
-
-        // Optionally add inner table BM25 predicate
-        if include_inner_bm25 && num_tables >= 2 {
-            bm25_where_parts.push(inner_bm25.to_sql("@@@"));
-            pg_where_parts.push(inner_bm25.to_sql(" = "));
-        }
+        let mut bm25_where_parts = vec![where_expr.to_sql("@@@")];
+        let mut pg_where_parts = vec![where_expr.to_sql(" = ")];
 
         // Optionally add HeapCondition (same for both queries since it's a regular comparison)
-        if include_heap_condition {
-            let heap_sql = heap_condition.to_sql();
+        if let Some(heap_cond) = &heap_condition {
+            let heap_sql = heap_cond.to_sql();
             bm25_where_parts.push(heap_sql.clone());
             pg_where_parts.push(heap_sql);
         }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2733

## What

- Inlines `JoinLevelSearchPredicate` and `MultiTablePredicateInfo` directly into `JoinLevelExpr` tree variants rather than indexing into vectors on `JoinCSClause`.
- Unifies join and `WHERE` clause generators in `arb_joins_and_wheres` to produce multi-table joins, arbitrary boolean expression trees (`AND`/`OR`/`NOT`), and optional cross-relation heap predicates.
- Removes the obsolete ignored `generated_joins_large_limit` test and updates `nested_loop` regression test comments.

## Why

Now that `joinscan` and `aggregatescan` are enabled by default, queries with multi-table disjunctions are planned via ParadeDB custom scans instead of falling back to exponential nested-loop plans (#2733).

## How

- Modified `JoinLevelExpr` variants in `pg_search/src/postgres/customscan/joinscan/build.rs` to hold boxed predicate structs, removing `join_level_predicates` and `multi_table_predicates` vectors from `JoinCSClause`.
- Updated `collect_join_sources` in `pg_search/src/postgres/customscan/joinscan/planning.rs` to return a `CollectedJoinRel` carrying the plan, join keys, and multi-table clauses.
- Extended `arb_joins_and_wheres` in `tests/src/fixtures/querygen/mod.rs` to incorporate `arb_cross_rel_expr` and simplified `generated_joinscan` in `tests/tests/qgen.rs`.

## Tests

Expanded the `qgen` tests to cover cross-table predicates in more cases.