### PR TITLE
feat: match ScalarArrayOpExpr clauses against the index

### DIFF
--- a/docs/documentation/filtering/external-indexes.mdx
+++ b/docs/documentation/filtering/external-indexes.mdx
@@ -173,7 +173,6 @@ The most common reasons are:
 
 - The filter appears under `OR` or `NOT`. Only `AND` is currently supported.
 - More than one external index could help. ParadeDB currently chooses the best single external index instead of combining several.
-- The filter uses SQL's `= ANY (...)` array form.
 - The candidate set from the external index is expected to be too large, or the filter is not selective enough to justify the extra work.
 
 If your query still checks the filter row by row, please [open a GitHub issue](https://github.com/paradedb/paradedb/issues/new) with the query, index definitions, and `EXPLAIN` output.

--- a/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
+++ b/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
@@ -519,6 +519,7 @@ impl IndexClause {
             match (*(*ri).clause.cast::<pg_sys::Node>()).type_ {
                 pg_sys::NodeTag::T_OpExpr => Self::from_opexpr(root, ri, ioi),
                 pg_sys::NodeTag::T_FuncExpr => Self::from_funcexpr(root, ri, ioi),
+                pg_sys::NodeTag::T_ScalarArrayOpExpr => Self::from_saop(ri, ioi),
                 _ => None,
             }
         }
@@ -569,6 +570,42 @@ impl IndexClause {
                     {
                         return Some(iclause);
                     }
+                }
+            }
+            None
+        }
+    }
+
+    /// Mirrors core's `match_saopclause_to_indexcol`: `key = ANY(array)` answers from the
+    /// index when the array is a pseudoconstant. `ALL` is rejected because the index
+    /// cannot answer a conjunction over the array in one scan, and there is no commuted
+    /// form to try because the array can only be the right operand.
+    unsafe fn from_saop(
+        ri: *mut pg_sys::RestrictInfo,
+        ioi: *mut pg_sys::IndexOptInfo,
+    ) -> Option<Self> {
+        unsafe {
+            let saop = (*ri).clause.cast::<pg_sys::ScalarArrayOpExpr>();
+            if !(*saop).useOr {
+                return None;
+            }
+            let args = PgList::<pg_sys::Node>::from_pg((*saop).args);
+            if args.len() != 2 {
+                return None;
+            }
+            let (leftop, rightop) = (
+                strip_relabel(args.get_ptr(0)?),
+                strip_relabel(args.get_ptr(1)?),
+            );
+            if !is_pseudoconstant(rightop) {
+                return None;
+            }
+
+            for indexcol in 0..(*ioi).nkeycolumns {
+                if pg_sys::match_index_to_operand(leftop, indexcol, ioi)
+                    && Self::direct_match_ok((*saop).opno, (*saop).inputcollid, indexcol, ioi)
+                {
+                    return Some(Self::direct(ri, ri, indexcol));
                 }
             }
             None

--- a/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
+++ b/pg_search/src/postgres/customscan/bitmap_intersection/planning.rs
@@ -541,21 +541,11 @@ impl IndexClause {
             );
 
             for indexcol in 0..(*ioi).nkeycolumns {
-                let opfamily = *(*ioi).opfamily.add(indexcol as usize);
-                // The direct opfamily arms require the index collation to match the operator's
-                // input collation, or the index answers under different comparison semantics
-                // and its bitmap can miss valid rows.
-                let idxcoll = *(*ioi).indexcollations.add(indexcol as usize);
-                let collation_ok =
-                    idxcoll == pg_sys::InvalidOid || idxcoll == (*opexpr).inputcollid;
-
                 if pg_sys::match_index_to_operand(leftop, indexcol, ioi)
                     && is_pseudoconstant(rightop)
                 {
-                    if collation_ok && pg_sys::op_in_opfamily((*opexpr).opno, opfamily) {
-                        let mut indexquals = PgList::<pg_sys::RestrictInfo>::new();
-                        indexquals.push(ri);
-                        return Some(Self::new(ri, indexquals, false, indexcol));
+                    if Self::direct_match_ok((*opexpr).opno, (*opexpr).inputcollid, indexcol, ioi) {
+                        return Some(Self::direct(ri, ri, indexcol));
                     }
                     if let Some(iclause) =
                         Self::from_support_function(root, ri, (*opexpr).opfuncid, 0, indexcol, ioi)
@@ -568,13 +558,11 @@ impl IndexClause {
                     && is_pseudoconstant(leftop)
                 {
                     let comm_op = pg_sys::get_commutator((*opexpr).opno);
-                    if collation_ok
-                        && comm_op != pg_sys::InvalidOid
-                        && pg_sys::op_in_opfamily(comm_op, opfamily)
+                    if comm_op != pg_sys::InvalidOid
+                        && Self::direct_match_ok(comm_op, (*opexpr).inputcollid, indexcol, ioi)
                     {
-                        let mut indexquals = PgList::<pg_sys::RestrictInfo>::new();
-                        indexquals.push(pg_sys::commute_restrictinfo(ri, comm_op));
-                        return Some(Self::new(ri, indexquals, false, indexcol));
+                        let commuted = pg_sys::commute_restrictinfo(ri, comm_op);
+                        return Some(Self::direct(ri, commuted, indexcol));
                     }
                     if let Some(iclause) =
                         Self::from_support_function(root, ri, (*opexpr).opfuncid, 1, indexcol, ioi)
@@ -584,6 +572,38 @@ impl IndexClause {
                 }
             }
             None
+        }
+    }
+
+    /// Gates every direct (non support function) match must clear: the operator belongs
+    /// to the index column's opfamily, and the index collation matches the operator's
+    /// input collation. Without the collation check the index answers under different
+    /// comparison semantics and its bitmap can miss valid rows.
+    unsafe fn direct_match_ok(
+        opno: pg_sys::Oid,
+        inputcollid: pg_sys::Oid,
+        indexcol: i32,
+        ioi: *mut pg_sys::IndexOptInfo,
+    ) -> bool {
+        unsafe {
+            let idxcoll = *(*ioi).indexcollations.add(indexcol as usize);
+            let collation_ok = idxcoll == pg_sys::InvalidOid || idxcoll == inputcollid;
+            collation_ok && pg_sys::op_in_opfamily(opno, *(*ioi).opfamily.add(indexcol as usize))
+        }
+    }
+
+    /// The `IndexClause` for a cleared direct match. `indexqual` is what the index AM
+    /// evaluates: the clause itself, or its commuted form when the key is the right
+    /// operand.
+    unsafe fn direct(
+        ri: *mut pg_sys::RestrictInfo,
+        indexqual: *mut pg_sys::RestrictInfo,
+        indexcol: i32,
+    ) -> Self {
+        unsafe {
+            let mut indexquals = PgList::<pg_sys::RestrictInfo>::new();
+            indexquals.push(indexqual);
+            Self::new(ri, indexquals, false, indexcol)
         }
     }
 

--- a/pg_search/tests/pg_regress/expected/bitmap_intersection.out
+++ b/pg_search/tests/pg_regress/expected/bitmap_intersection.out
@@ -324,6 +324,36 @@ WHERE description === 'cardiology'
 (1 row)
 
 CREATE INDEX providers_service_area ON providers USING gist (service_area);
+-- ANY over a constant array: exact membership proves the clause, same as a direct
+-- btree equality match.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM providers
+WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')
+ORDER BY id LIMIT 5;
+                                                                                                                                                                      QUERY PLAN                                                                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on providers
+         Table: providers
+         Index: providers_paradedb
+         Bitmap Intersection: providers_specialty
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id asc
+            TopK Limit: 5
+         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[],"recheck_filters":[{"heap_filter":"(specialty = ANY ('{specialty13,specialty14}'::text[]))"}],"uses_tid_bitmap":true,"bitmap_consumer_id":0}}]}}
+         ->  Bitmap Index Scan on providers_specialty
+               Index Cond: (specialty = ANY ('{specialty13,specialty14}'::text[]))
+(12 rows)
+
+SELECT count(*) AS saop_count FROM (
+    SELECT id FROM providers
+    WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')) q;
+ saop_count 
+------------
+        400
+(1 row)
+
 -- Multicolumn index: quals come out in index-column order, not WHERE order.
 CREATE INDEX providers_loc_area ON providers USING gist (location, service_area);
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -556,6 +586,33 @@ SELECT count(*) AS not_count FROM (
       9919
 (1 row)
 
+-- ALL over an array: the index cannot answer a conjunction over every element in one
+-- scan, so it stays a heap filter. Results match plain heap filtering.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM providers
+WHERE description === 'cardiology' AND specialty = ALL('{specialty13,specialty13}')
+ORDER BY id LIMIT 5;
+                                                                                                                                     QUERY PLAN                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on providers
+         Table: providers
+         Index: providers_paradedb
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id asc
+            TopK Limit: 5
+         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[{"heap_filter":"(specialty = ALL ('{specialty13,specialty13}'::text[]))"}]}}]}}
+(9 rows)
+
+SELECT count(*) AS saop_all_count FROM (
+    SELECT id FROM providers
+    WHERE description === 'cardiology' AND specialty = ALL('{specialty13,specialty13}')) q;
+ saop_all_count 
+----------------
+            200
+(1 row)
+
 -- Cost gate: an unselective bitmap is not worth building.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM providers
