### PR TITLE
fix: keep the pdb.agg join proptest inside work_mem

### DIFF
--- a/tests/src/fixtures/querygen/joingen.rs
+++ b/tests/src/fixtures/querygen/joingen.rs
@@ -120,6 +120,14 @@ impl JoinExpr {
             .all(|s| !matches!(s.join_type, JoinType::Cross))
     }
 
+    /// A step joined on a non-equi condition alone, which nothing keeps from
+    /// fanning out to nearly the cross product of its two sides.
+    pub fn has_keyless_step(&self) -> bool {
+        self.steps
+            .iter()
+            .any(|s| matches!(s.on_condition, Some(OnCondition::NonEqui { .. })))
+    }
+
     /// Render as a SQL fragment, e.g.
     /// `FROM t0 JOIN t1 ON t0.a = t1.b LEFT JOIN t2 ON t1.x = t2.y ...`
     pub fn to_sql(&self) -> String {

--- a/tests/src/fixtures/querygen/pdbagggen.rs
+++ b/tests/src/fixtures/querygen/pdbagggen.rs
@@ -286,28 +286,40 @@ struct SpecShape {
     numeric_metrics: bool,
     /// A `size` may cut any level, not only a lone top level under no group.
     size_anywhere: bool,
+    /// Bucket keys a spec with a `cardinality` metric may have. Every bucket
+    /// carries its own sketch, and the DataFusion aggregate holds them all in
+    /// `work_mem` with no spill.
+    sketch_keys: usize,
 }
 
 /// A join over a prefix of `tables` and a `pdb.agg()` whose fields belong to
 /// those tables. `key_columns` are the join keys; `terms` keys come from the
-/// text and integer columns, metrics from the integer and NUMERIC ones.
+/// text and integer columns, metrics from the integer and NUMERIC ones. A join
+/// with a keyless step yields tens of thousands of buckets under several keys,
+/// so `cardinality` keeps to one key there.
 pub fn arb_pdb_agg_join(
     tables: Vec<String>,
     key_columns: &[Column],
 ) -> impl Strategy<Value = (JoinExpr, PdbAggExpr)> {
-    let shape = SpecShape {
-        grouped: false,
-        numeric_metrics: true,
-        size_anywhere: false,
-    };
     let key_columns = key_columns.to_vec();
     (2..=tables.len()).prop_flat_map(move |num_tables| {
         let joined: Vec<String> = tables[..num_tables].to_vec();
         // The planner cannot see the fields inside a spec, so it removes an outer
         // join whose table nothing else reads, and the spec then names a table
         // that is gone. Inner joins are never removed.
-        let join = arb_joins(Just(JoinType::Inner), joined.clone(), &key_columns);
-        (join, arb_pdb_agg(joined, shape))
+        arb_joins(Just(JoinType::Inner), joined.clone(), &key_columns).prop_flat_map(move |join| {
+            let shape = SpecShape {
+                grouped: false,
+                numeric_metrics: true,
+                size_anywhere: false,
+                sketch_keys: if join.has_keyless_step() {
+                    1
+                } else {
+                    usize::MAX
+                },
+            };
+            (Just(join), arb_pdb_agg(joined.clone(), shape))
+        })
     })
 }
 
@@ -322,6 +334,7 @@ pub fn arb_pdb_agg_single_table() -> impl Strategy<Value = PdbAggExpr> {
             grouped: true,
             numeric_metrics: false,
             size_anywhere: true,
+            sketch_keys: usize::MAX,
         },
     )
 }
@@ -397,6 +410,13 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
                     });
                 }
             }
