### PR TITLE
fix: Add explicit limits to Docker auto-tuning

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -340,9 +340,9 @@ jobs:
           effective_cache_size = '1536MB'               # 75% of RAM
           maintenance_work_mem = '128MB'                # RAM / 16, capped at 2GB
           work_mem = '15MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
-          max_parallel_workers = '13'                   # CPUs * 5
+          max_parallel_workers = '13'                   # CPUs * 5, capped at 1024
           max_worker_processes = '21'                   # max_parallel_workers + 8
-          max_parallel_workers_per_gather = '1'         # CPUs / 2, at least 1
+          max_parallel_workers_per_gather = '1'         # CPUs / 2, between 1 and 128
           max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
           # End ParadeDB tuning recommendations
           EOF
@@ -366,9 +366,9 @@ jobs:
           effective_cache_size = '768MB'                # 75% of RAM
           maintenance_work_mem = '64MB'                 # RAM / 16, capped at 2GB
           work_mem = '15MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
-          max_parallel_workers = '5'                    # CPUs * 5
+          max_parallel_workers = '5'                    # CPUs * 5, capped at 1024
           max_worker_processes = '13'                   # max_parallel_workers + 8
-          max_parallel_workers_per_gather = '1'         # CPUs / 2, at least 1
+          max_parallel_workers_per_gather = '1'         # CPUs / 2, between 1 and 128
           max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
           # End ParadeDB tuning recommendations
           EOF
@@ -392,9 +392,9 @@ jobs:
           effective_cache_size = '6144MB'               # 75% of RAM
           maintenance_work_mem = '512MB'                # RAM / 16, capped at 2GB
           work_mem = '20MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
-          max_parallel_workers = '20'                   # CPUs * 5
+          max_parallel_workers = '20'                   # CPUs * 5, capped at 1024
           max_worker_processes = '28'                   # max_parallel_workers + 8
-          max_parallel_workers_per_gather = '2'         # CPUs / 2, at least 1
+          max_parallel_workers_per_gather = '2'         # CPUs / 2, between 1 and 128
           max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
           # End ParadeDB tuning recommendations
           EOF

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -337,7 +337,7 @@ jobs:
           # Begin ParadeDB tuning recommendations
           # Parameters based on auto-detected 2.7 CPUs and 2048MB RAM
           shared_buffers = '512MB'                      # 25% of RAM, capped at 16GB
-          effective_cache_size = '1536MB'               # 75% of RAM
+          effective_cache_size = '1536MB'               # 75% of RAM, capped at 16TB
           maintenance_work_mem = '128MB'                # RAM / 16, capped at 2GB
           work_mem = '15MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
           max_parallel_workers = '13'                   # CPUs * 5, capped at 1024
@@ -363,7 +363,7 @@ jobs:
           # Begin ParadeDB tuning recommendations
           # Parameters based on auto-detected 1 CPUs and 1024MB RAM
           shared_buffers = '256MB'                      # 25% of RAM, capped at 16GB
-          effective_cache_size = '768MB'                # 75% of RAM
+          effective_cache_size = '768MB'                # 75% of RAM, capped at 16TB
           maintenance_work_mem = '64MB'                 # RAM / 16, capped at 2GB
           work_mem = '15MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
           max_parallel_workers = '5'                    # CPUs * 5, capped at 1024
@@ -389,7 +389,7 @@ jobs:
           # Begin ParadeDB tuning recommendations
           # Parameters based on auto-detected 4 CPUs and 8192MB RAM
           shared_buffers = '2048MB'                     # 25% of RAM, capped at 16GB
