### PR TITLE
ci: Run CNPG operator highly available in Antithesis

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -42,10 +42,10 @@ postgresql:
 ```bash
 helm repo add cnpg https://cloudnative-pg.github.io/charts
 helm repo update
-helm template cnpg cnpg/cloudnative-pg --namespace cnpg-system --version <chart_version>
+helm template cnpg cnpg/cloudnative-pg --namespace cnpg-system --version <chart_version> --set replicaCount=2
 ```
 
-Prepend the `cnpg-system` `Namespace` (the chart does not create it) and keep the trailing comment-only documents at the end of the file. The current file is chart `0.29.0` / CNPG `1.30.0`.
+Prepend the `cnpg-system` `Namespace` (the chart does not create it) and keep the trailing comment-only documents at the end of the file. The two operator replicas retain leader election so reconciliation can continue when one operator is unavailable. The current file is chart `0.29.0` / CNPG `1.30.0`.
 
 ## Release Process
 

--- a/docker/manifests/cnpg.yaml
+++ b/docker/manifests/cnpg.yaml
@@ -20584,7 +20584,7 @@ metadata:
     app.kubernetes.io/version: "1.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: cloudnative-pg


### PR DESCRIPTION
## Summary
- run two CloudNativePG operator replicas in the Antithesis Kubernetes environment
- retain leader election so a surviving operator can take over reconciliation
- preserve the replica count in the documented Helm render command

## Context
This ports the operator topology from paradedb/cloud#791. A network-partitioned leader may still exit with `leader election lost`, but the second replica allows operator-driven reconciliation and failover to continue.

## Validation
- `git diff --check`
- parsed `docker/manifests/cnpg.yaml` with Ruby YAML
- verified `--leader-elect` remains enabled