### PR TITLE
feat: clarify error when pdb.score/snippet run without a search operator

### DIFF
--- a/docs/changelog/unreleased/6187.stability.mdx
+++ b/docs/changelog/unreleased/6187.stability.mdx
@@ -1,0 +1,5 @@
+---
+header: stability
+---
+
+`pdb.score()` and `pdb.snippet()` now explain that a ParadeDB search operator is required in the `WHERE` clause, instead of raising a generic unsupported-query-shape error.

--- a/docs/changelog/unreleased/6187.stability.mdx
+++ b/docs/changelog/unreleased/6187.stability.mdx
@@ -2,4 +2,4 @@
 header: stability
 ---
 
-`pdb.score()` and `pdb.snippet()` now explain that a ParadeDB search operator is required in the `WHERE` clause, instead of raising a generic unsupported-query-shape error.
+`pdb.score()` and `pdb.snippet()` now explain why they could not be rewritten: a missing ParadeDB search operator, a disabled custom/join/aggregate scan, or an unsupported query shape such as a top-level join without `LIMIT`.

--- a/pg_search/src/postgres/customscan/basescan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/mod.rs
@@ -18,3 +18,13 @@
 pub mod score;
 pub mod snippet;
 pub mod window_agg;
+
+/// `pdb.score` / `pdb.snippet*` are placeholders rewritten by a ParadeDB custom
+/// scan. Reaching here means the scan did not take over the query — most often
+/// because no ParadeDB operator is in `WHERE`.
+pub(crate) fn placeholder_not_rewritten() -> ! {
+    pgrx::error!(
+        "pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. \
+         If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose"
+    )
+}

--- a/pg_search/src/postgres/customscan/basescan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/mod.rs
@@ -19,12 +19,183 @@ pub mod score;
 pub mod snippet;
 pub mod window_agg;
 
+use crate::api::operator::is_anyelement_search_opoid;
+use crate::gucs;
+use crate::nodecast;
+use pgrx::pg_sys::expression_tree_walker;
+use pgrx::{PgList, pg_guard, pg_sys};
+use std::ffi::CStr;
+use std::ptr::addr_of_mut;
+
+const REPORT_URL: &str = "https://github.com/paradedb/paradedb/issues/new/choose";
+
 /// `pdb.score` / `pdb.snippet*` are placeholders rewritten by a ParadeDB custom