-          effective_cache_size = '6144MB'               # 75% of RAM
+          effective_cache_size = '6144MB'               # 75% of RAM, capped at 16TB
           maintenance_work_mem = '512MB'                # RAM / 16, capped at 2GB
           work_mem = '20MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
           max_parallel_workers = '20'                   # CPUs * 5, capped at 1024

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -77,7 +77,7 @@ tune() {
   SHARED_BUFFERS_MB=$(awk "BEGIN {s=int($TOTAL_RAM_MB * 0.25); print (s > 16384 ? 16384 : s)}")
   MAX_CONNECTIONS=100 # This is the postgres default
   WORK_MEM_MB=$(awk "BEGIN {w=int(($TOTAL_RAM_MB - $SHARED_BUFFERS_MB) / ($MAX_CONNECTIONS * 3)); print (w < 15 ? 15 : w)}")
-  PARALLEL_WORKERS=$(awk "BEGIN {print int($CPU_COUNT * 5)}")
+  PARALLEL_WORKERS=$(awk "BEGIN {p=int($CPU_COUNT * 5); print (p > 1024 ? 1024 : p)}")
 
   echo "ParadeDB auto-tune: Writing configuration to $PGDATA/postgresql.conf"
   {
@@ -88,9 +88,9 @@ tune() {
     printf "%-45s # %s\n" "effective_cache_size = '$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")MB'" "75% of RAM"
     printf "%-45s # %s\n" "maintenance_work_mem = '$(awk "BEGIN {m=int($TOTAL_RAM_MB / 16); print (m > 2048 ? 2048 : m)}")MB'" "RAM / 16, capped at 2GB"
     printf "%-45s # %s\n" "work_mem = '${WORK_MEM_MB}MB'" "(RAM - shared_buffers) / (3 * max_connections), at least 15MB"
-    printf "%-45s # %s\n" "max_parallel_workers = '$PARALLEL_WORKERS'" "CPUs * 5"
+    printf "%-45s # %s\n" "max_parallel_workers = '$PARALLEL_WORKERS'" "CPUs * 5, capped at 1024"
     printf "%-45s # %s\n" "max_worker_processes = '$(awk "BEGIN {print int($PARALLEL_WORKERS + 8)}")'" "max_parallel_workers + 8"
-    printf "%-45s # %s\n" "max_parallel_workers_per_gather = '$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")'" "CPUs / 2, at least 1"
+    printf "%-45s # %s\n" "max_parallel_workers_per_gather = '$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p > 128 ? 128 : (p < 1 ? 1 : p))}")'" "CPUs / 2, between 1 and 128"
     printf "%-45s # %s\n" "max_parallel_maintenance_workers = '$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p > 8 ? 8 : (p < 2 ? 2 : p))}")'" "CPUs / 2, at least 2, at most 8"
     echo "# End ParadeDB tuning recommendations"
   } | tee -a "$PGDATA/postgresql.conf"

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -85,7 +85,7 @@ tune() {
     echo "# Begin ParadeDB tuning recommendations"
     echo "# Parameters based on auto-detected $CPU_COUNT CPUs and ${TOTAL_RAM_MB}MB RAM"
     printf "%-45s # %s\n" "shared_buffers = '${SHARED_BUFFERS_MB}MB'" "25% of RAM, capped at 16GB"
-    printf "%-45s # %s\n" "effective_cache_size = '$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")MB'" "75% of RAM"
+    printf "%-45s # %s\n" "effective_cache_size = '$(awk "BEGIN {e=int($TOTAL_RAM_MB * 0.75); print (e > 16777215 ? 16777215 : e)}")MB'" "75% of RAM, capped at 16TB"
     printf "%-45s # %s\n" "maintenance_work_mem = '$(awk "BEGIN {m=int($TOTAL_RAM_MB / 16); print (m > 2048 ? 2048 : m)}")MB'" "RAM / 16, capped at 2GB"
     printf "%-45s # %s\n" "work_mem = '${WORK_MEM_MB}MB'" "(RAM - shared_buffers) / (3 * max_connections), at least 15MB"
     printf "%-45s # %s\n" "max_parallel_workers = '$PARALLEL_WORKERS'" "CPUs * 5, capped at 1024"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6169

## What

The Docker image automatically tunes some important PG parameters on startup based on the CPU and memory available to it. A user running on a 256 core machine discovered that the max_parallel_worker count exceeds Postgres' limit of 1024. This PR adds explicit limits to max_parallel_workers, max_parallel_workers_per_gather, and effective_cache_size to prevent this.

## Why

## How

## Tests