+            if usize::from(outer_group.is_some()) + terms.len() > shape.sketch_keys {
+                for metric in &mut metrics {
+                    if metric.kind == MetricKind::Cardinality {
+                        metric.kind = MetricKind::ValueCount;
+                    }
+                }
+            }
             let size = size.filter(|&(level, _)| {
                 level < terms.len()
                     && (shape.size_anywhere
@@ -409,4 +429,45 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
                 metrics,
             }
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::strategy::ValueTree;
+    use proptest::test_runner::TestRunner;
+
+    #[test]
+    fn cardinality_keeps_to_one_key_over_a_keyless_join() {
+        let mut runner = TestRunner::default();
+        let tables = vec![
+            "users".to_string(),
+            "products".to_string(),
+            "orders".to_string(),
+        ];
+        let key_columns = vec![
+            Column::new("id", "BIGINT", "1"),
+            Column::new("age", "INTEGER", "20"),
+        ];
+        let strategy = arb_pdb_agg_join(tables, &key_columns);
+
+        let mut saw_sketch_over_keyless = false;
+        let mut saw_sketch_under_keys = false;
+        for _ in 0..500 {
+            let (join, agg) = strategy.new_tree(&mut runner).unwrap().current();
+            let keys = usize::from(agg.outer_group.is_some()) + agg.terms.len();
+            let sketch = agg
+                .metrics
+                .iter()
+                .any(|m| m.kind == MetricKind::Cardinality);
+            if join.has_keyless_step() {
+                assert!(!(sketch && keys > 1), "{join:?} {agg:?}");
+                saw_sketch_over_keyless |= sketch;
+            } else {
+                saw_sketch_under_keys |= sketch && keys > 1;
+            }
+        }
+        assert!(saw_sketch_over_keyless);
+        assert!(saw_sketch_under_keys);
+    }
 }

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -1598,6 +1598,9 @@ async fn generated_pdb_agg_join(database: Db) {
             &pool,
             &setup_sql,
             |query, conn| {
+                // A keyless join under three bucket keys makes tens of thousands of
+                // buckets, and the DataFusion aggregate cannot spill past `work_mem`.
+                "SET work_mem TO '64MB';".execute_result(conn)?;
                 let rows = query.fetch_dynamic_result(conn)?;
                 let mut rows = agg.rows(rows)?;
                 rows.sort();


### PR DESCRIPTION
## Ticket(s) Closed

None.

## What

This PR keeps `generated_pdb_agg_join` inside `work_mem`.

## Why

The proptest can draw a join with a step joined on a non-equi condition alone, such as `users.age <> products.age`, which fans out to nearly the cross product of its two sides. Under a SQL `GROUP BY` and two nested `terms`, that yields tens of thousands of buckets. The DataFusion aggregate runs with the `DiskManager` disabled, so it fails once its state outgrows `work_mem` instead of spilling. In addition, `create_memory_pool` in `pg_search/src/postgres/customscan/datafusion/memory.rs` grows the pool only for a `HashJoinExec` or a `SortExec`, so under a `NestedLoopJoinExec` the pool is the default 4MB.

Both reproduction scripts from run 33983476495 (PG16 system and PG18 pgrx) fail on a local instance at `work_mem = 4MB` every time, so this was never a flake. Measured on the PG18 data:

| Shape | Buckets | Fails at | Passes at |
| --- | --- | --- | --- |
| PG18 seed: `GROUP BY` + 2 `terms`, 2 `cardinality` | 982 | 8MB | 16MB |
| 3 keys, `sum`/`min`/`max` on NUMERIC, keyless 3-way join | 55035 | 16MB | 24MB |
| 3 keys, 3 `cardinality`, keyless 3-way join | 55035 | 256MB | 1GB |

## How

- The oracle closure sets `work_mem` to `64MB`, the way `generated_joins_small` does. That covers every shape without a sketch with about 3x margin.
- `arb_pdb_agg_join` passes the join into the spec shape. Over a join with a keyless step, a spec with `cardinality` keeps to at most one bucket key; with more keys the metric becomes `value_count` on the same field. Equi and mixed joins keep every shape, since their equality bounds the fan-out.
- `JoinExpr::has_keyless_step` is the new predicate.

Whether `create_memory_pool` should also budget for a `NestedLoopJoinExec` is a separate question.

## Tests

Existing tests.

