### PR TITLE
Share pg_search toolchain setup across CI

### DIFF
--- a/.github/actions/setup-pg-search-build/action.yml
+++ b/.github/actions/setup-pg-search-build/action.yml
@@ -20,44 +20,13 @@ runs:
         pg_version: ${{ inputs.pg_version }}
         extra_packages: ${{ inputs.extra_packages }}
 
-    - name: Extract pinned toolchain versions
-      id: versions
-      shell: bash
-      run: |
-        set -euo pipefail
-        rust=$(sed -nE 's/^channel = "([^"]+)"$/\1/p' rust-toolchain.toml)
-        pgrx=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)
-        echo "rust=$rust" >> "$GITHUB_OUTPUT"
-        echo "pgrx=$pgrx" >> "$GITHUB_OUTPUT"
-        echo "Resolved rust=$rust cargo-pgrx=$pgrx"
-
-    - name: Install Rust ${{ steps.versions.outputs.rust }}
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Set up pg_search toolchain
+      uses: ./.github/actions/setup-pg-search-toolchain
       with:
-        toolchain: ${{ steps.versions.outputs.rust }}
-        cache: false
-        rustflags: "" # Respect .cargo/config.toml target-cpu flags.
-
-    # All benchmark workflows compile pg_search in release mode and can safely
-    # share this cache. rust-cache owns both Cargo binaries and target artifacts.
-    - name: Install Rust cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        prefix-key: "v2-benchmarks-rust-cache"
-        shared-key: pg${{ inputs.pg_version }}
-        cache-targets: true
-        cache-all-crates: true
-        cache-on-failure: true
-
-    - name: Install cargo-pgrx ${{ steps.versions.outputs.pgrx }}
-      shell: bash
-      run: |
-        version="${{ steps.versions.outputs.pgrx }}"
-        if cargo pgrx --version 2>/dev/null | grep -Eq "^cargo-pgrx ${version}([[:space:]]|$)"; then
-          echo "cargo-pgrx ${version} restored from rust-cache"
-        else
-          cargo install cargo-pgrx --version "${version}" --debug --locked --force
-        fi
+        pg_version: ${{ inputs.pg_version }}
+        cache_prefix_key: "v2-benchmarks-rust-cache"
+        cache_save: "true"
+        cache_on_failure: "true"
 
     - name: Initialize pgrx environment
       shell: bash

--- a/.github/actions/setup-pg-search-toolchain/action.yml
+++ b/.github/actions/setup-pg-search-toolchain/action.yml
@@ -1,0 +1,75 @@
+name: Set up pg_search toolchain
+description: Install pinned Rust and cargo-pgrx with a configurable shared Rust cache
+
+inputs:
+  pg_version:
+    description: "PostgreSQL major version used to partition the Rust cache."
+    required: true
+  rust_components:
+    description: "Optional comma-separated rustup components."
+    required: false
+    default: ""
+  cache_prefix_key:
+    description: "rust-cache prefix separating compatible build profiles."
+    required: false
+    default: "v3-rust-cache"
+  cache_save:
+    description: "Whether this run may save a new Rust cache entry."
+    required: false
+    default: "false"
+  cache_on_failure:
+    description: "Whether to save the Rust cache when a later step fails."
+    required: false
+    default: "false"
+  install_cargo_pgrx:
+    description: "Whether to install the repository-pinned cargo-pgrx."
+    required: false
+    default: "true"
+
+outputs:
+  pgrx_version:
+    description: "The pgrx version pinned in Cargo.toml."
+    value: ${{ steps.versions.outputs.pgrx }}
+
+runs:
+  using: composite
+  steps:
+    - name: Extract pinned toolchain versions
+      id: versions
+      shell: bash
+      run: |
+        set -euo pipefail
+        rust=$(sed -nE 's/^channel = "([^"]+)"$/\1/p' rust-toolchain.toml)
+        pgrx=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)
+        echo "rust=$rust" >> "$GITHUB_OUTPUT"
+        echo "pgrx=$pgrx" >> "$GITHUB_OUTPUT"
+        echo "Resolved rust=$rust cargo-pgrx=$pgrx"
+
+    - name: Install Rust ${{ steps.versions.outputs.rust }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ steps.versions.outputs.rust }}
+        components: ${{ inputs.rust_components }}
+        cache: false
+        rustflags: "" # Respect .cargo/config.toml target-cpu flags.
+
+    - name: Install Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: ${{ inputs.cache_prefix_key }}
+        shared-key: pg${{ inputs.pg_version }}
+        cache-targets: true
+        cache-all-crates: true
+        save-if: ${{ inputs.cache_save == 'true' }}
+        cache-on-failure: ${{ inputs.cache_on_failure == 'true' }}
+
+    - name: Install cargo-pgrx ${{ steps.versions.outputs.pgrx }}
+      if: inputs.install_cargo_pgrx == 'true'
+      shell: bash
+      run: |
+        version="${{ steps.versions.outputs.pgrx }}"
+        if cargo pgrx --version 2>/dev/null | grep -Eq "^cargo-pgrx ${version}([[:space:]]|$)"; then
+          echo "cargo-pgrx ${version} restored from rust-cache"
+        else
+          cargo install -j "$(nproc)" cargo-pgrx --version "${version}" --debug --locked --force
+        fi

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -18,6 +18,7 @@ on:
       - ".github/workflows/benchmark-benchmarker.yml"
       - ".github/actions/build-pg_search-source/**"
       - ".github/actions/setup-pg-search-build/**"
