### PR TITLE
fix: kept null-extended rows NULL in a deferred string column.

### DIFF
--- a/docs/changelog/unreleased/6247.stability.mdx
+++ b/docs/changelog/unreleased/6247.stability.mdx
@@ -1,0 +1,5 @@
+---
+header: stability
+---
+
+The join scan now returns the right rows when a `LIMIT` query sorts on a text columnar field of the nullable side of an outer join. Those rows used to sort as if they carried the first document's value.

--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -541,7 +541,7 @@ impl WhichFastField {
             )),
             WhichFastField::Junk(_) => DataType::Null,
             WhichFastField::Deferred(_, _field_type) => {
-                crate::scan::deferred_encode::deferred_union_data_type()
+                crate::scan::deferred_encode::deferred_data_type()
             }
             WhichFastField::DeferredCtid(_) => DataType::UInt64,
             WhichFastField::MatchTag(_) => DataType::Boolean,
@@ -557,9 +557,13 @@ pub fn build_arrow_schema(which_fast_fields: &[WhichFastField]) -> arrow_schema:
     use arrow_schema::{Field, Schema};
     use std::sync::Arc;
 
+    // A deferred column is a plain `UInt64` to Arrow; its field's metadata is what marks it.
     let fields: Vec<Field> = which_fast_fields
         .iter()
-        .map(|wff| Field::new(wff.name(), wff.arrow_data_type(), true))
+        .map(|wff| match wff {
+            WhichFastField::Deferred(name, _) => crate::scan::deferred_encode::deferred_field(name),
+            _ => Field::new(wff.name(), wff.arrow_data_type(), true),
+        })
         .collect();
     Arc::new(Schema::new(fields))
 }

--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -23,7 +23,6 @@ use crate::postgres::datetime::PostgresDateTime;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::types::{TantivyValue, is_pgoid_datetime_type};
 use crate::postgres::types_arrow::datetime_to_pg_micros;
-use crate::scan::deferred_encode::unpack_doc_address;
 use crate::schema::SearchFieldType;
 
 use arrow_array::builder::{BinaryViewBuilder, StringViewBuilder};
@@ -568,23 +567,20 @@ pub fn build_arrow_schema(which_fast_fields: &[WhichFastField]) -> arrow_schema:
     Arc::new(Schema::new(fields))
 }
 
-/// Partitions packed doc addresses by segment ordinal and invokes `process`
+/// Partitions doc addresses by segment ordinal and invokes `process`
 /// once per segment (in sorted segment order) with the segment ordinal and
 /// its `(row_index, doc_id)` pairs.
