### PR TITLE
Vector scan telemetry and read-only diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "cascade"
 version = "0.1.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "fht",
  "grid-plane",
@@ -3083,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "fht"
 version = "0.1.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "grid-plane"
 version = "0.1.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "quant-model",
 ]
@@ -4988,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "quant-model"
 version = "0.1.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -6631,7 +6631,7 @@ checksum = "6057adedbec913419c92996f395ba69931acbd50b7d56955394cd3f7bedbfa45"
 [[package]]
 name = "sign-plane"
 version = "0.1.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "quant-model",
 ]
@@ -7177,7 +7177,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7237,7 +7237,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "bitpacking",
 ]
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7260,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7305,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7355,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=17289c11bd9c3cdf9402aa463a913d7572cf5f2d#17289c11bd9c3cdf9402aa463a913d7572cf5f2d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d9daef11bf972a6ef7f6ced99654ee06182b5397#d9daef11bf972a6ef7f6ced99654ee06182b5397"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ pgrx-tests = "=0.19.2"
 
 # Keep the Git revisions for `tantivy`, `tantivy-common`, and the crates.io
 # patches in sync.
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "17289c11bd9c3cdf9402aa463a913d7572cf5f2d", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "d9daef11bf972a6ef7f6ced99654ee06182b5397", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -78,12 +78,12 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
   "stemmer",
   "stopwords",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-common", rev = "17289c11bd9c3cdf9402aa463a913d7572cf5f2d" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-common", rev = "d9daef11bf972a6ef7f6ced99654ee06182b5397" }
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-common", rev = "17289c11bd9c3cdf9402aa463a913d7572cf5f2d" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "17289c11bd9c3cdf9402aa463a913d7572cf5f2d" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-common", rev = "d9daef11bf972a6ef7f6ced99654ee06182b5397" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "d9daef11bf972a6ef7f6ced99654ee06182b5397" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -133,7 +133,8 @@
                         "pages": [
                           "documentation/vector/overview",
                           "documentation/vector/querying",
-                          "documentation/vector/tuning"
+                          "documentation/vector/tuning",
+                          "documentation/vector/diagnosing-quantized-indexes"
                         ]
                       },
                       {

--- a/docs/documentation/vector/diagnosing-quantized-indexes.mdx
+++ b/docs/documentation/vector/diagnosing-quantized-indexes.mdx
@@ -1,0 +1,81 @@
+---
+title: Diagnosing Quantized Vector Indexes
+description: Check whether quantized vector estimates match your data
+canonical: https://www.paradedb.com/docs/documentation/vector/diagnosing-quantized-indexes
+---
+
+Quantization stores compact codes beside full-precision vectors. During a scan, ParadeDB filters candidates using per-row error bars, then reranks the surviving candidates exactly.
+
+## Inspect the Index
+
+Use `paradedb.vector_info` to see whether a vector field is quantized and which bit-width schedule it uses:
+
+```sql
+SELECT vector_field, quantized, layers, bytes_per_row, format
+FROM paradedb.vector_info('search_idx', 'embedding');
+```
+
+`layers` lists the bit width of each quantization layer in scoring order. Vector fields with at least 64 dimensions use `[1, 1]` quantization by default; lower-dimensional fields remain unquantized. Set `"quantization": false` in a field's `vector_fields` configuration to disable quantization explicitly. An unquantized field reports `quantized = false` and `NULL` for `layers`, `bytes_per_row`, and `format`. The other `vector_info` columns continue to describe the field's segments and cluster layout.
+
+## Measure the Estimator
+
+No query sample is needed for the first check:
+
+```sql
+SELECT *
+FROM paradedb.vector_estimator_info('search_idx', 'embedding');
+```
+
+Example output:
+
+```text
+ depth | bias  | spread | sample_rows | query_count | query_source
+-------+-------+--------+-------------+-------------+--------------
+     1 |  0.04 |   1.03 |        1000 |         100 | held_out
+     2 | -0.01 |   0.99 |        1000 |         100 | held_out
+```
+
+With no query argument, the function samples stored vectors as pseudo-queries and reports `query_source = 'held_out'`. For a stronger check, pass 50–256 representative real queries. This is recommended when the query distribution differs from the indexed corpus, such as short queries against long passages or cross-modal queries:
+
+```sql
+SELECT *
+FROM paradedb.vector_estimator_info(
+    'search_idx',
+    'embedding',
+    ARRAY(
+        SELECT embedding
+        FROM representative_queries
+        ORDER BY id
+        LIMIT 100
+    )
+);
+```
+
+Provided queries report `query_source = 'provided'`. The function accepts at most 256 queries.
+
+| Measurement | Interpretation                                                                                                                                                                                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bias`      | `0` means the estimator is centered. A healthy reading has \|bias\| ≤ `0.3`. A larger magnitude indicates systematic mis-scoring for these queries and creates recall risk at the candidate filter.                                                                      |
+| `spread`    | `1.0` means the error model is exact. A value below `1.0` is conservative: it is safe but may do slightly more work. A healthy reading is at most `1.15`; above that, the safety margin no longer covers the observed error and recall may drop at high probe fractions. |
+
+## What the Measurement Covers
+
+`vector_estimator_info` measures the honesty of the per-row estimator over an un-routed sample. It compares production quantized estimates with exact full-precision scores at every layer depth. It does not run a search: routing, candidate boundaries, reranking, and top-K are not involved. It therefore does not measure search recall; measuring recall requires queries with known ground-truth neighbors.
+
+It reads the current snapshot, excludes deleted rows, selects samples deterministically, and writes nothing. The same index state and query input produce the same result.
+
+The work is approximately 1,000 sampled rows times the query count for every layer depth. Expect seconds on a warm index, and do not call it for individual search requests.
+
+## When to Run It
+
+Run the diagnostic:
+
+- after the initial index build;
+- after a bulk load from a different data source;
+- when vector recall appears incorrect.
+
+## Respond to an Unhealthy Reading
+
+Raise `paradedb.vector_cluster_max_probe` so the scan considers more clusters, or rebuild the index with a quantization schedule that keeps more bits. There is no calibration knob, by design.
+
+This function tells you whether the index is accurate on your data; it never changes how the index behaves.

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-Zn8zlwo7fo/ac3HnrL+M6pP1AZEa1B63sppsvXVTYJI=";
+  cargoHash = "sha256-1NRuzxdJ1xyWVxqo1sQRqs4KBiTxg6Y14NFWiguxZkk=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/unreleased/6071.vector_estimator_info.sql
+++ b/pg_search/sql/unreleased/6071.vector_estimator_info.sql
@@ -1,0 +1,21 @@
+-- The extension control file fixes the installation schema to `paradedb`.
+
+CREATE FUNCTION paradedb.vector_estimator_info(
+    index regclass,
+    field text,
+    queries vector[] DEFAULT NULL
+) RETURNS TABLE(
+    depth integer,
+    bias real,
+    spread real,
+    sample_rows integer,
+    query_count integer,
+    query_source text
+)
+STABLE PARALLEL UNSAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'vector_estimator_info_internal_wrapper';
+
+DROP FUNCTION IF EXISTS vector_info(index regclass, field text);
+
+CREATE OR REPLACE FUNCTION vector_info(index regclass, field text) RETURNS TABLE(segno text, vector_field text, vector_format text, vector_num_vectors pg_catalog."numeric", vector_num_centroids pg_catalog."numeric", vector_min_cluster_size pg_catalog."numeric", vector_max_cluster_size pg_catalog."numeric", vector_avg_cluster_size pg_catalog.float8, vector_empty_clusters pg_catalog."numeric", vector_total_rows pg_catalog."numeric", quantized bool, layers pg_catalog.int4[], bytes_per_row pg_catalog.int4, format pg_catalog.int4) AS 'MODULE_PATHNAME', 'vector_info_wrapper' LANGUAGE c STRICT;

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -17,6 +17,7 @@
 
 use crate::api::FieldName;
 use crate::api::{HashMap, HashSet};
+use crate::index::directory::utils::load_index_settings;
 use crate::index::fast_fields_helper::FFType;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
@@ -30,7 +31,7 @@ use crate::postgres::utils::{item_pointer_to_u64, u64_to_item_pointer};
 use crate::query::SearchQueryInput;
 use crate::query::pdb_query::pdb as pdb_query;
 use crate::schema::{IndexRecordOption, SearchFieldType};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use pgrx::JsonB;
 use pgrx::PgRelation;
 use pgrx::datum::DatumWithOid;
@@ -389,9 +390,7 @@ fn index_info(
 /// explicitly rather than only the first one an index happens to carry. `segno`
 /// aligns with [`index_info`]'s so the two can be joined.
 ///
-/// The cluster columns are IVF-only (`NULL` for flat segments). `*_cluster_size`
-/// and `vector_total_memberships` count posting rows, so under replication their
-/// totals exceed `vector_num_vectors`, which counts distinct docs.
+/// The cluster columns are IVF-only (`NULL` for flat segments).
 #[allow(clippy::type_complexity)]
 #[pg_extern]
 fn vector_info(
@@ -410,7 +409,11 @@ fn vector_info(
             name!(vector_max_cluster_size, Option<AnyNumeric>),
             name!(vector_avg_cluster_size, Option<f64>),
             name!(vector_empty_clusters, Option<AnyNumeric>),
-            name!(vector_total_memberships, Option<AnyNumeric>),
+            name!(vector_total_rows, Option<AnyNumeric>),
+            name!(quantized, bool),
+            name!(layers, Option<Vec<i32>>),
+            name!(bytes_per_row, Option<i32>),
+            name!(format, Option<i32>),
         ),
     >,
 > {
@@ -431,6 +434,7 @@ fn vector_info(
             continue;
         }
         let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)?;
+        let settings = load_index_settings(&index)?;
         let resolved = search_reader
             .schema()
             .fields()
@@ -445,15 +449,34 @@ fn vector_info(
         let Some(vector_field) = resolved else {
             anyhow::bail!("`{field}` is not a vector field of the index");
         };
+        let quantization = settings
+            .as_ref()
+            .into_iter()
+            .flat_map(|settings| &settings.vector_quantization)
+            .find(|config| config.field == field);
+        let quantized = quantization.is_some();
+        let layers = quantization.map(|config| {
+            config
+                .layers
+                .iter()
+                .map(|layer| i32::from(layer.bits))
+                .collect()
+        });
+        let bytes_per_row = quantization
+            .map(|config| i32::try_from(config.bytes_per_row()))
+            .transpose()
+            .context("quantized bytes per row exceeds SQL integer range")?;
+        let format = quantization
+            .map(|config| i32::try_from(config.format_version))
+            .transpose()
+            .context("quantization format exceeds SQL integer range")?;
         for segment_reader in search_reader.segment_readers() {
             let vector_index = segment_reader.vector_index(vector_field)?;
             let Some(info) = vector_index.info() else {
                 continue;
             };
             let cluster_stats = info.cluster_stats.as_ref();
-            // Summed here rather than read off `cluster_stats`, which only
-            // carries the average: this keeps the membership total exact.
-            let total_memberships = vector_index
+            let total_rows = vector_index
                 .cluster_sizes()
                 .map(|sizes| sizes.iter().map(|size| *size as u64).sum::<u64>());
             rows.push((
@@ -470,7 +493,11 @@ fn vector_info(
                 cluster_stats.map(|stats| stats.max_cluster_size.into()),
                 cluster_stats.map(|stats| stats.avg_cluster_size),
                 cluster_stats.map(|stats| stats.empty_clusters.into()),
-                total_memberships.map(Into::into),
+                total_rows.map(Into::into),
+                quantized,
+                layers.clone(),
+                bytes_per_row,
+                format,
             ));
         }
     }

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -25,6 +25,7 @@ pub mod config;
 pub mod operator;
 pub mod tokenize;
 pub mod tokenizers;
+mod vector;
 pub mod version;
 pub mod window_aggregate;
 

--- a/pg_search/src/api/vector.rs
+++ b/pg_search/src/api/vector.rs
@@ -1,0 +1,1231 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! SQL diagnostics for vector quantization.
+
+use crate::index::directory::utils::load_index_settings;
+use crate::index::mvcc::MvccSatisfies;
+use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::catalog::is_pgvector_oid;
+use crate::postgres::is_bm25_index;
+use crate::postgres::rel::PgSearchRelation;
+use crate::vector::PgVector;
+use anyhow::{Context, Result, bail, ensure};
+#[cfg(feature = "pg_test")]
+use pgrx::JsonB;
+use pgrx::prelude::*;
+use pgrx::{AnyArray, PgRelation, Spi, pg_sys};
+use tantivy::schema::FieldType;
+#[cfg(feature = "pg_test")]
+use tantivy::vector::{
+    VectorAuditMoments, VectorErrorAuditMeasurements, VectorErrorConeAuditMeasurements,
+};
+use tantivy::vector::{VectorEstimatorMeasurements, VectorEstimatorQuery, VectorEstimatorSource};
+
+const MAX_ESTIMATOR_QUERIES: usize = 256;
+const ESTIMATOR_SAMPLE_ROWS: usize = 1_000;
+const HELD_OUT_ESTIMATOR_QUERIES: usize = 100;
+#[cfg(feature = "pg_test")]
+const EXACT_E_AUDIT_QUERY_COUNT: usize = 100;
+#[cfg(feature = "pg_test")]
+const EXACT_E_AUDIT_SAMPLE_ROWS: usize = 1_000;
+#[cfg(feature = "pg_test")]
+const REAL_QUERY_EXACT_E_PROTOCOL: &str = "REAL_QUERY_EXACT_E_BQ4";
+#[cfg(feature = "pg_test")]
+const HELD_OUT_EXACT_E_PROTOCOL: &str = "HELD_OUT_EXACT_E_BQ4";
+#[cfg(feature = "pg_test")]
+const EXACT_E_CONE_PROTOCOL: &str = "ALL_CLUSTERS_EXACT_E_CONE_K10_KAPPA2";
+
+#[cfg(feature = "pg_test")]
+type ExactEAuditRow = (
+    name!(source, String),
+    name!(protocol, String),
+    name!(depth, i32),
+    name!(bias, f32),
+    name!(spread, f32),
+    name!(sample_count, i32),
+    name!(residual_norm_squared_sample_count, i64),
+    name!(residual_norm_squared_mean, f64),
+    name!(residual_norm_squared_spread, f64),
+    name!(residual_norm_squared_p95, f64),
+    name!(residual_norm_squared_p99, f64),
+    name!(residual_norm_squared_max, f64),
+    name!(gamma_sample_count, i64),
+    name!(gamma_mean, f64),
+    name!(gamma_spread, f64),
+    name!(gamma_p95, f64),
+    name!(gamma_p99, f64),
+    name!(gamma_max, f64),
+    name!(corrected_error_ratio_sample_count, i64),
+    name!(corrected_error_ratio_mean, f64),
+    name!(corrected_error_ratio_spread, f64),
+    name!(corrected_error_ratio_p95, f64),
+    name!(corrected_error_ratio_p99, f64),
+    name!(corrected_error_ratio_max, f64),
+    name!(sigma_sample_count, i64),
+    name!(sigma_mean, f64),
+    name!(sigma_spread, f64),
+    name!(sigma_p95, f64),
+    name!(sigma_p99, f64),
+    name!(sigma_max, f64),
+    name!(gamma_diagnostics, JsonB),
+);
+
+#[cfg(feature = "pg_test")]
+type ExactEConeAuditRow = (
+    name!(protocol, String),
+    name!(depth, i32),
+    name!(kappa, f32),
+    name!(query_count, i32),
+    name!(top_k, i32),
+    name!(mean_scored_rows, f64),
+    name!(mean_survivor_rows, f64),
+    name!(mean_survivor_docs, f64),
+    name!(mean_survivor_fraction, f64),
+    name!(mean_candidate_recall, f64),
+    name!(min_candidate_recall, f64),
+    name!(queries_with_miss, i32),
+    name!(final_depth, bool),
+);
+
+/// Measures normalized quantized-estimator errors without running a search.
+///
+/// The work is approximately 1,000 sampled rows times the query count per depth. It takes seconds
+/// on a warm index and is not intended for per-request use.
+///
+/// # Errors
+///
+/// Returns an error for invalid input, a partitioned parent, or unavailable quantized storage.
+#[allow(clippy::type_complexity)]
+#[pg_extern(
+    name = "vector_estimator_info",
+    sql = r#"
+CREATE FUNCTION paradedb.vector_estimator_info(
+    index regclass,
+    field text,
+    queries vector[] DEFAULT NULL
+) RETURNS TABLE(
+    depth integer,
+    bias real,
+    spread real,
+    sample_rows integer,
+    query_count integer,
+    query_source text
+)
+STABLE PARALLEL UNSAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'vector_estimator_info_internal_wrapper';
+"#
+)]
+fn vector_estimator_info_internal(
+    index: Option<PgRelation>,
+    field: Option<String>,
+    queries: Option<AnyArray>,
+) -> Result<
+    TableIterator<
+        'static,
+        (
+            name!(depth, i32),
+            name!(bias, f32),
+            name!(spread, f32),
+            name!(sample_rows, i32),
+            name!(query_count, i32),
+            name!(query_source, String),
+        ),
+    >,
+> {
+    let index = index.context("index must not be NULL")?;
+    let field = field.context("field must not be NULL")?;
+    let index_oid = index.oid();
+    drop(index);
+
+    let index = PgSearchRelation::with_lock(index_oid, pg_sys::AccessShareLock as _);
+    reject_partitioned_index(index.oid(), PartitionedIndexOperation::EstimatorInfo)?;
+    ensure!(
+        unsafe { pg_sys::get_rel_relkind(index.oid()) as u8 } == pg_sys::RELKIND_INDEX
+            && is_bm25_index(&index),
+        "vector_estimator_info requires a ParadeDB index"
+    );
+    ensure!(index.is_usable(), "index is not valid, ready, and live");
+
+    let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)?;
+    let vector_field = search_reader
+        .schema()
+        .tantivy_schema()
+        .get_field(&field)
+        .with_context(|| format!("field {field:?} is absent from the index schema"))?;
+    let field_entry = search_reader
+        .schema()
+        .tantivy_schema()
+        .get_field_entry(vector_field);
+    let FieldType::Vector(vector_options) = field_entry.field_type() else {
+        bail!("field {field:?} is not a vector field");
+    };
+    let settings = load_index_settings(&index)?;
+    let quantization = settings
+        .as_ref()
+        .into_iter()
+        .flat_map(|settings| &settings.vector_quantization)
+        .find(|config| config.field == field)
+        .with_context(|| format!("field is not quantized; nothing to diagnose: {field:?}"))?;
+    let expected_dim = quantization.dim;
+    ensure!(
+        vector_options.dim() == expected_dim,
+        "quantization dimension {expected_dim} for field {field:?} does not match schema dimension {}",
+        vector_options.dim()
+    );
+
+    let membership_rows = search_reader
+        .segment_readers()
+        .iter()
+        .map(|segment_reader| -> Result<u64> {
+            let vector_index = segment_reader.vector_index(vector_field)?;
+            u64::try_from(vector_index.live_posting_row_count(segment_reader.alive_bitset()))
+                .context("live posting-membership row count exceeds u64")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let sample_rows = allocate_sample_rows(&membership_rows, ESTIMATOR_SAMPLE_ROWS);
+    ensure!(
+        sample_rows.iter().sum::<usize>() != 0,
+        "field {field:?} has no visible IVF posting-membership rows to diagnose"
+    );
+
+    let (queries, query_source) = match queries {
+        Some(queries) => {
+            let queries = decode_estimator_queries(&queries, expected_dim)?
+                .into_iter()
+                .map(|values| VectorEstimatorQuery {
+                    values,
+                    excluded_doc_id: None,
+                })
+                .map(|query| (None, query))
+                .collect();
+            (queries, "provided")
+        }
+        None => (
+            sample_held_out_queries(&search_reader, vector_field)?,
+            "held_out",
+        ),
+    };
+    let estimator_source = match query_source {
+        "provided" => VectorEstimatorSource::Provided,
+        "held_out" => VectorEstimatorSource::HeldOut,
+        _ => unreachable!("query source is selected above"),
+    };
+
+    let mut measurements: Option<VectorEstimatorMeasurements> = None;
+    for (target_segment, (segment_reader, &segment_sample_rows)) in search_reader
+        .segment_readers()
+        .iter()
+        .zip(&sample_rows)
+        .enumerate()
+    {
+        if segment_sample_rows == 0 {
+            continue;
+        }
+        let vector_index = segment_reader.vector_index(vector_field)?;
+        let target_queries = queries
+            .iter()
+            .map(|(origin_segment, query)| VectorEstimatorQuery {
+                values: query.values.clone(),
+                excluded_doc_id: (*origin_segment == Some(target_segment))
+                    .then_some(query.excluded_doc_id)
+                    .flatten(),
+            })
+            .collect::<Vec<_>>();
+        let segment_measurements = vector_index
+            .measure_estimator_queries(
+                estimator_source,
+                &target_queries,
+                segment_sample_rows,
+                segment_reader.alive_bitset(),
+            )?
+            .with_context(|| {
+                format!(
+                    "visible segment {} has sampled rows but no quantized storage for field {field:?}",
+                    segment_reader.segment_id().short_uuid_string()
+                )
+            })?;
+        merge_estimator_measurements(&mut measurements, segment_measurements)?;
+    }
+
+    let measurements =
+        measurements.context("no visible quantized segment supplied estimator measurements")?;
+    ensure!(
+        measurements.source() == estimator_source,
+        "estimator measurement source does not match the requested query source"
+    );
+    let sample_rows = i32::try_from(measurements.sample_rows())
+        .context("estimator sample-row count exceeds SQL integer range")?;
+    let query_count = i32::try_from(measurements.query_count())
+        .context("estimator query count exceeds SQL integer range")?;
+    let rows = measurements
+        .aggregate()
+        .iter()
+        .enumerate()
+        .map(|(depth, moments)| {
+            Ok((
+                i32::try_from(depth + 1).context("quantization depth exceeds SQL integer range")?,
+                measurement_to_real(
+                    moments
+                        .bias()
+                        .context("estimator depth has no finite bias measurements")?,
+                    "estimator bias",
+                )?,
+                measurement_to_real(
+                    moments
+                        .spread()
+                        .context("estimator depth has no finite spread measurements")?,
+                    "estimator spread",
+                )?,
+                sample_rows,
+                query_count,
+                query_source.to_string(),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(TableIterator::new(rows))
+}
+
+/// Measures exact-error estimator diagnostics without changing index settings.
+///
+/// # Errors
+///
+/// Returns an error for invalid input or unavailable quantized storage.
+#[cfg(feature = "pg_test")]
+#[pg_extern(
+    name = "vector_error_audit",
+    sql = r#"
+CREATE FUNCTION paradedb.vector_error_audit(
+    index regclass,
+    field text,
+    queries vector[]
+) RETURNS TABLE(
+    source text,
+    protocol text,
+    depth integer,
+    bias real,
+    spread real,
+    sample_count integer,
+    residual_norm_squared_sample_count bigint,
+    residual_norm_squared_mean double precision,
+    residual_norm_squared_spread double precision,
+    residual_norm_squared_p95 double precision,
+    residual_norm_squared_p99 double precision,
+    residual_norm_squared_max double precision,
+    gamma_sample_count bigint,
+    gamma_mean double precision,
+    gamma_spread double precision,
+    gamma_p95 double precision,
+    gamma_p99 double precision,
+    gamma_max double precision,
+    corrected_error_ratio_sample_count bigint,
+    corrected_error_ratio_mean double precision,
+    corrected_error_ratio_spread double precision,
+    corrected_error_ratio_p95 double precision,
+    corrected_error_ratio_p99 double precision,
+    corrected_error_ratio_max double precision,
+    sigma_sample_count bigint,
+    sigma_mean double precision,
+    sigma_spread double precision,
+    sigma_p95 double precision,
+    sigma_p99 double precision,
+    sigma_max double precision,
+    gamma_diagnostics jsonb
+)
+STABLE PARALLEL UNSAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'vector_error_audit_internal_wrapper';
+"#
+)]
+fn vector_error_audit_internal(
+    index: Option<PgRelation>,
+    field: Option<String>,
+    queries: Option<AnyArray>,
+) -> Result<
+    TableIterator<
+        'static,
+        (
+            name!(source, String),
+            name!(protocol, String),
+            name!(depth, i32),
+            name!(bias, f32),
+            name!(spread, f32),
+            name!(sample_count, i32),
+            name!(residual_norm_squared_sample_count, i64),
+            name!(residual_norm_squared_mean, f64),
+            name!(residual_norm_squared_spread, f64),
+            name!(residual_norm_squared_p95, f64),
+            name!(residual_norm_squared_p99, f64),
+            name!(residual_norm_squared_max, f64),
+            name!(gamma_sample_count, i64),
+            name!(gamma_mean, f64),
+            name!(gamma_spread, f64),
+            name!(gamma_p95, f64),
+            name!(gamma_p99, f64),
+            name!(gamma_max, f64),
+            name!(corrected_error_ratio_sample_count, i64),
+            name!(corrected_error_ratio_mean, f64),
+            name!(corrected_error_ratio_spread, f64),
+            name!(corrected_error_ratio_p95, f64),
+            name!(corrected_error_ratio_p99, f64),
+            name!(corrected_error_ratio_max, f64),
+            name!(sigma_sample_count, i64),
+            name!(sigma_mean, f64),
+            name!(sigma_spread, f64),
+            name!(sigma_p95, f64),
+            name!(sigma_p99, f64),
+            name!(sigma_max, f64),
+            name!(gamma_diagnostics, JsonB),
+        ),
+    >,
+> {
+    let index = index.context("index must not be NULL")?;
+    let field = field.context("field must not be NULL")?;
+    let queries = queries.context("queries must not be NULL")?;
+    let index_oid = index.oid();
+    reject_partitioned_index(index_oid, PartitionedIndexOperation::ErrorAudit)?;
+    drop(index);
+
+    let index = PgSearchRelation::with_lock(index_oid, pg_sys::AccessShareLock as _);
+    ensure!(
+        unsafe { pg_sys::get_rel_relkind(index.oid()) as u8 } == pg_sys::RELKIND_INDEX,
+        "vector error audit requires a physical index"
+    );
+    ensure!(
+        is_bm25_index(&index),
+        "vector error audit requires a ParadeDB index"
+    );
+    ensure!(index.is_usable(), "index is not valid, ready, and live");
+
+    let settings = load_index_settings(&index)?
+        .with_context(|| format!("index {:?} has no persisted settings", index.name()))?;
+    let quantization = settings
+        .vector_quantization
+        .iter()
+        .find(|config| config.field == field)
+        .with_context(|| format!("field {field:?} is not configured for quantization"))?;
+    let expected_dim = quantization.dim;
+    let (external_queries, input_query_count) = decode_queries_capped(
+        &queries,
+        expected_dim,
+        EXACT_E_AUDIT_QUERY_COUNT,
+        "error audit",
+    )?;
+    ensure!(
+        input_query_count >= EXACT_E_AUDIT_QUERY_COUNT,
+        "vector error audit requires at least {EXACT_E_AUDIT_QUERY_COUNT} queries; received {input_query_count}"
+    );
+    debug_assert_eq!(external_queries.len(), EXACT_E_AUDIT_QUERY_COUNT);
+    let external_queries = external_queries
+        .into_iter()
+        .map(|values| VectorEstimatorQuery {
+            values,
+            excluded_doc_id: None,
+        })
+        .collect::<Vec<_>>();
+
+    let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)?;
+    let vector_field = search_reader
+        .schema()
+        .tantivy_schema()
+        .get_field(&field)
+        .with_context(|| format!("field {field:?} is absent from the index schema"))?;
+    let field_entry = search_reader
+        .schema()
+        .tantivy_schema()
+        .get_field_entry(vector_field);
+    let FieldType::Vector(vector_options) = field_entry.field_type() else {
+        bail!("field {field:?} is not a vector field");
+    };
+    ensure!(
+        vector_options.dim() == expected_dim,
+        "quantization dimension {expected_dim} for field {field:?} does not match schema dimension {}",
+        vector_options.dim()
+    );
+
+    let membership_rows = search_reader
+        .segment_readers()
+        .iter()
+        .map(|segment_reader| -> Result<u64> {
+            let vector_index = segment_reader.vector_index(vector_field)?;
+            u64::try_from(vector_index.live_posting_row_count(segment_reader.alive_bitset()))
+                .context("live posting-membership row count exceeds u64")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let sample_rows = allocate_sample_rows(&membership_rows, EXACT_E_AUDIT_SAMPLE_ROWS);
+    ensure!(
+        sample_rows.iter().sum::<usize>() != 0,
+        "field {field:?} has no visible IVF posting-membership rows to audit"
+    );
+
+    let distinct_rows = search_reader
+        .segment_readers()
+        .iter()
+        .map(|segment_reader| -> Result<u64> {
+            let vector_index = segment_reader.vector_index(vector_field)?;
+            u64::try_from(vector_index.live_distinct_vector_count(segment_reader.alive_bitset()))
+                .context("live distinct-vector count exceeds u64")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let held_out_allocations = allocate_sample_rows(&distinct_rows, EXACT_E_AUDIT_QUERY_COUNT);
+    ensure!(
+        held_out_allocations.iter().sum::<usize>() == EXACT_E_AUDIT_QUERY_COUNT,
+        "vector error audit requires at least {EXACT_E_AUDIT_QUERY_COUNT} visible stored vectors; found {}",
+        distinct_rows.iter().sum::<u64>()
+    );
+
+    let mut held_out_queries = Vec::with_capacity(EXACT_E_AUDIT_QUERY_COUNT);
+    for (origin_segment, (segment_reader, &segment_query_count)) in search_reader
+        .segment_readers()
+        .iter()
+        .zip(&held_out_allocations)
+        .enumerate()
+    {
+        if segment_query_count == 0 {
+            continue;
+        }
+        let vector_index = segment_reader.vector_index(vector_field)?;
+        let segment_queries = vector_index
+            .sample_estimator_pseudo_queries(segment_query_count, segment_reader.alive_bitset())?
+            .with_context(|| {
+                format!(
+                    "visible segment {} has vectors but no quantized storage for field {field:?}",
+                    segment_reader.segment_id().short_uuid_string()
+                )
+            })?;
+        ensure!(
+            segment_queries.len() == segment_query_count,
+            "segment {} returned {} held-out exact-E queries; expected {segment_query_count}",
+            segment_reader.segment_id().short_uuid_string(),
+            segment_queries.len()
+        );
+        ensure!(
+            segment_queries
+                .iter()
+                .all(|query| query.excluded_doc_id.is_some()),
+            "held-out exact-E queries from their origin segment must carry a document id"
+        );
+        held_out_queries.extend(
+            segment_queries
+                .into_iter()
+                .map(|query| (origin_segment, query)),
+        );
+    }
+    debug_assert_eq!(held_out_queries.len(), EXACT_E_AUDIT_QUERY_COUNT);
+
+    let mut real_measurements: Option<VectorErrorAuditMeasurements> = None;
+    let mut held_out_measurements: Option<VectorErrorAuditMeasurements> = None;
+    for (target_segment, (segment_reader, &segment_sample_rows)) in search_reader
+        .segment_readers()
+        .iter()
+        .zip(&sample_rows)
+        .enumerate()
+    {
+        if segment_sample_rows == 0 {
+            continue;
+        }
+        let vector_index = segment_reader.vector_index(vector_field)?;
+        let segment_real = vector_index
+            .audit_error_queries(
+                VectorEstimatorSource::Provided,
+                &external_queries,
+                segment_sample_rows,
+                segment_reader.alive_bitset(),
+            )?
+            .with_context(|| {
+                format!(
+                    "visible segment {} has sampled rows but no quantized storage for field {field:?}",
+                    segment_reader.segment_id().short_uuid_string()
+                )
+            })?;
+        merge_exact_e_measurements(&mut real_measurements, segment_real)?;
+
+        let segment_held_out_queries = held_out_queries
+            .iter()
+            .map(|(origin_segment, query)| VectorEstimatorQuery {
+                values: query.values.clone(),
+                excluded_doc_id: if *origin_segment == target_segment {
+                    query.excluded_doc_id
+                } else {
+                    None
+                },
+            })
+            .collect::<Vec<_>>();
+        let segment_held_out = vector_index
+            .audit_error_queries(
+                VectorEstimatorSource::HeldOut,
+                &segment_held_out_queries,
+                segment_sample_rows,
+                segment_reader.alive_bitset(),
+            )?
+            .with_context(|| {
+                format!(
+                    "visible segment {} has sampled rows but no quantized storage for field {field:?}",
+                    segment_reader.segment_id().short_uuid_string()
+                )
+            })?;
+        merge_exact_e_measurements(&mut held_out_measurements, segment_held_out)?;
+    }
+
+    let held_out_measurements = held_out_measurements
+        .context("no visible quantized segment supplied held-out exact-E measurements")?;
+    let real_measurements = real_measurements
+        .context("no visible quantized segment supplied real-query exact-E measurements")?;
+    let mut rows = exact_e_audit_rows(&held_out_measurements)?;
+    rows.extend(exact_e_audit_rows(&real_measurements)?);
+    Ok(TableIterator::new(rows))
+}
+
+/// Measures confidence-band survivor behavior across all clusters.
+///
+/// # Errors
+///
+/// Returns an error for invalid input or unavailable quantized storage.
+#[cfg(feature = "pg_test")]
+#[pg_extern(
+    name = "vector_error_cone_audit",
+    sql = r#"
+CREATE FUNCTION paradedb.vector_error_cone_audit(
+    index regclass,
+    field text,
+    queries vector[]
+) RETURNS TABLE(
+    protocol text,
+    depth integer,
+    kappa real,
+    query_count integer,
+    top_k integer,
+    mean_scored_rows double precision,
+    mean_survivor_rows double precision,
+    mean_survivor_docs double precision,
+    mean_survivor_fraction double precision,
+    mean_candidate_recall double precision,
+    min_candidate_recall double precision,
+    queries_with_miss integer,
+    final_depth boolean
+)
+STABLE PARALLEL UNSAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'vector_error_cone_audit_internal_wrapper';
+"#
+)]
+fn vector_error_cone_audit_internal(
+    index: Option<PgRelation>,
+    field: Option<String>,
+    queries: Option<AnyArray>,
+) -> Result<
+    TableIterator<
+        'static,
+        (
+            name!(protocol, String),
+            name!(depth, i32),
+            name!(kappa, f32),
+            name!(query_count, i32),
+            name!(top_k, i32),
+            name!(mean_scored_rows, f64),
+            name!(mean_survivor_rows, f64),
+            name!(mean_survivor_docs, f64),
+            name!(mean_survivor_fraction, f64),
+            name!(mean_candidate_recall, f64),
+            name!(min_candidate_recall, f64),
+            name!(queries_with_miss, i32),
+            name!(final_depth, bool),
+        ),
+    >,
+> {
+    let index = index.context("index must not be NULL")?;
+    let field = field.context("field must not be NULL")?;
+    let queries = queries.context("queries must not be NULL")?;
+    let index_oid = index.oid();
+    reject_partitioned_index(index_oid, PartitionedIndexOperation::ErrorConeAudit)?;
+    drop(index);
+
+    let index = PgSearchRelation::with_lock(index_oid, pg_sys::AccessShareLock as _);
+    ensure!(
+        unsafe { pg_sys::get_rel_relkind(index.oid()) as u8 } == pg_sys::RELKIND_INDEX,
+        "vector error cone audit requires a physical index"
+    );
+    ensure!(
+        is_bm25_index(&index),
+        "vector error cone audit requires a ParadeDB index"
+    );
+    ensure!(index.is_usable(), "index is not valid, ready, and live");
+
+    let settings = load_index_settings(&index)?
+        .with_context(|| format!("index {:?} has no persisted settings", index.name()))?;
+    let quantization = settings
+        .vector_quantization
+        .iter()
+        .find(|config| config.field == field)
+        .with_context(|| format!("field {field:?} is not configured for quantization"))?;
+    let (external_queries, input_query_count) = decode_queries_capped(
+        &queries,
+        quantization.dim,
+        EXACT_E_AUDIT_QUERY_COUNT,
+        "error cone audit",
+    )?;
+    ensure!(
+        input_query_count == EXACT_E_AUDIT_QUERY_COUNT,
+        "vector error cone audit requires exactly {EXACT_E_AUDIT_QUERY_COUNT} queries; received {input_query_count}"
+    );
+    let external_queries = external_queries
+        .into_iter()
+        .map(|values| VectorEstimatorQuery {
+            values,
+            excluded_doc_id: None,
+        })
+        .collect::<Vec<_>>();
+
+    let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)?;
+    let vector_field = search_reader
+        .schema()
+        .tantivy_schema()
+        .get_field(&field)
+        .with_context(|| format!("field {field:?} is absent from the index schema"))?;
+    let field_entry = search_reader
+        .schema()
+        .tantivy_schema()
+        .get_field_entry(vector_field);
+    let FieldType::Vector(vector_options) = field_entry.field_type() else {
+        bail!("field {field:?} is not a vector field");
+    };
+    ensure!(
+        vector_options.dim() == quantization.dim,
+        "quantization dimension {} for field {field:?} does not match schema dimension {}",
+        quantization.dim,
+        vector_options.dim()
+    );
+
+    let mut vector_segments = Vec::new();
+    for segment_reader in search_reader.segment_readers() {
+        let vector_index = segment_reader.vector_index(vector_field)?;
+        if vector_index.num_vectors() != 0 {
+            vector_segments.push((segment_reader, vector_index));
+        }
+    }
+    ensure!(
+        vector_segments.len() == 1,
+        "vector error cone audit requires exactly one non-empty vector segment; found {}",
+        vector_segments.len()
+    );
+    let (segment_reader, vector_index) = vector_segments.into_iter().next().unwrap();
+    let measurements = vector_index
+        .audit_error_cone(&external_queries, segment_reader.alive_bitset())?
+        .with_context(|| {
+            format!(
+                "segment {} has no quantized IVF storage for field {field:?}",
+                segment_reader.segment_id().short_uuid_string()
+            )
+        })?;
+    Ok(TableIterator::new(exact_e_cone_audit_rows(&measurements)?))
+}
+
+#[derive(Clone, Copy)]
+enum PartitionedIndexOperation {
+    EstimatorInfo,
+    #[cfg(feature = "pg_test")]
+    ErrorAudit,
+    #[cfg(feature = "pg_test")]
+    ErrorConeAudit,
+}
+
+fn reject_partitioned_index(
+    index_oid: pg_sys::Oid,
+    operation: PartitionedIndexOperation,
+) -> Result<()> {
+    let relkind = unsafe { pg_sys::get_rel_relkind(index_oid) as u8 };
+    if relkind != pg_sys::RELKIND_PARTITIONED_INDEX {
+        return Ok(());
+    }
+
+    let children = Spi::get_one_with_args::<Vec<String>>(
+        "SELECT ARRAY_AGG(c.oid::regclass::text ORDER BY c.oid::regclass::text) \
+         FROM pg_inherits i \
+         JOIN pg_class c ON c.oid = i.inhrelid \
+         WHERE i.inhparent = $1",
+        &[index_oid.into()],
+    )?
+    .unwrap_or_default();
+    let children = if children.is_empty() {
+        "<none>".to_string()
+    } else {
+        children.join(", ")
+    };
+    let (message, hint) = match operation {
+        PartitionedIndexOperation::EstimatorInfo => (
+            format!(
+                "cannot diagnose a partitioned index parent; child indexes: {children}; run vector_estimator_info for each child index"
+            ),
+            "run paradedb.vector_estimator_info for each child index individually".to_string(),
+        ),
+        #[cfg(feature = "pg_test")]
+        PartitionedIndexOperation::ErrorAudit => (
+            format!(
+                "cannot audit exact-E on a partitioned index parent; child indexes: {children}; audit each child index individually with paradedb.vector_error_audit"
+            ),
+            "call paradedb.vector_error_audit for each child index individually".to_string(),
+        ),
+        #[cfg(feature = "pg_test")]
+        PartitionedIndexOperation::ErrorConeAudit => (
+            format!(
+                "cannot audit an exact-E cone on a partitioned index parent; child indexes: {children}; audit each child index individually with paradedb.vector_error_cone_audit"
+            ),
+            "call paradedb.vector_error_cone_audit for each child index individually".to_string(),
+        ),
+    };
+    pgrx::pg_sys::panic::ErrorReport::new(
+        pgrx::PgSqlErrorCode::ERRCODE_WRONG_OBJECT_TYPE,
+        message,
+        pgrx::function_name!(),
+    )
+    .set_hint(hint)
+    .report(pgrx::PgLogLevel::ERROR);
+    Ok(())
+}
+
+fn decode_estimator_queries(queries: &AnyArray, expected_dim: usize) -> Result<Vec<Vec<f32>>> {
+    let (queries, input_count) =
+        decode_queries_capped(queries, expected_dim, MAX_ESTIMATOR_QUERIES, "estimator")?;
+    ensure!(
+        input_count <= MAX_ESTIMATOR_QUERIES,
+        "vector_estimator_info accepts at most {MAX_ESTIMATOR_QUERIES} queries; received {input_count}"
+    );
+    Ok(queries)
+}
+
+fn decode_queries_capped(
+    queries: &AnyArray,
+    expected_dim: usize,
+    max_queries: usize,
+    query_kind: &str,
+) -> Result<(Vec<Vec<f32>>, usize)> {
+    let element_oid = unsafe { pg_sys::get_element_type(queries.oid()) };
+    ensure!(
+        is_pgvector_oid(element_oid),
+        "queries must have type vector[]"
+    );
+
+    let array = pgrx::AnyArray::into::<pgrx::Array<pg_sys::Datum>>(queries)
+        .context("could not decode queries vector[]")?;
+    let mut decoded = Vec::new();
+    let mut input_count = 0usize;
+    for (query_idx, datum) in array.iter().enumerate() {
+        let datum =
+            datum.with_context(|| format!("{query_kind} query {} is NULL", query_idx + 1))?;
+        // SAFETY: `element_oid` is pgvector and `datum` is non-null.
+        let query = unsafe { PgVector::from_polymorphic_datum(datum, false, element_oid) }
+            .with_context(|| format!("could not decode {query_kind} query {}", query_idx + 1))?;
+        ensure!(
+            query.0.len() == expected_dim,
+            "{query_kind} query {} has dimension {}; expected {expected_dim}",
+            query_idx + 1,
+            query.0.len()
+        );
+        input_count += 1;
+        if decoded.len() < max_queries {
+            decoded.push(query.0);
+        }
+    }
+    ensure!(input_count != 0, "queries must not be empty");
+    Ok((decoded, input_count))
+}
+
+fn allocate_sample_rows(membership_rows: &[u64], requested: usize) -> Vec<usize> {
+    let total = membership_rows
+        .iter()
+        .copied()
+        .map(u128::from)
+        .sum::<u128>();
+    if total == 0 || requested == 0 {
+        return vec![0; membership_rows.len()];
+    }
+    let target = total.min(requested as u128) as usize;
+    let mut allocations = Vec::with_capacity(membership_rows.len());
+    let mut remainders = Vec::with_capacity(membership_rows.len());
+    let mut allocated = 0usize;
+    for (segment, &rows) in membership_rows.iter().enumerate() {
+        let numerator = u128::from(rows) * target as u128;
+        let floor = (numerator / total) as usize;
+        allocations.push(floor);
+        remainders.push((numerator % total, segment));
+        allocated += floor;
+    }
+
+    remainders.sort_unstable_by(
+        |(left_remainder, left_segment), (right_remainder, right_segment)| {
+            right_remainder
+                .cmp(left_remainder)
+                .then_with(|| left_segment.cmp(right_segment))
+        },
+    );
+    for &(_, segment) in remainders.iter().take(target - allocated) {
+        allocations[segment] += 1;
+    }
+    allocations
+}
+
+fn sample_held_out_queries(
+    search_reader: &SearchIndexReader,
+    vector_field: tantivy::schema::Field,
+) -> Result<Vec<(Option<usize>, VectorEstimatorQuery)>> {
+    let distinct_rows = search_reader
+        .segment_readers()
+        .iter()
+        .map(|segment_reader| -> Result<u64> {
+            let vector_index = segment_reader.vector_index(vector_field)?;
+            u64::try_from(vector_index.live_distinct_vector_count(segment_reader.alive_bitset()))
+                .context("live distinct-vector count exceeds u64")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let allocations = allocate_sample_rows(&distinct_rows, HELD_OUT_ESTIMATOR_QUERIES);
+    let total_distinct = distinct_rows.iter().sum::<u64>();
+    ensure!(
+        allocations.iter().sum::<usize>() == HELD_OUT_ESTIMATOR_QUERIES,
+        "vector_estimator_info held-out mode requires at least {HELD_OUT_ESTIMATOR_QUERIES} visible stored vectors; found {total_distinct}"
+    );
+
+    let mut queries = Vec::with_capacity(HELD_OUT_ESTIMATOR_QUERIES);
+    for (origin_segment, (segment_reader, &query_count)) in search_reader
+        .segment_readers()
+        .iter()
+        .zip(&allocations)
+        .enumerate()
+    {
+        if query_count == 0 {
+            continue;
+        }
+        let vector_index = segment_reader.vector_index(vector_field)?;
+        let segment_queries = vector_index
+            .sample_estimator_pseudo_queries(query_count, segment_reader.alive_bitset())?
+            .with_context(|| {
+                format!(
+                    "visible segment {} has vectors but no quantized storage",
+                    segment_reader.segment_id().short_uuid_string()
+                )
+            })?;
+        ensure!(
+            segment_queries.len() == query_count,
+            "segment {} returned {} held-out estimator queries; expected {query_count}",
+            segment_reader.segment_id().short_uuid_string(),
+            segment_queries.len()
+        );
+        ensure!(
+            segment_queries
+                .iter()
+                .all(|query| query.excluded_doc_id.is_some()),
+            "held-out estimator queries must carry their source document id"
+        );
+        queries.extend(
+            segment_queries
+                .into_iter()
+                .map(|query| (Some(origin_segment), query)),
+        );
+    }
+    ensure!(
+        queries.len() == HELD_OUT_ESTIMATOR_QUERIES,
+        "held-out estimator query count does not match its deterministic allocation"
+    );
+    Ok(queries)
+}
+
+fn merge_estimator_measurements(
+    aggregate: &mut Option<VectorEstimatorMeasurements>,
+    segment: VectorEstimatorMeasurements,
+) -> Result<()> {
+    if let Some(aggregate) = aggregate {
+        aggregate.merge(&segment)?;
+    } else {
+        *aggregate = Some(segment);
+    }
+    Ok(())
+}
+
+fn measurement_to_real(value: f64, label: &str) -> Result<f32> {
+    ensure!(
+        value.is_finite() && value.abs() <= f64::from(f32::MAX),
+        "{label} is outside the SQL real range"
+    );
+    Ok(value as f32)
+}
+
+#[cfg(feature = "pg_test")]
+fn calibration_source_label(source: VectorEstimatorSource) -> &'static str {
+    match source {
+        VectorEstimatorSource::HeldOut => "held_out",
+        VectorEstimatorSource::Provided => "real_query",
+    }
+}
+
+#[cfg(feature = "pg_test")]
+fn exact_e_protocol(source: VectorEstimatorSource) -> &'static str {
+    match source {
+        VectorEstimatorSource::HeldOut => HELD_OUT_EXACT_E_PROTOCOL,
+        VectorEstimatorSource::Provided => REAL_QUERY_EXACT_E_PROTOCOL,
+    }
+}
+
+#[cfg(feature = "pg_test")]
+fn merge_exact_e_measurements(
+    aggregate: &mut Option<VectorErrorAuditMeasurements>,
+    segment: VectorErrorAuditMeasurements,
+) -> Result<()> {
+    if let Some(aggregate) = aggregate {
+        aggregate.merge(&segment)?;
+    } else {
+        *aggregate = Some(segment);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "pg_test")]
+#[derive(Clone, Copy)]
+struct DistributionSummary {
+    sample_count: i64,
+    mean: f64,
+    spread: f64,
+    min: f64,
+    p50: f64,
+    p95: f64,
+    p99: f64,
+    max: f64,
+}
+
+#[cfg(feature = "pg_test")]
+fn moment_count(moments: &VectorAuditMoments, label: &str) -> Result<i64> {
+    i64::try_from(moments.sample_count)
+        .with_context(|| format!("{label} sample count exceeds SQL bigint range"))
+}
+
+#[cfg(feature = "pg_test")]
+fn distribution_summary(moments: &VectorAuditMoments, label: &str) -> Result<DistributionSummary> {
+    Ok(DistributionSummary {
+        sample_count: moment_count(moments, label)?,
+        mean: moments
+            .mean()
+            .with_context(|| format!("{label} has no finite measurements"))?,
+        spread: moments
+            .spread()
+            .with_context(|| format!("{label} has no finite measurements"))?,
+        min: (moments.sample_count != 0)
+            .then_some(moments.min)
+            .with_context(|| format!("{label} has no finite measurements"))?,
+        p50: moments
+            .p50()
+            .with_context(|| format!("{label} has no finite measurements"))?,
+        p95: moments
+            .p95()
+            .with_context(|| format!("{label} has no finite measurements"))?,
+        p99: moments
+            .p99()
+            .with_context(|| format!("{label} has no finite measurements"))?,
+        max: (moments.sample_count != 0)
+            .then_some(moments.max)
+            .with_context(|| format!("{label} has no finite measurements"))?,
+    })
+}
+
+#[cfg(feature = "pg_test")]
+fn gamma_diagnostics_json(
+    diagnostics: &tantivy::vector::VectorErrorDepthMeasurements,
+) -> Result<JsonB> {
+    let stored = distribution_summary(&diagnostics.stored_gamma, "stored gamma")?;
+    let raw = distribution_summary(&diagnostics.raw_gamma, "raw gamma")?;
+    let round_trip = &diagnostics.gamma_round_trip_band_error;
+    Ok(JsonB(serde_json::json!({
+        "stored": {
+            "sample_count": stored.sample_count,
+            "mean": stored.mean,
+            "spread": stored.spread,
+            "min": stored.min,
+            "p50": stored.p50,
+            "p95": stored.p95,
+            "p99": stored.p99,
+            "max": stored.max,
+        },
+        "raw": {
+            "sample_count": raw.sample_count,
+            "mean": raw.mean,
+            "spread": raw.spread,
+            "min": raw.min,
+            "p50": raw.p50,
+            "p95": raw.p95,
+            "p99": raw.p99,
+            "max": raw.max,
+        },
+        "zero_scale_count": diagnostics.zero_scale_count,
+        "lower_clamp_count": diagnostics.gamma_lower_clamp_count,
+        "upper_clamp_count": diagnostics.gamma_upper_clamp_count,
+        "round_trip_band_error": {
+            "sample_count": moment_count(round_trip, "gamma round-trip band error")?,
+            "p99_abs": round_trip
+                .p99_abs()
+                .context("gamma round-trip band error has no finite measurements")?,
+            "max_abs": round_trip
+                .max_abs()
+                .context("gamma round-trip band error has no finite measurements")?,
+        },
+    })))
+}
+
+#[cfg(feature = "pg_test")]
+fn exact_e_audit_rows(measurements: &VectorErrorAuditMeasurements) -> Result<Vec<ExactEAuditRow>> {
+    let protocol = exact_e_protocol(measurements.source);
+    ensure!(
+        measurements.estimator.aggregate().len() == measurements.depths.len(),
+        "exact-E audit estimator and diagnostic depth counts differ"
+    );
+    let source = calibration_source_label(measurements.source);
+    measurements
+        .depths
+        .iter()
+        .zip(measurements.estimator.aggregate())
+        .enumerate()
+        .map(|(depth, (diagnostics, estimator))| {
+            let residual_norm_squared =
+                distribution_summary(&diagnostics.residual_norm_squared, "residual squared norm")?;
+            let gamma = distribution_summary(&diagnostics.stored_gamma, "stored gamma")?;
+            let corrected_error_ratio =
+                distribution_summary(&diagnostics.corrected_error_ratio, "corrected error ratio")?;
+            let sigma = distribution_summary(&diagnostics.sigma, "production sigma")?;
+            Ok((
+                source.to_string(),
+                protocol.to_string(),
+                i32::try_from(depth + 1).context("quantization depth exceeds SQL integer range")?,
+                measurement_to_real(
+                    estimator
+                        .bias()
+                        .context("exact-E audit depth has no bias measurements")?,
+                    "exact-E audit bias",
+                )?,
+                measurement_to_real(
+                    estimator
+                        .spread()
+                        .context("exact-E audit depth has no spread measurements")?,
+                    "exact-E audit spread",
+                )?,
+                i32::try_from(estimator.sample_count)
+                    .context("exact-E audit sample count exceeds SQL integer range")?,
+                residual_norm_squared.sample_count,
+                residual_norm_squared.mean,
+                residual_norm_squared.spread,
+                residual_norm_squared.p95,
+                residual_norm_squared.p99,
+                residual_norm_squared.max,
+                gamma.sample_count,
+                gamma.mean,
+                gamma.spread,
+                gamma.p95,
+                gamma.p99,
+                gamma.max,
+                corrected_error_ratio.sample_count,
+                corrected_error_ratio.mean,
+                corrected_error_ratio.spread,
+                corrected_error_ratio.p95,
+                corrected_error_ratio.p99,
+                corrected_error_ratio.max,
+                sigma.sample_count,
+                sigma.mean,
+                sigma.spread,
+                sigma.p95,
+                sigma.p99,
+                sigma.max,
+                gamma_diagnostics_json(diagnostics)?,
+            ))
+        })
+        .collect()
+}
+
+#[cfg(feature = "pg_test")]
+fn exact_e_cone_audit_rows(
+    measurements: &VectorErrorConeAuditMeasurements,
+) -> Result<Vec<ExactEConeAuditRow>> {
+    ensure!(
+        measurements.query_count != 0 && measurements.top_k != 0,
+        "exact-E cone audit returned an empty query or top-k protocol"
+    );
+    let depth_count = measurements.depths.len();
+    measurements
+        .depths
+        .iter()
+        .enumerate()
+        .map(|(depth, measurement)| {
+            let mean = |moments: &VectorAuditMoments, label: &str| {
+                moments
+                    .mean()
+                    .with_context(|| format!("exact-E cone {label} has no measurements"))
+            };
+            ensure!(
+                measurement.candidate_recall.sample_count == u64::from(measurements.query_count),
+                "exact-E cone depth {} measured {} queries; expected {}",
+                depth + 1,
+                measurement.candidate_recall.sample_count,
+                measurements.query_count
+            );
+            Ok((
+                EXACT_E_CONE_PROTOCOL.to_string(),
+                i32::try_from(depth + 1).context("exact-E cone depth exceeds SQL integer range")?,
+                measurement.kappa,
+                i32::try_from(measurements.query_count)
+                    .context("exact-E cone query count exceeds SQL integer range")?,
+                i32::try_from(measurements.top_k)
+                    .context("exact-E cone top-k exceeds SQL integer range")?,
+                mean(&measurement.scored_rows, "scored rows")?,
+                mean(&measurement.survivor_rows, "survivor rows")?,
+                mean(&measurement.survivor_docs, "survivor docs")?,
+                mean(&measurement.survivor_fraction, "survivor fraction")?,
+                mean(&measurement.candidate_recall, "candidate recall")?,
+                measurement.candidate_recall.min,
+                i32::try_from(measurement.queries_with_miss)
+                    .context("exact-E cone miss count exceeds SQL integer range")?,
+                depth + 1 == depth_count,
+            ))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::allocate_sample_rows;
+
+    #[test]
+    fn sample_row_allocation_handles_empty_inputs() {
+        assert_eq!(allocate_sample_rows(&[], 1_000), Vec::<usize>::new());
+        assert_eq!(allocate_sample_rows(&[0, 0], 1_000), vec![0, 0]);
+        assert_eq!(allocate_sample_rows(&[10, 20], 0), vec![0, 0]);
+    }
+
+    #[test]
+    fn sample_row_allocation_uses_every_row_below_the_cap() {
+        assert_eq!(allocate_sample_rows(&[2, 0, 3], 1_000), vec![2, 0, 3]);
+    }
+
+    #[test]
+    fn sample_row_allocation_breaks_equal_remainders_by_segment_order() {
+        assert_eq!(
+            allocate_sample_rows(&[1_000, 1_000, 1_000], 1_000),
+            vec![334, 333, 333]
+        );
+    }
+
+    #[test]
+    fn sample_row_allocation_is_proportional_and_exact() {
+        let allocations = allocate_sample_rows(&[1, 2, 7, 0], 6);
+        assert_eq!(allocations, vec![1, 1, 4, 0]);
+        assert_eq!(allocations.iter().sum::<usize>(), 6);
+    }
+}

--- a/pg_search/src/index/reader/io_stats.rs
+++ b/pg_search/src/index/reader/io_stats.rs
@@ -27,10 +27,10 @@
 #[cfg(feature = "io_stats")]
 mod imp {
     use pgrx::pg_sys;
-    use serde_json::json;
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::collections::BTreeMap;
     use tantivy::index::{SegmentComponent, SegmentId};
+    use tantivy::vector::current_vector_stage;
 
     #[derive(Debug, Default, Clone, Copy, serde::Serialize)]
     struct IoCounters {
@@ -38,28 +38,98 @@ mod imp {
         blks_read: u64,
     }
 
-    type SegmentIo = BTreeMap<String, IoCounters>;
+    #[derive(Debug, Default)]
+    struct SegmentIo {
+        components: BTreeMap<String, IoCounters>,
+        stages: BTreeMap<String, IoCounters>,
+        scan_init_components: BTreeMap<String, IoCounters>,
+    }
 
-    pub struct ScanInitGuard;
-
-    #[inline(always)]
-    pub fn begin_scan_init() -> ScanInitGuard {
-        ScanInitGuard
+    impl SegmentIo {
+        fn is_empty(&self) -> bool {
+            self.components.is_empty()
+        }
     }
 
     thread_local! {
         static CURRENT: RefCell<SegmentIo> = RefCell::default();
         static PER_SEGMENT: RefCell<Vec<(SegmentId, SegmentIo)>> = RefCell::default();
+        static PRE_SCAN_INIT: Cell<bool> = const { Cell::new(false) };
+        static PRESERVE_NEXT_RESET: Cell<bool> = const { Cell::new(false) };
+    }
+
+    pub struct ScanInitGuard {
+        hit0: i64,
+        read0: i64,
+    }
+
+    impl Drop for ScanInitGuard {
+        fn drop(&mut self) {
+            let (hit1, read1) = snapshot();
+            let total = IoCounters {
+                blks_hit: hit1.saturating_sub(self.hit0) as u64,
+                blks_read: read1.saturating_sub(self.read0) as u64,
+            };
+            CURRENT.with_borrow_mut(|current| {
+                let attributed = current.stages.get("scan_init").copied().unwrap_or_default();
+                let direct = IoCounters {
+                    blks_hit: total.blks_hit.saturating_sub(attributed.blks_hit),
+                    blks_read: total.blks_read.saturating_sub(attributed.blks_read),
+                };
+                let stage = current.stages.entry("scan_init".to_string()).or_default();
+                stage.blks_hit += direct.blks_hit;
+                stage.blks_read += direct.blks_read;
+                let component = current
+                    .scan_init_components
+                    .entry("executor".to_string())
+                    .or_default();
+                component.blks_hit += direct.blks_hit;
+                component.blks_read += direct.blks_read;
+            });
+            PRE_SCAN_INIT.set(false);
+            PRESERVE_NEXT_RESET.set(true);
+        }
+    }
+
+    /// Start the query-level reader-open window. The next collector reset is
+    /// suppressed so these counters join the first collected segment.
+    pub fn begin_scan_init() -> ScanInitGuard {
+        CURRENT.take();
+        PER_SEGMENT.take();
+        PRESERVE_NEXT_RESET.set(false);
+        PRE_SCAN_INIT.set(true);
+        let (hit0, read0) = snapshot();
+        ScanInitGuard { hit0, read0 }
     }
 
     pub fn record<R>(component: &SegmentComponent, read: impl FnOnce() -> R) -> R {
         let (hit0, read0) = snapshot();
         let result = read();
         let (hit1, read1) = snapshot();
+        let delta = IoCounters {
+            blks_hit: hit1.saturating_sub(hit0) as u64,
+            blks_read: read1.saturating_sub(read0) as u64,
+        };
         CURRENT.with_borrow_mut(|current| {
-            let slot = current.entry(component.to_string()).or_default();
-            slot.blks_hit += hit1.saturating_sub(hit0) as u64;
-            slot.blks_read += read1.saturating_sub(read0) as u64;
+            let component = component.to_string();
+            let slot = current.components.entry(component.clone()).or_default();
+            slot.blks_hit += delta.blks_hit;
+            slot.blks_read += delta.blks_read;
+            let stage = if PRE_SCAN_INIT.get() {
+                Some("scan_init".to_string())
+            } else {
+                current_vector_stage().name().map(Into::into)
+            };
+            if let Some(stage) = stage {
+                let stage_slot = current.stages.entry(stage.clone()).or_default();
+                stage_slot.blks_hit += delta.blks_hit;
+                stage_slot.blks_read += delta.blks_read;
+                if stage == "scan_init" {
+                    let component_slot = current.scan_init_components.entry(component).or_default();
+                    component_slot.blks_hit += delta.blks_hit;
+                    component_slot.blks_read += delta.blks_read;
+                }
+            }
         });
         result
     }
@@ -73,6 +143,9 @@ mod imp {
 
     /// Forget any counts from outside a segment-collection window.
     pub fn reset() {
+        if PRESERVE_NEXT_RESET.replace(false) {
+            return;
+        }
         CURRENT.take();
         PER_SEGMENT.take();
     }
@@ -91,7 +164,67 @@ mod imp {
                 continue;
             }
             if let Some(serde_json::Value::Object(map)) = segment_info.get_mut(&segment_id) {
-                map.insert("io".to_string(), json!(io));
+                let mut total = IoCounters::default();
+                for (component, counters) in io.components {
+                    total.blks_hit += counters.blks_hit;
+                    total.blks_read += counters.blks_read;
+                    let component = component
+                        .chars()
+                        .map(|character| {
+                            if character.is_ascii_alphanumeric() {
+                                character.to_ascii_lowercase()
+                            } else {
+                                '_'
+                            }
+                        })
+                        .collect::<String>();
+                    map.insert(
+                        format!("io_{component}_buffer_hits"),
+                        counters.blks_hit.into(),
+                    );
+                    map.insert(
+                        format!("io_{component}_buffer_reads"),
+                        counters.blks_read.into(),
+                    );
+                }
+                map.insert("buffer_hits".to_string(), total.blks_hit.into());
+                map.insert("buffer_reads".to_string(), total.blks_read.into());
+                map.insert(
+                    "blocks_fetched".to_string(),
+                    (total.blks_hit + total.blks_read).into(),
+                );
+                for (name, counters) in io.stages {
+                    map.insert(format!("{name}_buffer_hits"), counters.blks_hit.into());
+                    map.insert(format!("{name}_buffer_reads"), counters.blks_read.into());
+                    if name == "rerank_fetch" {
+                        map.insert("rerank_buffer_hits".to_string(), counters.blks_hit.into());
+                        map.insert("rerank_buffer_reads".to_string(), counters.blks_read.into());
+                        map.insert(
+                            "rerank_blocks_fetched".to_string(),
+                            (counters.blks_hit + counters.blks_read).into(),
+                        );
+                    }
+                }
+                for (component, counters) in io.scan_init_components {
+                    let component = component
+                        .chars()
+                        .map(|character| {
+                            if character.is_ascii_alphanumeric() {
+                                character.to_ascii_lowercase()
+                            } else {
+                                '_'
+                            }
+                        })
+                        .collect::<String>();
+                    map.insert(
+                        format!("scan_init_io_{component}_buffer_hits"),
+                        counters.blks_hit.into(),
+                    );
+                    map.insert(
+                        format!("scan_init_io_{component}_buffer_reads"),
+                        counters.blks_read.into(),
+                    );
+                }
             }
         }
     }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -123,6 +123,9 @@ impl BaseScan {
     ///    In this case, every worker executes the full scan independently using its own
     ///    transaction snapshot (`MvccSatisfies::Snapshot`).
     pub(crate) fn init_search_reader(state: &mut CustomScanStateWrapper<Self>) {
+        let wrapper_start = std::time::Instant::now();
+        let executor_scan_init_ns =
+            std::mem::take(&mut state.custom_state_mut().executor_scan_init_ns);
         let planstate = state.planstate();
         let expr_context = state.runtime_context;
         state
@@ -235,6 +238,15 @@ impl BaseScan {
         unsafe {
             inject_pdb_placeholders(state);
         }
+
+        let wrapper_ns = wrapper_start.elapsed().as_nanos() as u64;
+        let reader = state
+            .custom_state_mut()
+            .search_reader
+            .as_mut()
+            .expect("search reader was initialized above");
+        let wrapper_residual_ns = wrapper_ns.saturating_sub(reader.scan_init_ns());
+        reader.add_scan_init_ns(executor_scan_init_ns.saturating_add(wrapper_residual_ns));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -649,6 +661,24 @@ unsafe fn is_limit_pushdown_safe(
     (rel_is_single_or_partitioned || is_left_driven_lateral)
         && has_non_pushable_predicates(rel, quals).is_ok()
         && !classify_target_list_srf(root).is_unsafe()
+}
+
+fn finish_result_assembly_accounting(
+    state: &mut CustomScanStateWrapper<BaseScan>,
+    accounting: Option<(std::time::Instant, u64)>,
+) {
+    let Some((start, stages_before)) = accounting else {
+        return;
+    };
+    let stage_delta = state
+        .custom_state()
+        .telemetry
+        .stage_elapsed_ns()
+        .saturating_sub(stages_before);
+    state
+        .custom_state_mut()
+        .telemetry
+        .add_result_assembly_ns((start.elapsed().as_nanos() as u64).saturating_sub(stage_delta));
 }
 
 impl CustomScan for BaseScan {
@@ -1620,6 +1650,9 @@ impl CustomScan for BaseScan {
         estate: *mut pg_sys::EState,
         eflags: i32,
     ) {
+        let begin_start = std::time::Instant::now();
+        let explain_analyze = unsafe { (*estate).es_instrument != 0 };
+        state.custom_state_mut().explain_stage_accounting = explain_analyze;
         unsafe {
             // open the heap and index relations with the proper locks
             let rte = pg_sys::exec_rt_fetch(state.custom_state().execution_rti, estate);
@@ -1691,6 +1724,10 @@ impl CustomScan for BaseScan {
                 .init_expr_context(estate, planstate);
             state.runtime_context = state.csstate.ss.ps.ps_ExprContext;
         }
+        let begin_ns = begin_start.elapsed().as_nanos() as u64;
+        let custom_state = state.custom_state_mut();
+        custom_state.executor_scan_init_ns =
+            custom_state.executor_scan_init_ns.saturating_add(begin_ns);
     }
 
     fn rescan_custom_scan(state: &mut CustomScanStateWrapper<Self>) {
@@ -1713,17 +1750,25 @@ impl CustomScan for BaseScan {
 
     #[allow(clippy::blocks_in_conditions)]
     fn exec_custom_scan(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
+        let result_assembly_accounting = state.custom_state().explain_stage_accounting.then(|| {
+            (
+                std::time::Instant::now(),
+                state.custom_state().telemetry.stage_elapsed_ns(),
+            )
+        });
         if state.custom_state().search_reader.is_none() {
             Self::init_search_reader(state);
         }
 
         loop {
             let exec_method = state.custom_state_mut().exec_method_mut();
+            let next = exec_method.next(state.custom_state_mut());
 
             // get the next matching document from our search results and look for it in the heap
-            match exec_method.next(state.custom_state_mut()) {
+            match next {
                 // reached the end of the SearchResults
                 ExecState::Eof => {
+                    finish_result_assembly_accounting(state, result_assembly_accounting);
                     return std::ptr::null_mut();
                 }
 
@@ -1766,7 +1811,9 @@ impl CustomScan for BaseScan {
                             //
 
                             (*(*state.projection_info()).pi_exprContext).ecxt_scantuple = slot;
-                            return pg_sys::ExecProject(state.projection_info());
+                            let projected = pg_sys::ExecProject(state.projection_info());
+                            finish_result_assembly_accounting(state, result_assembly_accounting);
+                            return projected;
                         } else {
                             //
                             // we do need scores or snippets
@@ -1804,7 +1851,7 @@ impl CustomScan for BaseScan {
                             }
 
                             // finally, do the projection
-                            return per_tuple_context.switch_to(|_| {
+                            let projected = per_tuple_context.switch_to(|_| {
                                 // TODO: We go _back_ to the heap to get snippet information here
                                 // inside of `make_snippet` and `get_snippet_positions`. It's possible
                                 // that we could use a wider tuple slot to fetch the extra columns that
@@ -1828,12 +1875,15 @@ impl CustomScan for BaseScan {
                                 );
                                 pg_sys::ExecProject(proj_info)
                             });
+                            finish_result_assembly_accounting(state, result_assembly_accounting);
+                            return projected;
                         }
                     }
                 }
 
                 ExecState::Virtual { slot } => {
                     state.custom_state_mut().virtual_tuple_count += 1;
+                    finish_result_assembly_accounting(state, result_assembly_accounting);
                     return slot;
                 }
             }

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -62,6 +62,15 @@ pub struct BaseScanState {
     base_search_query_input: SearchQueryInput,
     search_query_input: SearchQueryInput,
     pub search_reader: Option<SearchIndexReader>,
+    /// Executor startup before `SearchIndexReader::open`; consumed into the
+    /// reader's flat `scan_init_ns` metric on first execution.
+    pub executor_scan_init_ns: u64,
+    /// End-to-end CustomScan execution interval used to assign only the
+    /// residual around named nested stages to result assembly.
+    /// Whether the current execution is collecting stage timings for
+    /// `EXPLAIN ANALYZE`.  Timed queries leave the executor delivery path
+    /// uninstrumented.
+    pub explain_stage_accounting: bool,
 
     pub targetlist_len: usize,
 

--- a/pg_search/src/postgres/customscan/basescan/telemetry.rs
+++ b/pg_search/src/postgres/customscan/basescan/telemetry.rs
@@ -118,6 +118,7 @@ impl ScanTelemetry {
                 let is_stage = matches!(
                     name.as_str(),
                     "scan_init_ns"
+                        | "non_vector_search_ns"
                         | "query_prep_ns"
                         | "routing_ns"
                         | "exact_scan_ns"
@@ -272,6 +273,23 @@ mod tests {
 
         assert_eq!(telemetry.segment_info()[&first]["layer0_scored"], 5);
         assert_eq!(telemetry.segment_info()[&second]["layer0_scored"], 8);
+    }
+
+    #[test]
+    fn stage_elapsed_includes_non_vector_search() {
+        let segment_id = SegmentId::from_bytes([1; 16]);
+        let mut telemetry = ScanTelemetry::default();
+        telemetry.accumulate_segment_info(segment_info(
+            segment_id,
+            json!({
+                "scan_init_ns": 10,
+                "non_vector_search_ns": 20,
+                "routing_ns": 30,
+                "layer0_scored": 100
+            }),
+        ));
+
+        assert_eq!(telemetry.stage_elapsed_ns(), 60);
     }
 
     #[test]


### PR DESCRIPTION
# Vector scan telemetry and read-only diagnostics

Instrumentation and diagnostics only; no scoring, build, or planning changes.

## Telemetry
`io_stats` gains two independent axes: per-component IO for every query type
(text components counted exactly as before, additively) and a per-stage overlay
that only the vector scan turns on — per-stage timings, `scan_init`,
`non_vector_search` (filter work inside the vector scan), and correct
aggregation of parallel-worker telemetry, under `EXPLAIN (ANALYZE, VERBOSE)`
with the `io_stats` feature.

> [!NOTE]
> **Text search is unchanged.** Text queries never acquire vector stage labels;
> the only addition visible to them is per-component IO rows.

## Diagnostics
- `paradedb.vector_info` gains `quantized`, `layers`, `bytes_per_row`, `format`.
- `paradedb.vector_estimator_info(index, field[, queries])` — read-only diagnostic
  reporting per-layer estimator bias and spread on indexed data (sampled
  pseudo-queries) or supplied `vector[]`. Deterministic, snapshot-aware,
  persists nothing.

> [!NOTE]
> This function tells you whether the index is accurate on your data; it never
> changes how the index behaves. There is no calibration knob, by design.

Docs: *Diagnosing Quantized Vector Indexes* (healthy ranges: |bias| ≤ 0.3,
spread ≤ 1.15; what to do with a bad reading). Schema fragment under
`pg_search/sql/unreleased/`.

> [!TIP]
> Read `io_stats.rs` → `customscan/basescan/*` → `api/vector.rs` →
> `api/admin.rs` → docs. Verify: EXPLAIN on a text query shows no vector stage
> keys; `vector_estimator_info` performs no writes; schema CI green.

Pins tantivy `d9daef11bf972a6ef7f6ced99654ee06182b5397`. Stack: 2/2 (ParadeDB), on top of #P1.