+      - ".github/actions/setup-pg-search-toolchain/**"
       - ".github/actions/setup-postgres/**"
       - "docker/Dockerfile.benchmarker"
   pull_request:

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -17,6 +17,7 @@ on:
       - ".github/actions/install-pg-search-source/**"
       - ".github/actions/setup-benchmark-cluster/**"
       - ".github/actions/setup-pg-search-build/**"
+      - ".github/actions/setup-pg-search-toolchain/**"
       - ".github/actions/setup-postgres/**"
       - ".github/workflows/benchmark-pg_search-queries.yml"
       - "benchmarks/**"

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -16,6 +16,7 @@ on:
       - ".github/actions/benchmarks-from-main/**"
       - ".github/actions/install-pg-search-source/**"
       - ".github/actions/setup-pg-search-build/**"
+      - ".github/actions/setup-pg-search-toolchain/**"
       - ".github/actions/setup-postgres/**"
       - ".github/workflows/benchmark-pg_search-stressgres.yml"
       - "stressgres/suites/**"

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      - ".github/actions/setup-pg-search-toolchain/**"
       - ".github/workflows/lint-rust.yml"
       - "**/*.rs"
       - "**/*.toml"
@@ -43,40 +44,20 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Set up pg_search toolchain
+        uses: ./.github/actions/setup-pg-search-toolchain
         with:
-          components: rustfmt, clippy
-          cache: false
-          rustflags: "" # Use .cargo/config.toml target-cpu flags
+          pg_version: ${{ matrix.pg_version }}
+          rust_components: rustfmt, clippy
 
       - name: Check Cargo.lock
         run: cargo metadata --format-version 1 --locked > /dev/null
-
-      - name: Extract pgrx Version
-        id: pgrx
-        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
-
-      # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
-      # See test-pg_search.yml for rationale.
-      - name: Install Rust Cache
-        uses: swatinem/rust-cache@v2
-        with:
-          prefix-key: "v3-rust-cache"
-          shared-key: pg${{ matrix.pg_version }}
-          cache-targets: true
-          cache-all-crates: true
-          # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
-          save-if: false
 
       - name: Install & Configure Supported PostgreSQL Version
         uses: ./.github/actions/setup-postgres
         with:
           pg_version: ${{ matrix.pg_version }}
           extra_packages: lld libfontconfig1-dev libopenblas-dev
-
-      - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -10,6 +10,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/scripts/check_migration_diff.py"
+      - ".github/actions/setup-pg-search-toolchain/**"
       - ".github/workflows/test-pg_search-schema.yml"
       - "pg_search/**"
       - "!pg_search/README.md"
@@ -51,29 +52,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
-      - name: Extract pgrx Version
-        id: pgrx
-        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
-
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false
-          rustflags: "" # Use .cargo/config.toml target-cpu flags
-
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
       # Only save cache on non-PR events; PRs restore from the default branch.
       # See test-pg_search.yml for rationale.
-      - name: Install Rust Cache
-        uses: swatinem/rust-cache@v2
+      - name: Set up pg_search toolchain
+        id: toolchain
+        uses: ./.github/actions/setup-pg-search-toolchain
         with:
-          prefix-key: "v3-rust-cache"
-          shared-key: pg${{ matrix.pg_version }}
-          cache-targets: true
-          cache-all-crates: true
-          # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
-          save-if: false
+          pg_version: ${{ matrix.pg_version }}
 
       - name: Install & Configure Supported PostgreSQL Version
         uses: ./.github/actions/setup-postgres
@@ -89,14 +76,11 @@ jobs:
           sudo apt install clang lld llvm diffutils
           cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --debug --force
 