@@ -774,32 +831,6 @@ ORDER BY id LIMIT 5;
             TopK Limit: 5
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}},{"boolean":{"should":[{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(location <@ '<(20,20),3>'::circle)"}]}},{"heap_filter":{"indexed_query":"all","always_filters":[{"heap_filter":"(location <@ '<(80,80),3>'::circle)"}]}}]}}]}}
 (9 rows)
-
--- TODO ScalarArrayOpExpr: = ANY could use the btree; today it stays a heap filter.
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT id FROM providers
-WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')
-ORDER BY id LIMIT 5;
-                                                                                                                                     QUERY PLAN                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit
-   ->  Custom Scan (ParadeDB Base Scan) on providers
-         Table: providers
-         Index: providers_paradedb
-         Exec Method: TopKScanExecState
-         Scores: false
-            TopK Order By: id asc
-            TopK Limit: 5
-         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"term":{"field":"description","value":"cardiology"}}}}]}},"always_filters":[{"heap_filter":"(specialty = ANY ('{specialty13,specialty14}'::text[]))"}]}}]}}
-(9 rows)
-
-SELECT count(*) AS saop_count FROM (
-    SELECT id FROM providers
-    WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')) q;
- saop_count 
-------------
-        400
-(1 row)
 
 DROP TABLE providers CASCADE;
 RESET paradedb.enable_filter_pushdown;

--- a/pg_search/tests/pg_regress/sql/bitmap_intersection.sql
+++ b/pg_search/tests/pg_regress/sql/bitmap_intersection.sql
@@ -146,6 +146,16 @@ WHERE description === 'cardiology'
   AND service_area && circle(point(50, 50), 1);
 CREATE INDEX providers_service_area ON providers USING gist (service_area);
 
+-- ANY over a constant array: exact membership proves the clause, same as a direct
+-- btree equality match.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM providers
+WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')
+ORDER BY id LIMIT 5;
+SELECT count(*) AS saop_count FROM (
+    SELECT id FROM providers
+    WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')) q;
+
 -- Multicolumn index: quals come out in index-column order, not WHERE order.
 CREATE INDEX providers_loc_area ON providers USING gist (location, service_area);
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -250,6 +260,16 @@ SELECT count(*) AS not_count FROM (
     WHERE description === 'cardiology'
       AND NOT (location <@ circle(point(50, 50), 5))) q;
 
+-- ALL over an array: the index cannot answer a conjunction over every element in one
+-- scan, so it stays a heap filter. Results match plain heap filtering.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM providers
+WHERE description === 'cardiology' AND specialty = ALL('{specialty13,specialty13}')
+ORDER BY id LIMIT 5;
+SELECT count(*) AS saop_all_count FROM (
+    SELECT id FROM providers
+    WHERE description === 'cardiology' AND specialty = ALL('{specialty13,specialty13}')) q;
+
 -- Cost gate: an unselective bitmap is not worth building.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id FROM providers
@@ -344,15 +364,6 @@ SELECT id FROM providers
 WHERE description === 'cardiology'
   AND (location <@ circle(point(20, 20), 3) OR location <@ circle(point(80, 80), 3))
 ORDER BY id LIMIT 5;
-
--- TODO ScalarArrayOpExpr: = ANY could use the btree; today it stays a heap filter.
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT id FROM providers
-WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')
-ORDER BY id LIMIT 5;
-SELECT count(*) AS saop_count FROM (
-    SELECT id FROM providers
-    WHERE description === 'cardiology' AND specialty = ANY('{specialty13,specialty14}')) q;
 
 DROP TABLE providers CASCADE;
 RESET paradedb.enable_filter_pushdown;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6091

## What

`IndexClause::from_clause` dispatched only `OpExpr` and `FuncExpr`, so `col = ANY(ARRAY[...])` stayed a heap filter even when a btree could answer it. Adds a `from_saop` arm.

## Why

Follow-up to #6088. The array membership is exactly what the index answers, so the bitmap rejects non-matching rows before the heap fetch and the filter drops to a recheck.

## How

`from_saop` mirrors core's `match_saopclause_to_indexcol`: `ANY` only, index key as the left operand, a pseudoconstant array on the right, then the collation and opfamily gates. `ALL` is refused because one index scan cannot answer a conjunction over every element, and there is no commuted form to try since the array can only be the right operand.

Those gates and the `IndexClause` construction were previously written out once per branch in `from_opexpr`. A preparatory commit extracts them into `direct_match_ok` and `direct`, which both existing branches and the new arm now share.

## Tests

The `TODO ScalarArrayOpExpr` shape moves into the supported section: it harvests `providers_specialty` and its filter becomes a recheck, with `saop_count` unchanged at 400. `ALL` is added as a refusal alongside it.

`cargo pgrx regress pg18` 333/333.
