### PR TITLE
docs: remove beta disclaimer from 32+ column indexing

### DIFF
--- a/docs/documentation/indexing/indexing-composite.mdx
+++ b/docs/documentation/indexing/indexing-composite.mdx
@@ -4,6 +4,8 @@ description: Use composite types to index more than 32 columns
 canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-composite
 ---
 
+<Note>This feature is available in versions `0.22.0` and above.</Note>
+
 Postgres allows a maximum of 32 columns in an index definition, but because ParadeDB benefits from pushing filters and ranking signals into the ParadeDB index this can become a limitation.
 
 To index more than 32 columns in a single ParadeDB index,

--- a/docs/documentation/indexing/indexing-composite.mdx
+++ b/docs/documentation/indexing/indexing-composite.mdx
@@ -4,8 +4,6 @@ description: Use composite types to index more than 32 columns
 canonical: https://www.paradedb.com/docs/documentation/indexing/indexing-composite
 ---
 
-<Note>This is a beta feature available in versions `0.22.0` and above.</Note>
-
 Postgres allows a maximum of 32 columns in an index definition, but because ParadeDB benefits from pushing filters and ranking signals into the ParadeDB index this can become a limitation.
 
 To index more than 32 columns in a single ParadeDB index,


### PR DESCRIPTION
Composite-type indexing is no longer beta; drop the beta note from the 32+ column docs page.