-///
-/// The `packed_iter` argument yields `(row_index, packed_doc_address)`
 pub fn for_each_segment<F>(
     num_segments: usize,
-    packed_iter: impl Iterator<Item = (usize, u64)>,
+    doc_addresses: impl Iterator<Item = (usize, DocAddress)>,
     mut process: F,
 ) -> Result<()>
 where
     F: FnMut(SegmentOrdinal, Vec<(usize, DocId)>) -> Result<()>,
 {
     let mut by_seg: Vec<Vec<(usize, DocId)>> = vec![Vec::new(); num_segments];
-    for (row_idx, packed) in packed_iter {
-        let (seg_ord, doc_id) = unpack_doc_address(packed);
-        by_seg[seg_ord as usize].push((row_idx, doc_id));
+    for (row_idx, doc_address) in doc_addresses {
+        by_seg[doc_address.segment_ord as usize].push((row_idx, doc_address.doc_id));
     }
     for (seg_ord, mut rows) in by_seg.into_iter().enumerate() {
         if rows.is_empty() {

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -48,7 +48,7 @@ When MPP is eligible, `DistributedPlanner` builds an MPP execution tree (`Distri
 
 ### 4. Deferred Columns
 
-String columns are emitted as a [2-way `UnionArray`](../../../scan/deferred_encode.rs) (doc_address | term_ordinal) so intermediate nodes work with cheap integer ordinals instead of decoded strings. The [decision to defer](../../../scan/table_provider.rs) is made in [`configure_deferred_outputs()`][defer-decision].
+String columns are emitted as a [packed `UInt64`](../../../scan/deferred_encode.rs) (doc_address | term_ordinal) so intermediate nodes work with cheap integer ordinals instead of decoded strings. The [decision to defer](../../../scan/table_provider.rs) is made in [`configure_deferred_outputs()`][defer-decision].
 
 The lookup has two halves with different access patterns, so they are separate nodes. [`TantivyFetchExec`][fetch-exec] reads the fast-field column (doc_address → term_ordinal, and packed ctid → real ctid); it wants doc order, which a join above the scan no longer keeps. [`TantivyDecodeExec`][decode-exec] reads the segment dictionary (term_ordinal → string); it is random access either way, and ordinals are much narrower than strings, so it can move above joins and shuffles at the same cost per row. The planner places the two next to each other; a cost model may separate them. `paradedb.defer_column_fetch` chooses between fetching in the scan (State 1 out of the scan, in doc order) and fetching at the decode point.
 
@@ -99,7 +99,7 @@ Execution-layer files under [`pg_search/src/scan/`](../../../scan/):
 | [`batch_scanner.rs`](../../../scan/batch_scanner.rs)     | [`Scanner::next()`][scanner-next] — batch iteration, pre-filter, visibility                                                         |
 | [`execution_plan.rs`](../../../scan/execution_plan.rs)   | [`PgSearchScanPlan`][scan-plan] — dynamic filter integration                                                                        |
 | [`pre_filter.rs`](../../../scan/pre_filter.rs)           | [`try_rewrite_binary`][rewrite-binary], [`collect_filters`][collect-filters]                                                        |
-| [`deferred_encode.rs`](../../../scan/deferred_encode.rs) | 2-way UnionArray construction and unpacking                                                                                         |
+| [`deferred_encode.rs`](../../../scan/deferred_encode.rs) | Packed deferred column construction and unpacking                                                                                   |
 
 ## GUCs
 

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -79,6 +79,7 @@ use crate::index::fast_fields_helper::{FFHelper, for_each_segment};
 use crate::postgres::customscan::joinscan::CtidColumn;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
+use crate::scan::deferred_encode::unpack_doc_address;
 use crate::scan::execution_plan::UnsafeSendStream;
 use crate::scan::late_materialization::is_reduction_node;
 use crate::scan::table_provider::{VisibilitySourceMetadata, pg_search_provider_from_scan};
@@ -1167,15 +1168,15 @@ pub(crate) fn materialize_deferred_ctid(
     state: &mut DeferredCtidMaterializationState,
 ) -> Result<ArrayRef> {
     let num_rows = doc_addr_array.len();
-    let packed_iter = (0..num_rows)
+    let doc_addresses = (0..num_rows)
         .filter(|&i| !doc_addr_array.is_null(i))
-        .map(|i| (i, doc_addr_array.value(i)));
+        .map(|i| (i, unpack_doc_address(doc_addr_array.value(i))));
 
     state.resolved_ctids.clear();
     state.resolved_ctids.resize(num_rows, None);
 
     let num_segments = ffhelper.num_segments();
-    for_each_segment(num_segments, packed_iter, |seg_ord, rows| {
+    for_each_segment(num_segments, doc_addresses, |seg_ord, rows| {
         state.segment_doc_ids.clear();
         state.segment_doc_ids.extend(rows.iter().map(|(_, id)| *id));
 

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -511,10 +511,10 @@ fn extract_ctid_lineage(schema: &DFSchemaRef) -> BTreeSet<usize> {
         .fields()
         .iter()
         .filter_map(|field| {
-            // Only match UInt64 fields to avoid misclassifying user columns
-            // that happen to be named `ctid_<n>`. Internal ctid columns are
-            // always UInt64 (real ctids or packed DocAddresses); no user-facing
-            // Postgres type maps to Arrow UInt64.
+            // The `ctid_<n>` name is what identifies an internal ctid column
+            // (a real ctid or a packed doc address); the type check only skips
+            // columns that cannot be one. `oid`, `xid` and deferred string
+            // columns are UInt64 as well.
             if field.data_type() == &arrow_schema::DataType::UInt64 {
                 CtidColumn::try_from(field.name().as_str())
                     .ok()

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -688,18 +688,21 @@ impl Scanner {
                         _ => Some(col_array),
                     }
                 }
-                // When resolving the data block, we build a 2-state UnionArray:
-                // 0. None -> We just have doc ids. Emit State 0 (Doc Address).
-                // 1. Some(UInt64) -> The term ordinals are already resolved, by a pre-filter
-                //    or because this column is fetched in the scan. Emit State 1.
+                // A deferred column leaves as packed doc addresses (State 0) unless its term
+                // ordinals were already read, by a pre-filter or because the column is
+                // fetched in the scan, in which case it leaves as packed ordinals (State 1).
                 WhichFastField::DeferredCtid(_) => Some(Arc::new(
                     crate::scan::deferred_encode::pack_doc_addresses(segment_ord, &ids),
                 ) as ArrayRef),
                 WhichFastField::Deferred(_, _field_type) => match &memoized_columns[ff_index] {
                     Some(col_array) => {
+                        let ordinals = col_array
+                            .as_any()
+                            .downcast_ref::<UInt64Array>()
+                            .expect("Expected UInt64Array for deferred ordinals");
                         Some(crate::scan::deferred_encode::build_state_term_ordinals(
                             segment_ord,
-                            col_array.clone(),
+                            ordinals,
                         ))
                     }
                     None => Some(crate::scan::deferred_encode::build_state_doc_address(

--- a/pg_search/src/scan/deferred_encode.rs
+++ b/pg_search/src/scan/deferred_encode.rs
@@ -15,251 +15,189 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use arrow_array::{
-    Array, ArrayRef, StructArray, UInt32Array, UInt64Array, UnionArray, new_empty_array,
-};
-use arrow_buffer::ScalarBuffer;
-use arrow_schema::{DataType, Field, UnionFields, UnionMode};
+//! The encoding of a deferred string/bytes column.
+//!
+//! A deferred column is a `UInt64` column. A row is a packed doc address (State 0) or a
+//! packed term ordinal (State 1), told apart by the top bit, and a NULL is an Arrow NULL.
+//! One primitive word per row is what makes the column cheap to carry: a join's `take`
+//! copies one buffer and keeps a validity bitmap for the rows it null-extends, and the
+//! fetch changes a row's state without changing the column's type, so it can run in the
+//! scan or anywhere above it.
+
+use arrow_array::{Array, ArrayRef, UInt64Array};
+use arrow_buffer::{NullBuffer, ScalarBuffer};
+use arrow_schema::{DataType, Field};
 use datafusion::common::{DataFusionError, Result};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tantivy::termdict::TermOrdinal;
 use tantivy::{DocId, SegmentOrdinal};
 
-pub const EXTENSION_DOC_ADDRESS: &str = "tantivy_doc_address";
-pub const EXTENSION_TERM_ORDINAL: &str = "tantivy_term_ordinal";
+/// The Arrow extension name on a deferred column's field, which is how a schema tells one
+/// apart from any other `UInt64` column.
+pub const EXTENSION_NAME: &str = "tantivy_deferred";
+const EXTENSION_KEY: &str = "ARROW:extension:name";
 
-// In Arrow, extension types are defined by the underlying storage type,
-// and the extension name is attached as metadata to the Field later!
-pub fn doc_address_type() -> DataType {
+/// Set on a packed term ordinal, clear on a packed doc address.
+const TERM_ORDINAL_BIT: u64 = 1 << 63;
+/// A term ordinal keeps the low 40 bits of the word and the segment ordinal the 23 above
+/// them. A segment holds fewer than 2^32 documents, so no dictionary comes near 2^40 terms.
+const TERM_ORDINAL_BITS: u32 = 40;
+const TERM_ORDINAL_MASK: u64 = (1 << TERM_ORDINAL_BITS) - 1;
+const MAX_STATE1_SEGMENT_ORD: u64 = (1 << (63 - TERM_ORDINAL_BITS)) - 1;
+/// A doc address keeps the doc id in the low 32 bits and the segment ordinal above it.
+const MAX_STATE0_SEGMENT_ORD: u64 = (1 << 31) - 1;
+
+pub fn deferred_data_type() -> DataType {
     DataType::UInt64
 }
 
-pub fn term_ordinal_type() -> DataType {
-    // We use a Struct to safely hold both a u32 segment_ord and a u64 term_ord
-    DataType::Struct(
-        vec![
-            Field::new("segment_ord", DataType::UInt32, false),
-            Field::new("term_ord", DataType::UInt64, true),
-        ]
-        .into(),
-    )
+/// The metadata a deferred column's field carries.
+pub fn deferred_metadata() -> HashMap<String, String> {
+    [(EXTENSION_KEY.to_string(), EXTENSION_NAME.to_string())].into()
 }
 
-/// Packs segment ordinals and doc IDs into a single 64-bit integer array.
+pub fn deferred_field(name: &str) -> Field {
+    Field::new(name, deferred_data_type(), true).with_metadata(deferred_metadata())
+}
+
+pub fn is_deferred_field(field: &Field) -> bool {
+    field.data_type() == &DataType::UInt64
+        && field.metadata().get(EXTENSION_KEY).map(String::as_str) == Some(EXTENSION_NAME)
+}
+
+/// Packs a segment ordinal and a doc id into one word (State 0).
 ///
-/// This preserves enough Tantivy row identity to resolve a surviving row back to a
-/// real ctid later, without paying heap-access costs up front.
+/// This preserves enough Tantivy row identity to resolve a surviving row back to a real
+/// ctid or a term ordinal later, without paying for either up front.
+pub fn pack_doc_address(segment_ord: SegmentOrdinal, doc_id: DocId) -> u64 {
+    assert!(
+        (segment_ord as u64) <= MAX_STATE0_SEGMENT_ORD,
+        "segment ordinal {segment_ord} does not fit a packed doc address"
+    );
+    ((segment_ord as u64) << 32) | (doc_id as u64)
+}
+
 pub fn pack_doc_addresses(segment_ord: SegmentOrdinal, doc_ids: &[DocId]) -> UInt64Array {
-    let mut b = arrow_array::builder::UInt64Builder::with_capacity(doc_ids.len());
-    for doc_id in doc_ids {
-        let packed = ((segment_ord as u64) << 32) | (*doc_id as u64);
-        b.append_value(packed);
-    }
-    b.finish()
+    UInt64Array::from_iter_values(
+        doc_ids
+            .iter()
+            .map(|doc_id| pack_doc_address(segment_ord, *doc_id)),
+    )
 }
 
-/// Unpacks a 64-bit integer into its segment ordinal and doc ID.
-pub fn unpack_doc_address(packed: u64) -> (u32, u32) {
-    let seg_ord = (packed >> 32) as u32;
-    let doc_id = (packed & 0xFFFF_FFFF) as u32;
-    (seg_ord, doc_id)
+/// Unpacks a doc address into its segment ordinal and doc id.
+pub fn unpack_doc_address(packed: u64) -> (SegmentOrdinal, DocId) {
+    debug_assert_eq!(packed & TERM_ORDINAL_BIT, 0, "not a doc address");
+    ((packed >> 32) as u32, (packed & 0xFFFF_FFFF) as u32)
 }
 
-/// Helper to get just the UnionFields (required by UnionArray::try_new)
-pub fn deferred_union_fields() -> UnionFields {
-    let fields = vec![
-        Field::new("doc_address", doc_address_type(), true).with_metadata(
-            [(
-                "ARROW:extension:name".to_string(),
-                EXTENSION_DOC_ADDRESS.to_string(),
-            )]
-            .into(),
-        ),
-        Field::new("term_ordinal", term_ordinal_type(), true).with_metadata(
-            [(
-                "ARROW:extension:name".to_string(),
-                EXTENSION_TERM_ORDINAL.to_string(),
-            )]
-            .into(),
-        ),
-    ];
-    UnionFields::try_new(vec![0, 1], fields).expect("Failed to create UnionFields")
+/// Packs a segment ordinal and a term ordinal in that segment's dictionary into one word
+/// (State 1). Equal words name equal terms of one segment.
+pub fn pack_term_ordinal(segment_ord: SegmentOrdinal, term_ord: TermOrdinal) -> u64 {
+    assert!(
+        (segment_ord as u64) <= MAX_STATE1_SEGMENT_ORD && term_ord <= TERM_ORDINAL_MASK,
+        "segment ordinal {segment_ord} or term ordinal {term_ord} does not fit a packed term ordinal"
+    );
+    TERM_ORDINAL_BIT | ((segment_ord as u64) << TERM_ORDINAL_BITS) | term_ord
 }
 
-/// The schema definition for our 2-way UnionArray
-pub fn deferred_union_data_type() -> DataType {
-    DataType::Union(deferred_union_fields(), UnionMode::Dense)
-}
-
-// State 0
+/// State 0 for one segment's rows.
 pub fn build_state_doc_address(segment_ord: SegmentOrdinal, doc_ids: &[DocId]) -> ArrayRef {
-    let len = doc_ids.len();
-    let fields = deferred_union_fields();
-    let type_ids = ScalarBuffer::from(vec![0_i8; len]);
-    let offsets = ScalarBuffer::from((0..len).map(|i| i as i32).collect::<Vec<_>>());
-
-    let children: Vec<ArrayRef> = vec![
-        Arc::new(pack_doc_addresses(segment_ord, doc_ids)),
-        new_empty_array(fields[1].1.data_type()),
-    ];
-
-    Arc::new(
-        UnionArray::try_new(fields, type_ids, Some(offsets), children)
-            .expect("Failed to construct State 0 UnionArray"),
-    )
+    Arc::new(pack_doc_addresses(segment_ord, doc_ids))
 }
 
-// State 1
-pub fn build_state_term_ordinals(segment_ord: SegmentOrdinal, ordinals: ArrayRef) -> ArrayRef {
-    let seg_array = UInt32Array::from(vec![segment_ord; ordinals.len()]);
-    build_state_term_ordinals_per_row(seg_array, ordinals)
+/// State 1 for one segment's rows, from their raw ordinals (NULL where the row has no value).
+pub fn build_state_term_ordinals(segment_ord: SegmentOrdinal, ordinals: &UInt64Array) -> ArrayRef {
+    Arc::new(UInt64Array::from_iter(
+        ordinals
+            .iter()
+            .map(|ord| ord.map(|ord| pack_term_ordinal(segment_ord, ord))),
+    ))
 }
 
-/// State 1 with a segment ordinal per row, for a batch whose rows were fetched out of
-/// several segments (anything above a join no longer groups rows by segment).
-pub fn build_state_term_ordinals_per_row(
-    segment_ords: UInt32Array,
-    ordinals: ArrayRef,
-) -> ArrayRef {
-    let len = ordinals.len();
-    let fields = deferred_union_fields();
-    let type_ids = ScalarBuffer::from(vec![1_i8; len]);
-    let offsets = ScalarBuffer::from((0..len).map(|i| i as i32).collect::<Vec<_>>());
-
-    let term_ord_struct = Arc::new(
-        StructArray::try_new(
-            if let DataType::Struct(f) = term_ordinal_type() {
-                f.clone()
-            } else {
-                unreachable!()
-            },
-            vec![Arc::new(segment_ords) as ArrayRef, ordinals],
-            None,
-        )
-        .unwrap(),
-    ) as ArrayRef;
-
-    let children: Vec<ArrayRef> = vec![new_empty_array(fields[0].1.data_type()), term_ord_struct];
-
-    Arc::new(
-        UnionArray::try_new(fields, type_ids, Some(offsets), children)
-            .expect("Failed to construct State 1 UnionArray"),
-    )
-}
-
-/// One row of a deferred column, as read through [`DeferredUnion`].
+/// One row of a deferred column, as read through [`DeferredColumn`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DeferredValue {
     /// State 0: the row still carries its packed `(segment_ord, doc_id)`.
     DocAddress(u64),
-    /// State 1: the row's term ordinal in `segment_ord`'s dictionary. `None` is a NULL term.
+    /// State 1: the row's term ordinal in `segment_ord`'s dictionary.
     TermOrdinal {
         segment_ord: SegmentOrdinal,
-        term_ord: Option<TermOrdinal>,
+        term_ord: TermOrdinal,
     },
-    /// The row is NULL in either state.
+    /// The row's value is NULL, or the row was null-extended by an outer join.
     Null,
 }
 
-/// Typed read access to a deferred column's dense 2-way `UnionArray`, so the fetch and
-/// decode nodes share one reading of the encoding.
-pub struct DeferredUnion<'a> {
-    type_ids: &'a [i8],
-    offsets: &'a [i32],
-    doc_addresses: &'a UInt64Array,
-    term_ords: &'a StructArray,
-    segment_ords: &'a UInt32Array,
-    ordinals: &'a UInt64Array,
+/// Typed read access to a deferred column, so the fetch, the decode and the segmented
+/// Top-K share one reading of the encoding.
+pub struct DeferredColumn<'a> {
+    values: &'a UInt64Array,
 }
 
-impl<'a> DeferredUnion<'a> {
+impl<'a> DeferredColumn<'a> {
     pub fn try_new(array: &'a dyn Array) -> Result<Self> {
-        let union = array.as_any().downcast_ref::<UnionArray>().ok_or_else(|| {
-            DataFusionError::Execution(format!(
-                "expected a deferred UnionArray, found {:?}",
-                array.data_type()
-            ))
-        })?;
-        let offsets = union.offsets().ok_or_else(|| {
-            DataFusionError::Execution(
-                "expected dense union with offsets in deferred column".into(),
-            )
-        })?;
-        let doc_addresses = union
-            .child(0)
+        let values = array
             .as_any()
             .downcast_ref::<UInt64Array>()
             .ok_or_else(|| {
-                DataFusionError::Execution(
-                    "expected UInt64Array for doc_address child in deferred union".into(),
-                )
+                DataFusionError::Execution(format!(
+                    "expected a deferred UInt64 column, found {:?}",
+                    array.data_type()
+                ))
             })?;
-        let term_ords = union
-            .child(1)
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .ok_or_else(|| {
-                DataFusionError::Execution(
-                    "expected StructArray for term_ord child in deferred union".into(),
-                )
-            })?;
-        let segment_ords = term_ords
-            .column(0)
-            .as_any()
-            .downcast_ref::<UInt32Array>()
-            .ok_or_else(|| {
-                DataFusionError::Execution("expected UInt32Array for seg_ord column".into())
-            })?;
-        let ordinals = term_ords
-            .column(1)
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .ok_or_else(|| {
-                DataFusionError::Execution("expected UInt64Array for term_ord column".into())
-            })?;
-        Ok(Self {
-            type_ids: union.type_ids(),
-            offsets,
-            doc_addresses,
-            term_ords,
-            segment_ords,
-            ordinals,
-        })
+        Ok(Self { values })
     }
 
     pub fn value(&self, row: usize) -> DeferredValue {
-        let ci = self.offsets[row] as usize;
-        match self.type_ids[row] {
-            0 => {
-                if self.doc_addresses.is_null(ci) {
-                    DeferredValue::Null
-                } else {
-                    DeferredValue::DocAddress(self.doc_addresses.value(ci))
-                }
+        if self.values.is_null(row) {
+            return DeferredValue::Null;
+        }
+        let packed = self.values.value(row);
+        if packed & TERM_ORDINAL_BIT == 0 {
+            DeferredValue::DocAddress(packed)
+        } else {
+            DeferredValue::TermOrdinal {
+                segment_ord: ((packed & !TERM_ORDINAL_BIT) >> TERM_ORDINAL_BITS) as u32,
+                term_ord: packed & TERM_ORDINAL_MASK,
             }
-            1 => {
-                if self.term_ords.is_null(ci) || self.segment_ords.is_null(ci) {
-                    DeferredValue::Null
-                } else {
-                    DeferredValue::TermOrdinal {
-                        segment_ord: self.segment_ords.value(ci),
-                        term_ord: (!self.ordinals.is_null(ci)).then(|| self.ordinals.value(ci)),
-                    }
-                }
-            }
-            other => unreachable!("invalid deferred union state {other}"),
         }
     }
 
     pub fn values(&self) -> impl Iterator<Item = DeferredValue> + '_ {
-        (0..self.type_ids.len()).map(|row| self.value(row))
+        (0..self.values.len()).map(|row| self.value(row))
+    }
+
+    /// A copy of the column with `resolved` rows written as term ordinals. A row resolved to
+    /// no ordinal becomes NULL; every other row keeps its value.
+    pub fn with_term_ordinals(
+        &self,
+        resolved: impl IntoIterator<Item = (usize, SegmentOrdinal, Option<TermOrdinal>)>,
+    ) -> ArrayRef {
+        let mut words: Vec<u64> = self.values.values().to_vec();
+        let mut valid: Vec<bool> = (0..words.len())
+            .map(|row| self.values.is_valid(row))
+            .collect();
+        for (row, segment_ord, term_ord) in resolved {
+            match term_ord {
+                Some(term_ord) => {
+                    words[row] = pack_term_ordinal(segment_ord, term_ord);
+                    valid[row] = true;
+                }
+                None => valid[row] = false,
+            }
+        }
+        Arc::new(UInt64Array::new(
+            ScalarBuffer::from(words),
+            Some(NullBuffer::from(valid)),
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::Array;
 
     #[test]
     fn pack_unpack_roundtrip() {
@@ -272,8 +210,11 @@ mod tests {
 
     #[test]
     fn pack_unpack_boundary_values() {
-        let packed_max = ((u32::MAX as u64) << 32) | (u32::MAX as u64);
-        assert_eq!(unpack_doc_address(packed_max), (u32::MAX, u32::MAX));
+        let packed_max = pack_doc_address(MAX_STATE0_SEGMENT_ORD as u32, u32::MAX);
+        assert_eq!(
+            unpack_doc_address(packed_max),
+            (MAX_STATE0_SEGMENT_ORD as u32, u32::MAX)
+        );
         assert_eq!(unpack_doc_address(0), (0, 0));
     }
 
@@ -284,70 +225,85 @@ mod tests {
     }
 
     #[test]
-    fn build_state_doc_address_creates_state_0() {
-        let array = build_state_doc_address(1, &[5, 10]);
-        let union_array = array.as_any().downcast_ref::<UnionArray>().unwrap();
-        assert_eq!(union_array.len(), 2);
-        assert!(union_array.type_ids().iter().all(|&id| id == 0));
-        let child = union_array.child(0);
-        let uint64_child = child.as_any().downcast_ref::<UInt64Array>().unwrap();
-        assert_eq!(unpack_doc_address(uint64_child.value(0)), (1, 5));
-        assert_eq!(unpack_doc_address(uint64_child.value(1)), (1, 10));
+    fn a_term_ordinal_keeps_its_segment_and_ordinal() {
+        let packed = pack_term_ordinal(MAX_STATE1_SEGMENT_ORD as u32, TERM_ORDINAL_MASK);
+        let array = UInt64Array::from(vec![packed]);
+        let column = DeferredColumn::try_new(&array).unwrap();
+        assert_eq!(
+            column.value(0),
+            DeferredValue::TermOrdinal {
+                segment_ord: MAX_STATE1_SEGMENT_ORD as u32,
+                term_ord: TERM_ORDINAL_MASK,
+            }
+        );
     }
 
     #[test]
-    fn deferred_union_reads_both_states_and_nulls() {
+    fn the_two_states_never_collide() {
+        let doc = pack_doc_address(7, 8);
+        let ord = pack_term_ordinal(7, 8);
+        assert_ne!(doc, ord);
+        assert_eq!(doc & TERM_ORDINAL_BIT, 0);
+        assert_ne!(ord & TERM_ORDINAL_BIT, 0);
+    }
+
+    #[test]
+    fn a_deferred_field_is_told_apart_from_a_plain_integer() {
+        assert!(is_deferred_field(&deferred_field("category")));
+        assert!(!is_deferred_field(&Field::new(
+            "id",
+            DataType::UInt64,
+            true
+        )));
+        assert!(!is_deferred_field(
+            &Field::new("category", DataType::Utf8View, true).with_metadata(deferred_metadata())
+        ));
+    }
+
+    #[test]
+    fn deferred_column_reads_both_states_and_nulls() {
         let state_0 = build_state_doc_address(3, &[7, 8]);
-        let view = DeferredUnion::try_new(state_0.as_ref()).unwrap();
+        let view = DeferredColumn::try_new(state_0.as_ref()).unwrap();
         assert_eq!(view.values().count(), 2);
         assert_eq!(
             view.value(0),
-            DeferredValue::DocAddress(pack_doc_addresses(3, &[7]).value(0))
+            DeferredValue::DocAddress(pack_doc_address(3, 7))
         );
 
-        let ordinals: ArrayRef = Arc::new(UInt64Array::from(vec![Some(5), None]));
-        let state_1 = build_state_term_ordinals_per_row(UInt32Array::from(vec![1, 2]), ordinals);
-        let view = DeferredUnion::try_new(state_1.as_ref()).unwrap();
+        let ordinals = UInt64Array::from(vec![Some(5), None]);
+        let state_1 = build_state_term_ordinals(1, &ordinals);
+        let view = DeferredColumn::try_new(state_1.as_ref()).unwrap();
         assert_eq!(
             view.values().collect::<Vec<_>>(),
             vec![
                 DeferredValue::TermOrdinal {
                     segment_ord: 1,
-                    term_ord: Some(5)
+                    term_ord: 5
                 },
-                DeferredValue::TermOrdinal {
-                    segment_ord: 2,
-                    term_ord: None
-                },
+                DeferredValue::Null,
             ]
         );
 
-        let not_a_union: ArrayRef = Arc::new(UInt64Array::from(vec![1]));
-        assert!(DeferredUnion::try_new(not_a_union.as_ref()).is_err());
+        let not_deferred = arrow_array::Int64Array::from(vec![1]);
+        assert!(DeferredColumn::try_new(&not_deferred).is_err());
     }
 
     #[test]
-    fn build_state_term_ordinals_creates_state_1() {
-        let ordinals: ArrayRef = Arc::new(UInt64Array::from(vec![Some(100), Some(200)]));
-        let array = build_state_term_ordinals(2, ordinals);
-        let union_array = array.as_any().downcast_ref::<UnionArray>().unwrap();
-        assert_eq!(union_array.len(), 2);
-        assert!(union_array.type_ids().iter().all(|&id| id == 1));
-        let child = union_array.child(1);
-        let struct_array = child.as_any().downcast_ref::<StructArray>().unwrap();
-        let seg_ords = struct_array
-            .column(0)
-            .as_any()
-            .downcast_ref::<UInt32Array>()
-            .unwrap();
-        assert_eq!(seg_ords.value(0), 2);
-        assert_eq!(seg_ords.value(1), 2);
-        let term_ords = struct_array
-            .column(1)
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .unwrap();
-        assert_eq!(term_ords.value(0), 100);
-        assert_eq!(term_ords.value(1), 200);
+    fn resolving_rows_keeps_the_others_and_nulls_the_missing() {
+        let state_0 = build_state_doc_address(2, &[1, 2, 3]);
+        let view = DeferredColumn::try_new(state_0.as_ref()).unwrap();
+        let resolved = view.with_term_ordinals([(0, 2, Some(40)), (2, 2, None)]);
+        let view = DeferredColumn::try_new(resolved.as_ref()).unwrap();
+        assert_eq!(
+            view.values().collect::<Vec<_>>(),
+            vec![
+                DeferredValue::TermOrdinal {
+                    segment_ord: 2,
+                    term_ord: 40
+                },
+                DeferredValue::DocAddress(pack_doc_address(2, 2)),
+                DeferredValue::Null,
+            ]
+        );
     }
 }

--- a/pg_search/src/scan/deferred_encode.rs
+++ b/pg_search/src/scan/deferred_encode.rs
@@ -31,7 +31,7 @@ use datafusion::common::{DataFusionError, Result};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tantivy::termdict::TermOrdinal;
-use tantivy::{DocId, SegmentOrdinal};
+use tantivy::{DocAddress, DocId, SegmentOrdinal};
 
 /// The Arrow extension name on a deferred column's field, which is how a schema tells one
 /// apart from any other `UInt64` column.
@@ -87,10 +87,16 @@ pub fn pack_doc_addresses(segment_ord: SegmentOrdinal, doc_ids: &[DocId]) -> UIn
     )
 }
 
-/// Unpacks a doc address into its segment ordinal and doc id.
-pub fn unpack_doc_address(packed: u64) -> (SegmentOrdinal, DocId) {
+/// Unpacks a doc address.
+///
+/// A packed ctid column is always State 0, so it unpacks here instead of going through
+/// [`DeferredColumn`].
+pub fn unpack_doc_address(packed: u64) -> DocAddress {
     debug_assert_eq!(packed & TERM_ORDINAL_BIT, 0, "not a doc address");
-    ((packed >> 32) as u32, (packed & 0xFFFF_FFFF) as u32)
+    DocAddress::new(
+        (packed >> 32) as SegmentOrdinal,
+        (packed & 0xFFFF_FFFF) as DocId,
+    )
 }
 
 /// Packs a segment ordinal and a term ordinal in that segment's dictionary into one word
@@ -120,8 +126,8 @@ pub fn build_state_term_ordinals(segment_ord: SegmentOrdinal, ordinals: &UInt64A
 /// One row of a deferred column, as read through [`DeferredColumn`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DeferredValue {
-    /// State 0: the row still carries its packed `(segment_ord, doc_id)`.
-    DocAddress(u64),
+    /// State 0: the row still names a Tantivy document, not a value.
+    DocAddress(DocAddress),
     /// State 1: the row's term ordinal in `segment_ord`'s dictionary.
     TermOrdinal {
         segment_ord: SegmentOrdinal,
@@ -157,7 +163,7 @@ impl<'a> DeferredColumn<'a> {
         }
         let packed = self.values.value(row);
         if packed & TERM_ORDINAL_BIT == 0 {
-            DeferredValue::DocAddress(packed)
+            DeferredValue::DocAddress(unpack_doc_address(packed))
         } else {
             DeferredValue::TermOrdinal {
                 segment_ord: ((packed & !TERM_ORDINAL_BIT) >> TERM_ORDINAL_BITS) as u32,
@@ -208,9 +214,9 @@ mod tests {
     fn pack_unpack_roundtrip() {
         let packed = pack_doc_addresses(3, &[10, 20, 30]);
         assert_eq!(packed.len(), 3);
-        assert_eq!(unpack_doc_address(packed.value(0)), (3, 10));
-        assert_eq!(unpack_doc_address(packed.value(1)), (3, 20));
-        assert_eq!(unpack_doc_address(packed.value(2)), (3, 30));
+        assert_eq!(unpack_doc_address(packed.value(0)), DocAddress::new(3, 10));
+        assert_eq!(unpack_doc_address(packed.value(1)), DocAddress::new(3, 20));
+        assert_eq!(unpack_doc_address(packed.value(2)), DocAddress::new(3, 30));
     }
 
     #[test]
@@ -218,9 +224,9 @@ mod tests {
         let packed_max = pack_doc_address(MAX_STATE0_SEGMENT_ORD as u32, u32::MAX);
         assert_eq!(
             unpack_doc_address(packed_max),
-            (MAX_STATE0_SEGMENT_ORD as u32, u32::MAX)
+            DocAddress::new(MAX_STATE0_SEGMENT_ORD as u32, u32::MAX)
         );
-        assert_eq!(unpack_doc_address(0), (0, 0));
+        assert_eq!(unpack_doc_address(0), DocAddress::new(0, 0));
     }
 
     #[test]
@@ -272,7 +278,7 @@ mod tests {
         assert_eq!(view.values().count(), 2);
         assert_eq!(
             view.value(0),
-            DeferredValue::DocAddress(pack_doc_address(3, 7))
+            DeferredValue::DocAddress(DocAddress::new(3, 7))
         );
 
         let ordinals = UInt64Array::from(vec![Some(5), None]);
@@ -306,7 +312,7 @@ mod tests {
                     segment_ord: 2,
                     term_ord: 40
                 },
-                DeferredValue::DocAddress(pack_doc_address(2, 2)),
+                DeferredValue::DocAddress(DocAddress::new(2, 2)),
                 DeferredValue::Null,
             ]
         );

--- a/pg_search/src/scan/deferred_encode.rs
+++ b/pg_search/src/scan/deferred_encode.rs
@@ -40,8 +40,9 @@ const EXTENSION_KEY: &str = "ARROW:extension:name";
 
 /// Set on a packed term ordinal, clear on a packed doc address.
 const TERM_ORDINAL_BIT: u64 = 1 << 63;
-/// A term ordinal keeps the low 40 bits of the word and the segment ordinal the 23 above
-/// them. A segment holds fewer than 2^32 documents, so no dictionary comes near 2^40 terms.
+/// A term ordinal keeps the low 40 bits of the word, and the 23 bits above them hold the
+/// segment ordinal. A segment holds fewer than 2^32 documents, so no dictionary comes near
+/// 2^40 terms.
 const TERM_ORDINAL_BITS: u32 = 40;
 const TERM_ORDINAL_MASK: u64 = (1 << TERM_ORDINAL_BITS) - 1;
 const MAX_STATE1_SEGMENT_ORD: u64 = (1 << (63 - TERM_ORDINAL_BITS)) - 1;
@@ -179,19 +180,23 @@ impl<'a> DeferredColumn<'a> {
         let mut valid: Vec<bool> = (0..words.len())
             .map(|row| self.values.is_valid(row))
             .collect();
+        let mut has_nulls = self.values.null_count() > 0;
         for (row, segment_ord, term_ord) in resolved {
             match term_ord {
                 Some(term_ord) => {
                     words[row] = pack_term_ordinal(segment_ord, term_ord);
                     valid[row] = true;
                 }
-                None => valid[row] = false,
+                None => {
+                    valid[row] = false;
+                    has_nulls = true;
+                }
             }
         }
-        Arc::new(UInt64Array::new(
-            ScalarBuffer::from(words),
-            Some(NullBuffer::from(valid)),
-        ))
+        // A missing bitmap reads as all valid, so a column without NULLs skips the
+        // bit-packing pass.
+        let nulls = has_nulls.then(|| NullBuffer::from(valid));
+        Arc::new(UInt64Array::new(ScalarBuffer::from(words), nulls))
     }
 }
 

--- a/pg_search/src/scan/deferred_lookup.rs
+++ b/pg_search/src/scan/deferred_lookup.rs
@@ -63,8 +63,6 @@ pub struct PhysicalDeferredField {
     pub canonical: CanonicalColumn,
     #[serde(default)]
     pub rebuild: Option<DeferredLookupRebuild>,
-    #[serde(default)]
-    pub ctid_col_name: Option<String>,
 }
 
 impl PhysicalDeferredField {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -31,7 +31,7 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use arrow_array::RecordBatch;
-use arrow_schema::{DataType, SchemaRef, SortOptions};
+use arrow_schema::{SchemaRef, SortOptions};
 use datafusion::common::stats::{ColumnStatistics, Precision};
 use datafusion::common::{DataFusionError, Result, Statistics};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
@@ -71,6 +71,7 @@ use crate::postgres::options::{SortByDirection, SortByField};
 use crate::postgres::rel::PgSearchRelation;
 use crate::query::SearchQueryInput;
 use crate::scan::Scanner;
+use crate::scan::deferred_encode::is_deferred_field;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
 use crate::scan::late_materialization::DeferredField;
 use crate::scan::pre_filter::{PreFilter, collect_filters, try_dynamic_filter_pushdown};
@@ -897,7 +898,7 @@ impl DisplayAs for PgSearchScanPlan {
                 d.fetch_at_scan
                     && schema
                         .column_with_name(&d.name)
-                        .is_some_and(|(_, f)| matches!(f.data_type(), DataType::Union(_, _)))
+                        .is_some_and(|(_, f)| is_deferred_field(f))
             })
             .map(|d| d.name.as_str())
             .collect();

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -817,7 +817,6 @@ impl ExtensionPlanner for LateMaterializePlanner {
                     is_bytes: deferred.is_bytes,
                     canonical: deferred.canonical.clone(),
                     rebuild: deferred.rebuild.clone(),
-                    ctid_col_name: deferred.ctid_col_name.clone(),
                 });
                 if !deferred.fetch_at_scan {
                     fetch_fields.push(physical_deferred_fields.last().unwrap().clone());
@@ -875,10 +874,6 @@ pub struct DeferredField {
     /// emits State 1; only the dictionary decode is deferred. When false, the scan emits
     /// doc addresses and a `TantivyFetchExec` resolves them at the decode point.
     pub fetch_at_scan: bool,
-    // TODO: Clean up our column tracking story, possibly by renaming the `ctid` columns
-    // to include the plan position (e.g. `ctid_<plan_pos>`) similarly to tag names.
-    #[serde(default)]
-    pub ctid_col_name: Option<String>,
 }
 
 /// Everything a worker needs to rebuild the fast-field reader for a deferred column when the

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -72,6 +72,21 @@ fn get_deferred_fields(plan: &LogicalPlan) -> Vec<DeferredField> {
     fields
 }
 
+/// The scan column a plan column comes from. Two tables can share a column name, and a
+/// plain `UInt64` column (an `oid`, say) can share one with a deferred string column, so
+/// the index tells their fields apart; a self-join's two scans share both.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BaseColumn {
+    pub indexrelid: u32,
+    pub name: String,
+}
+
+impl BaseColumn {
+    fn is(&self, field: &DeferredField) -> bool {
+        field.canonical.indexrelid == self.indexrelid && field.name == self.name
+    }
+}
+
 /// Traces a column backward through a logical plan down to the originating `TableScan`.
 ///
 /// This is necessary because DataFusion does not natively preserve custom metadata (like our
@@ -82,8 +97,8 @@ fn get_deferred_fields(plan: &LogicalPlan) -> Vec<DeferredField> {
 ///
 /// Instead of relying on brittle string suffix matching (`ends_with`) or unsafe positional
 /// indices, this function explicitly recursively traces the `Column`'s lineage back down the
-/// plan tree to find its exact root `Column` at the `TableScan` level, allowing robust exact matching.
-pub(crate) fn trace_column(plan: &LogicalPlan, col: &Column) -> Option<Column> {
+/// plan tree to find its exact root column at the `TableScan` level, allowing robust exact matching.
+pub(crate) fn trace_column(plan: &LogicalPlan, col: &Column) -> Option<BaseColumn> {
     match plan {
         LogicalPlan::TableScan(scan) => {
             if scan.projected_schema.has_column(col) {
@@ -92,7 +107,11 @@ pub(crate) fn trace_column(plan: &LogicalPlan, col: &Column) -> Option<Column> {
                     .projected_schema
                     .qualified_field_from_column(col)
                     .ok()?;
-                Some(Column::from_name(field.name()))
+                let provider = pg_search_provider_from_scan(scan)?;
+                Some(BaseColumn {
+                    indexrelid: provider.scan_info.indexrelid.to_u32(),
+                    name: field.name().clone(),
+                })
             } else {
                 None
             }
@@ -203,9 +222,9 @@ pub(crate) fn trace_column(plan: &LogicalPlan, col: &Column) -> Option<Column> {
 }
 
 /// The deferred field a plan column carries, if it is one. A deferred column is a
-/// `UInt64` whose lineage ends at a deferred field of its scan. The match is by name, and
-/// entries are consumed from `pool` one by one, so a self-join's two identical entries
-/// each claim their own column.
+/// `UInt64` whose lineage ends at a deferred field of its scan. The match is by index and
+/// name, and entries are consumed from `pool` one by one, so a self-join's two identical
+/// entries each claim their own column.
 fn take_deferred_field(
     plan: &LogicalPlan,
     qualifier: Option<&datafusion::common::TableReference>,
@@ -217,7 +236,7 @@ fn take_deferred_field(
     }
     let col = datafusion::common::Column::from((qualifier, field));
     let base_col = trace_column(plan, &col)?;
-    let pos = pool.iter().position(|d| d.name == base_col.name)?;
+    let pos = pool.iter().position(|d| base_col.is(d))?;
     Some(pool.remove(pos))
 }
 
@@ -295,7 +314,7 @@ fn should_anchor(node: &LogicalPlan, deferred_fields: &[DeferredField]) -> bool 
 
     let references_deferred = refs.iter().any(|c| {
         if let Some(base_col) = trace_column(node, c) {
-            deferred_fields.iter().any(|df| df.name == base_col.name)
+            deferred_fields.iter().any(|df| base_col.is(df))
         } else {
             false
         }
@@ -312,7 +331,7 @@ fn should_anchor(node: &LogicalPlan, deferred_fields: &[DeferredField]) -> bool 
                 expr.add_column_refs(&mut cols);
                 let uses_deferred = cols.iter().any(|c| {
                     if let Some(base_col) = trace_column(node, c) {
-                        deferred_fields.iter().any(|df| df.name == base_col.name)
+                        deferred_fields.iter().any(|df| base_col.is(df))
                     } else {
                         false
                     }
@@ -358,7 +377,7 @@ fn should_anchor(node: &LogicalPlan, deferred_fields: &[DeferredField]) -> bool 
             let join_cols: HashSet<Column> = join_refs.into_iter().cloned().collect();
             join_cols.iter().any(|c| {
                 if let Some(base_col) = trace_column(node, c) {
-                    deferred_fields.iter().any(|df| df.name == base_col.name)
+                    deferred_fields.iter().any(|df| base_col.is(df))
                 } else {
                     false
                 }
@@ -769,7 +788,7 @@ impl ExtensionPlanner for LateMaterializePlanner {
                     let col =
                         datafusion::common::Column::from((q.cloned().as_ref(), field.as_ref()));
                     if let Some(base_col) = trace_column(&mat_node.input, &col)
-                        && base_col.name == deferred.name
+                        && base_col.is(deferred)
                     {
                         found_col_idx = Some(i);
                         break;

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -488,10 +488,6 @@ impl OptimizerRule for LateMaterializationRule {
                         .any(|df| beneficial_fields.contains(&df.canonical));
 
                     if has_beneficial_deferred {
-                        if provider.is_late_materialization_schema_enabled() {
-                            return Ok(Transformed::no(node));
-                        }
-
                         // Tell the provider to flip its schema output from Utf8View to the
                         // deferred columns.
                         provider.enable_late_materialization_schema();
@@ -509,6 +505,14 @@ impl OptimizerRule for LateMaterializationRule {
 
                         let projected_arrow_schema =
                             new_scan.source.schema().project(&projected_indices)?;
+                        // The provider holds one schema for the relation, but a plan can
+                        // read it through more than one scan. Each has to be rebuilt, not
+                        // just whichever flips the provider first, or the ones left behind
+                        // promise a string the scan does not emit. The comparison also
+                        // stops the rule from rewriting the same node on every pass.
+                        if projected_arrow_schema.fields() == scan.projected_schema.fields() {
+                            return Ok(Transformed::no(node));
+                        }
                         let mut new_qualified_fields = Vec::new();
                         for (i, field) in projected_arrow_schema.fields().iter().enumerate() {
                             let (qualifier, _) = scan.projected_schema.qualified_field(i);

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -42,17 +42,17 @@ use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 /// **Strategy:**
 /// 1. We traverse the `LogicalPlan` bottom-up using `transform_up`.
 /// 2. At the base, we intercept any `TableScan` originating from a `PgSearchTableProvider`
-///    that has actively deferred columns. We wrap its source in a `UnionTableSource`,
-///    which safely overrides the declared schema from `Utf8View` (which the SQL planner needs)
-///    to `Union(UInt64, Utf8View)` (which reflects the true physical layout).
+///    that has actively deferred columns and flip the provider's declared schema from
+///    `Utf8View` (which the SQL planner needs) to the packed `UInt64` of a deferred column
+///    (which reflects the true physical layout, see `deferred_encode`).
 /// 3. As we bubble up through the plan, we evaluate each node via `should_anchor`.
 ///    If a node (like `Projection` or a `HashJoin` not joining on the deferred column)
-///    merely passes the column through without evaluating it, we let the `Union` schema
+///    merely passes the column through without evaluating it, we let the deferred schema
 ///    bubble through the node transparently (via `recompute_schema`).
 ///    If a node (like `Sort`, `Filter`, or `Aggregate`) natively evaluates the deferred column,
 ///    we *anchor* a `LateMaterializeNode` directly underneath it.
-/// 4. If the `Union` successfully bubbles all the way to the root of the plan, we wrap the
-///    final result in a `LateMaterializeNode` to ensure the client receives the standard
+/// 4. If a deferred column successfully bubbles all the way to the root of the plan, we wrap
+///    the final result in a `LateMaterializeNode` to ensure the client receives the standard
 ///    materialized strings.
 #[derive(Debug)]
 pub struct LateMaterializationRule;
@@ -202,61 +202,71 @@ pub(crate) fn trace_column(plan: &LogicalPlan, col: &Column) -> Option<Column> {
     }
 }
 
-/// Helper function to check if the given plan outputs a `Union` type that corresponds
-/// to a known deferred field. If it does, it returns the actively tracked deferred fields
-/// mapped accurately to the plan's current output schema (accounting for relation aliases).
-fn get_union_info(
+/// The deferred field a plan column carries, if it is one. A deferred column is a
+/// `UInt64` whose lineage ends at a deferred field of its scan. The match is by name, and
+/// entries are consumed from `pool` one by one, so a self-join's two identical entries
+/// each claim their own column.
+fn take_deferred_field(
+    plan: &LogicalPlan,
+    qualifier: Option<&datafusion::common::TableReference>,
+    field: &arrow_schema::Field,
+    pool: &mut Vec<DeferredField>,
+) -> Option<DeferredField> {
+    if field.data_type() != &arrow_schema::DataType::UInt64 {
+        return None;
+    }
+    let col = datafusion::common::Column::from((qualifier, field));
+    let base_col = trace_column(plan, &col)?;
+    let pos = pool.iter().position(|d| d.name == base_col.name)?;
+    Some(pool.remove(pos))
+}
+
+fn materialized_field(field: &arrow_schema::Field, is_bytes: bool) -> arrow_schema::Field {
+    let materialized_type = if is_bytes {
+        arrow_schema::DataType::BinaryView
+    } else {
+        arrow_schema::DataType::Utf8View
+    };
+    arrow_schema::Field::new(field.name(), materialized_type, field.is_nullable())
+}
+
+/// Helper function to check if the given plan outputs deferred columns. If it does, it
+/// returns the actively tracked deferred fields mapped accurately to the plan's current
+/// output schema (accounting for relation aliases), and that schema with each of them
+/// materialized.
+fn get_deferred_info(
     plan: &LogicalPlan,
 ) -> Option<(Vec<DeferredField>, datafusion::common::DFSchemaRef)> {
     let schema = plan.schema();
-    let mut has_union = false;
-    for field in schema.fields() {
-        if matches!(field.data_type(), arrow_schema::DataType::Union(_, _)) {
-            has_union = true;
-            break;
-        }
-    }
-    if !has_union {
+    if !schema
+        .fields()
+        .iter()
+        .any(|f| f.data_type() == &arrow_schema::DataType::UInt64)
+    {
         return None;
     }
 
     let mut all_deferred = get_deferred_fields(plan);
+    if all_deferred.is_empty() {
+        return None;
+    }
     let mut active_deferred = Vec::new();
     let mut new_fields = Vec::new();
 
     for (qualifier, field) in schema.iter() {
-        if let arrow_schema::DataType::Union(_, _) = field.data_type() {
-            // Find the matching deferred field by tracing the column lineage back to its
-            // base TableScan name. Name-matching is safe here because we consume entries from
-            // all_deferred one-by-one: for a self-join both sides produce an identical
-            // DeferredField (same name, is_bytes, canonical), so each Union field in the schema
-            // claims its own entry without duplication.
-            let col =
-                datafusion::common::Column::from((qualifier.cloned().as_ref(), field.as_ref()));
-            let mut is_bytes = false;
-            if let Some(base_col) = trace_column(plan, &col)
-                && let Some(pos) = all_deferred.iter().position(|d| d.name == base_col.name)
-            {
-                let d = all_deferred.remove(pos);
-                is_bytes = d.is_bytes;
+        match take_deferred_field(plan, qualifier, field, &mut all_deferred) {
+            Some(d) => {
+                new_fields.push((
+                    qualifier.cloned(),
+                    Arc::new(materialized_field(field, d.is_bytes)),
+                ));
                 active_deferred.push(d);
             }
-
-            let materialized_type = if is_bytes {
-                arrow_schema::DataType::BinaryView
-            } else {
-                arrow_schema::DataType::Utf8View
-            };
-
-            let materialized_field = Arc::new(arrow_schema::Field::new(
-                field.name(),
-                materialized_type,
-                field.is_nullable(),
-            ));
-            new_fields.push((qualifier.cloned(), materialized_field));
-        } else {
-            new_fields.push((qualifier.cloned(), field.clone()));
+            None => new_fields.push((qualifier.cloned(), field.clone())),
         }
+    }
+    if active_deferred.is_empty() {
+        return None;
     }
 
     let new_schema = Arc::new(
@@ -278,8 +288,8 @@ fn get_column_refs(node: &LogicalPlan) -> HashSet<Column> {
 }
 
 /// Determines whether a `LateMaterializeNode` must be anchored *below* the given logical plan node.
-/// If `true`, the `Union` values will be materialized into standard strings before this node executes.
-/// If `false`, the `Union` schema will bubble straight through it.
+/// If `true`, the deferred columns will be materialized into standard strings before this node executes.
+/// If `false`, the deferred schema will bubble straight through it.
 fn should_anchor(node: &LogicalPlan, deferred_fields: &[DeferredField]) -> bool {
     let refs = get_column_refs(node);
 
@@ -295,7 +305,7 @@ fn should_anchor(node: &LogicalPlan, deferred_fields: &[DeferredField]) -> bool 
         LogicalPlan::Filter(_) => references_deferred,
         LogicalPlan::Projection(proj) => {
             // Only anchor if the projection does something other than pass through or alias the deferred column.
-            // If it's just a Column or Alias(Column), the Union can safely pass through.
+            // If it's just a Column or Alias(Column), the deferred column can safely pass through.
             let mut anchors_deferred = false;
             for expr in &proj.expr {
                 let mut cols = HashSet::new();
@@ -459,19 +469,15 @@ impl OptimizerRule for LateMaterializationRule {
                         .any(|df| beneficial_fields.contains(&df.canonical));
 
                     if has_beneficial_deferred {
-                        let is_already_union =
-                            scan.projected_schema.fields().iter().any(|f| {
-                                matches!(f.data_type(), arrow_schema::DataType::Union(_, _))
-                            });
-
-                        if is_already_union {
+                        if provider.is_late_materialization_schema_enabled() {
                             return Ok(Transformed::no(node));
                         }
 
-                        // Tell the provider to flip its schema output from Utf8View to Union
+                        // Tell the provider to flip its schema output from Utf8View to the
+                        // deferred columns.
                         provider.enable_late_materialization_schema();
 
-                        // Now the provider natively outputs the Union schema!
+                        // Now the provider natively outputs the deferred schema!
                         // We must reconstruct the TableScan's projected schema to reflect this new reality.
                         let mut new_scan = scan.clone();
                         let projected_indices: Result<Vec<usize>, _> = scan
@@ -508,7 +514,7 @@ impl OptimizerRule for LateMaterializationRule {
 
             for input in node.inputs() {
                 let input_plan = input.clone();
-                if let Some((deferred_fields, output_schema)) = get_union_info(&input_plan) {
+                if let Some((deferred_fields, output_schema)) = get_deferred_info(&input_plan) {
                     if should_anchor(&node, &deferred_fields) {
                         let extension_node = LogicalPlan::Extension(Extension {
                             node: Arc::new(LateMaterializeNode {
@@ -531,14 +537,14 @@ impl OptimizerRule for LateMaterializationRule {
                 let new_node = node.with_new_exprs(node.expressions(), new_inputs)?;
                 Ok(Transformed::yes(new_node))
             } else {
-                let has_union_child = new_inputs.iter().any(|i| get_union_info(i).is_some());
-                if has_union_child {
-                    // Union bubbled into us. We MUST recompute our schema to reflect the Union.
+                let has_deferred_child = new_inputs.iter().any(|i| get_deferred_info(i).is_some());
+                if has_deferred_child {
+                    // A deferred column bubbled into us. We MUST recompute our schema to reflect it.
                     // DataFusion's `transform_up` uses `map_children` which intentionally preserves the
                     // Join's old `schema` to avoid overhead during structural recursion.
                     // Using `Join::try_new` is the recommended way to forcefully re-evaluate `build_join_schema`
                     // using the mutated child schemas, guaranteeing that the `Join` node correctly
-                    // reports the bubbled `Union` types to the rest of the plan.
+                    // reports the bubbled deferred types to the rest of the plan.
                     if let LogicalPlan::Join(join) = &node {
                         let new_join = datafusion::logical_expr::logical_plan::Join::try_new(
                             Arc::new(new_inputs[0].clone()),
@@ -563,7 +569,7 @@ impl OptimizerRule for LateMaterializationRule {
         })?;
 
         let final_plan = transformed_plan.data;
-        if let Some((deferred_fields, output_schema)) = get_union_info(&final_plan) {
+        if let Some((deferred_fields, output_schema)) = get_deferred_info(&final_plan) {
             let root_mat = LogicalPlan::Extension(Extension {
                 node: Arc::new(LateMaterializeNode {
                     input: final_plan,
@@ -662,47 +668,25 @@ impl UserDefinedLogicalNodeCore for LateMaterializeNode {
         for (i, field) in child_schema.fields().iter().enumerate() {
             let (qualifier, _) = child_schema.qualified_field(i);
 
-            if let arrow_schema::DataType::Union(_, _) = field.data_type() {
-                // Find the corresponding deferred field by tracing column lineage.
-                // Name-matching is safe: for a self-join both sides produce identical
-                // DeferredField structs; we consume entries one-by-one so each Union
-                // column in the child schema claims its own distinct slot.
-                let target_col = datafusion::common::Column::from((qualifier, field.as_ref()));
-                let mut is_bytes = false;
-                if let Some(base_col) = trace_column(&input, &target_col)
-                    && let Some(pos) = deferred_pool.iter().position(|d| d.name == base_col.name)
-                {
-                    let d = deferred_pool.remove(pos);
-                    is_bytes = d.is_bytes;
+            // When DataFusion's `OptimizeProjections` rule rebuilds nodes, it trims the schema.
+            // We must manually map the incoming deferred columns back to their materialized
+            // types to construct a truthful output schema, avoiding invariant panics.
+            match take_deferred_field(&input, qualifier, field, &mut deferred_pool) {
+                Some(d) => {
+                    qualified_fields.push((
+                        qualifier.cloned(),
+                        Arc::new(materialized_field(field, d.is_bytes)),
+                    ));
                     new_deferred_fields.push(d);
                 }
-
-                // When DataFusion's `OptimizeProjections` rule rebuilds nodes, it trims the schema.
-                // We must manually map the incoming `Union` types back to their materialized `T` types
-                // to construct a truthful output schema, avoiding invariant panics.
-                let materialized_type = if is_bytes {
-                    arrow_schema::DataType::BinaryView
-                } else {
-                    arrow_schema::DataType::Utf8View
-                };
-
-                qualified_fields.push((
-                    qualifier.cloned(),
-                    Arc::new(arrow_schema::Field::new(
-                        field.name(),
-                        materialized_type,
-                        field.is_nullable(),
-                    )),
-                ));
-            } else {
-                qualified_fields.push((
+                None => qualified_fields.push((
                     qualifier.cloned(),
                     Arc::new(arrow_schema::Field::new(
                         field.name(),
                         field.data_type().clone(),
                         field.is_nullable(),
                     )),
-                ));
+                )),
             }
         }
 
@@ -765,16 +749,16 @@ impl ExtensionPlanner for LateMaterializePlanner {
             let mut fetch_fields = Vec::new();
 
             for deferred in &mat_node.deferred_fields {
-                // Scan the child schema for the Union-typed field whose base column name
+                // Scan the child schema for the deferred column whose base column name
                 // matches this deferred field. We iterate by physical index so that duplicate
                 // column names (e.g. both sides of a self-join both called "ord") each resolve
                 // to their own distinct physical slot, not the first match by name.
                 let mut found_col_idx: Option<usize> = None;
                 for (i, field) in child_logical_schema.fields().iter().enumerate() {
-                    if !matches!(field.data_type(), arrow_schema::DataType::Union(_, _)) {
+                    if field.data_type() != &arrow_schema::DataType::UInt64 {
                         continue;
                     }
-                    // Only consider Union columns that haven't been claimed yet.
+                    // Only consider columns that haven't been claimed yet.
                     if physical_deferred_fields
                         .iter()
                         .any(|p: &PhysicalDeferredField| p.col_idx == i)
@@ -794,7 +778,7 @@ impl ExtensionPlanner for LateMaterializePlanner {
 
                 let col_idx = found_col_idx.ok_or_else(|| {
                     DataFusionError::Internal(format!(
-                        "LateMaterializePlanner: could not locate physical Union column \
+                        "LateMaterializePlanner: could not locate the physical deferred column \
                          for deferred field '{}' in child schema. \
                          Child schema fields: [{}]",
                         deferred.name,
@@ -844,7 +828,7 @@ impl ExtensionPlanner for LateMaterializePlanner {
 
 /// Tracks a deferred column's metadata through DataFusion's logical query plan.
 ///
-/// DataFusion's logical schema engine natively tracks data types (like our `Union`)
+/// DataFusion's logical schema engine natively tracks data types (like a deferred `UInt64`)
 /// as they bubble up through projections and joins. However, the schema engine does
 /// *not* preserve custom metadata attached to fields.
 ///

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -107,6 +107,7 @@ use crate::api::HashSet;
 use crate::index::fast_fields_helper::{FFHelper, FFType, NULL_TERM_ORDINAL};
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::query::value_to_term;
+use crate::scan::deferred_encode::is_deferred_field;
 use tantivy::Term;
 use tantivy::query::{
     BooleanQuery, ConstScoreQuery, Occur, Query, TermSetQuery, TermSetStrategyConfig,
@@ -209,10 +210,11 @@ impl PreFilter {
                 .ok_or_else(|| format!("Column {} not fetched", ff_index))?
                 .clone();
 
-            let schema_type = schema.field(ff_index).data_type();
+            let schema_field = schema.field(ff_index);
+            let schema_type = schema_field.data_type();
 
             // Cast numeric fast fields to match the expected DataFusion schema type
-            if !is_string_like_type(schema_type) && array.data_type() != schema_type {
+            if !is_string_like_field(schema_field) && array.data_type() != schema_type {
                 array = cast(&array, schema_type).map_err(|e| {
                     format!(
                         "Failed to cast columnar field from {:?} to DataFusion schema type {:?}: {}",
@@ -402,19 +404,21 @@ fn try_extract_score_threshold(
     }
 }
 
-/// Helper to centrally identify string, bytes, dictionary, and deferred string columns.
-fn is_string_like_type(data_type: &DataType) -> bool {
-    matches!(
-        data_type,
-        DataType::Utf8
-            | DataType::LargeUtf8
-            | DataType::Utf8View
-            | DataType::Binary
-            | DataType::LargeBinary
-            | DataType::BinaryView
-            | DataType::Dictionary(_, _)
-            | DataType::Union(_, _)
-    )
+/// Helper to centrally identify string, bytes, dictionary, and deferred string columns. A
+/// deferred column is a `UInt64` of term ordinals that string literals compare against once
+/// `try_rewrite_binary` has translated them, so it counts as a string here.
+fn is_string_like_field(field: &Field) -> bool {
+    is_deferred_field(field)
+        || matches!(
+            field.data_type(),
+            DataType::Utf8
+                | DataType::LargeUtf8
+                | DataType::Utf8View
+                | DataType::Binary
+                | DataType::LargeBinary
+                | DataType::BinaryView
+                | DataType::Dictionary(_, _)
+        )
 }
 /// Validates that an expression only contains nodes we can evaluate during pre-filtering.
 ///
@@ -474,9 +478,7 @@ fn is_supported(
                 if let Some(col) = sub_node.downcast_ref::<Column>() {
                     let idx = col.index();
                     if idx < schema.fields().len() {
-                        let data_type = schema.field(idx).data_type();
-
-                        if is_string_like_type(data_type) {
+                        if is_string_like_field(schema.field(idx)) {
                             is_numeric = false;
                             return Ok(datafusion::common::tree_node::TreeNodeRecursion::Stop);
                         }
@@ -553,9 +555,6 @@ fn extract_bytes_from_scalar(scalar: &ScalarValue) -> Option<Option<&[u8]>> {
         | ScalarValue::Binary(None)
         | ScalarValue::LargeBinary(None)
         | ScalarValue::BinaryView(None) => Some(None),
-
-        ScalarValue::Union(Some((_, boxed_val)), _, _) => extract_bytes_from_scalar(boxed_val),
-        ScalarValue::Union(None, _, _) => Some(None),
 
         _ => None,
     }

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -22,11 +22,11 @@
 //!
 //! `SegmentedTopKExec` sits below the deferred lookup (`TantivyDecodeExec`, and the
 //! `TantivyFetchExec` under it when the scan emits doc addresses) in the physical
-//! plan. It operates on the 2-way deferred `UnionArray` columns emitted by late
-//! materialization:
-//!   - State 0 (doc_address): unpacks `(segment_ord, doc_id)` and bulk-fetches
+//! plan. It operates on the packed deferred columns emitted by late materialization
+//! (see `deferred_encode`):
+//!   - State 0 (doc address): unpacks `(segment_ord, doc_id)` and bulk-fetches
 //!     term ordinals via `FFHelper`.
-//!   - State 1 (term_ordinals): uses ordinals directly (already resolved by
+//!   - State 1 (term ordinal): uses the ordinal directly (already resolved by
 //!     pre-filter memoization or by the scan).
 //!
 //! For States 0 and 1, a per-segment Vec-based buffer (capacity 2×K) with
@@ -72,7 +72,7 @@
 //! `survivors_s` bound above.
 
 use crate::api::HashMap;
-use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, FFType, NULL_TERM_ORDINAL};
+use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, FFType};
 use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::postgres::customscan::joinscan::build::CtidColumn;
 use crate::postgres::customscan::joinscan::visibility_filter::{
@@ -80,12 +80,10 @@ use crate::postgres::customscan::joinscan::visibility_filter::{
 };
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
-use crate::scan::deferred_encode::unpack_doc_address;
+use crate::scan::deferred_encode::{DeferredColumn, DeferredValue, unpack_doc_address};
 use crate::scan::deferred_lookup::{LookupRebuildContext, open_rebuilt_ffhelper, rebuild_mvcc};
 use crate::scan::execution_plan::UnsafeSendStream;
-use arrow_array::{
-    Array, ArrayRef, BooleanArray, RecordBatch, StructArray, UInt32Array, UInt64Array, UnionArray,
-};
+use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch, UInt64Array};
 use arrow_schema::SchemaRef;
 use arrow_select::concat::concat_batches;
 use arrow_select::filter::filter_record_batch;
@@ -851,7 +849,8 @@ struct SegmentBuf {
 struct PassThroughRow {
     batch_idx: usize,
     row_idx: usize,
-    seg_ord: SegmentOrdinal,
+    /// `None` when the row is NULL in every deferred sort column.
+    seg_ord: Option<SegmentOrdinal>,
     row_val: OwnedRow,
 }
 
@@ -1081,15 +1080,12 @@ impl SegmentedTopKState {
         for row_idx in 0..num_rows {
             if self.pass_through_scratch[row_idx] {
                 // Keep the compound key the converter already built for this
-                // row. `row_to_seg_scratch` is populated unconditionally in
-                // `extract_deferred_ordinals` for every row a deferred column
-                // touched, which includes any row that reached this branch.
-                let seg_ord = self.row_to_seg_scratch[row_idx]
-                    .expect("row_to_seg_scratch must be populated for pass-through rows");
+                // row. A row with no segment is NULL in every deferred column,
+                // so nothing of it needs a dictionary later.
                 self.pass_through_rows.push(PassThroughRow {
                     batch_idx,
                     row_idx,
-                    seg_ord,
+                    seg_ord: self.row_to_seg_scratch[row_idx],
                     row_val: converted_rows.row(row_idx).owned(),
                 });
                 continue;
@@ -1127,8 +1123,9 @@ impl SegmentedTopKState {
         Ok(())
     }
 
-    /// Helper to extract term ordinals from a deferred UnionArray.
+    /// Helper to extract term ordinals from a deferred column.
     /// Mutates `pass_through` for rows that contain NULLs, and populates `row_to_seg` mapping.
+    /// A NULL row has no segment: it is a NULL value or a row an outer join null-extended.
     fn extract_deferred_ordinals(
         ffhelper: &FFHelper,
         batch: &RecordBatch,
@@ -1138,100 +1135,33 @@ impl SegmentedTopKState {
         row_to_seg: &mut [Option<SegmentOrdinal>],
     ) -> Result<Vec<Option<TermOrdinal>>> {
         let column = batch.column(deferred_col.sort_col_idx);
-        let union_col = column
-            .as_any()
-            .downcast_ref::<UnionArray>()
-            .ok_or_else(|| {
-                DataFusionError::Internal(format!(
-                    "SegmentedTopKExec: sort column should be a deferred UnionArray but found {:?} at index {}",
-                    column.data_type(), deferred_col.sort_col_idx
-                ))
-            })?;
-
-        let type_ids = union_col.type_ids();
-        let offsets = union_col.offsets().ok_or_else(|| {
-            DataFusionError::Internal("SegmentedTopKExec: expected dense union with offsets".into())
+        let deferred = DeferredColumn::try_new(column.as_ref()).map_err(|e| {
+            DataFusionError::Internal(format!(
+                "SegmentedTopKExec: sort column at index {}: {e}",
+                deferred_col.sort_col_idx
+            ))
         })?;
 
-        let mut state0_rows: Vec<usize> = Vec::new();
-        let mut state1_rows: Vec<usize> = Vec::new();
-        for row_idx in 0..num_rows {
-            match type_ids[row_idx] {
-                0 => state0_rows.push(row_idx),
-                1 => state1_rows.push(row_idx),
-                _ => unreachable!("Invalid Union state"),
-            }
-        }
-
         let mut global_term_ords: Vec<Option<TermOrdinal>> = vec![None; num_rows];
-
-        // State 0: compact doc address child.
         let mut state0_by_seg: HashMap<SegmentOrdinal, Vec<(usize, DocId)>> = HashMap::default();
-        if !state0_rows.is_empty() {
-            let doc_addr_child = union_col
-                .child(0)
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "SegmentedTopKExec: child 0 should be UInt64 doc addresses".into(),
-                    )
-                })?;
-            for &row_idx in &state0_rows {
-                let packed = doc_addr_child.value(offsets[row_idx] as usize);
-                let (seg_ord, doc_id) = unpack_doc_address(packed);
-                state0_by_seg
-                    .entry(seg_ord)
-                    .or_default()
-                    .push((row_idx, doc_id));
-                row_to_seg[row_idx] = Some(seg_ord);
-            }
-        }
-
-        // State 1: compact term ordinal child.
-        if !state1_rows.is_empty() {
-            let term_ord_child = union_col
-                .child(1)
-                .as_any()
-                .downcast_ref::<StructArray>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "SegmentedTopKExec: child 1 should be StructArray of term ordinals".into(),
-                    )
-                })?;
-            let seg_ord_array = term_ord_child
-                .column(0)
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "SegmentedTopKExec: term_ordinal.segment_ord should be UInt32".into(),
-                    )
-                })?;
-            let ord_array = term_ord_child
-                .column(1)
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "SegmentedTopKExec: term_ordinal.term_ord should be UInt64".into(),
-                    )
-                })?;
-
-            for &row_idx in &state1_rows {
-                let ci = offsets[row_idx] as usize;
-                let seg_ord = seg_ord_array.value(ci);
-                row_to_seg[row_idx] = Some(seg_ord);
-                if !ord_array.is_null(ci) {
-                    let ord = ord_array.value(ci);
-                    if ord != NULL_TERM_ORDINAL {
-                        global_term_ords[row_idx] = Some(ord);
-                    } else {
-                        pass_through[row_idx] = true;
-                    }
-                } else {
-                    pass_through[row_idx] = true;
+        for (row_idx, value) in deferred.values().enumerate() {
+            match value {
+                DeferredValue::DocAddress(packed) => {
+                    let (seg_ord, doc_id) = unpack_doc_address(packed);
+                    state0_by_seg
+                        .entry(seg_ord)
+                        .or_default()
+                        .push((row_idx, doc_id));
+                    row_to_seg[row_idx] = Some(seg_ord);
                 }
+                DeferredValue::TermOrdinal {
+                    segment_ord,
+                    term_ord,
+                } => {
+                    row_to_seg[row_idx] = Some(segment_ord);
+                    global_term_ords[row_idx] = Some(term_ord);
+                }
+                DeferredValue::Null => pass_through[row_idx] = true,
             }
         }
 
@@ -1258,11 +1188,9 @@ impl SegmentedTopKState {
             }
 
             for (i, (row_idx, _)) in rows.into_iter().enumerate() {
-                let ord = term_ords[i].unwrap_or(NULL_TERM_ORDINAL);
-                if ord == NULL_TERM_ORDINAL {
-                    pass_through[row_idx] = true;
-                } else {
-                    global_term_ords[row_idx] = Some(ord);
+                match term_ords[i] {
+                    Some(ord) => global_term_ords[row_idx] = Some(ord),
+                    None => pass_through[row_idx] = true,
                 }
             }
         }
@@ -1784,7 +1712,7 @@ impl SegmentedTopKState {
         //
         // Ordinal-tracked survivors and pass-through rows carry the same compound
         // key, so both resolve through one path below.
-        type Candidate = (usize, usize, SegmentOrdinal, OwnedRow);
+        type Candidate = (usize, usize, Option<SegmentOrdinal>, OwnedRow);
         let mut candidates: Vec<Candidate> = Vec::new();
 
         for (seg_idx, slot) in self.segment_bufs.iter().enumerate() {
@@ -1793,7 +1721,7 @@ impl SegmentedTopKState {
                 candidates.push((
                     *batch_idx,
                     *row_idx,
-                    seg_idx as SegmentOrdinal,
+                    Some(seg_idx as SegmentOrdinal),
                     row_val.clone(),
                 ));
             }
@@ -1919,7 +1847,13 @@ impl SegmentedTopKState {
                         .map(|a| a.value(cand_idx));
                     match term_ord {
                         Some(term_ord) => {
-                            self.materialize_deferred_ordinal(*seg_ord, term_ord, deferred)?
+                            let seg_ord = seg_ord.ok_or_else(|| {
+                                DataFusionError::Internal(
+                                    "SegmentedTopKExec: a row with a term ordinal has no segment"
+                                        .into(),
+                                )
+                            })?;
+                            self.materialize_deferred_ordinal(seg_ord, term_ord, deferred)?
                         }
                         None => typed_null(sort_col)?,
                     }
@@ -2050,7 +1984,7 @@ mod tests {
     use crate::index::reader::index::SearchIndexReader;
     use crate::postgres::rel::PgSearchRelation;
     use crate::query::SearchQueryInput;
-    use crate::scan::deferred_encode::{build_state_doc_address, deferred_union_data_type};
+    use crate::scan::deferred_encode::{build_state_doc_address, deferred_field};
     use crate::scan::segmented_topk_exec::DeferredSortColumn;
     use crate::schema::SearchFieldType;
 
@@ -2141,7 +2075,7 @@ mod tests {
         ));
 
         let schema = Arc::new(Schema::new(vec![
-            Field::new("sort_col", deferred_union_data_type(), true),
+            deferred_field("sort_col"),
             Field::new("id", arrow_schema::DataType::Int64, true),
         ]));
 

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -1080,8 +1080,10 @@ impl SegmentedTopKState {
         for row_idx in 0..num_rows {
             if self.pass_through_scratch[row_idx] {
                 // Keep the compound key the converter already built for this
-                // row. A row with no segment is NULL in every deferred column,
-                // so nothing of it needs a dictionary later.
+                // row. A row that is NULL in one deferred column but not in
+                // another keeps that column's segment for the final decode; a
+                // row with no segment is NULL in every deferred column and
+                // needs no dictionary.
                 self.pass_through_rows.push(PassThroughRow {
                     batch_idx,
                     row_idx,

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -80,7 +80,7 @@ use crate::postgres::customscan::joinscan::visibility_filter::{
 };
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
-use crate::scan::deferred_encode::{DeferredColumn, DeferredValue, unpack_doc_address};
+use crate::scan::deferred_encode::{DeferredColumn, DeferredValue};
 use crate::scan::deferred_lookup::{LookupRebuildContext, open_rebuilt_ffhelper, rebuild_mvcc};
 use crate::scan::execution_plan::UnsafeSendStream;
 use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch, UInt64Array};
@@ -1148,13 +1148,12 @@ impl SegmentedTopKState {
         let mut state0_by_seg: HashMap<SegmentOrdinal, Vec<(usize, DocId)>> = HashMap::default();
         for (row_idx, value) in deferred.values().enumerate() {
             match value {
-                DeferredValue::DocAddress(packed) => {
-                    let (seg_ord, doc_id) = unpack_doc_address(packed);
+                DeferredValue::DocAddress(doc_address) => {
                     state0_by_seg
-                        .entry(seg_ord)
+                        .entry(doc_address.segment_ord)
                         .or_default()
-                        .push((row_idx, doc_id));
-                    row_to_seg[row_idx] = Some(seg_ord);
+                        .push((row_idx, doc_address.doc_id));
+                    row_to_seg[row_idx] = Some(doc_address.segment_ord);
                 }
                 DeferredValue::TermOrdinal {
                     segment_ord,

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -102,13 +102,13 @@ pub struct PgSearchTableProvider {
     /// - **Phase 1 (false) - SQL Planning:** During initial plan construction (`joinscan`),
     ///   this provider must expose a standard relational schema (i.e. `Utf8View` for strings)
     ///   so that DataFusion's SQL expression builder and `TypeCoercion` pass don't panic
-    ///   when trying to apply normal string functions/sorts to a `Union` type.
+    ///   when trying to apply normal string functions/sorts to a packed integer column.
     ///
     /// - **Phase 2 (true) - Logical Optimization:** Once the plan is structurally validated,
     ///   our `LateMaterializationRule` flips this to `true` (via interior mutability).
-    ///   The provider immediately begins returning the physical `Union` schema. The rule
-    ///   then updates the `TableScan.projected_schema` to match, allowing the `Union`
-    ///   types to legally bubble up to our `LateMaterializeNode` anchor.
+    ///   The provider immediately begins returning the physical deferred schema. The rule
+    ///   then updates the `TableScan.projected_schema` to match, allowing the deferred
+    ///   columns to legally bubble up to our `LateMaterializeNode` anchor.
     ///
     /// SAFETY: Relaxed ordering is sufficient because the store (in LateMaterializationRule)
     /// and load (in get_schema) execute sequentially within the same single-threaded optimization pass.
@@ -252,10 +252,14 @@ impl PgSearchTableProvider {
         self.range_split_points.as_ref()
     }
 
-    /// Transitions the provider from Phase 1 (`Utf8View`) into Phase 2 (`Union`)
+    /// Transitions the provider from Phase 1 (`Utf8View`) into Phase 2 (deferred columns)
     pub fn enable_late_materialization_schema(&self) {
         self.late_materialization_active
             .store(true, Ordering::Relaxed);
+    }
+
+    pub(crate) fn is_late_materialization_schema_enabled(&self) -> bool {
+        self.late_materialization_active.load(Ordering::Relaxed)
     }
 
     /// Activates deferred visibility mode (emitting packed DocAddresses for VisibilityFilterExec)

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -395,17 +395,6 @@ impl PgSearchTableProvider {
 
     pub fn deferred_fields(&self) -> Vec<DeferredField> {
         let mut deferred = Vec::new();
-        let ctid_col_name = self
-            .configured_deferred_ctid_plan_position()
-            .map(|pos| {
-                crate::postgres::customscan::joinscan::build::CtidColumn::new(pos).to_string()
-            })
-            .or_else(|| {
-                self.fields.iter().find_map(|wff| match wff {
-                    WhichFastField::DeferredCtid(name) => Some(name.clone()),
-                    _ => None,
-                })
-            });
         for (ff_index, wff) in self.fields.iter().enumerate() {
             if let WhichFastField::Deferred(name, field_type) = wff {
                 let is_bytes = matches!(
@@ -428,7 +417,6 @@ impl PgSearchTableProvider {
                         source_idx: self.source_idx,
                     }),
                     fetch_at_scan: self.deferred_fetch_at_scan,
-                    ctid_col_name: ctid_col_name.clone(),
                 });
             }
         }

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -258,10 +258,6 @@ impl PgSearchTableProvider {
             .store(true, Ordering::Relaxed);
     }
 
-    pub(crate) fn is_late_materialization_schema_enabled(&self) -> bool {
-        self.late_materialization_active.load(Ordering::Relaxed)
-    }
-
     /// Activates deferred visibility mode (emitting packed DocAddresses for VisibilityFilterExec)
     pub fn enable_deferred_visibility_schema(&self) {
         self.deferred_visibility_active

--- a/pg_search/src/scan/tantivy_decode_exec.rs
+++ b/pg_search/src/scan/tantivy_decode_exec.rs
@@ -32,7 +32,7 @@ use crate::api::HashMap;
 use crate::index::fast_fields_helper::{
     FFHelper, FFType, ords_to_bytes_array, ords_to_string_array,
 };
-use crate::scan::deferred_encode::{DeferredUnion, DeferredValue};
+use crate::scan::deferred_encode::{DeferredColumn, DeferredValue};
 use crate::scan::deferred_lookup::{
     LookupRebuildContext, PhysicalDeferredField, ffhelper_for, preserved_ordering,
     rebuild_missing_ffhelpers,
@@ -139,7 +139,7 @@ impl TantivyDecodeExec {
     }
 }
 
-/// The input schema with each deferred union column replaced by its decoded type.
+/// The input schema with each deferred column replaced by its decoded type.
 fn build_output_schema(
     input_schema: SchemaRef,
     deferred: &[PhysicalDeferredField],
@@ -156,9 +156,9 @@ fn build_output_schema(
                 d.col_idx, d.display_name
             ))
         })?;
-        if !matches!(field.data_type(), DataType::Union(_, _)) {
+        if field.data_type() != &DataType::UInt64 {
             return Err(DataFusionError::Plan(format!(
-                "TantivyDecodeExec: column {} ('{}') is {:?}, expected a deferred union",
+                "TantivyDecodeExec: column {} ('{}') is {:?}, expected a deferred UInt64 column",
                 d.col_idx,
                 d.display_name,
                 field.data_type()
@@ -285,29 +285,8 @@ fn decode_batch(
     let mut columns = batch.columns().to_vec();
     for field in deferred_fields {
         let ffhelper = ffhelper_for(ffhelpers, field)?;
-        let ctid_col = match field.ctid_col_name.as_deref() {
-            Some(name) => {
-                let idx = batch.schema().index_of(name).map_err(|e| {
-                    DataFusionError::Internal(format!(
-                        "CTID column '{name}' for deferred field '{}' not found in batch: {e}",
-                        field.display_name
-                    ))
-                })?;
-                let col = batch
-                    .column(idx)
-                    .as_any()
-                    .downcast_ref::<UInt64Array>()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal(format!(
-                            "CTID column '{name}' at index {idx} is not a UInt64Array"
-                        ))
-                    })?;
-                Some(col)
-            }
-            None => None,
-        };
         columns[field.col_idx] =
-            decode_term_ordinals(ffhelper, field, &columns[field.col_idx], ctid_col)?;
+            decode_term_ordinals(ffhelper, field, &columns[field.col_idx])?;
     }
     RecordBatch::try_new(schema.clone(), columns)
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
@@ -321,25 +300,17 @@ fn decode_term_ordinals(
     ffhelper: &FFHelper,
     field: &PhysicalDeferredField,
     column: &ArrayRef,
-    ctid_col: Option<&UInt64Array>,
 ) -> Result<ArrayRef> {
-    let union = DeferredUnion::try_new(column.as_ref())?;
+    let deferred = DeferredColumn::try_new(column.as_ref())?;
     let num_rows = column.len();
     let num_segments = ffhelper.num_segments();
     let mut by_segment: Vec<Vec<(usize, TermOrdinal)>> = vec![Vec::new(); num_segments];
     let mut null_rows: Vec<usize> = Vec::new();
-    for (row, value) in union.values().enumerate() {
-        // If the relation was null-extended by an outer join, its ctid is NULL.
-        // Arrow's `take` kernel on dense `UnionArray` corrupts null indices by replacing
-        // them with 0 (offset 0 into child 0), so we must check the relation's ctid nullness.
-        if ctid_col.is_some_and(|c| c.is_null(row)) {
-            null_rows.push(row);
-            continue;
-        }
+    for (row, value) in deferred.values().enumerate() {
         match value {
             DeferredValue::TermOrdinal {
                 segment_ord,
-                term_ord: Some(term_ord),
+                term_ord,
             } => {
                 let entry = by_segment.get_mut(segment_ord as usize).ok_or_else(|| {
                     DataFusionError::Execution(format!(
@@ -349,9 +320,7 @@ fn decode_term_ordinals(
                 })?;
                 entry.push((row, term_ord));
             }
-            DeferredValue::TermOrdinal { term_ord: None, .. } | DeferredValue::Null => {
-                null_rows.push(row)
-            }
+            DeferredValue::Null => null_rows.push(row),
             DeferredValue::DocAddress(_) => {
                 return Err(DataFusionError::Internal(format!(
                     "TantivyDecodeExec: column '{}' row {row} still carries a doc address; a TantivyFetchExec must resolve it first",

--- a/pg_search/src/scan/tantivy_decode_exec.rs
+++ b/pg_search/src/scan/tantivy_decode_exec.rs
@@ -285,8 +285,7 @@ fn decode_batch(
     let mut columns = batch.columns().to_vec();
     for field in deferred_fields {
         let ffhelper = ffhelper_for(ffhelpers, field)?;
-        columns[field.col_idx] =
-            decode_term_ordinals(ffhelper, field, &columns[field.col_idx])?;
+        columns[field.col_idx] = decode_term_ordinals(ffhelper, field, &columns[field.col_idx])?;
     }
     RecordBatch::try_new(schema.clone(), columns)
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))

--- a/pg_search/src/scan/tantivy_fetch_exec.rs
+++ b/pg_search/src/scan/tantivy_fetch_exec.rs
@@ -394,8 +394,7 @@ fn fetch_batch(
     let mut columns = batch.columns().to_vec();
     for field in fetch_fields {
         let ffhelper = ffhelper_for(ffhelpers, field)?;
-        columns[field.col_idx] =
-            fetch_term_ordinals(ffhelper, field, &columns[field.col_idx])?;
+        columns[field.col_idx] = fetch_term_ordinals(ffhelper, field, &columns[field.col_idx])?;
     }
     RecordBatch::try_new(schema, columns)
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))

--- a/pg_search/src/scan/tantivy_fetch_exec.rs
+++ b/pg_search/src/scan/tantivy_fetch_exec.rs
@@ -35,7 +35,7 @@ use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::postgres::customscan::joinscan::visibility_filter::{
     DeferredCtidMaterializationState, materialize_deferred_ctid,
 };
-use crate::scan::deferred_encode::{DeferredColumn, DeferredValue, unpack_doc_address};
+use crate::scan::deferred_encode::{DeferredColumn, DeferredValue};
 use crate::scan::deferred_lookup::{
     LookupRebuildContext, PhysicalDeferredField, ffhelper_for, open_rebuilt_ffhelper,
     preserved_ordering, rebuild_missing_ffhelpers,
@@ -57,7 +57,7 @@ use datafusion::physical_plan::metrics::{
 };
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use tantivy::termdict::TermOrdinal;
-use tantivy::{DocId, SegmentOrdinal};
+use tantivy::{DocAddress, DocId, SegmentOrdinal};
 
 /// A `ctid_<plan_position>` column (packed doc-addresses) that a `TantivyFetchExec` resolves
 /// to real ctids, so a `VisibilityFilterExec` above it consumes real ctids directly.
@@ -409,28 +409,28 @@ fn fetch_term_ordinals(
 ) -> Result<ArrayRef> {
     let deferred = DeferredColumn::try_new(column.as_ref())?;
     let num_segments = ffhelper.num_segments();
-    let mut packed_rows: Vec<(usize, u64)> = Vec::new();
+    let mut doc_addresses: Vec<(usize, DocAddress)> = Vec::new();
     for (row, value) in deferred.values().enumerate() {
-        if let DeferredValue::DocAddress(packed) = value {
-            let (segment_ord, _) = unpack_doc_address(packed);
+        if let DeferredValue::DocAddress(doc_address) = value {
+            let segment_ord = doc_address.segment_ord;
             if segment_ord as usize >= num_segments {
                 return Err(DataFusionError::Execution(format!(
                     "TantivyFetchExec: column '{}' row {row} names segment {segment_ord}, but its index has {num_segments} segments",
                     field.display_name
                 )));
             }
-            packed_rows.push((row, packed));
+            doc_addresses.push((row, doc_address));
         }
     }
-    if packed_rows.is_empty() {
+    if doc_addresses.is_empty() {
         return Ok(Arc::clone(column));
     }
 
     let mut resolved: Vec<(usize, SegmentOrdinal, Option<TermOrdinal>)> =
-        Vec::with_capacity(packed_rows.len());
+        Vec::with_capacity(doc_addresses.len());
     for_each_segment(
         num_segments,
-        packed_rows.into_iter(),
+        doc_addresses.into_iter(),
         |segment_ord, rows| {
             let ids: Vec<DocId> = rows.iter().map(|(_, doc_id)| *doc_id).collect();
             let mut ords: Vec<Option<TermOrdinal>> = vec![None; ids.len()];

--- a/pg_search/src/scan/tantivy_fetch_exec.rs
+++ b/pg_search/src/scan/tantivy_fetch_exec.rs
@@ -19,10 +19,10 @@
 //!
 //! `TantivyFetchExec` reads fast-field columns for rows that still carry a packed doc
 //! address: a deferred string/bytes column moves from State 0 to State 1 (its term ordinal
-//! in the segment dictionary), and a `ctid_<plan_position>` column moves from a packed
-//! address to a real ctid. The schema does not change; a State 1 row passes through
-//! untouched, so a scan or a `SegmentedTopKExec` that resolved ordinals already costs
-//! nothing here.
+//! in the segment dictionary, packed into the same word), and a `ctid_<plan_position>`
+//! column moves from a packed address to a real ctid. The schema does not change; a State 1
+//! row passes through untouched, so a scan that resolved ordinals already costs nothing
+//! here.
 //!
 //! Fast-field reads are cheapest in doc order, which a join above the scan no longer keeps,
 //! so this node is the part of the lookup that is sensitive to where it sits in the plan.
@@ -35,16 +35,14 @@ use crate::index::mvcc::{MvccSatisfies, SegmentView};
 use crate::postgres::customscan::joinscan::visibility_filter::{
     DeferredCtidMaterializationState, materialize_deferred_ctid,
 };
-use crate::scan::deferred_encode::{
-    DeferredUnion, DeferredValue, build_state_term_ordinals_per_row, unpack_doc_address,
-};
+use crate::scan::deferred_encode::{DeferredColumn, DeferredValue, unpack_doc_address};
 use crate::scan::deferred_lookup::{
     LookupRebuildContext, PhysicalDeferredField, ffhelper_for, open_rebuilt_ffhelper,
     preserved_ordering, rebuild_missing_ffhelpers,
 };
 use crate::scan::execution_plan::UnsafeSendStream;
 
-use arrow_array::{Array, ArrayRef, RecordBatch, UInt32Array, UInt64Array};
+use arrow_array::{ArrayRef, RecordBatch, UInt64Array};
 use arrow_schema::DataType;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -58,8 +56,8 @@ use datafusion::physical_plan::metrics::{
     BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet, RecordOutput,
 };
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-use tantivy::DocId;
 use tantivy::termdict::TermOrdinal;
+use tantivy::{DocId, SegmentOrdinal};
 
 /// A `ctid_<plan_position>` column (packed doc-addresses) that a `TantivyFetchExec` resolves
 /// to real ctids, so a `VisibilityFilterExec` above it consumes real ctids directly.
@@ -127,16 +125,16 @@ impl TantivyFetchExec {
                     field.col_idx, field.display_name
                 ))
             })?;
-            if !matches!(input_field.data_type(), DataType::Union(_, _)) {
+            if input_field.data_type() != &DataType::UInt64 {
                 return Err(DataFusionError::Plan(format!(
-                    "TantivyFetchExec: column {} ('{}') is {:?}, expected a deferred union",
+                    "TantivyFetchExec: column {} ('{}') is {:?}, expected a deferred UInt64 column",
                     field.col_idx,
                     field.display_name,
                     input_field.data_type()
                 )));
             }
         }
-        // Rows keep their order and their types; only the union state changes. Only the
+        // Rows keep their order and their types; only a row's state changes. Only the
         // ordering is carried up, not the input's equivalence classes: above a hash join
         // those would let DataFusion rewrite a Top-K sort key onto the other join side and
         // move its dynamic filter off the probe scan.
@@ -396,80 +394,41 @@ fn fetch_batch(
     let mut columns = batch.columns().to_vec();
     for field in fetch_fields {
         let ffhelper = ffhelper_for(ffhelpers, field)?;
-        let ctid_col = match field.ctid_col_name.as_deref() {
-            Some(name) => {
-                let idx = batch.schema().index_of(name).map_err(|e| {
-                    DataFusionError::Internal(format!(
-                        "CTID column '{name}' for deferred field '{}' not found in batch: {e}",
-                        field.display_name
-                    ))
-                })?;
-                let col = batch
-                    .column(idx)
-                    .as_any()
-                    .downcast_ref::<UInt64Array>()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal(format!(
-                            "CTID column '{name}' at index {idx} is not a UInt64Array"
-                        ))
-                    })?;
-                Some(col)
-            }
-            None => None,
-        };
         columns[field.col_idx] =
-            fetch_term_ordinals(ffhelper, field, &columns[field.col_idx], ctid_col)?;
+            fetch_term_ordinals(ffhelper, field, &columns[field.col_idx])?;
     }
     RecordBatch::try_new(schema, columns)
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
 }
 
-/// Resolves a deferred column's doc addresses to term ordinals, returning a State 1 array.
-/// A column with no State 0 rows is returned as is.
+/// Resolves a deferred column's doc addresses to term ordinals. A column with no State 0
+/// rows is returned as is.
 fn fetch_term_ordinals(
     ffhelper: &FFHelper,
     field: &PhysicalDeferredField,
     column: &ArrayRef,
-    ctid_col: Option<&UInt64Array>,
 ) -> Result<ArrayRef> {
-    let union = DeferredUnion::try_new(column.as_ref())?;
-    let num_rows = column.len();
-    let mut segment_ords = vec![0u32; num_rows];
-    let mut term_ords: Vec<Option<TermOrdinal>> = vec![None; num_rows];
+    let deferred = DeferredColumn::try_new(column.as_ref())?;
     let num_segments = ffhelper.num_segments();
     let mut packed_rows: Vec<(usize, u64)> = Vec::new();
-    for (row, value) in union.values().enumerate() {
-        // If the relation was null-extended by an outer join, its ctid is NULL.
-        // Arrow's `take` kernel on dense `UnionArray` corrupts null indices by replacing
-        // them with 0 (offset 0 into child 0), so we must skip fetching for this row.
-        if ctid_col.is_some_and(|c| c.is_null(row)) {
-            continue;
-        }
-        match value {
-            DeferredValue::DocAddress(packed) => {
-                let (segment_ord, _) = unpack_doc_address(packed);
-                if segment_ord as usize >= num_segments {
-                    return Err(DataFusionError::Execution(format!(
-                        "TantivyFetchExec: column '{}' row {row} names segment {segment_ord}, but its index has {num_segments} segments",
-                        field.display_name
-                    )));
-                }
-                packed_rows.push((row, packed));
+    for (row, value) in deferred.values().enumerate() {
+        if let DeferredValue::DocAddress(packed) = value {
+            let (segment_ord, _) = unpack_doc_address(packed);
+            if segment_ord as usize >= num_segments {
+                return Err(DataFusionError::Execution(format!(
+                    "TantivyFetchExec: column '{}' row {row} names segment {segment_ord}, but its index has {num_segments} segments",
+                    field.display_name
+                )));
             }
-            DeferredValue::TermOrdinal {
-                segment_ord,
-                term_ord,
-            } => {
-                segment_ords[row] = segment_ord;
-                term_ords[row] = term_ord;
-            }
-            DeferredValue::Null => {}
+            packed_rows.push((row, packed));
         }
     }
     if packed_rows.is_empty() {
         return Ok(Arc::clone(column));
     }
 
+    let mut resolved: Vec<(usize, SegmentOrdinal, Option<TermOrdinal>)> =
+        Vec::with_capacity(packed_rows.len());
     for_each_segment(
         num_segments,
         packed_rows.into_iter(),
@@ -491,18 +450,16 @@ fn fetch_term_ordinals(
                     )));
                 }
             }
-            for ((row, _), ord) in rows.into_iter().zip(ords) {
-                segment_ords[row] = segment_ord;
-                term_ords[row] = ord;
-            }
+            resolved.extend(
+                rows.into_iter()
+                    .zip(ords)
+                    .map(|((row, _), ord)| (row, segment_ord, ord)),
+            );
             Ok(())
         },
     )?;
 
-    Ok(build_state_term_ordinals_per_row(
-        UInt32Array::from(segment_ords),
-        Arc::new(UInt64Array::from(term_ords)),
-    ))
+    Ok(deferred.with_term_ordinals(resolved))
 }
 
 /// Replaces each configured ctid column's packed doc-addresses with real ctids, using the

--- a/pg_search/tests/pg_regress/expected/aggregate_late_materialization.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_late_materialization.out
@@ -94,3 +94,79 @@ ORDER BY p.category;
 (3 rows)
 
 DROP TABLE alm_products, alm_tags;
+-- A nested level on an array field reads the join a second time. Both reads have to
+-- agree on the group key's type, or the array level's buckets belong to no parent and
+-- drop out of the result.
+CREATE TABLE alm_posts (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    author TEXT,
+    labels TEXT[]
+);
+CREATE TABLE alm_views (
+    id SERIAL PRIMARY KEY,
+    post_id INTEGER
+);
+INSERT INTO alm_posts (title, author, labels)
+SELECT 'post ' || i,
+       (ARRAY['ann', 'bob', 'cid'])[1 + i % 3],
+       ARRAY[(ARRAY['red', 'green', 'blue'])[1 + i % 3], 'all']
+FROM generate_series(1, 60) AS i;
+INSERT INTO alm_views (post_id) SELECT id FROM alm_posts;
+CREATE INDEX alm_posts_idx ON alm_posts
+USING bm25 (id, title, author, labels)
+WITH (key_field='id', text_fields='{"title": {}, "author": {"fast": true}, "labels": {"fast": true}}');
+CREATE INDEX alm_views_idx ON alm_views
+USING bm25 (id, post_id)
+WITH (key_field='id', numeric_fields='{"post_id": {"fast": true}}');
+SET max_parallel_workers_per_gather TO 0;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "p.author", "order": {"_key": "asc"}, "size": 10}, "aggs": {"by_label": {"terms": {"field": "p.labels", "order": {"_key": "asc"}, "size": 10}}}}')
+FROM alm_posts p JOIN alm_views v ON p.id = v.post_id
+WHERE p.title @@@ 'post';
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Backend: DataFusion
+   Indexes: alm_posts_idx (p), alm_views_idx (v)
+   Aggregates: pdb.agg({"aggs":{"by_label":{"terms":{"size":10,"field":"p.labels","order":{"_key":"asc"}}}},"terms":{"size":10,"field":"p.author","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : CoalescePartitionsExec
+     :   ProjectionExec: expr=[__grouping_id@2 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, __pdb_m0@3 as __pdb_m0]
+     :     UnionExec
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, NULL as __pdb_k1, CASE CAST(__grouping_id@1 AS UInt64) WHEN 1 THEN 3 WHEN 0 THEN 1 ELSE 0 END as __grouping_id, __pdb_m0@2 as __pdb_m0]
+     :         AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __grouping_id@1 as __grouping_id], aggr=[count(1) as __pdb_m0]
+     :           AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0), (author@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+     :             TantivyDecodeExec: decode=[author]
+     :               TantivyFetchExec: fetch=[author]
+     :                 VisibilityFilterExec: tables=[p, v]
+     :                   TantivyFetchExec: fetch=[ctid_0, ctid_1]
+     :                     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, post_id@0)], projection=[author@1, ctid_0@2, ctid_1@4]
+     :                       CooperativeExec
+     :                         PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+     :                       CooperativeExec
+     :                         PgSearchScan: table=v, segments=1, dynamic_filters=1, query="all"
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, 0 as __grouping_id, __pdb_m0@2 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[author@0 as __pdb_k0, p_0_labels@1 as __pdb_k1], aggr=[count(1) as __pdb_m0]
+     :           VisibilityFilterExec: tables=[p, v]
+     :             TantivyFetchExec: fetch=[ctid_0, ctid_1]
+     :               UnnestExec
+     :                 TantivyDecodeExec: decode=[author]
+     :                   TantivyFetchExec: fetch=[author]
+     :                     ProjectionExec: expr=[author@0 as author, labels@1 as p_0_labels, ctid_0@2 as ctid_0, ctid_1@3 as ctid_1]
+     :                       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, post_id@0)], projection=[author@1, labels@2, ctid_0@3, ctid_1@5]
+     :                         CooperativeExec
+     :                           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+     :                         CooperativeExec
+     :                           PgSearchScan: table=v, segments=1, dynamic_filters=1, query="all"
+(33 rows)
+
+SELECT pdb.agg('{"terms": {"field": "p.author", "order": {"_key": "asc"}, "size": 10}, "aggs": {"by_label": {"terms": {"field": "p.labels", "order": {"_key": "asc"}, "size": 10}}}}')
+FROM alm_posts p JOIN alm_views v ON p.id = v.post_id
+WHERE p.title @@@ 'post';
+                                                                                                                                                                                                                                                        agg                                                                                                                                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "ann", "by_label": {"buckets": [{"key": "all", "doc_count": 20}, {"key": "red", "doc_count": 20}], "sum_other_doc_count": 0}, "doc_count": 20}, {"key": "bob", "by_label": {"buckets": [{"key": "all", "doc_count": 20}, {"key": "green", "doc_count": 20}], "sum_other_doc_count": 0}, "doc_count": 20}, {"key": "cid", "by_label": {"buckets": [{"key": "all", "doc_count": 20}, {"key": "blue", "doc_count": 20}], "sum_other_doc_count": 0}, "doc_count": 20}], "sum_other_doc_count": 0}
+(1 row)
+
+DROP TABLE alm_posts, alm_views;

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -363,13 +363,13 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   TantivyDecodeExec: decode=[val], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
-           :     TantivyFetchExec: fetch=[val], metrics=[output_rows=10, output_bytes=330.0 B, output_batches=1]
+           :     TantivyFetchExec: fetch=[val], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
            :       SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, visibility_checks=[t2, t1], metrics=[rows_filtered_invisible=0, rows_input=8.25 K, rows_output=10, segments_seen=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=361.6 KB, output_batches=2, build_mem_used=390.6 KB, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=384.0 KB, output_batches=2, build_mem_used=390.6 KB, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
            :           CooperativeExec
            :             PgSearchScan: table=t2, segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :           CooperativeExec
-           :             PgSearchScan: table=t1, segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, dynamic_filter_pushdown_gallop=1, rows_pruned=11.75 K, rows_scanned=20.00 K]
+           :             PgSearchScan: table=t1, segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=193.5 KB, output_batches=4, dynamic_filter_pushdown_gallop=1, rows_pruned=11.75 K, rows_scanned=20.00 K]
 (16 rows)
 
 -- Verify results
@@ -477,13 +477,13 @@ LIMIT 25;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :   TantivyDecodeExec: decode=[val], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
-           :     TantivyFetchExec: fetch=[val], metrics=[output_rows=25, output_bytes=1089.0 B, output_batches=1]
+           :     TantivyFetchExec: fetch=[val], metrics=[output_rows=25, output_bytes=864.0 B, output_batches=1]
            :       SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, visibility_checks=[t2, t1], metrics=[rows_filtered_invisible=0, rows_input=8.43 K, rows_output=25, segments_seen=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.43 K, output_bytes=493.9 KB, output_batches=2, build_mem_used=390.6 KB, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.43 K, avg_fanout=100% (8.43 K/8.43 K), probe_hit_rate=100% (8.43 K/8.43 K)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.43 K, output_bytes=513.0 KB, output_batches=2, build_mem_used=390.6 KB, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.43 K, avg_fanout=100% (8.43 K/8.43 K), probe_hit_rate=100% (8.43 K/8.43 K)]
            :           CooperativeExec
            :             PgSearchScan: table=t2, segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :           CooperativeExec
-           :             PgSearchScan: table=t1, segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, dynamic_filter_pushdown_gallop=1, rows_pruned=11.57 K, rows_scanned=20.00 K]
+           :             PgSearchScan: table=t1, segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=197.8 KB, output_batches=4, dynamic_filter_pushdown_gallop=1, rows_pruned=11.57 K, rows_scanned=20.00 K]
 (16 rows)
 
 SELECT t1.id, t1.val

--- a/pg_search/tests/pg_regress/expected/join_outer_deferred_sort.out
+++ b/pg_search/tests/pg_regress/expected/join_outer_deferred_sort.out
@@ -1,0 +1,565 @@
+-- A deferred string column of an outer join's nullable side must come out NULL for
+-- the null-extended rows, both as a Top-K sort key and as an output column.
+-- `oj_dim` row 1 carries the smallest `tag`, so a null-extended row that borrows the
+-- first document's ordinal would sort ahead of every real row.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS oj_dim CASCADE;
+DROP TABLE IF EXISTS oj_fact CASCADE;
+DROP TABLE IF EXISTS oj_side CASCADE;
+CREATE TABLE oj_dim (id INT PRIMARY KEY, k INT, txt TEXT, tag TEXT);
+CREATE TABLE oj_fact (id INT PRIMARY KEY, k INT, txt TEXT);
+CREATE TABLE oj_side (id INT PRIMARY KEY, txt TEXT);
+-- oj_fact rows 21..40 have no oj_dim partner.
+INSERT INTO oj_dim
+SELECT g, g, 'alpha item ' || g, CASE WHEN g = 1 THEN 'aaa' ELSE 'tag' || lpad(g::text, 2, '0') END
+FROM generate_series(1, 20) g;
+INSERT INTO oj_fact
+SELECT g, g, 'beta item ' || g
+FROM generate_series(1, 40) g;
+INSERT INTO oj_side
+SELECT g, 'gamma item ' || g
+FROM generate_series(1, 3) g;
+CREATE INDEX oj_dim_idx ON oj_dim
+USING paradedb (id, k, txt, tag)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true},"tag":{"fast":true}}');
+CREATE INDEX oj_fact_idx ON oj_fact
+USING paradedb (id, k, txt)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
+CREATE INDEX oj_side_idx ON oj_side
+USING paradedb (id, txt)
+WITH (key_field='id', text_fields='{"txt":{"fast":true}}');
+ANALYZE oj_dim;
+ANALYZE oj_fact;
+ANALYZE oj_side;
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
+-- RIGHT JOIN: the left input is null-extended
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Result
+         Output: d.id, d.tag, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Limit: 25
+               Order By: d.tag asc, f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, tag@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyDecodeExec: decode=[tag]
+                 :     TantivyFetchExec: fetch=[tag]
+                 :       SegmentedTopKExec: expr=[tag@1 ASC NULLS LAST, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+ id |  tag  | id 
+----+-------+----
+  1 | aaa   |  1
+  2 | tag02 |  2
+  3 | tag03 |  3
+  4 | tag04 |  4
+  5 | tag05 |  5
+  6 | tag06 |  6
+  7 | tag07 |  7
+  8 | tag08 |  8
+  9 | tag09 |  9
+ 10 | tag10 | 10
+ 11 | tag11 | 11
+ 12 | tag12 | 12
+ 13 | tag13 | 13
+ 14 | tag14 | 14
+ 15 | tag15 | 15
+ 16 | tag16 | 16
+ 17 | tag17 | 17
+ 18 | tag18 | 18
+ 19 | tag19 | 19
+ 20 | tag20 | 20
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+(25 rows)
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag DESC, f.id LIMIT 25;
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Result
+         Output: d.id, d.tag, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Limit: 25
+               Order By: d.tag desc, f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, tag@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyDecodeExec: decode=[tag]
+                 :     TantivyFetchExec: fetch=[tag]
+                 :       SegmentedTopKExec: expr=[tag@1 DESC, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag DESC, f.id LIMIT 25;
+ id |  tag  | id 
+----+-------+----
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+    |       | 26
+    |       | 27
+    |       | 28
+    |       | 29
+    |       | 30
+    |       | 31
+    |       | 32
+    |       | 33
+    |       | 34
+    |       | 35
+    |       | 36
+    |       | 37
+    |       | 38
+    |       | 39
+    |       | 40
+ 20 | tag20 | 20
+ 19 | tag19 | 19
+ 18 | tag18 | 18
+ 17 | tag17 | 17
+ 16 | tag16 | 16
+(25 rows)
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag NULLS FIRST, f.id LIMIT 25;
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Result
+         Output: d.id, d.tag, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Limit: 25
+               Order By: d.tag asc nulls first, f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, tag@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyDecodeExec: decode=[tag]
+                 :     TantivyFetchExec: fetch=[tag]
+                 :       SegmentedTopKExec: expr=[tag@1 ASC, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag NULLS FIRST, f.id LIMIT 25;
+ id |  tag  | id 
+----+-------+----
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+    |       | 26
+    |       | 27
+    |       | 28
+    |       | 29
+    |       | 30
+    |       | 31
+    |       | 32
+    |       | 33
+    |       | 34
+    |       | 35
+    |       | 36
+    |       | 37
+    |       | 38
+    |       | 39
+    |       | 40
+  1 | aaa   |  1
+  2 | tag02 |  2
+  3 | tag03 |  3
+  4 | tag04 |  4
+  5 | tag05 |  5
+(25 rows)
+
+-- A mixed ON condition keeps the nullable side deferred as well.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.id <= f.id WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Result
+         Output: d.id, d.tag, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Join Filter: (d.id <= f.id)
+               Limit: 25
+               Order By: d.tag asc, f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@4 as col_1, id@1 as col_2, tag@2 as col_3, ctid_0@0 as ctid_0, ctid_1@3 as ctid_1]
+                 :   TantivyDecodeExec: decode=[tag]
+                 :     TantivyFetchExec: fetch=[tag]
+                 :       SegmentedTopKExec: expr=[tag@2 ASC NULLS LAST, id@4 ASC NULLS LAST], k=25, visibility_checks=[f]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], filter=id@0 <= id@1, projection=[ctid_0@0, id@2, tag@3, ctid_1@4, id@6]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.id <= f.id WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+ id |  tag  | id 
+----+-------+----
+  1 | aaa   |  1
+  2 | tag02 |  2
+  3 | tag03 |  3
+  4 | tag04 |  4
+  5 | tag05 |  5
+  6 | tag06 |  6
+  7 | tag07 |  7
+  8 | tag08 |  8
+  9 | tag09 |  9
+ 10 | tag10 | 10
+ 11 | tag11 | 11
+ 12 | tag12 | 12
+ 13 | tag13 | 13
+ 14 | tag14 | 14
+ 15 | tag15 | 15
+ 16 | tag16 | 16
+ 17 | tag17 | 17
+ 18 | tag18 | 18
+ 19 | tag19 | 19
+ 20 | tag20 | 20
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+(25 rows)
+
+-- =============================================================================
+-- LEFT JOIN: the right input is null-extended
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_fact f LEFT JOIN oj_dim d ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Result
+         Output: d.id, d.tag, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Limit: 25
+               Order By: d.tag asc, f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, tag@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyDecodeExec: decode=[tag]
+                 :     TantivyFetchExec: fetch=[tag]
+                 :       SegmentedTopKExec: expr=[tag@1 ASC NULLS LAST, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_fact f LEFT JOIN oj_dim d ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+ id |  tag  | id 
+----+-------+----
+  1 | aaa   |  1
+  2 | tag02 |  2
+  3 | tag03 |  3
+  4 | tag04 |  4
+  5 | tag05 |  5
+  6 | tag06 |  6
+  7 | tag07 |  7
+  8 | tag08 |  8
+  9 | tag09 |  9
+ 10 | tag10 | 10
+ 11 | tag11 | 11
+ 12 | tag12 | 12
+ 13 | tag13 | 13
+ 14 | tag14 | 14
+ 15 | tag15 | 15
+ 16 | tag16 | 16
+ 17 | tag17 | 17
+ 18 | tag18 | 18
+ 19 | tag19 | 19
+ 20 | tag20 | 20
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+(25 rows)
+
+-- =============================================================================
+-- FULL JOIN: both inputs are null-extended
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' OR d.txt @@@ 'alpha' ORDER BY d.tag, f.id LIMIT 25;
+                                                                                                                                       QUERY PLAN                                                                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: d.id, d.tag, f.id
+         Relation Tree: f FULL d
+         Join Cond: d.k = f.k
+         Join Predicate: (f:{"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}} OR d:{"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}})
+         Limit: 25
+         Order By: d.tag asc, f.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, tag@3 as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   TantivyDecodeExec: decode=[tag]
+           :     TantivyFetchExec: fetch=[tag]
+           :       SegmentedTopKExec: expr=[tag@3 ASC NULLS LAST, id@1 ASC NULLS LAST], k=25
+           :         FilterExec: __f_0_tag_0@2 OR __d_1_tag_0@5, projection=[ctid_0@0, id@1, ctid_1@3, tag@4]
+           :           HashJoinExec: mode=CollectLeft, join_type=Full, on=[(k@1, k@1)], projection=[ctid_0@4, id@6, __f_0_tag_0@7, ctid_1@0, tag@2, __d_1_tag_0@3]
+           :             CooperativeExec
+           :               PgSearchScan: table=d, segments=1, visibility=eager, tag_0={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+           :             CooperativeExec
+           :               PgSearchScan: table=f, segments=1, visibility=eager, tag_0={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' OR d.txt @@@ 'alpha' ORDER BY d.tag, f.id LIMIT 25;
+ id |  tag  | id 
+----+-------+----
+  1 | aaa   |  1
+  2 | tag02 |  2
+  3 | tag03 |  3
+  4 | tag04 |  4
+  5 | tag05 |  5
+  6 | tag06 |  6
+  7 | tag07 |  7
+  8 | tag08 |  8
+  9 | tag09 |  9
+ 10 | tag10 | 10
+ 11 | tag11 | 11
+ 12 | tag12 | 12
+ 13 | tag13 | 13
+ 14 | tag14 | 14
+ 15 | tag15 | 15
+ 16 | tag16 | 16
+ 17 | tag17 | 17
+ 18 | tag18 | 18
+ 19 | tag19 | 19
+ 20 | tag20 | 20
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+(25 rows)
+
+-- =============================================================================
+-- A third relation under the outer join, and the column as plain output
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k CROSS JOIN oj_side s WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id, s.id LIMIT 70;
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id, s.id
+   ->  Result
+         Output: d.id, d.tag, f.id, s.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag, s.id
+               Relation Tree: d RIGHT (f INNER s)
+               Join Cond: d.k = f.k
+               Limit: 70
+               Order By: d.tag asc, f.id asc, s.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, tag@1 as col_3, id@5 as col_4, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
+                 :   TantivyDecodeExec: decode=[tag]
+                 :     TantivyFetchExec: fetch=[tag]
+                 :       SegmentedTopKExec: expr=[tag@1 ASC NULLS LAST, id@3 ASC NULLS LAST, id@5 ASC NULLS LAST], k=70, visibility_checks=[f, s]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5, ctid_2@6, id@7]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :           ProjectionExec: expr=[ctid_1@2 as ctid_1, k@3 as k, id@4 as id, ctid_2@0 as ctid_2, id@1 as id]
+                 :             CrossJoinExec
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=s, segments=1, query="all"
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(24 rows)
+
+SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k CROSS JOIN oj_side s WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id, s.id LIMIT 70;
+ id |  tag  | id | id 
+----+-------+----+----
+  1 | aaa   |  1 |  1
+  1 | aaa   |  1 |  2
+  1 | aaa   |  1 |  3
+  2 | tag02 |  2 |  1
+  2 | tag02 |  2 |  2
+  2 | tag02 |  2 |  3
+  3 | tag03 |  3 |  1
+  3 | tag03 |  3 |  2
+  3 | tag03 |  3 |  3
+  4 | tag04 |  4 |  1
+  4 | tag04 |  4 |  2
+  4 | tag04 |  4 |  3
+  5 | tag05 |  5 |  1
+  5 | tag05 |  5 |  2
+  5 | tag05 |  5 |  3
+  6 | tag06 |  6 |  1
+  6 | tag06 |  6 |  2
+  6 | tag06 |  6 |  3
+  7 | tag07 |  7 |  1
+  7 | tag07 |  7 |  2
+  7 | tag07 |  7 |  3
+  8 | tag08 |  8 |  1
+  8 | tag08 |  8 |  2
+  8 | tag08 |  8 |  3
+  9 | tag09 |  9 |  1
+  9 | tag09 |  9 |  2
+  9 | tag09 |  9 |  3
+ 10 | tag10 | 10 |  1
+ 10 | tag10 | 10 |  2
+ 10 | tag10 | 10 |  3
+ 11 | tag11 | 11 |  1
+ 11 | tag11 | 11 |  2
+ 11 | tag11 | 11 |  3
+ 12 | tag12 | 12 |  1
+ 12 | tag12 | 12 |  2
+ 12 | tag12 | 12 |  3
+ 13 | tag13 | 13 |  1
+ 13 | tag13 | 13 |  2
+ 13 | tag13 | 13 |  3
+ 14 | tag14 | 14 |  1
+ 14 | tag14 | 14 |  2
+ 14 | tag14 | 14 |  3
+ 15 | tag15 | 15 |  1
+ 15 | tag15 | 15 |  2
+ 15 | tag15 | 15 |  3
+ 16 | tag16 | 16 |  1
+ 16 | tag16 | 16 |  2
+ 16 | tag16 | 16 |  3
+ 17 | tag17 | 17 |  1
+ 17 | tag17 | 17 |  2
+ 17 | tag17 | 17 |  3
+ 18 | tag18 | 18 |  1
+ 18 | tag18 | 18 |  2
+ 18 | tag18 | 18 |  3
+ 19 | tag19 | 19 |  1
+ 19 | tag19 | 19 |  2
+ 19 | tag19 | 19 |  3
+ 20 | tag20 | 20 |  1
+ 20 | tag20 | 20 |  2
+ 20 | tag20 | 20 |  3
+    |       | 21 |  1
+    |       | 21 |  2
+    |       | 21 |  3
+    |       | 22 |  1
+    |       | 22 |  2
+    |       | 22 |  3
+    |       | 23 |  1
+    |       | 23 |  2
+    |       | 23 |  3
+    |       | 24 |  1
+(70 rows)
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY f.id LIMIT 40;
+                                                                                                      QUERY PLAN                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Result
+         Output: d.id, d.tag, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Limit: 40
+               Order By: f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+                 :   SortExec: TopK(fetch=40), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[f]
+                 :       TantivyFetchExec: fetch=[ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=f, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY f.id LIMIT 40;
+ id |  tag  | id 
+----+-------+----
+  1 | aaa   |  1
+  2 | tag02 |  2
+  3 | tag03 |  3
+  4 | tag04 |  4
+  5 | tag05 |  5
+  6 | tag06 |  6
+  7 | tag07 |  7
+  8 | tag08 |  8
+  9 | tag09 |  9
+ 10 | tag10 | 10
+ 11 | tag11 | 11
+ 12 | tag12 | 12
+ 13 | tag13 | 13
+ 14 | tag14 | 14
+ 15 | tag15 | 15
+ 16 | tag16 | 16
+ 17 | tag17 | 17
+ 18 | tag18 | 18
+ 19 | tag19 | 19
+ 20 | tag20 | 20
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+    |       | 26
+    |       | 27
+    |       | 28
+    |       | 29
+    |       | 30
+    |       | 31
+    |       | 32
+    |       | 33
+    |       | 34
+    |       | 35
+    |       | 36
+    |       | 37
+    |       | 38
+    |       | 39
+    |       | 40
+(40 rows)
+
+DROP TABLE oj_side;
+DROP TABLE oj_fact;
+DROP TABLE oj_dim;

--- a/pg_search/tests/pg_regress/expected/join_outer_deferred_sort.out
+++ b/pg_search/tests/pg_regress/expected/join_outer_deferred_sort.out
@@ -1,38 +1,52 @@
--- A deferred string column of an outer join's nullable side must come out NULL for
--- the null-extended rows, both as a Top-K sort key and as an output column.
--- `oj_dim` row 1 carries the smallest `tag`, so a null-extended row that borrows the
--- first document's ordinal would sort ahead of every real row.
+-- A deferred string column of an outer join's nullable side must come out NULL for the
+-- null-extended rows when it is a Top-K sort key. `oj_dim` row 1 carries the smallest
+-- `tag`, so a null-extended row that borrows the first document's ordinal would sort
+-- ahead of every real row. Row 10 has a NULL `tag` of its own, and `oj_dim` spans more
+-- than one segment so a borrowed ordinal can name a segment other than the first.
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan TO OFF;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 DROP TABLE IF EXISTS oj_dim CASCADE;
 DROP TABLE IF EXISTS oj_fact CASCADE;
 DROP TABLE IF EXISTS oj_side CASCADE;
-CREATE TABLE oj_dim (id INT PRIMARY KEY, k INT, txt TEXT, tag TEXT);
+DROP TABLE IF EXISTS oj_ref CASCADE;
+CREATE TABLE oj_dim (id INT PRIMARY KEY, k INT, txt TEXT, tag TEXT, amt NUMERIC);
 CREATE TABLE oj_fact (id INT PRIMARY KEY, k INT, txt TEXT);
 CREATE TABLE oj_side (id INT PRIMARY KEY, txt TEXT);
--- oj_fact rows 21..40 have no oj_dim partner.
-INSERT INTO oj_dim
-SELECT g, g, 'alpha item ' || g, CASE WHEN g = 1 THEN 'aaa' ELSE 'tag' || lpad(g::text, 2, '0') END
-FROM generate_series(1, 20) g;
-INSERT INTO oj_fact
-SELECT g, g, 'beta item ' || g
-FROM generate_series(1, 40) g;
-INSERT INTO oj_side
-SELECT g, 'gamma item ' || g
-FROM generate_series(1, 3) g;
+-- `tag` here is a plain integer column that shares its name with the deferred column.
+CREATE TABLE oj_ref (id INT PRIMARY KEY, k INT, tag OID);
 CREATE INDEX oj_dim_idx ON oj_dim
-USING paradedb (id, k, txt, tag)
-WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true},"tag":{"fast":true}}');
+USING paradedb (id, k, txt, tag, amt)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true},"amt":{"fast":true}}', text_fields='{"txt":{"fast":true},"tag":{"fast":true}}', mutable_segment_rows = 5);
 CREATE INDEX oj_fact_idx ON oj_fact
 USING paradedb (id, k, txt)
 WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
 CREATE INDEX oj_side_idx ON oj_side
 USING paradedb (id, txt)
 WITH (key_field='id', text_fields='{"txt":{"fast":true}}');
+CREATE INDEX oj_ref_idx ON oj_ref
+USING paradedb (id, k, tag)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true},"tag":{"fast":true}}');
+-- One insert of twenty rows lands in more than one segment. Rows 16..20 have a NULL `amt`.
+INSERT INTO oj_dim
+SELECT g, g, 'alpha item ' || g,
+       CASE WHEN g = 1 THEN 'aaa' WHEN g = 10 THEN NULL ELSE 'tag' || lpad(g::text, 2, '0') END,
+       CASE WHEN g > 15 THEN NULL ELSE g * 1.5 END
+FROM generate_series(1, 20) g;
+-- oj_fact rows 21..40 have no oj_dim partner.
+INSERT INTO oj_fact
+SELECT g, g, 'beta item ' || g
+FROM generate_series(1, 40) g;
+INSERT INTO oj_side
+SELECT g, 'gamma item ' || g
+FROM generate_series(1, 3) g;
+INSERT INTO oj_ref
+SELECT g, g, (1000 + g)::oid
+FROM generate_series(1, 40) g;
 ANALYZE oj_dim;
 ANALYZE oj_fact;
 ANALYZE oj_side;
+ANALYZE oj_ref;
 SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================
 -- RIGHT JOIN: the left input is null-extended
@@ -58,7 +72,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
                  :       SegmentedTopKExec: expr=[tag@1 ASC NULLS LAST, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
                  :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
                  :           CooperativeExec
                  :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
@@ -75,7 +89,6 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
   7 | tag07 |  7
   8 | tag08 |  8
   9 | tag09 |  9
- 10 | tag10 | 10
  11 | tag11 | 11
  12 | tag12 | 12
  13 | tag13 | 13
@@ -86,6 +99,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
  18 | tag18 | 18
  19 | tag19 | 19
  20 | tag20 | 20
+ 10 |       | 10
     |       | 21
     |       | 22
     |       | 23
@@ -114,7 +128,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
                  :       SegmentedTopKExec: expr=[tag@1 DESC, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
                  :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
                  :           CooperativeExec
                  :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
@@ -122,6 +136,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
 SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag DESC, f.id LIMIT 25;
  id |  tag  | id 
 ----+-------+----
+ 10 |       | 10
     |       | 21
     |       | 22
     |       | 23
@@ -146,7 +161,6 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
  19 | tag19 | 19
  18 | tag18 | 18
  17 | tag17 | 17
- 16 | tag16 | 16
 (25 rows)
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
@@ -170,7 +184,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
                  :       SegmentedTopKExec: expr=[tag@1 ASC, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
                  :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
                  :           CooperativeExec
                  :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
@@ -178,6 +192,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
 SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag NULLS FIRST, f.id LIMIT 25;
  id |  tag  | id 
 ----+-------+----
+ 10 |       | 10
     |       | 21
     |       | 22
     |       | 23
@@ -202,7 +217,6 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
   2 | tag02 |  2
   3 | tag03 |  3
   4 | tag04 |  4
-  5 | tag05 |  5
 (25 rows)
 
 -- A mixed ON condition keeps the nullable side deferred as well.
@@ -228,7 +242,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.i
                  :       SegmentedTopKExec: expr=[tag@2 ASC NULLS LAST, id@4 ASC NULLS LAST], k=25, visibility_checks=[f]
                  :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], filter=id@0 <= id@1, projection=[ctid_0@0, id@2, tag@3, ctid_1@4, id@6]
                  :           CooperativeExec
-                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
                  :           CooperativeExec
                  :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
@@ -245,7 +259,6 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.i
   7 | tag07 |  7
   8 | tag08 |  8
   9 | tag09 |  9
- 10 | tag10 | 10
  11 | tag11 | 11
  12 | tag12 | 12
  13 | tag13 | 13
@@ -256,6 +269,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.i
  18 | tag18 | 18
  19 | tag19 | 19
  20 | tag20 | 20
+ 10 |       | 10
     |       | 21
     |       | 22
     |       | 23
@@ -263,6 +277,123 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.i
     |       | 25
 (25 rows)
 
+-- A bytes-backed deferred column (NUMERIC) on the nullable side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.amt, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.amt, f.id LIMIT 25;
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.amt, f.id
+   ->  Result
+         Output: d.id, d.amt, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.amt
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Limit: 25
+               Order By: d.amt asc, f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, amt@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyDecodeExec: decode=[amt]
+                 :     TantivyFetchExec: fetch=[amt]
+                 :       SegmentedTopKExec: expr=[amt@1 ASC NULLS LAST, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, amt@2, ctid_1@3, id@5]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT d.id, d.amt, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.amt, f.id LIMIT 25;
+ id | amt  | id 
+----+------+----
+  1 |  1.5 |  1
+  2 |  3.0 |  2
+  3 |  4.5 |  3
+  4 |  6.0 |  4
+  5 |  7.5 |  5
+  6 |  9.0 |  6
+  7 | 10.5 |  7
+  8 | 12.0 |  8
+  9 | 13.5 |  9
+ 10 | 15.0 | 10
+ 11 | 16.5 | 11
+ 12 | 18.0 | 12
+ 13 | 19.5 | 13
+ 14 | 21.0 | 14
+ 15 | 22.5 | 15
+ 16 |      | 16
+ 17 |      | 17
+ 18 |      | 18
+ 19 |      | 19
+ 20 |      | 20
+    |      | 21
+    |      | 22
+    |      | 23
+    |      | 24
+    |      | 25
+(25 rows)
+
+-- =============================================================================
+-- The scan resolves the term ordinals itself
+-- =============================================================================
+SET paradedb.defer_column_fetch = off;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, f.id
+   ->  Result
+         Output: d.id, d.tag, f.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: f.id, d.id, d.tag
+               Relation Tree: d RIGHT f
+               Join Cond: d.k = f.k
+               Limit: 25
+               Order By: d.tag asc, f.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, tag@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyDecodeExec: decode=[tag]
+                 :     SegmentedTopKExec: expr=[tag@1 ASC NULLS LAST, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=d, segments=2, fetch=[tag], visibility=eager, query="all"
+                 :         CooperativeExec
+                 :           PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+ id |  tag  | id 
+----+-------+----
+  1 | aaa   |  1
+  2 | tag02 |  2
+  3 | tag03 |  3
+  4 | tag04 |  4
+  5 | tag05 |  5
+  6 | tag06 |  6
+  7 | tag07 |  7
+  8 | tag08 |  8
+  9 | tag09 |  9
+ 11 | tag11 | 11
+ 12 | tag12 | 12
+ 13 | tag13 | 13
+ 14 | tag14 | 14
+ 15 | tag15 | 15
+ 16 | tag16 | 16
+ 17 | tag17 | 17
+ 18 | tag18 | 18
+ 19 | tag19 | 19
+ 20 | tag20 | 20
+ 10 |       | 10
+    |       | 21
+    |       | 22
+    |       | 23
+    |       | 24
+    |       | 25
+(25 rows)
+
+RESET paradedb.defer_column_fetch;
 -- =============================================================================
 -- LEFT JOIN: the right input is null-extended
 -- =============================================================================
@@ -287,7 +418,7 @@ SELECT d.id, d.tag, f.id FROM oj_fact f LEFT JOIN oj_dim d ON d.k = f.k WHERE f.
                  :       SegmentedTopKExec: expr=[tag@1 ASC NULLS LAST, id@3 ASC NULLS LAST], k=25, visibility_checks=[f]
                  :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5]
                  :           CooperativeExec
-                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
                  :           CooperativeExec
                  :             PgSearchScan: table=f, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
@@ -304,7 +435,6 @@ SELECT d.id, d.tag, f.id FROM oj_fact f LEFT JOIN oj_dim d ON d.k = f.k WHERE f.
   7 | tag07 |  7
   8 | tag08 |  8
   9 | tag09 |  9
- 10 | tag10 | 10
  11 | tag11 | 11
  12 | tag12 | 12
  13 | tag13 | 13
@@ -315,6 +445,7 @@ SELECT d.id, d.tag, f.id FROM oj_fact f LEFT JOIN oj_dim d ON d.k = f.k WHERE f.
  18 | tag18 | 18
  19 | tag19 | 19
  20 | tag20 | 20
+ 10 |       | 10
     |       | 21
     |       | 22
     |       | 23
@@ -346,7 +477,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.
            :         FilterExec: __f_0_tag_0@2 OR __d_1_tag_0@5, projection=[ctid_0@0, id@1, ctid_1@3, tag@4]
            :           HashJoinExec: mode=CollectLeft, join_type=Full, on=[(k@1, k@1)], projection=[ctid_0@4, id@6, __f_0_tag_0@7, ctid_1@0, tag@2, __d_1_tag_0@3]
            :             CooperativeExec
-           :               PgSearchScan: table=d, segments=1, visibility=eager, tag_0={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+           :               PgSearchScan: table=d, segments=2, visibility=eager, tag_0={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
            :             CooperativeExec
            :               PgSearchScan: table=f, segments=1, visibility=eager, tag_0={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
@@ -363,7 +494,6 @@ SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.
   7 | tag07 |  7
   8 | tag08 |  8
   9 | tag09 |  9
- 10 | tag10 | 10
  11 | tag11 | 11
  12 | tag12 | 12
  13 | tag13 | 13
@@ -374,6 +504,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.
  18 | tag18 | 18
  19 | tag19 | 19
  20 | tag20 | 20
+ 10 |       | 10
     |       | 21
     |       | 22
     |       | 23
@@ -382,7 +513,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.
 (25 rows)
 
 -- =============================================================================
--- A third relation under the outer join, and the column as plain output
+-- A third relation under the outer join
 -- =============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k CROSS JOIN oj_side s WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id, s.id LIMIT 70;
@@ -405,7 +536,7 @@ SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k C
                  :       SegmentedTopKExec: expr=[tag@1 ASC NULLS LAST, id@3 ASC NULLS LAST, id@5 ASC NULLS LAST], k=70, visibility_checks=[f, s]
                  :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, tag@2, ctid_1@3, id@5, ctid_2@6, id@7]
                  :           CooperativeExec
-                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
                  :           ProjectionExec: expr=[ctid_1@2 as ctid_1, k@3 as k, id@4 as id, ctid_2@0 as ctid_2, id@1 as id]
                  :             CrossJoinExec
                  :               CooperativeExec
@@ -444,9 +575,6 @@ SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k C
   9 | tag09 |  9 |  1
   9 | tag09 |  9 |  2
   9 | tag09 |  9 |  3
- 10 | tag10 | 10 |  1
- 10 | tag10 | 10 |  2
- 10 | tag10 | 10 |  3
  11 | tag11 | 11 |  1
  11 | tag11 | 11 |  2
  11 | tag11 | 11 |  3
@@ -477,6 +605,9 @@ SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k C
  20 | tag20 | 20 |  1
  20 | tag20 | 20 |  2
  20 | tag20 | 20 |  3
+ 10 |       | 10 |  1
+ 10 |       | 10 |  2
+ 10 |       | 10 |  3
     |       | 21 |  1
     |       | 21 |  2
     |       | 21 |  3
@@ -489,6 +620,7 @@ SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k C
     |       | 24 |  1
 (70 rows)
 
+-- With no sort on the column, the join scan reads it from the heap.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY f.id LIMIT 40;
                                                                                                       QUERY PLAN                                                                                                      
@@ -510,7 +642,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
                  :       TantivyFetchExec: fetch=[ctid_1]
                  :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@1, k@1)], projection=[ctid_0@0, ctid_1@2, id@4]
                  :           CooperativeExec
-                 :             PgSearchScan: table=d, segments=1, visibility=eager, query="all"
+                 :             PgSearchScan: table=d, segments=2, visibility=eager, query="all"
                  :           CooperativeExec
                  :             PgSearchScan: table=f, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
@@ -527,7 +659,7 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
   7 | tag07 |  7
   8 | tag08 |  8
   9 | tag09 |  9
- 10 | tag10 | 10
+ 10 |       | 10
  11 | tag11 | 11
  12 | tag12 | 12
  13 | tag13 | 13
@@ -560,6 +692,44 @@ SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f
     |       | 40
 (40 rows)
 
+-- =============================================================================
+-- A plain integer column with the deferred column's name on the other relation
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, r.tag FROM oj_dim d JOIN oj_ref r ON d.k = r.k WHERE d.txt @@@ 'alpha' ORDER BY d.tag, r.tag LIMIT 5;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: d.id, d.tag, r.tag
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: d.id, d.tag, r.tag
+         Relation Tree: r INNER d
+         Join Cond: d.k = r.k
+         Limit: 5
+         Order By: d.tag asc, r.tag asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, tag@3 as col_2, tag@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   TantivyDecodeExec: decode=[tag]
+           :     TantivyFetchExec: fetch=[tag]
+           :       SegmentedTopKExec: expr=[tag@3 ASC NULLS LAST, tag@1 ASC NULLS LAST], k=5, visibility_checks=[r, d]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(k@1, k@1)], projection=[ctid_0@3, tag@5, ctid_1@0, tag@2]
+           :           CooperativeExec
+           :             PgSearchScan: table=d, segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: table=r, segments=1, dynamic_filters=2, query="all"
+(18 rows)
+
+SELECT d.id, d.tag, r.tag FROM oj_dim d JOIN oj_ref r ON d.k = r.k WHERE d.txt @@@ 'alpha' ORDER BY d.tag, r.tag LIMIT 5;
+ id |  tag  | tag  
+----+-------+------
+  1 | aaa   | 1001
+  2 | tag02 | 1002
+  3 | tag03 | 1003
+  4 | tag04 | 1004
+  5 | tag05 | 1005
+(5 rows)
+
+DROP TABLE oj_ref;
 DROP TABLE oj_side;
 DROP TABLE oj_fact;
 DROP TABLE oj_dim;

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -344,8 +344,8 @@ WHERE documents.content @@@ 'postgres'
   AND pages.content @@@ 'vector'
 ORDER BY pdb_score DESC, pages.id ASC
 LIMIT 10;
-                                                                                                            QUERY PLAN                                                                                                             
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                QUERY PLAN                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: documents.id, files.id, pages.id, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
    ->  Result
@@ -365,7 +365,7 @@ LIMIT 10;
                  :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_2@4, id@6]
                  :             ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
                  :               CooperativeExec
-                 :                 PgSearchScan: table=documents, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
+                 :                 PgSearchScan: table=documents, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"postgres","lenient":null,"conjunction_mode":null}}}}
                  :             ProjectionExec: expr=[pdb.score()@0 as score, ctid_2@1 as ctid_2, documentId@2 as documentId, id@3 as id]
                  :               CooperativeExec
                  :                 PgSearchScan: table=files, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"index","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -358,9 +358,9 @@ LIMIT 10;
                Order By: sum(pdb.score()) desc, pages.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, id@8 as col_3, score@6 as col_4, id@5 as col_5, score@3 as col_6, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@7 as ctid_2]
-                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@6 + score@3 DESC, id@5 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[documents, pages, files]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+                 :   TantivyDecodeExec: decode=[id]
+                 :     TantivyFetchExec: fetch=[id]
+                 :       SegmentedTopKExec: expr=[score@0 + score@6 + score@3 DESC, id@5 ASC NULLS LAST], k=10, visibility_checks=[documents, pages, files]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@5, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@6, ctid_1@7, id@9, score@3, ctid_2@4, id@5]
                  :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_2@4, id@6]
                  :             ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
@@ -436,9 +436,9 @@ LIMIT 10;
                Order By: sum(pdb.score()) desc, documents.id asc, pages.fileId asc, pages.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, score@0 as col_3, id@9 as col_4, score@7 as col_5, score@7 as col_6, id@6 as col_7, score@3 as col_8, score@3 as col_9, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@8 as ctid_2]
-                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[documents, pages, files]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+                 :   TantivyDecodeExec: decode=[id]
+                 :     TantivyFetchExec: fetch=[id]
+                 :       SegmentedTopKExec: expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], k=10, visibility_checks=[documents, pages, files]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@6, fileId@2)], filter=__documents_0_tag_0@0 OR __files_2_tag_0@1 OR __pages_1_tag_0@2, projection=[score@0, ctid_0@1, id@2, score@8, ctid_1@9, fileId@10, id@11, score@4, ctid_2@5, id@6]
                  :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, __documents_0_tag_0@3, score@4, ctid_2@5, id@7, __files_2_tag_0@8]
                  :             ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id, __documents_0_tag_0@3 as __documents_0_tag_0]
@@ -506,9 +506,9 @@ LIMIT 10;
          Order By: pdb.score() desc, documents.id asc, pages.fileId asc, pages.id asc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@1 as col_1, id@7 as col_2, id@5 as col_3, score@2 as col_4, ctid_0@0 as ctid_0, ctid_1@3 as ctid_1, ctid_2@6 as ctid_2]
-           :   SortExec: TopK(fetch=10), expr=[score@2 DESC, id@1 ASC NULLS LAST, fileId@4 ASC NULLS LAST, id@5 ASC NULLS LAST], preserve_partitioning=[false]
-           :     VisibilityFilterExec: tables=[documents, pages, files]
-           :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+           :   TantivyDecodeExec: decode=[id]
+           :     TantivyFetchExec: fetch=[id]
+           :       SegmentedTopKExec: expr=[score@2 DESC, id@1 ASC NULLS LAST, fileId@4 ASC NULLS LAST, id@5 ASC NULLS LAST], k=10, visibility_checks=[documents, pages, files]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@4, fileId@2)], filter=__documents_0_tag_0@0 OR __files_2_tag_0@1 OR __pages_1_tag_0@2, projection=[ctid_0@0, id@1, score@6, ctid_1@7, fileId@8, id@9, ctid_2@3, id@4]
            :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, documentId@1)], projection=[ctid_0@0, id@1, __documents_0_tag_0@2, ctid_2@3, id@5, __files_2_tag_0@6]
            :             CooperativeExec
@@ -574,9 +574,9 @@ LIMIT 10;
                Order By: sum(pdb.score()) desc, documents.id asc, pages.fileId asc, pages.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, score@0 as col_3, id@9 as col_4, score@7 as col_5, score@7 as col_6, id@6 as col_7, score@3 as col_8, score@3 as col_9, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@8 as ctid_2]
-                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[documents, pages, files]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+                 :   TantivyDecodeExec: decode=[id]
+                 :     TantivyFetchExec: fetch=[id]
+                 :       SegmentedTopKExec: expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], k=10, visibility_checks=[documents, pages, files]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@6)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_1@4, fileId@5, id@6, score@7, ctid_2@8, id@10]
                  :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
                  :             CooperativeExec
@@ -645,9 +645,9 @@ LIMIT 10;
                Order By: pdb.score() desc, documents.id asc, pages.fileId asc, pages.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, id@8 as col_3, id@6 as col_4, score@3 as col_5, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@7 as ctid_2]
-                 :   SortExec: TopK(fetch=10), expr=[score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[documents, pages, files]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+                 :   TantivyDecodeExec: decode=[id]
+                 :     TantivyFetchExec: fetch=[id]
+                 :       SegmentedTopKExec: expr=[score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], k=10, visibility_checks=[documents, pages, files]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@4, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@5, ctid_1@6, fileId@7, id@8, ctid_2@3, id@4]
                  :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@1)], projection=[score@0, ctid_0@1, id@2, ctid_2@3, id@5]
                  :             ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
@@ -718,9 +718,9 @@ LIMIT 10;
                Order By: sum(pdb.score()) desc, documents.id asc, pages.fileId asc, pages.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, score@0 as col_2, score@0 as col_3, id@9 as col_4, score@7 as col_5, score@7 as col_6, id@6 as col_7, score@3 as col_8, score@3 as col_9, ctid_0@1 as ctid_0, ctid_1@4 as ctid_1, ctid_2@8 as ctid_2]
-                 :   SortExec: TopK(fetch=10), expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[documents, pages, files]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+                 :   TantivyDecodeExec: decode=[id]
+                 :     TantivyFetchExec: fetch=[id]
+                 :       SegmentedTopKExec: expr=[score@0 + score@7 + score@3 DESC, id@2 ASC NULLS LAST, fileId@5 ASC NULLS LAST, id@6 ASC NULLS LAST], k=10, visibility_checks=[documents, pages, files]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@5, fileId@2)], projection=[score@0, ctid_0@1, id@2, score@6, ctid_1@7, fileId@8, id@9, score@3, ctid_2@4, id@5]
                  :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, documentId@2)], projection=[score@0, ctid_0@1, id@2, score@3, ctid_2@4, id@6]
                  :             ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -160,13 +160,13 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyDecodeExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=3, output_bytes=99.0 B, output_batches=1]
+           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=3, output_bytes=72.0 B, output_batches=1]
            :       SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=50, rows_output=3, segments_seen=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, build_mem_used=344.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=192.0 KB, output_batches=1, build_mem_used=344.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
            :           CooperativeExec
            :             PgSearchScan: table=d, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: table=f, segments=1, dynamic_filters=2, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=50]
+           :             PgSearchScan: table=f, segments=1, dynamic_filters=2, query="all", metrics=[output_rows=50, output_bytes=1632.0 B, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=50]
 (16 rows)
 
 -- =============================================================================
@@ -661,8 +661,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 5;
-                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                             
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=5.00 loops=1)
          Relation Tree: d INNER f
@@ -672,13 +672,13 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :   TantivyDecodeExec: decode=[title], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
-           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=5, output_bytes=165.0 B, output_batches=1]
+           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=5, output_bytes=120.0 B, output_batches=1]
            :       SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=25.81 K, rows_output=5, segments_seen=3]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=25.81 K, output_bytes=1008.9 KB, output_batches=4, build_mem_used=228.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=25.81 K, avg_fanout=100% (25.81 K/25.81 K), probe_hit_rate=53.08% (25.81 K/48.63 K)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=25.81 K, output_bytes=768.0 KB, output_batches=4, build_mem_used=228.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=25.81 K, avg_fanout=100% (25.81 K/25.81 K), probe_hit_rate=53.08% (25.81 K/48.63 K)]
            :           CooperativeExec
            :             PgSearchScan: table=d, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: table=f, segments=4, dynamic_filters=2, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=4.19 K, rows_scanned=30.00 K]
+           :             PgSearchScan: table=f, segments=4, dynamic_filters=2, query="all", metrics=[output_rows=25.81 K, output_bytes=806.8 KB, output_batches=4, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=4.19 K, rows_scanned=30.00 K]
 (16 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -489,13 +489,13 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyDecodeExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=3, output_bytes=99.0 B, output_batches=1]
+           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=3, output_bytes=72.0 B, output_batches=1]
            :       SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=70, rows_output=3, segments_seen=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, build_mem_used=424.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=192.0 KB, output_batches=1, build_mem_used=424.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
            :           CooperativeExec
            :             PgSearchScan: table=d, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: table=f, segments=1, dynamic_filters=2, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=70]
+           :             PgSearchScan: table=f, segments=1, dynamic_filters=2, query="all", metrics=[output_rows=70, output_bytes=2.2 KB, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=70]
 (16 rows)
 
 SELECT f.id, f.title
@@ -536,13 +536,13 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyDecodeExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=3, output_bytes=99.0 B, output_batches=1]
+           :     TantivyFetchExec: fetch=[title], metrics=[output_rows=3, output_bytes=72.0 B, output_batches=1]
            :       SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=10, rows_output=3, segments_seen=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, build_mem_used=105.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=192.0 KB, output_batches=1, build_mem_used=105.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
            :           CooperativeExec
            :             PgSearchScan: table=d, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: table=f, segments=1, dynamic_filters=2, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=10]
+           :             PgSearchScan: table=f, segments=1, dynamic_filters=2, query="all", metrics=[output_rows=10, output_bytes=328.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=10]
 (16 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/sql/aggregate_late_materialization.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_late_materialization.sql
@@ -69,3 +69,43 @@ GROUP BY p.category
 ORDER BY p.category;
 
 DROP TABLE alm_products, alm_tags;
+
+-- A nested level on an array field reads the join a second time. Both reads have to
+-- agree on the group key's type, or the array level's buckets belong to no parent and
+-- drop out of the result.
+CREATE TABLE alm_posts (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    author TEXT,
+    labels TEXT[]
+);
+CREATE TABLE alm_views (
+    id SERIAL PRIMARY KEY,
+    post_id INTEGER
+);
+
+INSERT INTO alm_posts (title, author, labels)
+SELECT 'post ' || i,
+       (ARRAY['ann', 'bob', 'cid'])[1 + i % 3],
+       ARRAY[(ARRAY['red', 'green', 'blue'])[1 + i % 3], 'all']
+FROM generate_series(1, 60) AS i;
+INSERT INTO alm_views (post_id) SELECT id FROM alm_posts;
+
+CREATE INDEX alm_posts_idx ON alm_posts
+USING bm25 (id, title, author, labels)
+WITH (key_field='id', text_fields='{"title": {}, "author": {"fast": true}, "labels": {"fast": true}}');
+CREATE INDEX alm_views_idx ON alm_views
+USING bm25 (id, post_id)
+WITH (key_field='id', numeric_fields='{"post_id": {"fast": true}}');
+
+SET max_parallel_workers_per_gather TO 0;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "p.author", "order": {"_key": "asc"}, "size": 10}, "aggs": {"by_label": {"terms": {"field": "p.labels", "order": {"_key": "asc"}, "size": 10}}}}')
+FROM alm_posts p JOIN alm_views v ON p.id = v.post_id
+WHERE p.title @@@ 'post';
+
+SELECT pdb.agg('{"terms": {"field": "p.author", "order": {"_key": "asc"}, "size": 10}, "aggs": {"by_label": {"terms": {"field": "p.labels", "order": {"_key": "asc"}, "size": 10}}}}')
+FROM alm_posts p JOIN alm_views v ON p.id = v.post_id
+WHERE p.title @@@ 'post';
+
+DROP TABLE alm_posts, alm_views;

--- a/pg_search/tests/pg_regress/sql/join_outer_deferred_sort.sql
+++ b/pg_search/tests/pg_regress/sql/join_outer_deferred_sort.sql
@@ -1,0 +1,97 @@
+-- A deferred string column of an outer join's nullable side must come out NULL for
+-- the null-extended rows, both as a Top-K sort key and as an output column.
+-- `oj_dim` row 1 carries the smallest `tag`, so a null-extended row that borrows the
+-- first document's ordinal would sort ahead of every real row.
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS oj_dim CASCADE;
+DROP TABLE IF EXISTS oj_fact CASCADE;
+DROP TABLE IF EXISTS oj_side CASCADE;
+
+CREATE TABLE oj_dim (id INT PRIMARY KEY, k INT, txt TEXT, tag TEXT);
+CREATE TABLE oj_fact (id INT PRIMARY KEY, k INT, txt TEXT);
+CREATE TABLE oj_side (id INT PRIMARY KEY, txt TEXT);
+
+-- oj_fact rows 21..40 have no oj_dim partner.
+INSERT INTO oj_dim
+SELECT g, g, 'alpha item ' || g, CASE WHEN g = 1 THEN 'aaa' ELSE 'tag' || lpad(g::text, 2, '0') END
+FROM generate_series(1, 20) g;
+INSERT INTO oj_fact
+SELECT g, g, 'beta item ' || g
+FROM generate_series(1, 40) g;
+INSERT INTO oj_side
+SELECT g, 'gamma item ' || g
+FROM generate_series(1, 3) g;
+
+CREATE INDEX oj_dim_idx ON oj_dim
+USING paradedb (id, k, txt, tag)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true},"tag":{"fast":true}}');
+CREATE INDEX oj_fact_idx ON oj_fact
+USING paradedb (id, k, txt)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
+CREATE INDEX oj_side_idx ON oj_side
+USING paradedb (id, txt)
+WITH (key_field='id', text_fields='{"txt":{"fast":true}}');
+
+ANALYZE oj_dim;
+ANALYZE oj_fact;
+ANALYZE oj_side;
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
+-- RIGHT JOIN: the left input is null-extended
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag DESC, f.id LIMIT 25;
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag DESC, f.id LIMIT 25;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag NULLS FIRST, f.id LIMIT 25;
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag NULLS FIRST, f.id LIMIT 25;
+
+-- A mixed ON condition keeps the nullable side deferred as well.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.id <= f.id WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.id <= f.id WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+
+-- =============================================================================
+-- LEFT JOIN: the right input is null-extended
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_fact f LEFT JOIN oj_dim d ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+SELECT d.id, d.tag, f.id FROM oj_fact f LEFT JOIN oj_dim d ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+
+-- =============================================================================
+-- FULL JOIN: both inputs are null-extended
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' OR d.txt @@@ 'alpha' ORDER BY d.tag, f.id LIMIT 25;
+SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' OR d.txt @@@ 'alpha' ORDER BY d.tag, f.id LIMIT 25;
+
+-- =============================================================================
+-- A third relation under the outer join, and the column as plain output
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k CROSS JOIN oj_side s WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id, s.id LIMIT 70;
+SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k CROSS JOIN oj_side s WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id, s.id LIMIT 70;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY f.id LIMIT 40;
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY f.id LIMIT 40;
+
+DROP TABLE oj_side;
+DROP TABLE oj_fact;
+DROP TABLE oj_dim;

--- a/pg_search/tests/pg_regress/sql/join_outer_deferred_sort.sql
+++ b/pg_search/tests/pg_regress/sql/join_outer_deferred_sort.sql
@@ -1,7 +1,8 @@
--- A deferred string column of an outer join's nullable side must come out NULL for
--- the null-extended rows, both as a Top-K sort key and as an output column.
--- `oj_dim` row 1 carries the smallest `tag`, so a null-extended row that borrows the
--- first document's ordinal would sort ahead of every real row.
+-- A deferred string column of an outer join's nullable side must come out NULL for the
+-- null-extended rows when it is a Top-K sort key. `oj_dim` row 1 carries the smallest
+-- `tag`, so a null-extended row that borrows the first document's ordinal would sort
+-- ahead of every real row. Row 10 has a NULL `tag` of its own, and `oj_dim` spans more
+-- than one segment so a borrowed ordinal can name a segment other than the first.
 
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan TO OFF;
@@ -11,35 +12,48 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 DROP TABLE IF EXISTS oj_dim CASCADE;
 DROP TABLE IF EXISTS oj_fact CASCADE;
 DROP TABLE IF EXISTS oj_side CASCADE;
+DROP TABLE IF EXISTS oj_ref CASCADE;
 
-CREATE TABLE oj_dim (id INT PRIMARY KEY, k INT, txt TEXT, tag TEXT);
+CREATE TABLE oj_dim (id INT PRIMARY KEY, k INT, txt TEXT, tag TEXT, amt NUMERIC);
 CREATE TABLE oj_fact (id INT PRIMARY KEY, k INT, txt TEXT);
 CREATE TABLE oj_side (id INT PRIMARY KEY, txt TEXT);
-
--- oj_fact rows 21..40 have no oj_dim partner.
-INSERT INTO oj_dim
-SELECT g, g, 'alpha item ' || g, CASE WHEN g = 1 THEN 'aaa' ELSE 'tag' || lpad(g::text, 2, '0') END
-FROM generate_series(1, 20) g;
-INSERT INTO oj_fact
-SELECT g, g, 'beta item ' || g
-FROM generate_series(1, 40) g;
-INSERT INTO oj_side
-SELECT g, 'gamma item ' || g
-FROM generate_series(1, 3) g;
+-- `tag` here is a plain integer column that shares its name with the deferred column.
+CREATE TABLE oj_ref (id INT PRIMARY KEY, k INT, tag OID);
 
 CREATE INDEX oj_dim_idx ON oj_dim
-USING paradedb (id, k, txt, tag)
-WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true},"tag":{"fast":true}}');
+USING paradedb (id, k, txt, tag, amt)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true},"amt":{"fast":true}}', text_fields='{"txt":{"fast":true},"tag":{"fast":true}}', mutable_segment_rows = 5);
 CREATE INDEX oj_fact_idx ON oj_fact
 USING paradedb (id, k, txt)
 WITH (key_field='id', numeric_fields='{"k":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
 CREATE INDEX oj_side_idx ON oj_side
 USING paradedb (id, txt)
 WITH (key_field='id', text_fields='{"txt":{"fast":true}}');
+CREATE INDEX oj_ref_idx ON oj_ref
+USING paradedb (id, k, tag)
+WITH (key_field='id', numeric_fields='{"k":{"fast":true},"tag":{"fast":true}}');
+
+-- One insert of twenty rows lands in more than one segment. Rows 16..20 have a NULL `amt`.
+INSERT INTO oj_dim
+SELECT g, g, 'alpha item ' || g,
+       CASE WHEN g = 1 THEN 'aaa' WHEN g = 10 THEN NULL ELSE 'tag' || lpad(g::text, 2, '0') END,
+       CASE WHEN g > 15 THEN NULL ELSE g * 1.5 END
+FROM generate_series(1, 20) g;
+-- oj_fact rows 21..40 have no oj_dim partner.
+INSERT INTO oj_fact
+SELECT g, g, 'beta item ' || g
+FROM generate_series(1, 40) g;
+INSERT INTO oj_side
+SELECT g, 'gamma item ' || g
+FROM generate_series(1, 3) g;
+INSERT INTO oj_ref
+SELECT g, g, (1000 + g)::oid
+FROM generate_series(1, 40) g;
 
 ANALYZE oj_dim;
 ANALYZE oj_fact;
 ANALYZE oj_side;
+ANALYZE oj_ref;
 
 SET paradedb.enable_join_custom_scan = on;
 
@@ -64,6 +78,21 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.id <= f.id WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
 SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k AND d.id <= f.id WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
 
+-- A bytes-backed deferred column (NUMERIC) on the nullable side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.amt, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.amt, f.id LIMIT 25;
+SELECT d.id, d.amt, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.amt, f.id LIMIT 25;
+
+-- =============================================================================
+-- The scan resolves the term ordinals itself
+-- =============================================================================
+
+SET paradedb.defer_column_fetch = off;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
+RESET paradedb.defer_column_fetch;
+
 -- =============================================================================
 -- LEFT JOIN: the right input is null-extended
 -- =============================================================================
@@ -81,17 +110,27 @@ SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.
 SELECT d.id, d.tag, f.id FROM oj_dim d FULL JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' OR d.txt @@@ 'alpha' ORDER BY d.tag, f.id LIMIT 25;
 
 -- =============================================================================
--- A third relation under the outer join, and the column as plain output
+-- A third relation under the outer join
 -- =============================================================================
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k CROSS JOIN oj_side s WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id, s.id LIMIT 70;
 SELECT d.id, d.tag, f.id, s.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k CROSS JOIN oj_side s WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id, s.id LIMIT 70;
 
+-- With no sort on the column, the join scan reads it from the heap.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY f.id LIMIT 40;
 SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k WHERE f.txt @@@ 'beta' ORDER BY f.id LIMIT 40;
 
+-- =============================================================================
+-- A plain integer column with the deferred column's name on the other relation
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT d.id, d.tag, r.tag FROM oj_dim d JOIN oj_ref r ON d.k = r.k WHERE d.txt @@@ 'alpha' ORDER BY d.tag, r.tag LIMIT 5;
+SELECT d.id, d.tag, r.tag FROM oj_dim d JOIN oj_ref r ON d.k = r.k WHERE d.txt @@@ 'alpha' ORDER BY d.tag, r.tag LIMIT 5;
+
+DROP TABLE oj_ref;
 DROP TABLE oj_side;
 DROP TABLE oj_fact;
 DROP TABLE oj_dim;

--- a/tests/src/fixtures/querygen/orderbygen.rs
+++ b/tests/src/fixtures/querygen/orderbygen.rs
@@ -20,6 +20,7 @@ use proptest::prelude::*;
 #[derive(Clone, Copy, Debug)]
 enum JoinScanOrderKind {
     Columns,
+    ColumnarText,
     IndexedExpression,
     QuantityIsNull,
     QuantityIsNotNull,
@@ -31,6 +32,9 @@ fn order_parts(kind: JoinScanOrderKind, tables: &[String]) -> Vec<String> {
     let first_table = tables.first().expect("a join must use at least one table");
     let mut parts = match kind {
         JoinScanOrderKind::Columns => Vec::new(),
+        // A plain columnar text key is the only one an outer join's null-extended side keeps
+        // deferred on every Postgres version, so it is what reaches the segmented Top-K there.
+        JoinScanOrderKind::ColumnarText => vec![format!("{first_table}.name")],
         JoinScanOrderKind::IndexedExpression => {
             vec![format!("upper({first_table}.category)")]
         }
@@ -63,10 +67,10 @@ fn order_parts(kind: JoinScanOrderKind, tables: &[String]) -> Vec<String> {
 
 /// Generate deterministic JoinScan `ORDER BY` parts that are valid for the selected projection.
 ///
-/// When restricted, only projected ID columns are used. Unrestricted cases preserve all six
-/// combinations (regular columns, indexed expression, and nullable predicates). When DISTINCT
-/// is active, the caller projects any expression present in `ORDER BY` to satisfy PostgreSQL's
-/// projection requirements.
+/// When restricted, only projected ID columns are used. Unrestricted cases cover regular
+/// columns, a columnar text column, an indexed expression, and the nullable predicates. The
+/// caller always projects the first table's `name`, and when DISTINCT is active it projects any
+/// expression present in `ORDER BY`, to satisfy PostgreSQL's projection requirements.
 pub fn arb_joinscan_order_parts(
     tables: Vec<String>,
     restrict_to_projected_columns: bool,
@@ -76,6 +80,7 @@ pub fn arb_joinscan_order_parts(
     } else {
         prop_oneof![
             Just(JoinScanOrderKind::Columns),
+            Just(JoinScanOrderKind::ColumnarText),
             Just(JoinScanOrderKind::IndexedExpression),
             Just(JoinScanOrderKind::QuantityIsNull),
             Just(JoinScanOrderKind::QuantityIsNotNull),


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #6245

## What

This PR changes the encoding of a deferred string column from a dense `UnionArray` to a packed `UInt64` with a validity bitmap.

It also rebuilds every scan's projection when a relation's columns turn deferred, not just the first scan the rule reaches.

## Why

A dense union has no validity bitmap. When an outer join null-extends a side, DataFusion builds those rows with arrow's `take`, which for a NULL index copies row 0 instead of writing a NULL. Every null-extended row then carries the first build row's doc address.

#6236 guards against that by reading the relation's ctid in `TantivyFetchExec` and `TantivyDecodeExec`, so the decoded value comes out NULL. `SegmentedTopKExec` sits below both and still ranks on the borrowed ordinal, so the wrong rows survive the Top-K. On 350dbfbcf:

```sql
SELECT d.id, d.tag, f.id FROM oj_dim d RIGHT JOIN oj_fact f ON d.k = f.k
WHERE f.txt @@@ 'beta' ORDER BY d.tag, f.id LIMIT 25;
```

returns `oj_dim` row 1, then twenty null-extended rows, then rows 2 to 5. Postgres returns rows 1 to 20 and then five null-extended ones. Keeping the nulls in the column fixes it for every reader at once, so the ctid guard goes away with it.

The rule that flips a relation to the deferred schema sets a flag on the shared provider, and a plan can read one relation through more than one scan. A `pdb.agg` with a nested level on an array field is planned as one scan per level group, so the scans the flag skips keep claiming the column is a string. The rule then anchors a decode over columns that were never deferred, and with the placement rule of #6231 on top the array level's buckets belong to no parent and drop out of the result.

## How

A row is one `u64`: a packed doc address (segment ordinal in the high 32 bits, doc id in the low 32) or a packed term ordinal (top bit set, segment ordinal above bit 40, ordinal below), and a NULL is an Arrow NULL. The field's `ARROW:extension:name` metadata is what tells a deferred column apart from any other `UInt64`. `DeferredColumn` is the one reader for the fetch, the decode and the Top-K, and `with_term_ordinals` writes fetched rows in place. `SegmentedTopKExec` treats a NULL row as having no segment, which covers a NULL value and a null-extended row alike. The logical rule tells a deferred column apart by its scan's index and its name, since a plain `UInt64` column such as an `oid` can share the name.

One word per row is also cheaper to carry than a union with a struct child: a join's `take` copies one buffer, and the fetch changes a row's state without changing the column's type.

## Tests

- `join_outer_deferred_sort`
- An array-level case in `aggregate_late_materialization`
- Unit tests in `deferred_encode.rs`

