### PR TITLE
docs: add changelog fragment and columnar wording for DATE grouping

### DIFF
--- a/docs/changelog/unreleased/5936.features.mdx
+++ b/docs/changelog/unreleased/5936.features.mdx
@@ -1,0 +1,5 @@
+---
+header: features
+---
+
+`GROUP BY DATE(timestamp_column)` and `GROUP BY timestamp_column::date` are now pushed down to the aggregate custom scan when the column is a columnar `timestamp without time zone`. Results match Postgres for the full timestamp range, including `infinity`, `-infinity` and `NULL`. `DATE(timestamptz_column)` still falls back to Postgres because the result depends on the session `TimeZone`.

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -95,7 +95,7 @@ If your query does not contain a ParadeDB operator, a way to "force" aggregate p
 
 ## Date Grouping
 
-`GROUP BY DATE(created_at)` and `GROUP BY created_at::date` support aggregate pushdown when `created_at` is a bare `timestamp without time zone` column indexed as a fast field. The usual aggregate pushdown requirements still apply, including a ParadeDB operator in the query.
+`GROUP BY DATE(created_at)` and `GROUP BY created_at::date` support aggregate pushdown when `created_at` is a bare `timestamp without time zone` column that is [columnar indexed](/documentation/indexing/columnar). The usual aggregate pushdown requirements still apply, including a ParadeDB operator in the query.
 
 The result matches Postgres for the full timestamp range, including `infinity`, `-infinity` and `NULL`. Date grouping can be combined with other grouping columns and per-aggregate `FILTER` clauses.
 


### PR DESCRIPTION
This PR adds the release-notes fragment for #5936 and replaces `fast field` with `columnar` in the date grouping docs.

#5936 landed without a fragment under `docs/changelog/unreleased/`, so the feature would be missing from the next changelog. User-facing docs say `columnar`, not `fast field`.
