### PR TITLE
fix: avoid double-scaling Numeric64 hash-join InList filters

### DIFF
--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -269,6 +269,25 @@ impl PdbOwnedValue {
         }
     }
 
+    /// Converts a DataFusion execution [`ScalarValue`] (Arrow column representation)
+    /// into a [`PdbOwnedValue`] ready for Tantivy term construction.
+    ///
+    /// Unlike [`Self::from_scalar`], which treats `Int64` as a logical SQL value and
+    /// may apply `Numeric64` scale, this path assumes values already match the field's
+    /// Arrow encoding. Hash-join dynamic `InList` members are built from join-key
+    /// arrays, so `Numeric64` arrives as an already-scaled `Int64`.
+    pub fn from_execution_scalar(
+        scalar: &ScalarValue,
+        field_type: &SearchFieldType,
+    ) -> Option<Self> {
+        match (scalar, field_type) {
+            (ScalarValue::Int64(Some(v)), SearchFieldType::Numeric64(_, _)) => {
+                Some(PdbOwnedValue::I64(*v))
+            }
+            _ => Self::from_scalar(scalar, field_type),
+        }
+    }
+
     /// Converts this [`PdbOwnedValue`] into a DataFusion [`ScalarValue`] representation matching
     /// the column's Arrow [`DataType`].
     ///
@@ -523,6 +542,7 @@ impl TryFrom<serde_json::Value> for PdbOwnedValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pgrx::pg_sys;
     use std::cmp::Ordering;
     use std::net::Ipv6Addr;
 
