### PR TITLE
fix: Fix a hang in MPP during abnormal exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,6 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "3.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-08-20-204632#4d870ae1a5abb23618eac0b1844c265ffa2991d8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-distributed"
-version = "3.0.0"
+version = "4.0.0"
+source = "git+https://github.com/paradedb/datafusion-distributed?branch=stuhood.worker-lifecycle#e37f41eddd3bdc6349f35799862166440290fca6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5761,7 +5762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,5 +80,8 @@ tantivy-jieba = "0.20.0"
 [patch.crates-io]
 tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c3caae3f613d5906c8080a3c3c2845190e749b64" }
 
+[patch."https://github.com/paradedb/datafusion-distributed"]
+datafusion-distributed = { path = "/Users/stuhood/src/df-d-0" }
+
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,5 @@ tantivy-jieba = "0.20.0"
 [patch.crates-io]
 tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "c3caae3f613d5906c8080a3c3c2845190e749b64" }
 
-[patch."https://github.com/paradedb/datafusion-distributed"]
-datafusion-distributed = { path = "/Users/stuhood/src/df-d-0" }
-
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-1hb8BiWhG4iRKWYGKCsh9i8d8wKm2N4UawaN7O17aCE=";
+  cargoHash = "sha256-W0D+lKemSZkUdL7bC2WudRRjI3F7P8R98YZHwHEHKQc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -95,7 +95,7 @@ bytes = { version = "1", features = ["serde"] }
 # both point to the same datafusion ref.
 datafusion = { version = "55.0.0", default-features = false }
 datafusion-proto = { version = "55.0.0", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-08-20-204632", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", branch = "stuhood.worker-lifecycle", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1944,6 +1944,7 @@ impl AggregateScan {
             // On a launch fallback (nothing to distribute, or too few attached workers) no workers
             // remain and the `DistributedExec` shape has no mesh to read from, so replan serially
             // below.
+            let mut launched: Option<crate::postgres::customscan::mpp::glue::MppLeaderState> = None;
             let leader = if mpp_pending {
                 Self::launch_mpp(state, &physical_plan)
             } else {
@@ -1966,7 +1967,7 @@ impl AggregateScan {
                         let mut timing = leader.timing;
                         timing.plan_us = plan_us;
                         df_state.launch_timing = Some(timing);
-                        df_state.mpp = MppLifecycle::Launched(leader);
+                        launched = Some(leader);
                         (exec_ctx, physical_plan)
                     }
                     None => {
@@ -2013,10 +2014,17 @@ impl AggregateScan {
                 let _guard = runtime.enter();
                 match physical_plan.execute(0, task_ctx) {
                     Ok(s) => s,
-                    Err(e) => pgrx::error!("Failed to execute DataFusion aggregate plan: {}", e),
+                    Err(e) => {
+                        drop(ctx);
+                        drop(launched);
+                        pgrx::error!("Failed to execute DataFusion aggregate plan: {e}");
+                    }
                 }
             };
 
+            if let Some(leader) = launched.take() {
+                df_state.mpp = MppLifecycle::Launched(leader);
+            }
             df_state.runtime = Some(runtime);
             df_state.physical_plan = Some(physical_plan);
             df_state.stream = Some(stream);
@@ -2067,6 +2075,7 @@ impl AggregateScan {
                     df_state.batch_row_idx = 0;
                 }
                 Some(Err(e)) => {
+                    let _ = df_state.mpp.take_leader();
                     pgrx::error!("DataFusion aggregate execution failed: {}", e);
                 }
                 None => {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -721,7 +721,7 @@ impl CustomScan for AggregateScan {
                     current_batch: None,
                     batch_row_idx: 0,
                     group_df_indices: Vec::new(),
-                    mpp: MppLifecycle::Inactive,
+                    mpp: MppLifecycle::default(),
                     launch_timing: None,
                 });
                 builder.build()
@@ -1143,7 +1143,7 @@ impl AggregateScan {
         let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() else {
             return;
         };
-        df_state.mpp = MppLifecycle::Pending;
+        df_state.mpp.mark_pending();
     }
 
     /// Plan-first MPP launch (#5667). Called with the leader's already-built physical plan:
@@ -1887,13 +1887,13 @@ impl AggregateScan {
             .as_ref()
             .is_some_and(|d| d.runtime.is_none());
 
-        // Taken up front (not inside the df_state borrow below) because the launch needs `state`
-        // for the source manifests.
-        let mpp_pending = state
+        let df_state = state
             .custom_state_mut()
             .datafusion_state
             .as_mut()
-            .is_some_and(|d| d.mpp.take_pending());
+            .expect("DataFusion state must be initialized");
+        let mut mpp_guard = df_state.mpp.enter_guard();
+        let mpp_pending = mpp_guard.take_pending();
 
         // First call: build and execute the DataFusion plan
         if first_call {
@@ -1944,7 +1944,6 @@ impl AggregateScan {
             // On a launch fallback (nothing to distribute, or too few attached workers) no workers
             // remain and the `DistributedExec` shape has no mesh to read from, so replan serially
             // below.
-            let mut launched: Option<crate::postgres::customscan::mpp::glue::MppLeaderState> = None;
             let leader = if mpp_pending {
                 Self::launch_mpp(state, &physical_plan)
             } else {
@@ -1967,7 +1966,7 @@ impl AggregateScan {
                         let mut timing = leader.timing;
                         timing.plan_us = plan_us;
                         df_state.launch_timing = Some(timing);
-                        launched = Some(leader);
+                        mpp_guard.install_leader(leader);
                         (exec_ctx, physical_plan)
                     }
                     None => {
@@ -2012,19 +2011,11 @@ impl AggregateScan {
             };
             let stream = {
                 let _guard = runtime.enter();
-                match physical_plan.execute(0, task_ctx) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        drop(ctx);
-                        drop(launched);
-                        pgrx::error!("Failed to execute DataFusion aggregate plan: {e}");
-                    }
-                }
+                physical_plan.execute(0, task_ctx).unwrap_or_else(|e| {
+                    pgrx::error!("Failed to execute DataFusion aggregate plan: {e}")
+                })
             };
 
-            if let Some(leader) = launched.take() {
-                df_state.mpp = MppLifecycle::Launched(leader);
-            }
             df_state.runtime = Some(runtime);
             df_state.physical_plan = Some(physical_plan);
             df_state.stream = Some(stream);
@@ -2075,7 +2066,6 @@ impl AggregateScan {
                     df_state.batch_row_idx = 0;
                 }
                 Some(Err(e)) => {
-                    let _ = df_state.mpp.take_leader();
                     pgrx::error!("DataFusion aggregate execution failed: {}", e);
                 }
                 None => {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1539,6 +1539,8 @@ impl CustomScan for JoinScan {
                 // On a launch fallback (nothing to distribute, or too few attached workers) no
                 // workers remain and the `DistributedExec` shape has no mesh to read from, so
                 // replan serially.
+                let mut launched: Option<crate::postgres::customscan::mpp::glue::MppLeaderState> =
+                    None;
                 let (ctx, plan) = if mpp_pending {
                     match Self::launch_mpp(state, &plan) {
                         Some(leader) => {
@@ -1552,7 +1554,7 @@ impl CustomScan for JoinScan {
                             launch_us.attach_us = leader.timing.attach_us;
                             launch_us.leader_setup_us = leader.timing.leader_setup_us;
                             launch_us.workers = leader.timing.workers;
-                            state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
+                            launched = Some(leader);
                             (exec_ctx, plan)
                         }
                         None => {
@@ -1607,9 +1609,19 @@ impl CustomScan for JoinScan {
                 let t_exec = std::time::Instant::now();
                 let stream = {
                     let _guard = runtime.enter();
-                    plan.execute(0, task_ctx)
-                        .expect("Failed to execute DataFusion plan")
+                    match plan.execute(0, task_ctx) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            drop(plan);
+                            drop(ctx);
+                            drop(launched);
+                            pgrx::error!("Failed to execute DataFusion plan: {e}");
+                        }
+                    }
                 };
+                if let Some(leader) = launched.take() {
+                    state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
+                }
                 launch_us.exec_us = t_exec.elapsed().as_micros() as u64;
 
                 // Retain the executed plan so EXPLAIN ANALYZE can extract metrics. Record the
@@ -1659,20 +1671,19 @@ impl CustomScan for JoinScan {
 
                 match next_batch {
                     Some(Ok(batch)) => {
-                        // First distributed batch out: fold the worker decode, first scan, and
-                        // network hop into the launch timing.
-                        if let Some(built) = state.custom_state().stream_built_at {
-                            if let Some(t) = state.custom_state_mut().launch_timing.as_mut()
-                                && t.first_frame_us == 0
-                            {
-                                t.first_frame_us = built.elapsed().as_micros() as u64;
+                        if let Some(t_built) = state.custom_state().stream_built_at {
+                            if let Some(ref mut timing) = state.custom_state_mut().launch_timing {
+                                timing.first_frame_us = t_built.elapsed().as_micros() as u64;
                             }
                             state.custom_state_mut().stream_built_at = None;
                         }
                         state.custom_state_mut().current_batch = Some(batch);
                         state.custom_state_mut().batch_index = 0;
                     }
-                    Some(Err(e)) => panic!("DataFusion execution failed: {}", e),
+                    Some(Err(e)) => {
+                        let _ = state.custom_state_mut().mpp.take_leader();
+                        pgrx::error!("DataFusion execution failed: {}", e);
+                    }
                     None => return std::ptr::null_mut(),
                 }
             }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -183,7 +183,6 @@ use crate::postgres::customscan::joinscan::planning::{
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
-use crate::postgres::customscan::mpp::launch::MppLifecycle;
 use crate::postgres::customscan::mpp::launch::mpp_gated_by_min_rows;
 use crate::postgres::customscan::mpp::worker_fragments::mpp_plan_has_data_parallelism;
 use arrow_array::Array;
@@ -1398,16 +1397,13 @@ impl CustomScan for JoinScan {
                         .map(|source| &source.scan_info),
                 )
             {
-                state.custom_state_mut().mpp = MppLifecycle::Pending;
+                state.custom_state_mut().mpp.mark_pending();
             }
         }
     }
 
     fn rescan_custom_scan(state: &mut CustomScanStateWrapper<Self>) {
-        let relaunch_mpp = matches!(
-            &state.custom_state().mpp,
-            MppLifecycle::Pending | MppLifecycle::Launched(_)
-        );
+        let relaunch_mpp = state.custom_state().mpp.is_active();
         Self::finish_mpp_execution(state);
         state.custom_state_mut().relations.clear();
         state.custom_state_mut().reset();
@@ -1416,12 +1412,13 @@ impl CustomScan for JoinScan {
                 state.custom_state().logical_plan.is_some(),
                 "MPP rescan requires logical plan bytes"
             );
-            state.custom_state_mut().mpp = MppLifecycle::Pending;
+            state.custom_state_mut().mpp.mark_pending();
         }
     }
 
     fn exec_custom_scan(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
         let mut launch_us = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
+        let mut mpp_guard = state.custom_state_mut().mpp.enter_guard();
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
                 // Solve any Param/SubPlan-backed SearchQueryInputs on the leader and rebake the
@@ -1521,7 +1518,7 @@ impl CustomScan for JoinScan {
                             .expect("Failed to create execution plan")
                     };
 
-                let mpp_pending = state.custom_state_mut().mpp.take_pending();
+                let mpp_pending = mpp_guard.take_pending();
                 // Leader session context: on an MPP attempt, layer the DF-D fork's
                 // distributed-planner knobs over the Join profile so the resulting physical
                 // plan is a `DistributedExec`, with `producer_worker_cap()` acting as the
@@ -1539,8 +1536,6 @@ impl CustomScan for JoinScan {
                 // On a launch fallback (nothing to distribute, or too few attached workers) no
                 // workers remain and the `DistributedExec` shape has no mesh to read from, so
                 // replan serially.
-                let mut launched: Option<crate::postgres::customscan::mpp::glue::MppLeaderState> =
-                    None;
                 let (ctx, plan) = if mpp_pending {
                     match Self::launch_mpp(state, &plan) {
                         Some(leader) => {
@@ -1554,7 +1549,7 @@ impl CustomScan for JoinScan {
                             launch_us.attach_us = leader.timing.attach_us;
                             launch_us.leader_setup_us = leader.timing.leader_setup_us;
                             launch_us.workers = leader.timing.workers;
-                            launched = Some(leader);
+                            mpp_guard.install_leader(leader);
                             (exec_ctx, plan)
                         }
                         None => {
@@ -1609,25 +1604,15 @@ impl CustomScan for JoinScan {
                 let t_exec = std::time::Instant::now();
                 let stream = {
                     let _guard = runtime.enter();
-                    match plan.execute(0, task_ctx) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            drop(plan);
-                            drop(ctx);
-                            drop(launched);
-                            pgrx::error!("Failed to execute DataFusion plan: {e}");
-                        }
-                    }
+                    plan.execute(0, task_ctx)
+                        .expect("Failed to execute DataFusion plan")
                 };
-                if let Some(leader) = launched.take() {
-                    state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
-                }
                 launch_us.exec_us = t_exec.elapsed().as_micros() as u64;
 
                 // Retain the executed plan so EXPLAIN ANALYZE can extract metrics. Record the
                 // launch timing only when the query actually ran distributed (workers attached);
                 // a serial fallback never reaches `Launched` and leaves `workers` at zero.
-                if state.custom_state().mpp.is_launched() {
+                if mpp_guard.is_launched() {
                     state.custom_state_mut().launch_timing = Some(launch_us);
                     state.custom_state_mut().stream_built_at = Some(std::time::Instant::now());
                 }
@@ -1681,7 +1666,6 @@ impl CustomScan for JoinScan {
                         state.custom_state_mut().batch_index = 0;
                     }
                     Some(Err(e)) => {
-                        let _ = state.custom_state_mut().mpp.take_leader();
                         pgrx::error!("DataFusion execution failed: {}", e);
                     }
                     None => return std::ptr::null_mut(),

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -56,7 +56,9 @@ use tokio_util::sync::CancellationToken;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
 use crate::postgres::customscan::mpp::glue::producer_worker_cap;
-use crate::postgres::customscan::mpp::interrupt::{HeldInterrupts, check_for_interrupts};
+use crate::postgres::customscan::mpp::interrupt::{
+    HeldInterrupts, cancel_pending, check_for_interrupts,
+};
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::utils::ExprContextGuard;
 use crate::scan::execution_plan::{
@@ -185,6 +187,9 @@ async fn take_set_plan_draining(
         if let std::task::Poll::Ready(result) = futures::poll!(take.as_mut()) {
             return result;
         }
+        // A leader that fails before dispatching this stage never sends the frame; its abort
+        // terminates us via SIGTERM, and nothing else in this wait loop would notice the interrupt.
+        mesh.check_interrupt()?;
         mesh.try_drain_pass()?;
         tokio::task::yield_now().await;
     }
@@ -328,23 +333,40 @@ pub(crate) fn run_mpp_worker(
         pgrx::error!("mpp worker: no fragments assigned (proc={this_proc})");
     }
 
+    /// Returns true if the error represents an expected session teardown, query cancellation,
+    /// or leader departure where worker exit is normal and should not log an error.
+    fn is_clean_teardown_error(err: &datafusion::common::DataFusionError) -> bool {
+        if cancel_pending() {
+            return true;
+        }
+        let msg = err.to_string();
+        msg.contains("mpp: query interrupted")
+            || msg.contains("session closed")
+            || msg.contains("transport torn down")
+    }
+
     // Each fragment's plan arrives as a `SetPlan` frame on this proc's inbox, the same
     // `SetPlanRequest` Flight ships. Collect the frames first (the take drains the inbox while
     // it waits), then decode synchronously: decode injects `parallel_state`, a raw pointer that
     // must stay off the produce futures.
     let frames: Vec<SetPlanFrame> = {
-        let collected = runtime.block_on(async {
-            let mut frames = Vec::with_capacity(fragments.len());
-            for fragment in &fragments {
-                frames.push(
-                    take_set_plan_draining(worker_mesh, fragment.stage_id, fragment.task_idx)
-                        .await?,
-                );
-            }
-            Ok::<_, datafusion::common::DataFusionError>(frames)
-        });
+        let collected = {
+            let _held = HeldInterrupts::hold();
+            runtime.block_on(async {
+                let mut frames = Vec::with_capacity(fragments.len());
+                for fragment in &fragments {
+                    frames.push(
+                        take_set_plan_draining(worker_mesh, fragment.stage_id, fragment.task_idx)
+                            .await?,
+                    );
+                }
+                Ok::<_, datafusion::common::DataFusionError>(frames)
+            })
+        };
+        check_for_interrupts();
         match collected {
             Ok(frames) => frames,
+            Err(e) if is_clean_teardown_error(&e) => return,
             Err(e) => {
                 pgrx::error!("mpp worker: plan frames did not arrive: {e}");
             }
@@ -574,7 +596,9 @@ pub(crate) fn run_mpp_worker(
     // of mid-`block_on`.
     drop(held);
     check_for_interrupts();
-    if let Err(e) = outcome {
+    if let Err(e) = outcome
+        && !is_clean_teardown_error(&e)
+    {
         pgrx::error!("mpp worker: fragment dispatch failed: {e}");
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -231,7 +231,6 @@ fn spawn_fragment_execution_task(
 ) -> FragmentFuture {
     Box::pin(async move {
         let mut sinks_opt: Vec<_> = per_partition_sinks.into_iter().map(Some).collect();
-        let n_partitions = sinks_opt.len();
 
         // The cancellation token is never cancelled on this path; worker interrupts bail via
         // the cooperative drain pass.
@@ -241,7 +240,6 @@ fn spawn_fragment_execution_task(
             &mesh,
             stage_id,
             task_idx,
-            n_partitions,
             token,
             move |_request, _headers, range| {
                 let len = range.end - range.start;

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -309,7 +309,7 @@ mod tests {
             )
             .unwrap()
         };
-        let mesh = session.mesh;
+        let mesh = session.mesh.clone();
         mesh.mark_detached();
 
         assert!(

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -229,12 +229,21 @@ fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> Se
     run_mpp_worker(inputs, seed_ctx(), &runtime);
 }
 
-/// Where MPP sits in a scan's launch lifecycle. Every transition consumes the previous stage,
-/// so a scan is in exactly one stage at a time; a single field keeps the impossible
-/// combinations unrepresentable. Held only by the leader; builder-launched workers reconstruct
-/// their state from DSM and never carry this.
+/// Where MPP sits in a scan's launch lifecycle. Held only by the leader; builder-launched
+/// workers reconstruct their state from DSM and never carry this.
+///
+/// Encapsulates the internal [`LifecycleState`] transitions and ensures that active leader
+/// sessions cannot be orphaned during query aborts by requiring an [`MppGuard`] during execution.
 #[derive(Default)]
-pub enum MppLifecycle {
+pub struct MppLifecycle {
+    state: LifecycleState,
+}
+
+/// Internal stage machine for [`MppLifecycle`]. Every transition consumes the previous stage,
+/// so a scan is in exactly one stage at a time; a single field keeps impossible combinations
+/// unrepresentable.
+#[derive(Default)]
+enum LifecycleState {
     /// Serial execution: the query didn't qualify, a fallback abandoned the launch, or
     /// teardown already reclaimed the leader state.
     #[default]
@@ -248,45 +257,129 @@ pub enum MppLifecycle {
 }
 
 impl MppLifecycle {
+    pub fn mark_pending(&mut self) {
+        self.state = LifecycleState::Pending;
+    }
+
     /// Consume the pending launch marker. Leaves `Inactive`, so a launch fallback reads as the
     /// serial path from then on.
     pub fn take_pending(&mut self) -> bool {
-        match std::mem::take(self) {
-            MppLifecycle::Pending => true,
+        match std::mem::take(&mut self.state) {
+            LifecycleState::Pending => true,
             other => {
-                *self = other;
+                self.state = other;
                 false
             }
         }
     }
 
+    /// Returns true if currently in `Pending` or `Launched` state.
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self.state,
+            LifecycleState::Pending | LifecycleState::Launched(_)
+        )
+    }
+
+    pub fn is_launched(&self) -> bool {
+        matches!(self.state, LifecycleState::Launched(_))
+    }
+
+    pub fn install_leader(&mut self, leader: MppLeaderState) {
+        self.state = LifecycleState::Launched(leader);
+    }
+
     /// Consume the leader state at teardown, leaving `Inactive`.
     pub fn take_leader(&mut self) -> Option<MppLeaderState> {
-        match std::mem::take(self) {
-            MppLifecycle::Launched(leader) => Some(leader),
+        match std::mem::take(&mut self.state) {
+            LifecycleState::Launched(leader) => Some(leader),
             other => {
-                *self = other;
+                self.state = other;
                 None
             }
         }
     }
 
     pub fn leader(&self) -> Option<&MppLeaderState> {
-        match self {
-            MppLifecycle::Launched(leader) => Some(leader),
+        match &self.state {
+            LifecycleState::Launched(leader) => Some(leader),
             _ => None,
         }
     }
 
     pub fn leader_mut(&mut self) -> Option<&mut MppLeaderState> {
-        match self {
-            MppLifecycle::Launched(leader) => Some(leader),
+        match &mut self.state {
+            LifecycleState::Launched(leader) => Some(leader),
             _ => None,
         }
     }
 
+    /// Enter an active execution scope guarded against unwinding panics.
+    pub fn enter_guard(&mut self) -> MppGuard {
+        MppGuard {
+            lifecycle_ptr: self as *mut MppLifecycle,
+        }
+    }
+}
+
+/// Stack-bound RAII guard for MPP leader execution.
+///
+/// ### Why this stack guard is necessary
+/// On query abort, PostgreSQL invokes `AtAbort_Parallel()` at the start of `AbortTransaction()`,
+/// blocking in `WaitForParallelWorkersToExit()` before query memory contexts are reset. If parallel
+/// workers are waiting on the leader (e.g. for plan dispatch in `take_set_plan`), they only awaken
+/// and exit when [`LeaderSession`](datafusion_distributed::shm::LeaderSession) drops and broadcasts
+/// `SessionEnd`.
+///
+/// Because `pgrx` unwinds the Rust stack before `AbortTransaction()` begins, this guard's [`Drop`]
+/// consumes and drops [`MppLeaderState`] during unwinding, broadcasting `SessionEnd` so workers exit
+/// before PostgreSQL blocks in `WaitForParallelWorkersToExit()`.
+pub struct MppGuard {
+    lifecycle_ptr: *mut MppLifecycle,
+}
+
+impl MppGuard {
+    #[allow(dead_code)]
+    pub fn new(lifecycle: &mut MppLifecycle) -> Self {
+        Self {
+            lifecycle_ptr: lifecycle as *mut MppLifecycle,
+        }
+    }
+
+    pub fn take_pending(&mut self) -> bool {
+        unsafe { (*self.lifecycle_ptr).take_pending() }
+    }
+
     pub fn is_launched(&self) -> bool {
-        matches!(self, MppLifecycle::Launched(_))
+        unsafe { (*self.lifecycle_ptr).is_launched() }
+    }
+
+    pub fn install_leader(&mut self, leader: MppLeaderState) {
+        unsafe { (*self.lifecycle_ptr).install_leader(leader) }
+    }
+
+    #[allow(dead_code)]
+    pub fn leader(&self) -> Option<&MppLeaderState> {
+        unsafe { (*self.lifecycle_ptr).leader() }
+    }
+
+    #[allow(dead_code)]
+    pub fn leader_mut(&mut self) -> Option<&mut MppLeaderState> {
+        unsafe { (*self.lifecycle_ptr).leader_mut() }
+    }
+
+    pub fn take_leader(&mut self) -> Option<MppLeaderState> {
+        unsafe { (*self.lifecycle_ptr).take_leader() }
+    }
+}
+
+impl Drop for MppGuard {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            // Unwinding due to panic or pgrx::error!
+            // Automatically take and drop the leader session to broadcast SessionEnd!
+            let _ = self.take_leader();
+        }
     }
 }
 
@@ -551,7 +644,8 @@ mod tests {
 
     #[pg_test]
     fn pending_launch_is_consumed_once() {
-        let mut lifecycle = MppLifecycle::Pending;
+        let mut lifecycle = MppLifecycle::default();
+        lifecycle.mark_pending();
 
         assert!(lifecycle.take_pending());
         assert!(!lifecycle.take_pending());

--- a/tests/tests/mpp_leader_failure_teardown.rs
+++ b/tests/tests/mpp_leader_failure_teardown.rs
@@ -1,0 +1,205 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! A leader-side failure between the MPP launch and the first batch must not wedge the backend.
+//!
+//! The shape: a NOT IN subquery on the probe side of a broadcast join. The distributed planner
+//! caps the null-aware anti join to one task and leaves it in the leader's stage, so the leader
+//! itself executes that leaf — before it has dispatched plan frames for the other stages. A
+//! failure there unwinds into PostgreSQL's parallel-context teardown, which terminates
+//! the workers and waits for them.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use rstest::*;
+use sqlx::{AssertSqlSafe, Executor, PgConnection};
+use tests::fixtures::*;
+use tokio::time::{sleep, timeout};
+
+const SETUP_SQL: &str = r#"
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
+
+CREATE TABLE mlft_items (id bigint PRIMARY KEY, txt text NOT NULL);
+CREATE TABLE mlft_excl  (id bigint PRIMARY KEY, val bigint);
+CREATE TABLE mlft_small (id bigint PRIMARY KEY, val bigint NOT NULL, txt text NOT NULL);
+CREATE INDEX mlft_items_idx ON mlft_items USING paradedb (id, (txt::pdb.literal))
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+CREATE INDEX mlft_excl_idx ON mlft_excl USING paradedb (id, val)
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+CREATE INDEX mlft_small_idx ON mlft_small USING paradedb (id, val, (txt::pdb.literal))
+  WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mlft_items SELECT s, 'match' FROM generate_series(1, 2000) s;
+INSERT INTO mlft_items SELECT s, 'match' FROM generate_series(2001, 4000) s;
+INSERT INTO mlft_excl  SELECT s, s FROM generate_series(50, 300) s;
+INSERT INTO mlft_excl  SELECT s, s FROM generate_series(301, 600) s;
+INSERT INTO mlft_small SELECT s, s, 'small' FROM generate_series(1, 20) s;
+INSERT INTO mlft_small SELECT s, s, 'small' FROM generate_series(21, 40) s;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE mlft_items; ANALYZE mlft_excl; ANALYZE mlft_small;
+"#;
+
+const MPP_GUCS: &str = r#"
+SET paradedb.enable_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.mpp_min_rows TO 0;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+"#;
+
+const JOINSCAN_QUERY: &str = r#"
+SELECT i.id FROM mlft_items i JOIN mlft_small s ON s.val = i.id
+WHERE i.txt === 'match' AND s.txt === 'small'
+  AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ pdb.all())
+ORDER BY i.id LIMIT 5
+"#;
+
+const AGGREGATESCAN_QUERY: &str = r#"
+SELECT count(*) FROM (
+  SELECT i.id FROM mlft_items i JOIN mlft_small s ON s.val = i.id
+  WHERE i.txt === 'match' AND s.txt === 'small'
+    AND i.id NOT IN (SELECT val FROM mlft_excl WHERE id @@@ pdb.all())) q
+"#;
+
+/// Hard watchdog: a regression here wedges the backend and its workers, which would otherwise
+/// hang the whole shared test cluster.
+const WATCHDOG: Duration = Duration::from_secs(30);
+
+async fn launched_worker_pids(conn: &mut PgConnection) -> Result<Vec<i32>> {
+    Ok(sqlx::query_scalar(
+        "SELECT pid FROM pg_stat_activity WHERE backend_type = 'parallel worker' ORDER BY pid",
+    )
+    .fetch_all(conn)
+    .await?)
+}
+
+async fn guc_present(conn: &mut PgConnection, name: &str) -> Result<bool> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT name FROM pg_settings WHERE name = $1")
+        .bind(name)
+        .fetch_optional(conn)
+        .await?;
+    Ok(row.is_some())
+}
+
+/// Run `query` with a leader-side fault armed; the error must come back promptly, the backend
+/// must answer again, and every launched worker must exit rather than stay parked.
+async fn run_faulted(
+    conn: &mut PgConnection,
+    observer: &mut PgConnection,
+    query: &str,
+    expected_error: &str,
+) -> Result<()> {
+    let result = timeout(WATCHDOG, conn.execute(AssertSqlSafe(query.to_string())))
+        .await
+        .context("leader-side failure did not return; backend wedged")?;
+    let err = match result {
+        Ok(_) => bail!("query succeeded although the leader-side fault was armed"),
+        Err(err) => err.to_string(),
+    };
+    assert!(err.contains(expected_error), "unexpected error: {err}");
+
+    let one: i32 = timeout(
+        WATCHDOG,
+        sqlx::query_scalar("SELECT 1").fetch_one(&mut *conn),
+    )
+    .await
+    .context("backend did not answer after the aborted MPP run")??;
+    assert_eq!(one, 1);
+
+    let deadline = Instant::now() + WATCHDOG;
+    loop {
+        let pids = launched_worker_pids(observer).await?;
+        if pids.is_empty() {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            bail!("parallel workers survived the aborted MPP run: {pids:?}");
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[rstest]
+#[tokio::test]
+async fn mpp_leader_failure_tears_down_workers(database: Db) -> Result<()> {
+    let mut conn = database.connection().await;
+    conn.execute(SETUP_SQL).await?;
+    if !guc_present(&mut conn, "paradedb.mpp_test_panic_in_worker").await? {
+        println!(
+            "Skipping mpp_leader_failure_tears_down_workers: the fault-injection GUCs are not \
+             present (non-debug build)"
+        );
+        return Ok(());
+    }
+    conn.execute(MPP_GUCS).await?;
+
+    // The shape must actually put a multi-segment leaf in the leader's box, or the faults fire
+    // in a worker instead: the leader's box is everything before the first stage separator.
+    let plan: Vec<(String,)> = sqlx::query_as(AssertSqlSafe(format!(
+        "EXPLAIN (VERBOSE, COSTS OFF) {JOINSCAN_QUERY}"
+    )))
+    .fetch_all(&mut conn)
+    .await?;
+    let plan = plan
+        .into_iter()
+        .map(|(l,)| l)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let leader_box_end = plan.find("└──").context("distributed plan expected")?;
+    let leaf = plan
+        .find("table=mlft_excl, segments=2")
+        .context("2-segment mlft_excl leaf expected")?;
+    assert!(
+        leaf < leader_box_end,
+        "mlft_excl leaf is not leader-hosted:\n{plan}"
+    );
+
+    let mut observer = database.connection().await;
+
+    // PostgreSQL error raised inside the leader's execute: teardown runs from the abort path.
+    conn.execute("SET paradedb.mpp_test_panic_in_worker TO on")
+        .await?;
+    run_faulted(&mut conn, &mut observer, JOINSCAN_QUERY, "artificial panic").await?;
+    run_faulted(
+        &mut conn,
+        &mut observer,
+        AGGREGATESCAN_QUERY,
+        "artificial panic",
+    )
+    .await?;
+    conn.execute("SET paradedb.mpp_test_panic_in_worker TO off")
+        .await?;
+
+    // With the faults cleared the same connection runs the query to completion.
+    let ids: Vec<(i64,)> = timeout(
+        WATCHDOG,
+        sqlx::query_as(AssertSqlSafe(JOINSCAN_QUERY.to_string())).fetch_all(&mut conn),
+    )
+    .await
+    .context("query after the aborted runs did not return")??;
+    assert_eq!(
+        ids.into_iter().map(|(id,)| id).collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5]
+    );
+    Ok(())
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6031

## What

- Fixes parallel worker lifecycle management during leader-side query failures and aborts in MPP queries.
- Updates the `datafusion-distributed` dependency to include a `SessionEnd` frame signaling.
- Introduces `MppGuard`, a stack-bound RAII guard on the leader that drops `MppLeaderState` during stack unwinding to broadcast `SessionEnd` before PostgreSQL waits on worker termination.

## Why

When an error or panic occurs on the leader side during MPP query execution (for example, in a leader-hosted stage before dispatching plan frames to workers) or in with `LIMIT` but no `ORDER BY` (causing the leader to trigger tasks one at a time until it gets enough rows), the leader was not signaling parallel workers to exit.

Previously, if parallel workers were waiting on the leader (e.g., in `take_set_plan` or worker request loops), they remained blocked because:
1. `LeaderSession` was not dropped during Rust unwinding, because it was allocated in a `MemoryContext` until _after_ `Abort`.
2. Workers in `take_set_plan_draining` did not poll for interrupts when blocked.

This caused the leader backend to wedge indefinitely in `WaitForParallelWorkersToExit()` and leaked worker backends across subsequent queries.

## How

- Introduce a `SessionEnd` frame broadcasting and control channel closure on leader departure.
- Added `MppGuard` in `pg_search/src/postgres/customscan/mpp/launch.rs` and wrapped execution in `AggregateScan` and `JoinScan`: on stack unwinding, it drops `MppLeaderState` to broadcast `SessionEnd` before `WaitForParallelWorkersToExit()`.
- Added interrupt checks (`mesh.check_interrupt()?`) in `pg_search/src/postgres/customscan/mpp/exec_worker.rs` and ignored clean session teardown errors so workers exit quietly.

## Tests

New tests in `tests/tests/mpp_leader_failure_teardown.rs`