### PR TITLE
ci: Use runs-on/action to properly configure runs-on's caching

### DIFF
--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -65,9 +65,6 @@ jobs:
       IMAGE_TAG: paradedb-source:ci
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       # The label triggers this run; remove it so it can be re-applied to re-run.
       - name: Maybe Remove Label
         if: github.event_name == 'pull_request' && github.event.label.name == 'benchmark-benchmarker'
@@ -94,6 +91,9 @@ jobs:
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
           fetch-depth: 0
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       # HEAD is the benchmarked commit, even for a custom ref.
       - name: Derive Short Commit

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -65,7 +65,8 @@ jobs:
       IMAGE_TAG: paradedb-source:ci
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       # The label triggers this run; remove it so it can be re-applied to re-run.
       - name: Maybe Remove Label

--- a/.github/workflows/benchmark-benchmarker.yml
+++ b/.github/workflows/benchmark-benchmarker.yml
@@ -65,6 +65,8 @@ jobs:
       IMAGE_TAG: paradedb-source:ci
 
     steps:
+      - uses: runs-on/action@v2
+
       # The label triggers this run; remove it so it can be re-applied to re-run.
       - name: Maybe Remove Label
         if: github.event_name == 'pull_request' && github.event.label.name == 'benchmark-benchmarker'
@@ -199,14 +201,9 @@ jobs:
         if: failure()
         run: docker logs paradedb || true
 
-      # runs-on's s3-cache proxies ACTIONS_RESULTS_URL; upload-artifact POSTs
-      # there and fails, so pin it back to GitHub's receiver (see test-pg_search.yml).
       - name: Upload dashboards
         if: always()
         continue-on-error: true # Best effort: the gh-pages HTML + comment are the real deliverables.
-        env:
-          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
-          ACTIONS_CACHE_SERVICE_V2: ""
         uses: actions/upload-artifact@v7
         with:
           name: benchmarker-dashboards-${{ steps.commit_info.outputs.short_commit }}

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -116,9 +116,6 @@ jobs:
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-pgvectorscale' && 'pgvectorscale') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label
@@ -161,6 +158,9 @@ jobs:
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
           fetch-depth: 0
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -116,6 +116,8 @@ jobs:
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-pgvectorscale' && 'pgvectorscale') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:
+      - uses: runs-on/action@v2
+
       # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -116,7 +116,8 @@ jobs:
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-vchord' && 'vchord') || (github.event.label.name == 'benchmark-cohere-pg_search' && 'pg_search') || (github.event.label.name == 'benchmark-cohere-pgvectorscale' && 'pgvectorscale') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -72,6 +72,8 @@ jobs:
       pg_version: 18
 
     steps:
+      - uses: runs-on/action@v2
+
       # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -72,7 +72,8 @@ jobs:
       pg_version: 18
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -72,9 +72,6 @@ jobs:
       pg_version: 18
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label
@@ -110,6 +107,9 @@ jobs:
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
           fetch-depth: 0
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Derive Short Commit
         id: commit_info

--- a/.github/workflows/generate-benchmark-snapshots.yml
+++ b/.github/workflows/generate-benchmark-snapshots.yml
@@ -81,6 +81,8 @@ jobs:
       BACKREST_REPO_ENDPOINT: s3.us-east-1.amazonaws.com
       BACKREST_REPO_S3_KEY_TYPE: shared
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/generate-benchmark-snapshots.yml
+++ b/.github/workflows/generate-benchmark-snapshots.yml
@@ -81,13 +81,13 @@ jobs:
       BACKREST_REPO_ENDPOINT: s3.us-east-1.amazonaws.com
       BACKREST_REPO_S3_KEY_TYPE: shared
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/generate-benchmark-snapshots.yml
+++ b/.github/workflows/generate-benchmark-snapshots.yml
@@ -81,7 +81,8 @@ jobs:
       BACKREST_REPO_ENDPOINT: s3.us-east-1.amazonaws.com
       BACKREST_REPO_S3_KEY_TYPE: shared
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -41,6 +41,8 @@ jobs:
         pg_version: [18]
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -41,11 +41,11 @@ jobs:
         pg_version: [18]
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Set Up pg_search Toolchain
         uses: ./.github/actions/setup-pg-search-toolchain

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -41,7 +41,8 @@ jobs:
         pg_version: [18]
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -39,6 +39,8 @@ jobs:
         pg_version: [18]
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -39,7 +39,8 @@ jobs:
         pg_version: [18]
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -39,11 +39,11 @@ jobs:
         pg_version: [18]
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -126,6 +126,8 @@ jobs:
       COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Install Dependencies
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo git ca-certificates curl gnupg lsb-release binutils
 
@@ -216,9 +218,6 @@ jobs:
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
       - name: Upload pg_search .deb
-        env:
-          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
-          ACTIONS_CACHE_SERVICE_V2: ""
         uses: actions/upload-artifact@v7
         with:
           name: pg-search-antithesis-deb-${{ env.COMMIT_SHA }}
