### PR TITLE
fix: accept DataFusion work_mem exhaustion in qgen oracle

### DIFF
--- a/tests/src/fixtures/querygen/mod.rs
+++ b/tests/src/fixtures/querygen/mod.rs
@@ -922,6 +922,19 @@ where
     }
 }
 
+/// True when DataFusion refused the plan because its `work_mem`-sized pool is
+/// full and spilling is disabled. AggregateScan/JoinScan pair a `WorkMemMemoryPool`
+/// with `DiskManagerMode::Disabled` on purpose (see `build_runtime_env`): until
+/// spilling is wired to Postgres temp files, a plan that outgrows the pool errors
+/// instead of writing untracked files. The plain-Postgres oracle has no such
+/// budget, so counting that error as a qgen failure (#6220) is wrong — treat it
+/// as a known capability miss, like an unnormalized List declining translation.
+fn is_datafusion_work_mem_exhaustion(err: &sqlx::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("query exceeded the work_mem limit")
+        || msg.contains("temporary files are not enabled in the DiskManager")
+}
+
 fn compare_outcome_inner<R, F>(
     sides: &Sides,
     pg_query: &str,
@@ -955,6 +968,9 @@ where
         Ok(results) => results,
         Err(e) => match classify_transient(&e) {
             Some(kind) => return CaseOutcome::Transient(kind, e),
+            // Known DF resource limit (no Postgres-temp spill yet), not a
+            // correctness bug against the unbounded baseline. See #6220.
+            None if is_datafusion_work_mem_exhaustion(&e) => return CaseOutcome::Match,
             None => {
                 return CaseOutcome::Failure(handle_compare_error(
                     TestCaseError::fail(format!("{e}: error in query execution")),

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -1559,6 +1559,11 @@ async fn generated_numeric_range_precision(database: Db) {
 /// the oracle since `pdb.agg()` itself has no native fallback. Covers nested `terms`, a
 /// `size` cut under the default count order, NULL buckets, NUMERIC metrics, `cardinality`,
 /// a SQL `GROUP BY` beside the call, and MPP when the parallel GUCs are on.
+///
+/// Non-equi joins can inflate intermediate cardinality past DataFusion's `work_mem` pool
+/// (spilling is not wired yet). Raise `work_mem` so typical cases still compare; if the
+/// pool is still exhausted, `compare_outcome_retrying` accepts that as a capability miss
+/// rather than a failure (#6220).
 #[rstest]
 #[tokio::test]
 async fn generated_pdb_agg_join(database: Db) {
@@ -1598,6 +1603,9 @@ async fn generated_pdb_agg_join(database: Db) {
             &pool,
             &setup_sql,
             |query, conn| {
+                // Match generated_joinscan: keep the final hash aggregate in budget
+                // when possible; acceptance in compare_outcome covers the rest (#6220).
+                "SET work_mem TO '16MB';".execute_result(conn)?;
                 let rows = query.fetch_dynamic_result(conn)?;
                 let mut rows = agg.rows(rows)?;
                 rows.sort();


### PR DESCRIPTION
## Summary
- Treat DataFusion `work_mem` / DiskManager-spill exhaustion as an accepted capability miss in the qgen oracle instead of a false mismatch against unbounded Postgres `GROUP BY` (#6220).
- Raise `work_mem` to `16MB` in `generated_pdb_agg_join` (same pattern as `generated_joinscan`) so typical cases still compare results.

## Test plan
- [x] Reproduced DF pool exhaustion locally (`query exceeded the work_mem limit`)
- [x] Negative control: tiny `work_mem` without acceptance → fails; with acceptance → passes
- [x] `PROPTEST_CASES=256` + CI seeds `777977062730713946` and `4706007971346825089` → `generated_pdb_agg_join` ok
- [x] `generated_pdb_agg_single_table` still ok

Closes #6220