### PR TITLE
test: keep keyless joins out of the pdb.agg join proptest

### DIFF
--- a/tests/src/fixtures/querygen/joingen.rs
+++ b/tests/src/fixtures/querygen/joingen.rs
@@ -120,6 +120,13 @@ impl JoinExpr {
             .all(|s| !matches!(s.join_type, JoinType::Cross))
     }
 
+    /// A step joined on a non-equi condition alone, with no equality to bound its fan-out.
+    pub fn has_keyless_step(&self) -> bool {
+        self.steps
+            .iter()
+            .any(|s| matches!(s.on_condition, Some(OnCondition::NonEqui { .. })))
+    }
+
     /// Render as a SQL fragment, e.g.
     /// `FROM t0 JOIN t1 ON t0.a = t1.b LEFT JOIN t2 ON t1.x = t2.y ...`
     pub fn to_sql(&self) -> String {
@@ -220,6 +227,30 @@ where
     J: Strategy<Value = JoinType>,
     S: AsRef<str>,
 {
+    arb_joins_with_conditions(
+        join_types,
+        tables_to_join,
+        columns,
+        prop_oneof![
+            2 => Just(ConditionKind::Equi),
+            1 => Just(ConditionKind::NonEqui),
+            1 => Just(ConditionKind::Mixed),
+        ],
+    )
+}
+
+/// [`arb_joins`] with the kind of each `ON` condition drawn from `condition_kinds`.
+pub fn arb_joins_with_conditions<J, S, K>(
+    join_types: J,
+    tables_to_join: Vec<S>,
+    columns: &[Column],
+    condition_kinds: K,
+) -> impl Strategy<Value = JoinExpr> + use<J, S, K>
+where
+    J: Strategy<Value = JoinType>,
+    S: AsRef<str>,
+    K: Strategy<Value = ConditionKind>,
+{
     let tables_to_join = tables_to_join
         .into_iter()
         .map(|tn| tn.as_ref().to_string())
@@ -265,11 +296,7 @@ where
 
     let step_strategy = (
         join_types,
-        prop_oneof![
-            2 => Just(ConditionKind::Equi),
-            1 => Just(ConditionKind::NonEqui),
-            1 => Just(ConditionKind::Mixed),
-        ],
+        condition_kinds,
         0..table_cols.len(),
         0..orderable_cols.len(),
         0..NON_EQUI_OPS.len(),

--- a/tests/src/fixtures/querygen/pdbagggen.rs
+++ b/tests/src/fixtures/querygen/pdbagggen.rs
@@ -28,7 +28,9 @@ use sqlx::Row;
 use sqlx::postgres::PgRow;
 
 use crate::fixtures::querygen::Column;
-use crate::fixtures::querygen::joingen::{JoinExpr, JoinType, arb_joins};
+use crate::fixtures::querygen::joingen::{
+    ConditionKind, JoinExpr, JoinType, arb_joins_with_conditions,
+};
 
 /// Size that no generated bucket count reaches, so a level is never cut.
 const NO_CUT: u32 = 1000;
@@ -289,8 +291,9 @@ struct SpecShape {
 }
 
 /// A join over a prefix of `tables` and a `pdb.agg()` whose fields belong to
-/// those tables. `key_columns` are the join keys; `terms` keys come from the
-/// text and integer columns, metrics from the integer and NUMERIC ones.
+/// those tables. `key_columns` are the join keys, and every step keeps an
+/// equality on one of them; `terms` keys come from the text and integer
+/// columns, metrics from the integer and NUMERIC ones.
 pub fn arb_pdb_agg_join(
     tables: Vec<String>,
     key_columns: &[Column],
@@ -306,7 +309,19 @@ pub fn arb_pdb_agg_join(
         // The planner cannot see the fields inside a spec, so it removes an outer
         // join whose table nothing else reads, and the spec then names a table
         // that is gone. Inner joins are never removed.
-        let join = arb_joins(Just(JoinType::Inner), joined.clone(), &key_columns);
+        //
+        // A step joined on a non-equi condition alone is nearly a cross product, and
+        // the buckets over it outgrow any work_mem the oracle sets, since the
+        // aggregate cannot spill. The equality in a mixed condition bounds the rows.
+        let join = arb_joins_with_conditions(
+            Just(JoinType::Inner),
+            joined.clone(),
+            &key_columns,
+            prop_oneof![
+                2 => Just(ConditionKind::Equi),
+                1 => Just(ConditionKind::Mixed),
+            ],
+        );
         (join, arb_pdb_agg(joined, shape))
     })
 }
@@ -409,4 +424,38 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
                 metrics,
             }
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::strategy::ValueTree;
+    use proptest::test_runner::TestRunner;
+
+    #[test]
+    fn every_join_step_keeps_an_equality() {
+        let mut runner = TestRunner::default();
+        let tables = vec![
+            "users".to_string(),
+            "products".to_string(),
+            "orders".to_string(),
+        ];
+        let key_columns = vec![
+            Column::new("id", "BIGINT", "1"),
+            Column::new("age", "INTEGER", "20"),
+        ];
+        let strategy = arb_pdb_agg_join(tables, &key_columns);
+
+        let mut saw_mixed = false;
+        for _ in 0..200 {
+            let (join, _) = strategy.new_tree(&mut runner).unwrap().current();
+            let sql = join.to_sql();
+            assert!(!join.has_keyless_step(), "{sql}");
+            saw_mixed |= sql.contains(" AND ");
+        }
+        assert!(
+            saw_mixed,
+            "a non-equi part should still appear beside an equality"
+        );
+    }
 }

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -1598,6 +1598,8 @@ async fn generated_pdb_agg_join(database: Db) {
             &pool,
             &setup_sql,
             |query, conn| {
+                // The aggregate's work_mem pool cannot spill; leave headroom over the 4MB default.
+                "SET work_mem TO '16MB';".execute_result(conn)?;
                 let rows = query.fetch_dynamic_result(conn)?;
                 let mut rows = agg.rows(rows)?;
                 rows.sort();


### PR DESCRIPTION
# Ticket(s) Closed

None.

## What

This PR keeps `generated_pdb_agg_join` inside `work_mem`.

## Why

The proptest can draw a step joined on a non-equi condition alone, such as `users.age <> products.age`, which is nearly the cross product of its two sides. Over three 50-row tables that is about 110k rows and, under a `GROUP BY` beside two nested `terms`, about 52k buckets. The DataFusion aggregate runs with the `DiskManager` disabled and a pool of exactly `work_mem` (a `NestedLoopJoinExec` adds nothing in `create_memory_pool`), so it errors instead of spilling. Five CI sightings on 2026-09-05, all on branches that do not touch aggregates.

The three CI reproduction scripts fail at the default 4MB on a local PG17 every time, so the failure is deterministic once the shape is drawn. 16MB alone is not a budget either. On the data of seed 7602575653493464027, three `age` keys with NUMERIC `sum`/`min`/`max` fail at 16MB and pass at 64MB, and three `cardinality` sketches fail at 64MB too. Two of five random rounds with only `work_mem = 16MB` still hit the limit.

## How

- `arb_pdb_agg_join` draws only equi and mixed `ON` conditions, through a new `arb_joins_with_conditions`. The equality bounds the fan-out, and the non-equi part still appears in mixed conditions.
- The oracle closure sets `work_mem` to `16MB`, as `generated_joins_small` does.
- `JoinExpr::has_keyless_step` is the predicate the unit test uses.

This is an alternative to #6235, which keeps keyless joins and instead caps `cardinality` to one key over them, at 64MB. One of the two should be closed.

## Tests

- The three CI seeds (7602575653493464027, 1155148728537315987, 1144842735668466328), a default run, and five random rounds pass on local PG17. The CI logs carry no `PROPTEST_RNG_SEED`, so the exact case cannot be replayed bit for bit.
- A unit test in `pdbagggen.rs` checks that no drawn join has a keyless step and that mixed conditions still appear.
