### PR TITLE
chore: Dedupe the Postgres install in CI, and apply best practices

### DIFF
--- a/.github/actions/build-pg_search-source/action.yml
+++ b/.github/actions/build-pg_search-source/action.yml
@@ -49,21 +49,11 @@ runs:
   using: composite
   steps:
     - name: Install PostgreSQL ${{ inputs.pg-version }} and build dependencies
-      shell: bash
-      run: |
-        set -euo pipefail
-        sudo install -d -m 0755 /usr/share/keyrings
-        curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-          | sudo tee /usr/share/keyrings/postgresql.asc > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
-          | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
-        sudo apt-get update
-        # clang for bindgen; libopenblas-dev for pg_search's BLAS backend
-        # (SuperKMeans IVF clusterer); PG headers supply pg_config.
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-          build-essential ca-certificates curl git pkg-config libssl-dev clang lld \
-          libopenblas-dev \
-          "postgresql-${{ inputs.pg-version }}" "postgresql-server-dev-${{ inputs.pg-version }}"
+      uses: ./.github/actions/setup-postgres
+      with:
+        pg_version: ${{ inputs.pg-version }}
+        extra_packages: >-
+          build-essential ca-certificates curl git pkg-config libssl-dev clang lld libopenblas-dev
 
     - name: Extract pinned toolchain versions
       id: versions

--- a/.github/actions/setup-benchmark-cluster/action.yml
+++ b/.github/actions/setup-benchmark-cluster/action.yml
@@ -29,16 +29,10 @@ runs:
         rustflags: "" # Use .cargo/config.toml target-cpu flags
 
     - name: Install & Configure Supported PostgreSQL Version
-      shell: bash
-      run: |
-        set -euo pipefail
-        curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-          | gpg --dearmor \
-          | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
-        echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
-          | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-        sudo apt-get update && sudo apt-get install -y lld libopenblas-dev postgresql-${{ inputs.pg_version }} postgresql-server-dev-${{ inputs.pg_version }} postgresql-${{ inputs.pg_version }}-pgvector
-        echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> "$GITHUB_PATH"
+      uses: ./.github/actions/setup-postgres
+      with:
+        pg_version: ${{ inputs.pg_version }}
+        extra_packages: lld libopenblas-dev postgresql-${{ inputs.pg_version }}-pgvector
 
     # Separate prefix-key from debug workflows - benchmarks compile with --release.
     # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.

--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -1,0 +1,30 @@
+name: Set up PostgreSQL
+description: Configure the PostgreSQL APT repository (PGDG) and install PostgreSQL packages
+
+inputs:
+  pg_version:
+    description: "PostgreSQL major version to install (e.g. 17, 18)"
+    required: true
+  extra_packages:
+    description: "Additional apt packages to install alongside PostgreSQL"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Configure PGDG APT repository and install PostgreSQL
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo install -d -m 0755 /usr/share/keyrings
+        curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+          | sudo tee /usr/share/keyrings/postgresql.asc >/dev/null
+        echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+          | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          "postgresql-${{ inputs.pg_version }}" \
+          "postgresql-server-dev-${{ inputs.pg_version }}" \
+          ${{ inputs.extra_packages }}
+        echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -207,15 +207,10 @@ jobs:
           sudo apt-get update && sudo apt-get install -y lsof fontconfig pkg-config libfontconfig1-dev libopenblas-dev lld
 
       - name: Install & Configure Supported PostgreSQL Version
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }} postgresql-${{ env.pg_version }}-pgvector
-          echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ env.pg_version }}
+          extra_packages: postgresql-${{ env.pg_version }}-pgvector
 
       # Separate prefix-key from debug workflows — benchmarks compile with --release.
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -70,15 +70,10 @@ jobs:
           save-if: false
 
       - name: Install & Configure Supported PostgreSQL Version
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update && sudo apt-get install -y lld libfontconfig1-dev libopenblas-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ matrix.pg_version }}
+          extra_packages: lld libfontconfig1-dev libopenblas-dev
 
       - name: Install pgrx
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -247,20 +247,10 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         if: steps.guard.outputs.build == 'true'
-        run: |
-          # Create keyrings dir (works on Debian/Ubuntu)
-          sudo install -d -m 0755 /usr/share/keyrings
-
-          # Download PostgreSQL signing key & add PostgreSQL APT repository with signed-by
-          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/keyrings/postgresql.asc > /dev/null
-          sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-
-          # Install PostgreSQL + build tooling
-          DEBIAN_FRONTEND=noninteractive sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg libopenblas-dev
-
-          # Add Postgres bin dir to PATH for subsequent steps
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ matrix.pg_version }}
+          extra_packages: debhelper devscripts dput gnupg libopenblas-dev
 
       - name: Extract pgrx Version
         if: steps.guard.outputs.build == 'true'

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -69,15 +69,10 @@ jobs:
           cache-all-crates: true
 
       - name: Install & Configure PostgreSQL ${{ env.pg_version }}
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }} libopenblas-dev lld
-          echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ env.pg_version }}
+          extra_packages: libopenblas-dev lld
 
       - name: Install pgrx
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -248,20 +248,10 @@ jobs:
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version
-        run: |
-          # Create keyrings dir (works on Debian/Ubuntu)
-          sudo install -d -m 0755 /usr/share/keyrings
-
-          # Download PostgreSQL signing key & add PostgreSQL APT repository with signed-by
-          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/keyrings/postgresql.asc > /dev/null
-          sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-
-          # Install PostgreSQL + build tooling
-          DEBIAN_FRONTEND=noninteractive sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg libopenblas-dev
-
-          # Add Postgres bin dir to PATH for subsequent steps
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ matrix.pg_version }}
+          extra_packages: debhelper devscripts dput gnupg libopenblas-dev
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -76,15 +76,9 @@ jobs:
           save-if: false
 
       - name: Install & Configure Supported PostgreSQL Version
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ matrix.pg_version }}
 
       - name: Install OpenBLAS (superkmeans-rs BLAS backend)
         run: |

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -114,15 +114,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y lsof libopenblas-dev lld
 
       - name: Install & Configure Supported PostgreSQL Version
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ matrix.pg_version }}
 
       # Needed for hybrid search unit tests
       - name: Install pgvector

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -130,15 +130,9 @@ jobs:
       # ---------- System-managed Postgres setup ----------
       - name: Install & Configure Supported PostgreSQL Version (system)
         if: matrix.pg_impl == 'system'
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/postgresql-pgdg.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/postgresql-pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-postgres
+        with:
+          pg_version: ${{ matrix.pg_version }}
 
       - name: Initialize pgrx environment (system)
         if: matrix.pg_impl == 'system'


### PR DESCRIPTION
## What

Dedupe the Postgres install in CI, and add retries and best-practice keyring setup.

## Why

https://github.com/paradedb/paradedb-enterprise/actions/runs/33415552097/job/99565208259 was failing due to a race caused by restarting daemons during an APT install. Rather than waiting, retries allow us to optimistically complete more quickly.