### PR TITLE
chore: Backfill changelog entries which were not backported.

### DIFF
--- a/docs/changelog/unreleased/5148.features.mdx
+++ b/docs/changelog/unreleased/5148.features.mdx
@@ -1,0 +1,5 @@
+---
+header: features
+---
+
+Added support for pushing down `SELECT DISTINCT` into the ParadeDB index via `AggregateScan` when distinct clauses reference columnar fields with deterministic collations, avoiding HashAggregate execution over all matching rows.

--- a/docs/changelog/unreleased/5791.features.mdx
+++ b/docs/changelog/unreleased/5791.features.mdx
@@ -1,0 +1,5 @@
+---
+header: features
+---
+
+`ORDER BY` on PostgreSQL range columns is now pushed down into the ParadeDB index Top-K path when the range column is the leading sort key, ordering bounds according to PostgreSQL `range_cmp` semantics.

--- a/docs/changelog/unreleased/5969.other.mdx
+++ b/docs/changelog/unreleased/5969.other.mdx
@@ -1,0 +1,5 @@
+---
+header: other
+---
+
+Streamlined Docker image builds and removed extraneous bundled extensions in official container images to conform with Docker Official Images guidelines.

--- a/docs/changelog/unreleased/6127.other.mdx
+++ b/docs/changelog/unreleased/6127.other.mdx
@@ -1,0 +1,5 @@
+---
+header: other
+---
+
+Updated user-facing error messages, notices, and planner diagnostics to refer to "ParadeDB index" rather than legacy "BM25 index" terminology.


### PR DESCRIPTION
A few notable changes which had landed before the release process changes went through.