-      - name: Install pgrx
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
-
       - name: Initialize pgrx environment
         run: |
           cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           # Save the pgrx version for comparison later
-          echo "FIRST_PGRX_VERSION=${{ steps.pgrx.outputs.version }}" >> $GITHUB_ENV
+          echo "FIRST_PGRX_VERSION=${{ steps.toolchain.outputs.pgrx_version }}" >> $GITHUB_ENV
 
       - name: Generate Schema from this git rev
         run: cargo pgrx schema -p pg_search pg${{ matrix.pg_version }} > ~/this.sql

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -10,6 +10,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/actions/test-pg_search-upgrade/**"
+      - ".github/actions/setup-pg-search-toolchain/**"
       - ".github/workflows/test-pg_search-upgrade.yml"
       - "pg_search/**"
       - "!pg_search/README.md"
@@ -91,23 +92,15 @@ jobs:
         with:
           fetch-depth: 0 # Fetch the entire history (required to checkout tags)
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false
-          rustflags: "" # Use .cargo/config.toml target-cpu flags
-
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
-      - name: Install Rust Cache
-        uses: swatinem/rust-cache@v2
+      - name: Set up pg_search toolchain
+        uses: ./.github/actions/setup-pg-search-toolchain
         with:
-          prefix-key: "v3-rust-cache"
-          shared-key: pg${{ matrix.pg_version }}
-          cache-targets: true
-          cache-all-crates: true
-          # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
-          save-if: false
+          pg_version: ${{ matrix.pg_version }}
+          # The upgrade action intentionally installs the prior and current
+          # cargo-pgrx versions itself as it switches source revisions.
+          install_cargo_pgrx: "false"
 
       - name: Install required system tools
         run: |

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      - ".github/actions/setup-pg-search-toolchain/**"
       - ".github/workflows/test-pg_search.yml"
       - "pg_search/**"
       - "!pg_search/README.md"
@@ -81,16 +82,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false
-          rustflags: "" # Use .cargo/config.toml target-cpu flags
-
-      - name: Extract pgrx Version
-        id: pgrx
-        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
-
       # Cache notes:
       # - Do NOT add hashFiles('**/Cargo.lock') to shared-key — the action
       #   already hashes it internally. Putting it in shared-key defeats the
@@ -102,14 +93,12 @@ jobs:
       # entries — this prevents cache thrashing that fills the 30 GB limit and causes
       # every entry to be evicted before reuse. The nightly schedule run warms caches
       # for all PG versions on the default branch.
-      - name: Install Rust Cache
-        uses: swatinem/rust-cache@v2
+      - name: Set up pg_search toolchain
+        id: toolchain
+        uses: ./.github/actions/setup-pg-search-toolchain
         with:
-          prefix-key: "v3-rust-cache"
-          shared-key: pg${{ matrix.pg_version }}
-          cache-targets: true
-          cache-all-crates: true
-          save-if: ${{ github.event_name == 'schedule' && github.ref_name == github.event.repository.default_branch }}
+          pg_version: ${{ matrix.pg_version }}
+          cache_save: ${{ github.event_name == 'schedule' && github.ref_name == github.event.repository.default_branch }}
 
       - name: Install required system tools
         run: |
@@ -120,9 +109,6 @@ jobs:
 
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
-
-      - name: Install pgrx
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version "${{ steps.pgrx.outputs.version }}" --debug
 
       - name: Install cargo-llvm-cov
         run: command -v cargo-llvm-cov || cargo install -j $(nproc) cargo-llvm-cov --locked --debug
@@ -145,7 +131,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.pgrx
-          key: pgrx-pg-${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
+          key: pgrx-pg-${{ matrix.pg_version }}-${{ steps.toolchain.outputs.pgrx_version }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Initialize pgrx environment (pgrx download)
         if: matrix.pg_impl == 'pgrx' && steps.cache-pgrx-pg.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- add `setup-pg-search-toolchain`, a configurable composite action for pinned Rust, the shared Rust cache, and pinned `cargo-pgrx`
- compose the benchmark setup action from the generic toolchain action
- migrate `test-pg_search`, schema tests, upgrade tests, and Rust linting to the shared setup
- preserve each workflow's cache-save policy, Rust components, and cargo-pgrx version-switching behavior

## Structure
This is a stacked follow-up to #6183 and should be reviewed/merged after it. Its base is `fix/benchmarker-ci-slack`, so the diff contains only the generic toolchain extraction and test-workflow migration.

## Validation
- `git diff --check`
- parsed all nine modified or added YAML files with Ruby YAML