@@ -252,6 +251,8 @@ jobs:
         workload: ${{ fromJSON(needs.setup.outputs.workloads) }}
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
@@ -265,9 +266,6 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Download Antithesis pg_search .deb
-        env:
-          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
-          ACTIONS_CACHE_SERVICE_V2: ""
         uses: actions/download-artifact@v8
         with:
           name: pg-search-antithesis-deb-${{ env.COMMIT_SHA }}

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -126,9 +126,6 @@ jobs:
       COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Install Dependencies
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo git ca-certificates curl gnupg lsb-release binutils
 
@@ -136,6 +133,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Retrieve OS Version
         id: version
@@ -252,13 +252,13 @@ jobs:
         workload: ${{ fromJSON(needs.setup.outputs.workloads) }}
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
           ref: ${{ env.COMMIT_SHA }}
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       # The workload image and the run's `antithesis.source` are named after the repository
       - name: Resolve Registry Image Name From Repository

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -126,7 +126,8 @@ jobs:
       COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Install Dependencies
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo git ca-certificates curl gnupg lsb-release binutils
@@ -251,7 +252,8 @@ jobs:
         workload: ${{ fromJSON(needs.setup.outputs.workloads) }}
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -70,13 +70,13 @@ jobs:
             platform: linux/arm64
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -451,13 +451,13 @@ jobs:
             deb_sha_arg: PG_SEARCH_DEB_ARM64_SHA256
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -70,6 +70,8 @@ jobs:
             platform: linux/arm64
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
@@ -448,6 +450,8 @@ jobs:
             deb_sha_arg: PG_SEARCH_DEB_ARM64_SHA256
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -70,7 +70,8 @@ jobs:
             platform: linux/arm64
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7
@@ -450,7 +451,8 @@ jobs:
             deb_sha_arg: PG_SEARCH_DEB_ARM64_SHA256
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -45,15 +45,15 @@ jobs:
         pg_version: [18]
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetch the entire history
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -45,7 +45,8 @@ jobs:
         pg_version: [18]
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -45,6 +45,8 @@ jobs:
         pg_version: [18]
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -87,7 +87,8 @@ jobs:
         prior: ${{ fromJSON(needs.discover-upgrade-starting-points.outputs.prior_matrix) }}
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -87,13 +87,13 @@ jobs:
         prior: ${{ fromJSON(needs.discover-upgrade-starting-points.outputs.prior_matrix) }}
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetch the entire history (required to checkout tags)
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -87,6 +87,8 @@ jobs:
         prior: ${{ fromJSON(needs.discover-upgrade-starting-points.outputs.prior_matrix) }}
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -79,7 +79,8 @@ jobs:
             arch: amd64
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -79,11 +79,11 @@ jobs:
             arch: amd64
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       # Cache notes:
       # - Do NOT add hashFiles('**/Cargo.lock') to shared-key — the action

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -79,6 +79,8 @@ jobs:
             arch: amd64
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
@@ -314,16 +316,8 @@ jobs:
         if: matrix.pg_impl == 'pgrx' && (github.event_name != 'pull_request' || matrix.pg_version == 18) && always()
         run: cargo llvm-cov report --lcov --output-path coverage-combined-pgrx-${{ matrix.pg_version }}.lcov
 
-      # runs-on's extras=s3-cache proxies ACTIONS_RESULTS_URL to its local cache
-      # server (for s3-backed actions/cache), but actions/upload-artifact@v4+ uses
-      # the same env var and ends up POSTing artifacts to the cache proxy. Pin the
-      # env vars back to GitHub's canonical artifact endpoint just for this step
-      # so the upload bypasses the proxy.
       - name: Upload Coverage Artifact
         if: (github.event_name != 'pull_request' || matrix.pg_version == 18) && always()
-        env:
-          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
-          ACTIONS_CACHE_SERVICE_V2: ""
         uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}
@@ -353,10 +347,6 @@ jobs:
 
       - name: Upload Postgres Log Artifact
         if: failure()
-        env:
-          # Same runs-on s3-cache workaround as the coverage upload above.
-          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
-          ACTIONS_CACHE_SERVICE_V2: ""
         uses: actions/upload-artifact@v7
         with:
           name: postgres-log-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -37,7 +37,8 @@ jobs:
       - extras=s3-cache
 
     steps:
-      - uses: runs-on/action@v2
+      - name: Configure RunsOn caching
+        uses: runs-on/action@v2
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -37,11 +37,11 @@ jobs:
       - extras=s3-cache
 
     steps:
-      - name: Configure RunsOn caching
-        uses: runs-on/action@v2
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
+
+      - name: Configure RunsOn Caching
+        uses: runs-on/action@v2
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -37,6 +37,8 @@ jobs:
       - extras=s3-cache
 
     steps:
+      - uses: runs-on/action@v2
+
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This is the proper way to configure runs-on's cache that makes it work without us having to use workarounds for artifact uploads. https://runs-on.com/docs/performance/caching/actions/

## Why

## How

## Tests