-/// scan. Reaching here means the scan did not take over the query — most often
-/// because no ParadeDB operator is in `WHERE`.
+/// scan. Reaching here means the scan did not take over the query. The cause is
+/// not always a missing search operator — join/aggregate scans may be disabled,
+/// or the query shape may be unsupported (for example a top-level join without
+/// LIMIT).
 pub(crate) fn placeholder_not_rewritten() -> ! {
+    if !gucs::enable_custom_scan() {
+        pgrx::error!(
+            "pdb.score() / pdb.snippet() cannot be evaluated because paradedb.enable_custom_scan is off. \
+             SET paradedb.enable_custom_scan = on"
+        );
+    }
+
+    let has_operator = unsafe { query_has_search_operator() };
+
+    if has_operator && !gucs::enable_join_custom_scan() {
+        pgrx::error!(
+            "pdb.score() / pdb.snippet() cannot be evaluated because paradedb.enable_join_custom_scan is off. \
+             SET paradedb.enable_join_custom_scan = on"
+        );
+    }
+
+    if has_operator && !gucs::enable_aggregate_custom_scan() {
+        pgrx::error!(
+            "pdb.score() / pdb.snippet() cannot be evaluated because paradedb.enable_aggregate_custom_scan is off. \
+             SET paradedb.enable_aggregate_custom_scan = on"
+        );
+    }
+
+    if has_operator {
+        pgrx::error!(
+            "pdb.score() / pdb.snippet() cannot be evaluated for this query shape. \
+             A common cause is a top-level join without LIMIT, which prevents JoinScan. \
+             If this looks like a bug, please report it at {REPORT_URL}"
+        );
+    }
+
     pgrx::error!(
         "pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. \
-         If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose"
+         If this query already has one, please report it at {REPORT_URL}"
     )
+}
+
+unsafe fn query_has_search_operator() -> bool {
+    if source_text_has_search_operator(debug_query_text())
+        || source_text_has_search_operator(active_portal_source_text())
+    {
+        return true;
+    }
+    planned_stmt_has_search_operator()
+}
+
+fn source_text_has_search_operator(sql: Option<&str>) -> bool {
+    let Some(sql) = sql else {
+        return false;
+    };
+    sql.contains("@@@")
+        || sql.contains("|||")
+        || sql.contains("&&&")
+        || sql.contains("===")
+        || sql.contains("###")
+}
+
+unsafe fn debug_query_text() -> Option<&'static str> {
+    let ptr = pg_sys::debug_query_string;
+    if ptr.is_null() {
+        return None;
+    }
+    CStr::from_ptr(ptr).to_str().ok()
+}
+
+unsafe fn active_portal_source_text() -> Option<&'static str> {
+    let portal = pg_sys::ActivePortal;
+    if portal.is_null() {
+        return None;
+    }
+    let ptr = (*portal).sourceText;
+    if ptr.is_null() {
+        return None;
+    }
+    CStr::from_ptr(ptr).to_str().ok()
+}
+
+unsafe fn planned_stmt_has_search_operator() -> bool {
+    let portal = pg_sys::ActivePortal;
+    if portal.is_null() {
+        return false;
+    }
+    let query_desc = (*portal).queryDesc;
+    if query_desc.is_null() {
+        return false;
+    }
+    let pstmt = (*query_desc).plannedstmt;
+    if pstmt.is_null() {
+        return false;
+    }
+    if plan_has_search_operator((*pstmt).planTree) {
+        return true;
+    }
+    for plan in PgList::<pg_sys::Plan>::from_pg((*pstmt).subplans).iter_ptr() {
+        if plan_has_search_operator(plan) {
+            return true;
+        }
+    }
+    false
+}
+
+unsafe fn plan_has_search_operator(plan: *mut pg_sys::Plan) -> bool {
+    if plan.is_null() {
+        return false;
+    }
+    if list_has_search_operator((*plan).targetlist) || list_has_search_operator((*plan).qual) {
+        return true;
+    }
+
+    match (*plan).type_ {
+        pg_sys::NodeTag::T_NestLoop
+        | pg_sys::NodeTag::T_MergeJoin
+        | pg_sys::NodeTag::T_HashJoin => {
+            let join = plan.cast::<pg_sys::Join>();
+            if list_has_search_operator((*join).joinqual) {
+                return true;
+            }
+        }
+        _ => {}
+    }
+
+    plan_has_search_operator((*plan).lefttree) || plan_has_search_operator((*plan).righttree)
+}
+
+unsafe fn list_has_search_operator(list: *mut pg_sys::List) -> bool {
+    for node in PgList::<pg_sys::Node>::from_pg(list).iter_ptr() {
+        if expr_has_search_operator(node) {
+            return true;
+        }
+    }
+    false
+}
+
+unsafe fn expr_has_search_operator(node: *mut pg_sys::Node) -> bool {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        data: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+        if let Some(opexpr) = nodecast!(OpExpr, T_OpExpr, node)
+            && is_anyelement_search_opoid((*opexpr).opno)
+        {
+            return true;
+        }
+        if let Some(saop) = nodecast!(ScalarArrayOpExpr, T_ScalarArrayOpExpr, node)
+            && is_anyelement_search_opoid((*saop).opno)
+        {
+            return true;
+        }
+        if let Some(ri) = nodecast!(RestrictInfo, T_RestrictInfo, node) {
+            return expr_has_search_operator((*ri).clause.cast());
+        }
+        expression_tree_walker(node, Some(walker), data)
+    }
+
+    if node.is_null() {
+        return false;
+    }
+    let mut dummy = ();
+    walker(node, addr_of_mut!(dummy).cast())
 }

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -28,9 +28,7 @@ mod pdb {
     #[allow(unused_variables)]
     #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
     fn score_from_relation(relation_reference: AnyElement) -> f32 {
-        panic!(
-            "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-        );
+        crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
     }
 
     extension_sql!(
@@ -48,9 +46,7 @@ mod pdb {
 #[allow(unused_variables)]
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
 fn paradedb_score_from_relation(relation_reference: AnyElement) -> Option<f32> {
-    panic!(
-        "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-    );
+    crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
 }
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -348,9 +348,7 @@ pub mod pdb {
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> String {
-        panic!(
-            "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-        );
+        crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
     }
 
     #[allow(unused_variables)]
@@ -364,9 +362,7 @@ pub mod pdb {
         offset: default!(Option<i32>, "NULL"),
         sort_by: default!(String, "'score'"),
     ) -> Vec<String> {
-        panic!(
-            "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-        );
+        crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
     }
 
     #[allow(unused_variables)]
@@ -390,9 +386,7 @@ AS 'MODULE_PATHNAME', 'snippet_positions_from_relation_wrapper';
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> IntArray2D {
-        panic!(
-            "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-        );
+        crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
     }
 }
 
@@ -409,9 +403,7 @@ fn paradedb_snippet_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> Option<String> {
-    panic!(
-        "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-    );
+    crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
 }
 
 #[warn(deprecated)]
@@ -426,9 +418,7 @@ fn paradedb_snippets_from_relation(
     offset: default!(Option<i32>, "NULL"),
     sort_by: default!(String, "'score'"),
 ) -> Option<Vec<String>> {
-    panic!(
-        "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-    );
+    crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
 }
 
 #[warn(deprecated)]
@@ -453,9 +443,7 @@ fn paradedb_snippet_positions_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> pdb::IntArray2D {
-    panic!(
-        "Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose"
-    );
+    crate::postgres::customscan::basescan::projections::placeholder_not_rewritten()
 }
 
 extension_sql!(

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
@@ -633,7 +633,7 @@ JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
 WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: reviews)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5: Union of results from different tables
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 'Product' as type, name as item_name, description as content

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
@@ -633,7 +633,7 @@ JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
 WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.planner_warnings = 'off' (table: reviews)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5: Union of results from different tables
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 'Product' as type, name as item_name, description as content

--- a/pg_search/tests/pg_regress/expected/deprecated_score.out
+++ b/pg_search/tests/pg_regress/expected/deprecated_score.out
@@ -124,7 +124,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -151,7 +151,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -236,7 +236,7 @@ RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/deprecated_score.out
+++ b/pg_search/tests/pg_regress/expected/deprecated_score.out
@@ -124,7 +124,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -151,7 +151,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -236,7 +236,7 @@ RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/issue_4767.out
+++ b/pg_search/tests/pg_regress/expected/issue_4767.out
@@ -71,4 +71,15 @@ ORDER BY p.id;
   1 | 0.6931472
 (1 row)
 
+-- Join-without-LIMIT + pdb.score is covered by join_tests. A self-join
+-- of that shape trips a planner Assert (apply_tlist_labeling), so it is
+-- not reproduced here.
+\echo '--- pdb.score with an operator when custom scan is off ---'
+--- pdb.score with an operator when custom scan is off ---
+SET paradedb.enable_custom_scan = off;
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p
+WHERE p.description ||| 'shoes';
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated because paradedb.enable_custom_scan is off. SET paradedb.enable_custom_scan = on
+SET paradedb.enable_custom_scan = on;
 DROP TABLE issue_4767_products CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_4767.out
+++ b/pg_search/tests/pg_regress/expected/issue_4767.out
@@ -39,6 +39,21 @@ ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||
 SELECT paradedb.score(p.id) AS score
 FROM issue_4767_products AS p;
 ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- paradedb.snippet without a WHERE clause ---'
+--- paradedb.snippet without a WHERE clause ---
+SELECT paradedb.snippet(p.description) AS snippet
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- paradedb.snippets without a WHERE clause ---'
+--- paradedb.snippets without a WHERE clause ---
+SELECT paradedb.snippets(p.description) AS snippets
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- paradedb.snippet_positions without a WHERE clause ---'
+--- paradedb.snippet_positions without a WHERE clause ---
+SELECT paradedb.snippet_positions(p.description) AS positions
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 \echo '--- pdb.score with a non-search WHERE clause ---'
 --- pdb.score with a non-search WHERE clause ---
 SELECT p.id, pdb.score(p.id) AS score

--- a/pg_search/tests/pg_regress/expected/issue_4767.out
+++ b/pg_search/tests/pg_regress/expected/issue_4767.out
@@ -1,0 +1,59 @@
+-- Regression test for #4767: pdb.score / pdb.snippet without a ParadeDB
+-- operator in WHERE used to raise the generic "Unsupported query shape"
+-- message. They should name the operator requirement instead.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS issue_4767_products CASCADE;
+CREATE TABLE issue_4767_products (
+    id serial PRIMARY KEY,
+    description text
+);
+INSERT INTO issue_4767_products (description) VALUES
+    ('running shoes'),
+    ('wireless keyboard');
+CREATE INDEX issue_4767_products_idx
+    ON issue_4767_products
+    USING paradedb (id, description)
+    WITH (key_field = 'id');
+\echo '--- pdb.score without a WHERE clause ---'
+--- pdb.score without a WHERE clause ---
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- pdb.snippet without a WHERE clause ---'
+--- pdb.snippet without a WHERE clause ---
+SELECT pdb.snippet(p.description, '<div>', '</div>', 235) AS snippet
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- pdb.snippets without a WHERE clause ---'
+--- pdb.snippets without a WHERE clause ---
+SELECT pdb.snippets(p.description) AS snippets
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- pdb.snippet_positions without a WHERE clause ---'
+--- pdb.snippet_positions without a WHERE clause ---
+SELECT pdb.snippet_positions(p.description) AS positions
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- paradedb.score without a WHERE clause ---'
+--- paradedb.score without a WHERE clause ---
+SELECT paradedb.score(p.id) AS score
+FROM issue_4767_products AS p;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- pdb.score with a non-search WHERE clause ---'
+--- pdb.score with a non-search WHERE clause ---
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p
+WHERE p.id = 1;
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+\echo '--- pdb.score with a ParadeDB operator still works ---'
+--- pdb.score with a ParadeDB operator still works ---
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p
+WHERE p.description ||| 'shoes'
+ORDER BY p.id;
+ id |   score   
+----+-----------
+  1 | 0.6931472
+(1 row)
+
+DROP TABLE issue_4767_products CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -188,7 +188,7 @@ INNER JOIN books b ON a.id = b.author_id AND a.birth_year < 2000
 WHERE (a.bio @@@ 'writer' OR b.content @@@ 'mystery')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 2: Non-equi joins and problematic conditions
 -- =============================================================================
@@ -286,7 +286,7 @@ INNER JOIN books b ON b.price BETWEEN 20.00 AND 30.00 AND a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'romance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 3: CROSS-TABLE OR TESTS
 -- =============================================================================
@@ -480,7 +480,7 @@ JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author' AND b.category_id = 1
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5.3: LEFT JOIN semantics test
 SELECT 
     a.name as author_name,

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -188,7 +188,7 @@ INNER JOIN books b ON a.id = b.author_id AND a.birth_year < 2000
 WHERE (a.bio @@@ 'writer' OR b.content @@@ 'mystery')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 2: Non-equi joins and problematic conditions
 -- =============================================================================
@@ -286,7 +286,7 @@ INNER JOIN books b ON b.price BETWEEN 20.00 AND 30.00 AND a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'romance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 3: CROSS-TABLE OR TESTS
 -- =============================================================================
@@ -480,7 +480,7 @@ JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author' AND b.category_id = 1
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5.3: LEFT JOIN semantics test
 SELECT 
     a.name as author_name,

--- a/pg_search/tests/pg_regress/expected/partitioned_snippets.out
+++ b/pg_search/tests/pg_regress/expected/partitioned_snippets.out
@@ -113,7 +113,7 @@ FROM logs
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 \echo 'Test 3: UNNEST(pdb.snippets(...)) on a child table'
 Test 3: UNNEST(pdb.snippets(...)) on a child table
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -241,5 +241,5 @@ FROM logs_2020
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 DROP TABLE IF EXISTS logs CASCADE;

--- a/pg_search/tests/pg_regress/expected/partitioned_snippets.out
+++ b/pg_search/tests/pg_regress/expected/partitioned_snippets.out
@@ -113,7 +113,7 @@ FROM logs
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 \echo 'Test 3: UNNEST(pdb.snippets(...)) on a child table'
 Test 3: UNNEST(pdb.snippets(...)) on a child table
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -241,5 +241,5 @@ FROM logs_2020
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 DROP TABLE IF EXISTS logs CASCADE;

--- a/pg_search/tests/pg_regress/expected/score_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_join_predicates.out
@@ -138,7 +138,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -165,7 +165,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -250,7 +250,7 @@ RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/score_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_join_predicates.out
@@ -138,7 +138,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -165,7 +165,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -250,7 +250,7 @@ RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
@@ -88,7 +88,7 @@ SELECT
 FROM products 
 WHERE category_name = 'Electronics'
 ORDER BY id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 1.6: Simple test with just non-indexed predicate to isolate the issue
 SELECT 
     id,
@@ -255,7 +255,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -776,7 +776,7 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 14: Array operations (if supported)
 -- Tests heap filtering with array predicates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -1060,7 +1060,7 @@ FROM products
 WHERE description @@@ 'Apple'
   AND category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test edge case: Query with only indexed predicates should still work when GUC is disabled
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 

--- a/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
@@ -255,7 +255,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -1060,7 +1060,7 @@ FROM products
 WHERE description @@@ 'Apple'
   AND category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test edge case: Query with only indexed predicates should still work when GUC is disabled
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 

--- a/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
@@ -169,7 +169,7 @@ WHERE (a.id @@@ paradedb.parse('metadata.age:55'))
     AND (a.id @@@ paradedb.parse('metadata.text:author') OR b.id @@@ paradedb.parse('metadata.content:test'))
 ORDER BY a.id, b.id, r.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 \i common/snippet_json_advanced_cleanup.sql
 DROP TABLE IF EXISTS authors;
 DROP TABLE IF EXISTS books;

--- a/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
@@ -169,7 +169,7 @@ WHERE (a.id @@@ paradedb.parse('metadata.age:55'))
     AND (a.id @@@ paradedb.parse('metadata.text:author') OR b.id @@@ paradedb.parse('metadata.content:test'))
 ORDER BY a.id, b.id, r.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 \i common/snippet_json_advanced_cleanup.sql
 DROP TABLE IF EXISTS authors;
 DROP TABLE IF EXISTS books;

--- a/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
+++ b/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
@@ -227,7 +227,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -748,7 +748,7 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 14: Array operations (if supported)
 -- Tests heap filtering with array predicates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
+++ b/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
@@ -227,7 +227,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  pdb.score() / pdb.snippet() require a ParadeDB search operator (@@@, |||, &&&, ===, or ###) in the WHERE clause. If this query already has one, please report it at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() / pdb.snippet() cannot be evaluated for this query shape. A common cause is a top-level join without LIMIT, which prevents JoinScan. If this looks like a bug, please report it at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/sql/issue_4767.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4767.sql
@@ -1,0 +1,53 @@
+-- Regression test for #4767: pdb.score / pdb.snippet without a ParadeDB
+-- operator in WHERE used to raise the generic "Unsupported query shape"
+-- message. They should name the operator requirement instead.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS issue_4767_products CASCADE;
+CREATE TABLE issue_4767_products (
+    id serial PRIMARY KEY,
+    description text
+);
+
+INSERT INTO issue_4767_products (description) VALUES
+    ('running shoes'),
+    ('wireless keyboard');
+
+CREATE INDEX issue_4767_products_idx
+    ON issue_4767_products
+    USING paradedb (id, description)
+    WITH (key_field = 'id');
+
+\echo '--- pdb.score without a WHERE clause ---'
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p;
+
+\echo '--- pdb.snippet without a WHERE clause ---'
+SELECT pdb.snippet(p.description, '<div>', '</div>', 235) AS snippet
+FROM issue_4767_products AS p;
+
+\echo '--- pdb.snippets without a WHERE clause ---'
+SELECT pdb.snippets(p.description) AS snippets
+FROM issue_4767_products AS p;
+
+\echo '--- pdb.snippet_positions without a WHERE clause ---'
+SELECT pdb.snippet_positions(p.description) AS positions
+FROM issue_4767_products AS p;
+
+\echo '--- paradedb.score without a WHERE clause ---'
+SELECT paradedb.score(p.id) AS score
+FROM issue_4767_products AS p;
+
+\echo '--- pdb.score with a non-search WHERE clause ---'
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p
+WHERE p.id = 1;
+
+\echo '--- pdb.score with a ParadeDB operator still works ---'
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p
+WHERE p.description ||| 'shoes'
+ORDER BY p.id;
+
+DROP TABLE issue_4767_products CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_4767.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4767.sql
@@ -62,4 +62,14 @@ FROM issue_4767_products AS p
 WHERE p.description ||| 'shoes'
 ORDER BY p.id;
 
+-- Join-without-LIMIT + pdb.score is covered by join_tests. A self-join
+-- of that shape trips a planner Assert (apply_tlist_labeling), so it is
+-- not reproduced here.
+\echo '--- pdb.score with an operator when custom scan is off ---'
+SET paradedb.enable_custom_scan = off;
+SELECT p.id, pdb.score(p.id) AS score
+FROM issue_4767_products AS p
+WHERE p.description ||| 'shoes';
+SET paradedb.enable_custom_scan = on;
+
 DROP TABLE issue_4767_products CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_4767.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4767.sql
@@ -39,6 +39,18 @@ FROM issue_4767_products AS p;
 SELECT paradedb.score(p.id) AS score
 FROM issue_4767_products AS p;
 
+\echo '--- paradedb.snippet without a WHERE clause ---'
+SELECT paradedb.snippet(p.description) AS snippet
+FROM issue_4767_products AS p;
+
+\echo '--- paradedb.snippets without a WHERE clause ---'
+SELECT paradedb.snippets(p.description) AS snippets
+FROM issue_4767_products AS p;
+
+\echo '--- paradedb.snippet_positions without a WHERE clause ---'
+SELECT paradedb.snippet_positions(p.description) AS positions
+FROM issue_4767_products AS p;
+
 \echo '--- pdb.score with a non-search WHERE clause ---'
 SELECT p.id, pdb.score(p.id) AS score
 FROM issue_4767_products AS p


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4767

## What

Replace the generic `Unsupported query shape` panic from `pdb.score()` / `pdb.snippet()` (and the `paradedb.*` shims) with an error that names the real requirement: a ParadeDB search operator in `WHERE`.

## Why

Queries like `SELECT pdb.score(id) FROM t` currently fail with a message that asks the user to file a bug. The actual problem is almost always a missing ParadeDB operator (`@@@`, `|||`, `&&&`, `===`, or `###`). That requirement should be stated in the error.

These functions are placeholders rewritten by a ParadeDB custom scan. Reaching the function body means the scan did not take over the query. Other unsupported shapes (for example some joins) still hit the same path, so the message keeps the "if this query already has an operator, please report it" fallback.

## How

- Centralize the error in `placeholder_not_rewritten()` under `basescan/projections`.
- Call it from every `pdb` / `paradedb` `score` / `snippet*` placeholder.

## Tests

Added `pg_search/tests/pg_regress/sql/issue_4767.sql` covering:

- `pdb.score` / `pdb.snippet` / `pdb.snippets` / `pdb.snippet_positions` / `paradedb.score` with no `WHERE`
- `pdb.score` with a non-search `WHERE` (`id = 1`)
- `pdb.score` with `|||` still succeeds

Updated existing goldens that already expected the old generic message.

Verified locally:

- `cargo pgrx regress pg18 issue_4767`
- `cargo pgrx regress pg18 partitioned_snippets`
- `cargo pgrx regress pg18 deprecated_score`