### PR TITLE
ci: pin the json gem below 3 for the Rails docs snippets

### DIFF
--- a/.github/scripts/rails_snippet_harness.rb
+++ b/.github/scripts/rails_snippet_harness.rb
@@ -1,3 +1,6 @@
+# ActiveSupport 8.1 passes JSON.parse a positional options hash, which json 3 rejects.
+gem "json", "< 3"
+
 require "active_record"
 require "parade_db"
 

--- a/.github/scripts/smoke_test_code_snippets.sh
+++ b/.github/scripts/smoke_test_code_snippets.sh
@@ -165,7 +165,8 @@ if [[ $ORMS =~ "rails" ]]; then
   GEM_HOME="$RUBY_GEM_HOME" GEM_PATH="$RUBY_GEM_HOME" \
     gem install --silent --no-document --install-dir "$RUBY_GEM_HOME" \
     "rails-paradedb:0.12.0" \
-    "pg"
+    "pg" \
+    "json:<3"
 
   while IFS= read -r snippet_file; do
     rel_snippet="${snippet_file#"$REPO_ROOT"/}"


### PR DESCRIPTION
## Ticket(s) Closed

- None. Failing run on `main`: https://github.com/paradedb/paradedb/actions/runs/34093480069/job/101677890606

## What

This PR pins the `json` gem below 3 in the Rails leg of the docs smoke test.

## Why

`json` 3.0.0 came out on 2026-09-07 and made the options of `JSON.parse` keyword-only. The released ActiveSupport 8.1.3.1 still passes them as a positional hash, so reading a JSON column through ActiveRecord raises `ArgumentError`. The two facets snippets are the only Rails snippets that do that. Rails has the fix on `main` and `8-1-stable`, but no release yet.

## How

`gem install` resolves each requested gem on its own, so `json:<3` on the install line only puts 2.21.2 next to the 3.0.0 that `activesupport` pulls in. The harness activates the 2.x one with `gem "json", "< 3"` before requiring `active_record`. Both lines can go once a Rails release carries the fix.

## Tests

Ran the Rails leg locally against pgrx PG 18:

```shell
PARADEDB_DATABASE=docs_smoke ./.github/scripts/smoke_test_code_snippets.sh rails
```

Before: `Rails passed: 124 failed: 2`, same trace as CI. After: `Rails passed: 126 failed: 0`. The docs job on this PR is green.