@@ -645,6 +665,64 @@ mod tests {
                 .plain_display()
                 .to_string()
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn from_execution_scalar_preserves_already_scaled_numeric64() {
+        // 104.25 stored as Int64(10425) for numeric(..., 2). Execution values
+        // must not be scaled again; logical from_scalar still multiplies.
+        let field = SearchFieldType::Numeric64(pg_sys::InvalidOid, 2);
+        let execution = ScalarValue::Int64(Some(10_425));
+
+        assert_eq!(
+            PdbOwnedValue::from_execution_scalar(&execution, &field),
+            Some(PdbOwnedValue::I64(10_425))
+        );
+        assert_eq!(
+            PdbOwnedValue::from_scalar(&execution, &field),
+            Some(PdbOwnedValue::I64(1_042_500))
+        );
+    }
+
+    #[test]
+    fn from_execution_scalar_delegates_non_numeric64() {
+        let field = SearchFieldType::I64(pg_sys::InvalidOid);
+        let value = ScalarValue::Int64(Some(42));
+        assert_eq!(
+            PdbOwnedValue::from_execution_scalar(&value, &field),
+            PdbOwnedValue::from_scalar(&value, &field)
+        );
+
+        let numeric = SearchFieldType::Numeric64(pg_sys::InvalidOid, 2);
+        let logical_float = ScalarValue::Float64(Some(104.25));
+        assert_eq!(
+            PdbOwnedValue::from_execution_scalar(&logical_float, &numeric),
+            PdbOwnedValue::from_scalar(&logical_float, &numeric)
+        );
+        assert_eq!(
+            PdbOwnedValue::from_execution_scalar(&logical_float, &numeric),
+            Some(PdbOwnedValue::I64(10_425))
+        );
+    }
+
+    #[test]
+    fn from_execution_scalar_handles_negative_and_zero_scale() {
+        let scale2 = SearchFieldType::Numeric64(pg_sys::InvalidOid, 2);
+        assert_eq!(
+            PdbOwnedValue::from_execution_scalar(&ScalarValue::Int64(Some(-10_425)), &scale2),
+            Some(PdbOwnedValue::I64(-10_425))
+        );
+
+        let scale0 = SearchFieldType::Numeric64(pg_sys::InvalidOid, 0);
+        assert_eq!(
+            PdbOwnedValue::from_execution_scalar(&ScalarValue::Int64(Some(104)), &scale0),
+            Some(PdbOwnedValue::I64(104))
+        );
+        // scale 0: from_scalar multiplier is 1, so both paths agree.
+        assert_eq!(
+            PdbOwnedValue::from_execution_scalar(&ScalarValue::Int64(Some(104)), &scale0),
+            PdbOwnedValue::from_scalar(&ScalarValue::Int64(Some(104)), &scale0)
         );
     }
 }

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -879,7 +879,10 @@ fn try_convert_in_list_to_query(
         .iter()
         .map(|expr| {
             let scalar = extract_physical_scalar_value(expr)?;
-            let owned_value = PdbOwnedValue::from_scalar(&scalar, &field_type)?;
+            // Join-derived InList members are Arrow execution values. For
+            // Numeric64 that means already-scaled Int64 — do not re-apply scale
+            // via from_scalar (see #6158).
+            let owned_value = PdbOwnedValue::from_execution_scalar(&scalar, &field_type)?;
             value_to_term(
                 tantivy_field,
                 &owned_value,

--- a/pg_search/tests/pg_regress/expected/issue_6158.out
+++ b/pg_search/tests/pg_regress/expected/issue_6158.out
@@ -1,0 +1,215 @@
+-- Regression coverage for issue #6158.
+--
+-- Hash-join dynamic InList pushdown must not re-scale Numeric64 execution
+-- values. For numeric(10,2), 104.25 is stored / published as Int64(10425).
+-- Passing that through from_scalar() would multiply by 10^2 again and push
+-- Tantivy terms that reject the matching probe rows.
+--
+-- Asserts:
+--   1. Native PostgreSQL execution returns {104,105,106}
+--   2. JoinScan EXPLAIN ANALYZE reports probe-side dynamic_filter_pushdown_*=1
+--   3. JoinScan returns the same IDs
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan = off;
+SET enable_nestloop = off;
+SET enable_mergejoin = off;
+SET paradedb.planner_warnings = off;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS numeric64_dynamic_probe CASCADE;
+DROP TABLE IF EXISTS numeric64_dynamic_build CASCADE;
+CREATE TABLE numeric64_dynamic_probe (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    body text NOT NULL
+);
+CREATE TABLE numeric64_dynamic_build (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    body text NOT NULL
+);
+INSERT INTO numeric64_dynamic_probe
+SELECT g, g::numeric + 0.25, 'candidate'
+FROM generate_series(101, 116) g;
+INSERT INTO numeric64_dynamic_build VALUES
+    (1, 104.25, 'wanted'),
+    (2, 105.25, 'wanted'),
+    (3, 106.25, 'wanted');
+CREATE INDEX numeric64_dynamic_probe_idx ON numeric64_dynamic_probe
+USING paradedb (id, amount, body) WITH (key_field = 'id');
+CREATE INDEX numeric64_dynamic_build_idx ON numeric64_dynamic_build
+USING paradedb (id, amount, body) WITH (key_field = 'id');
+ANALYZE numeric64_dynamic_probe;
+ANALYZE numeric64_dynamic_build;
+-- 1) Native PostgreSQL baseline
+SET paradedb.enable_join_custom_scan = off;
+SELECT array_agg(id ORDER BY id) AS native_ids
+FROM (
+    SELECT p.id
+    FROM numeric64_dynamic_build b
+    JOIN numeric64_dynamic_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+  native_ids   
+---------------
+ {104,105,106}
+(1 row)
+
+-- 2) JoinScan with dynamic InList pushdown forced on
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+CREATE OR REPLACE FUNCTION issue_6158_explain_analyze_lines(q text)
+RETURNS SETOF text AS $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF) ' || q LOOP
+        RETURN NEXT r."QUERY PLAN";
+    END LOOP;
+END $$ LANGUAGE plpgsql;
+CREATE TEMP TABLE issue_6158_explain_analyze_output AS
+SELECT line
+FROM issue_6158_explain_analyze_lines(
+    'SELECT p.id
+     FROM numeric64_dynamic_build b
+     JOIN numeric64_dynamic_probe p ON b.amount = p.amount
+     WHERE b.body @@@ ''wanted''
+     ORDER BY p.id
+     LIMIT 10'
+) AS line;
+-- EXPLAIN prints the relation alias (`table=p`), not the physical table name.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM issue_6158_explain_analyze_output
+        WHERE line LIKE '%PgSearchScan: table=p%'
+          AND line LIKE '%dynamic_filter_pushdown_%'
+    ) THEN
+        RAISE EXCEPTION
+            'expected probe-side PgSearchScan with dynamic_filter_pushdown_*=1';
+    END IF;
+END $$;
+SELECT bool_or(
+    line LIKE '%PgSearchScan: table=p%'
+    AND line LIKE '%dynamic_filter_pushdown_%'
+) AS probe_dynamic_filter_pushdown
+FROM issue_6158_explain_analyze_output;
+ probe_dynamic_filter_pushdown 
+-------------------------------
+ t
+(1 row)
+
+DROP TABLE issue_6158_explain_analyze_output;
+DROP FUNCTION issue_6158_explain_analyze_lines(text);
+-- 3) JoinScan must match the native result set
+SELECT array_agg(id ORDER BY id) AS joinscan_ids
+FROM (
+    SELECT p.id
+    FROM numeric64_dynamic_build b
+    JOIN numeric64_dynamic_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+ joinscan_ids  
+---------------
+ {104,105,106}
+(1 row)
+
+DROP TABLE numeric64_dynamic_probe CASCADE;
+DROP TABLE numeric64_dynamic_build CASCADE;
+-- 4) Negatives, zero, and scale-0 Numeric64 must also survive pushdown.
+DROP TABLE IF EXISTS numeric64_edge_probe CASCADE;
+DROP TABLE IF EXISTS numeric64_edge_build CASCADE;
+CREATE TABLE numeric64_edge_probe (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    whole numeric(10, 0) NOT NULL,
+    body text NOT NULL
+);
+CREATE TABLE numeric64_edge_build (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    whole numeric(10, 0) NOT NULL,
+    body text NOT NULL
+);
+INSERT INTO numeric64_edge_probe VALUES
+    (1, -104.25, -104, 'candidate'),
+    (2, 0.00, 0, 'candidate'),
+    (3, 104.25, 104, 'candidate'),
+    (4, 999999.99, 999999, 'candidate'),
+    (5, -0.01, -1, 'candidate');
+INSERT INTO numeric64_edge_build VALUES
+    (10, -104.25, -104, 'wanted'),
+    (11, 0.00, 0, 'wanted'),
+    (12, 104.25, 104, 'wanted'),
+    (13, -0.01, -1, 'wanted');
+CREATE INDEX numeric64_edge_probe_idx ON numeric64_edge_probe
+USING paradedb (id, amount, whole, body) WITH (key_field = 'id');
+CREATE INDEX numeric64_edge_build_idx ON numeric64_edge_build
+USING paradedb (id, amount, whole, body) WITH (key_field = 'id');
+ANALYZE numeric64_edge_probe;
+ANALYZE numeric64_edge_build;
+SET paradedb.enable_join_custom_scan = off;
+SELECT array_agg(id ORDER BY id) AS native_amount_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+ native_amount_edge 
+--------------------
+ {1,2,3,5}
+(1 row)
+
+SELECT array_agg(id ORDER BY id) AS native_whole_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.whole = p.whole
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+ native_whole_edge 
+-------------------
+ {1,2,3,5}
+(1 row)
+
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+SELECT array_agg(id ORDER BY id) AS joinscan_amount_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+ joinscan_amount_edge 
+----------------------
+ {1,2,3,5}
+(1 row)
+
+SELECT array_agg(id ORDER BY id) AS joinscan_whole_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.whole = p.whole
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+ joinscan_whole_edge 
+---------------------
+ {1,2,3,5}
+(1 row)
+
+DROP TABLE numeric64_edge_probe CASCADE;
+DROP TABLE numeric64_edge_build CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_6158.sql
+++ b/pg_search/tests/pg_regress/sql/issue_6158.sql
@@ -1,0 +1,205 @@
+-- Regression coverage for issue #6158.
+--
+-- Hash-join dynamic InList pushdown must not re-scale Numeric64 execution
+-- values. For numeric(10,2), 104.25 is stored / published as Int64(10425).
+-- Passing that through from_scalar() would multiply by 10^2 again and push
+-- Tantivy terms that reject the matching probe rows.
+--
+-- Asserts:
+--   1. Native PostgreSQL execution returns {104,105,106}
+--   2. JoinScan EXPLAIN ANALYZE reports probe-side dynamic_filter_pushdown_*=1
+--   3. JoinScan returns the same IDs
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan = off;
+SET enable_nestloop = off;
+SET enable_mergejoin = off;
+SET paradedb.planner_warnings = off;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS numeric64_dynamic_probe CASCADE;
+DROP TABLE IF EXISTS numeric64_dynamic_build CASCADE;
+
+CREATE TABLE numeric64_dynamic_probe (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    body text NOT NULL
+);
+CREATE TABLE numeric64_dynamic_build (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    body text NOT NULL
+);
+
+INSERT INTO numeric64_dynamic_probe
+SELECT g, g::numeric + 0.25, 'candidate'
+FROM generate_series(101, 116) g;
+INSERT INTO numeric64_dynamic_build VALUES
+    (1, 104.25, 'wanted'),
+    (2, 105.25, 'wanted'),
+    (3, 106.25, 'wanted');
+
+CREATE INDEX numeric64_dynamic_probe_idx ON numeric64_dynamic_probe
+USING paradedb (id, amount, body) WITH (key_field = 'id');
+CREATE INDEX numeric64_dynamic_build_idx ON numeric64_dynamic_build
+USING paradedb (id, amount, body) WITH (key_field = 'id');
+ANALYZE numeric64_dynamic_probe;
+ANALYZE numeric64_dynamic_build;
+
+-- 1) Native PostgreSQL baseline
+SET paradedb.enable_join_custom_scan = off;
+SELECT array_agg(id ORDER BY id) AS native_ids
+FROM (
+    SELECT p.id
+    FROM numeric64_dynamic_build b
+    JOIN numeric64_dynamic_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+
+-- 2) JoinScan with dynamic InList pushdown forced on
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+
+CREATE OR REPLACE FUNCTION issue_6158_explain_analyze_lines(q text)
+RETURNS SETOF text AS $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF) ' || q LOOP
+        RETURN NEXT r."QUERY PLAN";
+    END LOOP;
+END $$ LANGUAGE plpgsql;
+
+CREATE TEMP TABLE issue_6158_explain_analyze_output AS
+SELECT line
+FROM issue_6158_explain_analyze_lines(
+    'SELECT p.id
+     FROM numeric64_dynamic_build b
+     JOIN numeric64_dynamic_probe p ON b.amount = p.amount
+     WHERE b.body @@@ ''wanted''
+     ORDER BY p.id
+     LIMIT 10'
+) AS line;
+
+-- EXPLAIN prints the relation alias (`table=p`), not the physical table name.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM issue_6158_explain_analyze_output
+        WHERE line LIKE '%PgSearchScan: table=p%'
+          AND line LIKE '%dynamic_filter_pushdown_%'
+    ) THEN
+        RAISE EXCEPTION
+            'expected probe-side PgSearchScan with dynamic_filter_pushdown_*=1';
+    END IF;
+END $$;
+
+SELECT bool_or(
+    line LIKE '%PgSearchScan: table=p%'
+    AND line LIKE '%dynamic_filter_pushdown_%'
+) AS probe_dynamic_filter_pushdown
+FROM issue_6158_explain_analyze_output;
+
+DROP TABLE issue_6158_explain_analyze_output;
+DROP FUNCTION issue_6158_explain_analyze_lines(text);
+
+-- 3) JoinScan must match the native result set
+SELECT array_agg(id ORDER BY id) AS joinscan_ids
+FROM (
+    SELECT p.id
+    FROM numeric64_dynamic_build b
+    JOIN numeric64_dynamic_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+
+DROP TABLE numeric64_dynamic_probe CASCADE;
+DROP TABLE numeric64_dynamic_build CASCADE;
+
+-- 4) Negatives, zero, and scale-0 Numeric64 must also survive pushdown.
+DROP TABLE IF EXISTS numeric64_edge_probe CASCADE;
+DROP TABLE IF EXISTS numeric64_edge_build CASCADE;
+
+CREATE TABLE numeric64_edge_probe (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    whole numeric(10, 0) NOT NULL,
+    body text NOT NULL
+);
+CREATE TABLE numeric64_edge_build (
+    id bigint PRIMARY KEY,
+    amount numeric(10, 2) NOT NULL,
+    whole numeric(10, 0) NOT NULL,
+    body text NOT NULL
+);
+
+INSERT INTO numeric64_edge_probe VALUES
+    (1, -104.25, -104, 'candidate'),
+    (2, 0.00, 0, 'candidate'),
+    (3, 104.25, 104, 'candidate'),
+    (4, 999999.99, 999999, 'candidate'),
+    (5, -0.01, -1, 'candidate');
+INSERT INTO numeric64_edge_build VALUES
+    (10, -104.25, -104, 'wanted'),
+    (11, 0.00, 0, 'wanted'),
+    (12, 104.25, 104, 'wanted'),
+    (13, -0.01, -1, 'wanted');
+
+CREATE INDEX numeric64_edge_probe_idx ON numeric64_edge_probe
+USING paradedb (id, amount, whole, body) WITH (key_field = 'id');
+CREATE INDEX numeric64_edge_build_idx ON numeric64_edge_build
+USING paradedb (id, amount, whole, body) WITH (key_field = 'id');
+ANALYZE numeric64_edge_probe;
+ANALYZE numeric64_edge_build;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT array_agg(id ORDER BY id) AS native_amount_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+
+SELECT array_agg(id ORDER BY id) AS native_whole_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.whole = p.whole
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+
+SELECT array_agg(id ORDER BY id) AS joinscan_amount_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.amount = p.amount
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+
+SELECT array_agg(id ORDER BY id) AS joinscan_whole_edge
+FROM (
+    SELECT p.id
+    FROM numeric64_edge_build b
+    JOIN numeric64_edge_probe p ON b.whole = p.whole
+    WHERE b.body @@@ 'wanted'
+    ORDER BY p.id
+    LIMIT 10
+) matched;
+
+DROP TABLE numeric64_edge_probe CASCADE;
+DROP TABLE numeric64_edge_build CASCADE;


### PR DESCRIPTION
## Summary
- Fixes hash-join dynamic `InList` pushdown double-scaling already-scaled `Numeric64` Arrow `Int64` values, which caused JoinScan to drop matching probe rows.
- Adds `PdbOwnedValue::from_execution_scalar` and uses it only in `try_convert_in_list_to_query`; leaves `from_scalar` unchanged for logical SQL literals.
- Adds `issue_6158` pg_regress coverage (native vs JoinScan, probe `dynamic_filter_pushdown_*=1`, negatives/zero/scale-0 edges).

Closes #6158

## Out of scope
- #6100 (cross-scale Numeric64 joins)
- #6104 (range-partition sampled bound double conversion)
- #6102 (Numeric64 query-literal rounding)

## Test plan
- [x] `cargo pgrx regress issue_6158`
- [x] Related regresses: `join_hash`, `join_hash_dynamic_filters_sparse`, `topk_dynamic_filter`, `numeric_pushdown`, `pushdown_numeric`, `filter_pushdown_datafusion`
- [x] Unit tests for `from_execution_scalar` vs `from_scalar`
- [x] Negative control: restoring `from_scalar` at the InList site returns empty JoinScan results while pushdown still fires


Made with [Cursor](https://cursor.com)