### PR TITLE
feat: Add support for `pdb.agg` atop joins over array fields.

### DIFF
--- a/docs/changelog/unreleased/6185.features.mdx
+++ b/docs/changelog/unreleased/6185.features.mdx
@@ -2,4 +2,4 @@
 header: features
 ---
 
-`pdb.agg()` now runs over joins and on single tables whose group count is past the bucket limit, with `terms` (`size`, `min_doc_count`, `missing`, `order`), `sum`, `avg`, `min`, `max`, `value_count`, `cardinality`, and nested `aggs`.
+`pdb.agg()` now runs over joins (including `terms` on array fields) and on single tables whose group count is past the bucket limit, with `terms` (`size`, `min_doc_count`, `missing`, `order`), `sum`, `avg`, `min`, `max`, `value_count`, `cardinality`, and nested `aggs`.

--- a/docs/documentation/aggregates/bucket/terms.mdx
+++ b/docs/documentation/aggregates/bucket/terms.mdx
@@ -200,5 +200,7 @@ WHERE id @@@ pdb.all();
 (1 row)
 ```
 
+Array fields (such as `text[]`) are also supported; each element is counted into its respective bucket.
+
 See the [Tantivy documentation](https://docs.rs/tantivy/latest/tantivy/aggregation/bucket/struct.TermsAggregation.html)
 for all available options.

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -128,7 +128,7 @@ A `pdb.agg()` field name must belong to exactly one indexed table in the join. W
 
 `pdb.agg()` over a NUMERIC field runs on this path as well, on a single table or over a join, while a `missing` value is not accepted for such a field.
 
-A few `pdb.agg()` shapes run on a single table but not over a join: metric aggregations over JSON sub-fields, such as `{"sum": {"field": "metadata.qty"}}`, `terms` on an array field or on a JSON sub-field that holds numbers, and `min_doc_count: 0`, which lists every term of the column.
+A few `pdb.agg()` shapes run on a single table but not over a join: metric aggregations over JSON sub-fields, such as `{"sum": {"field": "metadata.qty"}}`, `terms` on a JSON sub-field that holds numbers, and `min_doc_count: 0`, which lists every term of the column.
 
 `pdb.agg()` has no native Postgres implementation, so it cannot fall back. A `pdb.agg()` over a join that uses an aggregation outside the list above, such as `range`, `histogram`, `date_histogram`, `filter`, `composite`, `stats`, `percentiles`, or `top_hits`, raises an error.
 

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -120,13 +120,13 @@ Aggregate pushdown works across joins as well as single tables. When every parti
 | Per-aggregate `FILTER (WHERE ...)` | Yes |
 | `ORDER BY ... LIMIT K` | Pushed down as TopK when there is a single `ORDER BY` column targeting an aggregate, a group column, or `MIN(col)` / `MAX(col)`, and no `pdb.agg()` in the query uses `terms` |
 | `ORDER BY` inside `STRING_AGG` / `ARRAY_AGG` | Yes (produces deterministic element ordering) |
-| `pdb.agg()` | `terms` (with `size`, `min_doc_count` of 1 or more, `missing`, and `order` by `_count`, `_key`, or a metric sub-aggregation, but not `include` or `exclude`), `sum`, `avg`, `min`, `max`, `value_count`, `cardinality`, and nested `aggs` built from these. The `visibility` argument is honored; over a join, `threshold` makes one decision for every table, judged on the largest table's estimate. |
+| `pdb.agg()` | `terms` (scalar or array fields; with `size`, `min_doc_count` of 1 or more, `missing`, and `order` by `_count`, `_key`, or a metric sub-aggregation, but not `include` or `exclude`), `sum`, `avg`, `min`, `max`, `value_count`, `cardinality`, and nested `aggs` built from these. The `visibility` argument is honored; over a join, `threshold` makes one decision for every table, judged on the largest table's estimate. |
 
 ### `pdb.agg()` over joins
 
 A `pdb.agg()` field name must belong to exactly one indexed table in the join. When the same field name exists in several tables, qualify it with the table alias, as in `"field": "p.category"`. The qualifier is also accepted when the planner reduces the join to that one table. Postgres cannot see the fields inside a spec, so an outer join whose table is read only there is removed as unused and the spec fails with an unknown field; reference such a table outside the spec, or use an inner join.
 
-`pdb.agg()` over a NUMERIC field runs on this path as well, on a single table or over a join, while a `missing` value is not accepted for such a field.
+`pdb.agg()` over a NUMERIC field runs on this path as well, on a single table or over a join, while a `missing` value is not accepted for such a field. `terms` on an array field is also supported over joins; metric aggregations over array fields are not.
 
 A few `pdb.agg()` shapes run on a single table but not over a join: metric aggregations over JSON sub-fields, such as `{"sum": {"field": "metadata.qty"}}`, `terms` on a JSON sub-field that holds numbers, and `min_doc_count: 0`, which lists every term of the column.
 

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -109,6 +109,7 @@ pub struct ResolvedSourceField<'a> {
     /// The name as the index knows it, without a table qualifier.
     pub field_name: String,
     pub field_type: SearchFieldType,
+    pub is_array: bool,
 }
 
 /// Resolve an index field name against the join sources.
@@ -128,7 +129,7 @@ pub fn resolve_source_field<'a>(
         let (qualified, qualified_reasons) = source_field_candidates(sources, rest);
         candidates = qualified
             .into_iter()
-            .filter(|(source, _, _)| {
+            .filter(|(source, _)| {
                 RelationAlias::new(source.alias.as_deref()).display(source.rti as usize) == prefix
             })
             .collect();
@@ -143,12 +144,13 @@ pub fn resolve_source_field<'a>(
             )
         })),
         1 => {
-            let (source, attno, field_type) = candidates.remove(0);
+            let (source, resolved) = candidates.remove(0);
             Ok(ResolvedSourceField {
                 source,
-                attno,
+                attno: resolved.attno,
                 field_name,
-                field_type,
+                field_type: resolved.field_type,
+                is_array: resolved.is_array,
             })
         }
         _ => Err(format!(
@@ -163,7 +165,10 @@ fn source_field_candidates<'a>(
     sources: &'a [JoinAggSource],
     field: &str,
 ) -> (
-    Vec<(&'a JoinAggSource, pg_sys::AttrNumber, SearchFieldType)>,
+    Vec<(
+        &'a JoinAggSource,
+        crate::postgres::customscan::pullup::ResolvedIndexField,
+    )>,
     Vec<String>,
 ) {
     let mut matches = Vec::new();
@@ -173,7 +178,7 @@ fn source_field_candidates<'a>(
             continue;
         };
         match resolve_index_field_by_name(index, field) {
-            Ok(Some((attno, field_type))) => matches.push((source, attno, field_type)),
+            Ok(Some(resolved)) => matches.push((source, resolved)),
             Ok(None) => {}
             Err(reason) => reasons.push(reason),
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -38,7 +38,8 @@ use crate::postgres::customscan::joinscan::planning::{
     wrap_with_semi_anti,
 };
 use crate::postgres::customscan::pullup::{
-    get_attno_by_name, resolve_fast_field, resolve_fast_field_by_name, resolve_index_field_by_name,
+    ResolvedIndexField, get_attno_by_name, resolve_fast_field, resolve_fast_field_by_name,
+    resolve_index_field_by_name,
 };
 use crate::postgres::customscan::qual_inspect::{
     PlannerContext, QualExtractState, collect_implicit_and_conjuncts, contains_extern_param,
@@ -164,13 +165,7 @@ pub fn resolve_source_field<'a>(
 fn source_field_candidates<'a>(
     sources: &'a [JoinAggSource],
     field: &str,
-) -> (
-    Vec<(
-        &'a JoinAggSource,
-        crate::postgres::customscan::pullup::ResolvedIndexField,
-    )>,
-    Vec<String>,
-) {
+) -> (Vec<(&'a JoinAggSource, ResolvedIndexField)>, Vec<String>) {
     let mut matches = Vec::new();
     let mut reasons = Vec::new();
     for source in sources {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -377,9 +377,121 @@ fn apply_pdb_aggregate(
     };
     let mut all_agg_exprs = agg_exprs;
     all_agg_exprs.extend(metric_exprs);
+    struct UnnestTarget {
+        source_alias: String,
+        field_name: String,
+        temp_col_name: String,
+    }
+
+    let unnest_targets: Vec<UnnestTarget> = {
+        let mut targets = Vec::new();
+        for key in &pdb_plan.keys {
+            if key.field.is_array
+                && !plan
+                    .lateral_unnests()
+                    .iter()
+                    .any(|u| u.field_name == key.field.field_name)
+            {
+                let source = plan
+                    .source_at_plan_position(key.field.plan_position)
+                    .unwrap_or_else(|| {
+                        panic!("no source at plan_position {}", key.field.plan_position)
+                    });
+                let alias = RelationAlias::new(source.scan_info.alias.as_deref())
+                    .execution(source.plan_position);
+                let temp_col_name = format!("{}_{}", alias, key.field.field_name);
+                if !targets
+                    .iter()
+                    .any(|t: &UnnestTarget| t.temp_col_name == temp_col_name)
+                {
+                    targets.push(UnnestTarget {
+                        source_alias: alias,
+                        field_name: key.field.field_name.clone(),
+                        temp_col_name,
+                    });
+                }
+            }
+        }
+        targets
+    };
+
     // `DataFrame::aggregate` projects `__grouping_id` away; the assembler needs it,
     // so build the aggregate node directly.
     let (session_state, input) = df.into_parts();
+    let input = if unnest_targets.is_empty() {
+        input
+    } else {
+        use datafusion::common::{NullHandling, UnnestOptions};
+        let unnest_options =
+            UnnestOptions::new().with_null_handling(NullHandling::PreserveAndExpandEmpty);
+
+        // Pre-project to alias qualified columns (e.g. `users_0.tags`) to unique temporary
+        // column names (e.g. `users_0_tags`). This avoids ambiguity errors during `Unnest`
+        // if another joined table has a column with the same name (e.g. `products_1.tags`).
+        let pre_project_exprs: Vec<Expr> = input
+            .schema()
+            .iter()
+            .map(|(qualifier, field)| {
+                let col = Expr::Column(datafusion::common::Column::new(
+                    qualifier.cloned(),
+                    field.name(),
+                ));
+                if let Some(target) = unnest_targets.iter().find(|t| {
+                    qualifier.as_ref().map(|q| q.to_string()) == Some(t.source_alias.clone())
+                        && field.name() == &t.field_name
+                }) {
+                    col.alias(&target.temp_col_name)
+                } else {
+                    col
+                }
+            })
+            .collect();
+        let pre_unnest = LogicalPlanBuilder::from(input)
+            .project(pre_project_exprs)?
+            .build()?;
+
+        // Unnest each column in its own Unnest node. When multiple array columns are
+        // unnested together in DataFusion, UnnestExec locks them in step (per-row zip)
+        // instead of forming their Cartesian product. Chaining them sequentially unnests
+        // each array across the already-expanded rows of prior ones, matching the
+        // semantics of PostgreSQL's independent LEFT JOIN LATERAL unnest clauses.
+        let mut unnested = pre_unnest;
+        for target in &unnest_targets {
+            let unnest_col = datafusion::common::Column::from_name(&target.temp_col_name);
+            unnested = LogicalPlanBuilder::from(unnested)
+                .unnest_columns_with_options(vec![unnest_col], unnest_options.clone())?
+                .build()?;
+        }
+
+        // Post-project to re-qualify each unnested temporary column back to its original
+        // table reference and field name (e.g. `users_0.tags`).
+        let post_project_exprs: Vec<Expr> = unnested
+            .schema()
+            .iter()
+            .map(|(qualifier, field)| {
+                let col = Expr::Column(datafusion::common::Column::new(
+                    qualifier.cloned(),
+                    field.name(),
+                ));
+                if let Some(target) = unnest_targets
+                    .iter()
+                    .find(|t| field.name() == &t.temp_col_name)
+                {
+                    col.alias_qualified(
+                        Some(datafusion::common::TableReference::Bare {
+                            table: target.source_alias.clone().into(),
+                        }),
+                        &target.field_name,
+                    )
+                } else {
+                    col
+                }
+            })
+            .collect();
+        LogicalPlanBuilder::from(unnested)
+            .project(post_project_exprs)?
+            .build()?
+    };
     let options = LogicalPlanBuilderOptions::new().with_add_implicit_group_by_exprs(true);
     let aggregated = LogicalPlanBuilder::from(input)
         .with_options(options)

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -42,7 +42,7 @@ use crate::postgres::customscan::datafusion::numeric_agg::{
 use crate::postgres::customscan::datafusion::timestamp_to_date::timestamp_to_date_udf;
 use crate::postgres::customscan::datafusion::translator::{
     ColumnMapper, PredicateTranslator, apply_join_level_filter, apply_relnode_unnest,
-    build_join_df_with_filter, make_col, make_source_col,
+    build_join_df_with_filter, make_col, make_source_col, unnest_plan_column,
 };
 use crate::postgres::customscan::joinscan::CtidColumn;
 use crate::postgres::customscan::joinscan::build::{
@@ -55,7 +55,7 @@ use crate::postgres::customscan::joinscan::scan_state::{
 use crate::scan::PgSearchTableProvider;
 use crate::schema::SearchFieldType;
 use arrow_schema::DataType;
-use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::common::{DataFusionError, NullHandling, Result, ScalarValue};
 use datafusion::functions::core::expr_fn::coalesce;
 use datafusion::functions_aggregate::array_agg::array_agg_udaf;
 use datafusion::functions_aggregate::count::count_udaf;
@@ -66,7 +66,8 @@ use datafusion::functions_aggregate::expr_fn::{
 use datafusion::functions_aggregate::string_agg::string_agg_udaf;
 use datafusion::logical_expr::expr::{AggregateFunction, Sort};
 use datafusion::logical_expr::{
-    Aggregate, Cast, Expr, GroupingSet, LogicalPlanBuilder, LogicalPlanBuilderOptions, col, lit,
+    Aggregate, Cast, Expr, GroupingSet, LogicalPlan, LogicalPlanBuilder, LogicalPlanBuilderOptions,
+    col, lit,
 };
 use datafusion::prelude::{DataFrame, SessionContext};
 use futures::future::{FutureExt, LocalBoxFuture};
@@ -335,6 +336,140 @@ pub async fn build_join_aggregate_plan(
     })
 }
 
+/// An array key in a `pdb.agg()` spec that must be unnested.
+struct ArrayKeyToUnnest {
+    key_idx: usize,
+    source_alias: String,
+    field_name: String,
+}
+
+/// Build the aggregate logical plan for `pdb.agg()`. When array keys are grouped,
+/// builds an `Aggregate` per level over the join input unnested only for array
+/// keys required by that level, projecting typed NULL placeholders for inactive keys
+/// and an explicit `__grouping_id` so all levels share the exact same output schema
+/// and grouping ID bit layout. The levels are then unioned together so outer grouping
+/// levels and root aggregates are not over-counted by unnesting.
+fn build_pdb_aggregate_plan(
+    input: LogicalPlan,
+    pdb_plan: &PdbAggPlan,
+    plan: &RelNode,
+    all_group_exprs: &[Expr],
+    all_agg_exprs: &[Expr],
+    grouping: &[Expr],
+) -> Result<LogicalPlan> {
+    let array_keys: Vec<ArrayKeyToUnnest> = pdb_plan
+        .keys
+        .iter()
+        .enumerate()
+        .filter(|(_, key)| {
+            key.field.is_array
+                && !is_lateral_unnest(plan, key.field.plan_position, &key.field.field_name)
+        })
+        .map(|(key_idx, key)| {
+            let source = plan
+                .source_at_plan_position(key.field.plan_position)
+                .unwrap_or_else(|| {
+                    panic!("no source at plan_position {}", key.field.plan_position)
+                });
+            let alias = RelationAlias::new(source.scan_info.alias.as_deref())
+                .execution(source.plan_position);
+            ArrayKeyToUnnest {
+                key_idx,
+                source_alias: alias,
+                field_name: key.field.field_name.clone(),
+            }
+        })
+        .collect();
+
+    let options = LogicalPlanBuilderOptions::new().with_add_implicit_group_by_exprs(true);
+    if array_keys.is_empty() {
+        return LogicalPlanBuilder::from(input)
+            .with_options(options)
+            .aggregate(grouping.to_vec(), all_agg_exprs.to_vec())?
+            .build();
+    }
+
+    let num_outer = pdb_plan.num_outer_group_cols();
+    let num_keys = pdb_plan.keys.len();
+    let mut level_plans = Vec::with_capacity(pdb_plan.levels.len());
+
+    for (level_idx, level) in pdb_plan.levels.iter().enumerate() {
+        let mut level_plan = input.clone();
+        for ak in &array_keys {
+            if level.contains(&(num_outer + ak.key_idx)) {
+                level_plan = unnest_plan_column(
+                    level_plan,
+                    &ak.source_alias,
+                    &ak.field_name,
+                    NullHandling::PreserveAndExpandEmpty,
+                )?;
+            }
+        }
+
+        let level_group_exprs: Vec<Expr> =
+            level.iter().map(|&p| all_group_exprs[p].clone()).collect();
+
+        let level_agg = LogicalPlanBuilder::from(level_plan)
+            .with_options(options.clone())
+            .aggregate(level_group_exprs, all_agg_exprs.to_vec())?
+            .build()?;
+
+        // Project level_agg output to the unified schema:
+        // [group_exprs..., key_exprs..., __grouping_id, all_agg_exprs...]
+        let mut project_exprs = Vec::with_capacity(num_outer + num_keys + 1 + all_agg_exprs.len());
+
+        let columns = level_agg.schema().columns();
+
+        // 1. Outer SQL group columns (always first in level_agg schema)
+        for col in columns.iter().take(num_outer) {
+            project_exprs.push(Expr::Column(col.clone()));
+        }
+
+        // 2. Key expressions (__pdb_k0, __pdb_k1, ...)
+        for k in 0..num_keys {
+            if level.contains(&(num_outer + k)) {
+                project_exprs.push(col(format!("__pdb_k{k}")));
+            } else {
+                let null_expr = Expr::Cast(Cast::new(
+                    Box::new(lit(ScalarValue::Null)),
+                    pdb_plan.keys[k].field.field_type.arrow_data_type(),
+                ))
+                .alias(format!("__pdb_k{k}"));
+                project_exprs.push(null_expr);
+            }
+        }
+
+        // 3. Constant grouping id for this level
+        project_exprs.push(
+            lit(pdb_plan.grouping_id_for_level(level_idx)).alias(Aggregate::INTERNAL_GROUPING_ID),
+        );
+
+        // 4. Aggregates and metrics (following the group columns in level_agg schema)
+        let aggs_offset = level.len();
+        for col in columns.iter().skip(aggs_offset).take(all_agg_exprs.len()) {
+            project_exprs.push(Expr::Column(col.clone()));
+        }
+
+        let projected_level = LogicalPlanBuilder::from(level_agg)
+            .project(project_exprs)?
+            .build()?;
+        level_plans.push(projected_level);
+    }
+
+    if level_plans.len() == 1 {
+        Ok(level_plans.into_iter().next().unwrap())
+    } else {
+        let mut it = level_plans.into_iter();
+        let mut combined = it.next().unwrap();
+        for next_level in it {
+            combined = LogicalPlanBuilder::from(combined)
+                .union(next_level)?
+                .build()?;
+        }
+        Ok(combined)
+    }
+}
+
 /// Aggregate with every `pdb.agg()` level folded in as grouping sets, then
 /// project to the column order [`PdbAggPlan`] documents.
 ///
@@ -377,126 +512,16 @@ fn apply_pdb_aggregate(
     };
     let mut all_agg_exprs = agg_exprs;
     all_agg_exprs.extend(metric_exprs);
-    struct UnnestTarget {
-        source_alias: String,
-        field_name: String,
-        temp_col_name: String,
-    }
 
-    let unnest_targets: Vec<UnnestTarget> = {
-        let mut targets = Vec::new();
-        for key in &pdb_plan.keys {
-            if key.field.is_array
-                && !plan
-                    .lateral_unnests()
-                    .iter()
-                    .any(|u| u.field_name == key.field.field_name)
-            {
-                let source = plan
-                    .source_at_plan_position(key.field.plan_position)
-                    .unwrap_or_else(|| {
-                        panic!("no source at plan_position {}", key.field.plan_position)
-                    });
-                let alias = RelationAlias::new(source.scan_info.alias.as_deref())
-                    .execution(source.plan_position);
-                let temp_col_name = format!("{}_{}", alias, key.field.field_name);
-                if !targets
-                    .iter()
-                    .any(|t: &UnnestTarget| t.temp_col_name == temp_col_name)
-                {
-                    targets.push(UnnestTarget {
-                        source_alias: alias,
-                        field_name: key.field.field_name.clone(),
-                        temp_col_name,
-                    });
-                }
-            }
-        }
-        targets
-    };
-
-    // `DataFrame::aggregate` projects `__grouping_id` away; the assembler needs it,
-    // so build the aggregate node directly.
     let (session_state, input) = df.into_parts();
-    let input = if unnest_targets.is_empty() {
-        input
-    } else {
-        use datafusion::common::{NullHandling, UnnestOptions};
-        let unnest_options =
-            UnnestOptions::new().with_null_handling(NullHandling::PreserveAndExpandEmpty);
-
-        // Pre-project to alias qualified columns (e.g. `users_0.tags`) to unique temporary
-        // column names (e.g. `users_0_tags`). This avoids ambiguity errors during `Unnest`
-        // if another joined table has a column with the same name (e.g. `products_1.tags`).
-        let pre_project_exprs: Vec<Expr> = input
-            .schema()
-            .iter()
-            .map(|(qualifier, field)| {
-                let col = Expr::Column(datafusion::common::Column::new(
-                    qualifier.cloned(),
-                    field.name(),
-                ));
-                if let Some(target) = unnest_targets.iter().find(|t| {
-                    qualifier.as_ref().map(|q| q.to_string()) == Some(t.source_alias.clone())
-                        && field.name() == &t.field_name
-                }) {
-                    col.alias(&target.temp_col_name)
-                } else {
-                    col
-                }
-            })
-            .collect();
-        let pre_unnest = LogicalPlanBuilder::from(input)
-            .project(pre_project_exprs)?
-            .build()?;
-
-        // Unnest each column in its own Unnest node. When multiple array columns are
-        // unnested together in DataFusion, UnnestExec locks them in step (per-row zip)
-        // instead of forming their Cartesian product. Chaining them sequentially unnests
-        // each array across the already-expanded rows of prior ones, matching the
-        // semantics of PostgreSQL's independent LEFT JOIN LATERAL unnest clauses.
-        let mut unnested = pre_unnest;
-        for target in &unnest_targets {
-            let unnest_col = datafusion::common::Column::from_name(&target.temp_col_name);
-            unnested = LogicalPlanBuilder::from(unnested)
-                .unnest_columns_with_options(vec![unnest_col], unnest_options.clone())?
-                .build()?;
-        }
-
-        // Post-project to re-qualify each unnested temporary column back to its original
-        // table reference and field name (e.g. `users_0.tags`).
-        let post_project_exprs: Vec<Expr> = unnested
-            .schema()
-            .iter()
-            .map(|(qualifier, field)| {
-                let col = Expr::Column(datafusion::common::Column::new(
-                    qualifier.cloned(),
-                    field.name(),
-                ));
-                if let Some(target) = unnest_targets
-                    .iter()
-                    .find(|t| field.name() == &t.temp_col_name)
-                {
-                    col.alias_qualified(
-                        Some(datafusion::common::TableReference::Bare {
-                            table: target.source_alias.clone().into(),
-                        }),
-                        &target.field_name,
-                    )
-                } else {
-                    col
-                }
-            })
-            .collect();
-        LogicalPlanBuilder::from(unnested)
-            .project(post_project_exprs)?
-            .build()?
-    };
-    let options = LogicalPlanBuilderOptions::new().with_add_implicit_group_by_exprs(true);
-    let aggregated = LogicalPlanBuilder::from(input)
-        .with_options(options)
-        .aggregate(grouping, all_agg_exprs)?
-        .build()?;
+    let aggregated = build_pdb_aggregate_plan(
+        input,
+        pdb_plan,
+        plan,
+        &all_group_exprs,
+        &all_agg_exprs,
+        &grouping,
+    )?;
     let mut df = DataFrame::new(session_state, aggregated);
 
     if let Some(having) = having_expr {
@@ -549,7 +574,16 @@ fn pdb_missing_lit(missing: &Key, field: &PdbAggFieldRef) -> Expr {
 }
 
 fn pdb_key_expr(key: &PdbKeySpec, plan: &RelNode) -> Expr {
-    let column = make_plan_position_col(plan, key.field.plan_position, &key.field.field_name);
+    let source = plan
+        .source_at_plan_position(key.field.plan_position)
+        .unwrap_or_else(|| panic!("no source at plan_position {}", key.field.plan_position));
+    let alias =
+        RelationAlias::new(source.scan_info.alias.as_deref()).execution(source.plan_position);
+    let column = if key.field.is_array {
+        col(format!("{alias}_{}", key.field.field_name))
+    } else {
+        make_col(&alias, &key.field.field_name)
+    };
     match &key.missing {
         None => column,
         Some(missing) => coalesce(vec![column, pdb_missing_lit(missing, &key.field)]),
@@ -1062,6 +1096,15 @@ async fn build_source_df(
     }
 }
 
+fn is_lateral_unnest(plan: &RelNode, plan_position: usize, field_name: &str) -> bool {
+    let Some(source) = plan.source_at_plan_position(plan_position) else {
+        return false;
+    };
+    plan.lateral_unnests()
+        .iter()
+        .any(|u| source.contains_rti(u.source_rti.0) && u.field_name == field_name)
+}
+
 /// Build a DataFusion column expression for a targetlist ref by its
 /// previously-resolved `plan_position`.
 fn make_plan_position_col(plan: &RelNode, plan_position: usize, field_name: &str) -> Expr {
@@ -1070,12 +1113,8 @@ fn make_plan_position_col(plan: &RelNode, plan_position: usize, field_name: &str
         .unwrap_or_else(|| panic!("no source at plan_position {plan_position}"));
     let alias =
         RelationAlias::new(source.scan_info.alias.as_deref()).execution(source.plan_position);
-    if plan
-        .lateral_unnests()
-        .iter()
-        .any(|u| source.contains_rti(u.source_rti.0) && u.field_name == field_name)
-    {
-        datafusion::logical_expr::col(format!("{alias}_{field_name}"))
+    if is_lateral_unnest(plan, plan_position, field_name) {
+        col(format!("{alias}_{field_name}"))
     } else {
         make_col(&alias, field_name)
     }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -343,12 +343,15 @@ struct ArrayKeyToUnnest {
     field_name: String,
 }
 
-/// Build the aggregate logical plan for `pdb.agg()`. When array keys are grouped,
-/// builds an `Aggregate` per level over the join input unnested only for array
-/// keys required by that level, projecting typed NULL placeholders for inactive keys
-/// and an explicit `__grouping_id` so all levels share the exact same output schema
-/// and grouping ID bit layout. The levels are then unioned together so outer grouping
-/// levels and root aggregates are not over-counted by unnesting.
+/// Build the aggregate logical plan for `pdb.agg()`.
+///
+/// Unnesting changes relation cardinality, so levels that do not group by an
+/// array key must not see expanded rows. When array keys are grouped, levels
+/// are partitioned by the distinct set of array keys they require. Each group
+/// is built as an `Aggregate` unnested only for its required array keys. If a
+/// group contains multiple levels (e.g. root and scalar term levels), they
+/// share a single pass over the join via DataFusion grouping sets, with their
+/// local grouping IDs remapped to the unified bit layout before unioning.
 fn build_pdb_aggregate_plan(
     input: LogicalPlan,
     pdb_plan: &PdbAggPlan,
@@ -391,12 +394,30 @@ fn build_pdb_aggregate_plan(
 
     let num_outer = pdb_plan.num_outer_group_cols();
     let num_keys = pdb_plan.keys.len();
-    let mut level_plans = Vec::with_capacity(pdb_plan.levels.len());
 
+    // Group levels by the array keys they require so levels sharing the same
+    // unnest depth (e.g. the root level and any scalar levels preceding an array)
+    // share a single Aggregate and scan the join only once.
+    let mut groups: Vec<(Vec<usize>, Vec<usize>)> = Vec::new();
     for (level_idx, level) in pdb_plan.levels.iter().enumerate() {
+        let needed: Vec<usize> = array_keys
+            .iter()
+            .filter(|ak| level.contains(&(num_outer + ak.key_idx)))
+            .map(|ak| ak.key_idx)
+            .collect();
+        if let Some(group) = groups.iter_mut().find(|g| g.0 == needed) {
+            group.1.push(level_idx);
+        } else {
+            groups.push((needed, vec![level_idx]));
+        }
+    }
+
+    let mut level_plans = Vec::with_capacity(groups.len());
+
+    for (needed_keys, levels_in_group) in groups {
         let mut level_plan = input.clone();
         for ak in &array_keys {
-            if level.contains(&(num_outer + ak.key_idx)) {
+            if needed_keys.contains(&ak.key_idx) {
                 level_plan = unnest_plan_column(
                     level_plan,
                     &ak.source_alias,
@@ -406,18 +427,44 @@ fn build_pdb_aggregate_plan(
             }
         }
 
-        let level_group_exprs: Vec<Expr> =
-            level.iter().map(|&p| all_group_exprs[p].clone()).collect();
-
-        let level_agg = LogicalPlanBuilder::from(level_plan)
-            .with_options(options.clone())
-            .aggregate(level_group_exprs, all_agg_exprs.to_vec())?
-            .build()?;
+        let (level_agg, distinct_positions) = if levels_in_group.len() == 1 {
+            let level_idx = levels_in_group[0];
+            let level = &pdb_plan.levels[level_idx];
+            let level_group_exprs: Vec<Expr> =
+                level.iter().map(|&p| all_group_exprs[p].clone()).collect();
+            let agg = LogicalPlanBuilder::from(level_plan)
+                .with_options(options.clone())
+                .aggregate(level_group_exprs, all_agg_exprs.to_vec())?
+                .build()?;
+            (agg, level.clone())
+        } else {
+            let mut sets = Vec::with_capacity(levels_in_group.len());
+            let mut distinct_positions = Vec::new();
+            for &level_idx in &levels_in_group {
+                let set: Vec<Expr> = pdb_plan.levels[level_idx]
+                    .iter()
+                    .map(|&p| {
+                        if !distinct_positions.contains(&p) {
+                            distinct_positions.push(p);
+                        }
+                        all_group_exprs[p].clone()
+                    })
+                    .collect();
+                sets.push(set);
+            }
+            let agg = LogicalPlanBuilder::from(level_plan)
+                .with_options(options.clone())
+                .aggregate(
+                    vec![Expr::GroupingSet(GroupingSet::GroupingSets(sets))],
+                    all_agg_exprs.to_vec(),
+                )?
+                .build()?;
+            (agg, distinct_positions)
+        };
 
         // Project level_agg output to the unified schema:
         // [group_exprs..., key_exprs..., __grouping_id, all_agg_exprs...]
         let mut project_exprs = Vec::with_capacity(num_outer + num_keys + 1 + all_agg_exprs.len());
-
         let columns = level_agg.schema().columns();
 
         // 1. Outer SQL group columns (always first in level_agg schema)
@@ -427,7 +474,7 @@ fn build_pdb_aggregate_plan(
 
         // 2. Key expressions (__pdb_k0, __pdb_k1, ...)
         for k in 0..num_keys {
-            if level.contains(&(num_outer + k)) {
+            if distinct_positions.contains(&(num_outer + k)) {
                 project_exprs.push(col(format!("__pdb_k{k}")));
             } else {
                 let null_expr = Expr::Cast(Cast::new(
@@ -439,14 +486,36 @@ fn build_pdb_aggregate_plan(
             }
         }
 
-        // 3. Constant grouping id for this level
-        project_exprs.push(
-            lit(pdb_plan.grouping_id_for_level(level_idx)).alias(Aggregate::INTERNAL_GROUPING_ID),
-        );
+        // 3. Grouping ID (constant for a single level, remapped from local bitmask if grouped)
+        if levels_in_group.len() == 1 {
+            project_exprs.push(
+                lit(pdb_plan.grouping_id_for_level(levels_in_group[0]))
+                    .alias(Aggregate::INTERNAL_GROUPING_ID),
+            );
+        } else {
+            let id_u64 = Expr::Cast(Cast::new(
+                Box::new(col(Aggregate::INTERNAL_GROUPING_ID)),
+                DataType::UInt64,
+            ));
+            let mut case_builder = datafusion::prelude::case(id_u64);
+            for &level_idx in &levels_in_group {
+                let local_id = (0..distinct_positions.len())
+                    .filter(|&j| !pdb_plan.levels[level_idx].contains(&distinct_positions[j]))
+                    .fold(0u64, |acc, j| {
+                        acc | (1u64 << (distinct_positions.len() - 1 - j))
+                    });
+                let global_id = pdb_plan.grouping_id_for_level(level_idx);
+                case_builder = case_builder.when(lit(local_id), lit(global_id));
+            }
+            let grouping_id_expr = case_builder
+                .otherwise(lit(0u64))?
+                .alias(Aggregate::INTERNAL_GROUPING_ID);
+            project_exprs.push(grouping_id_expr);
+        }
 
-        // 4. Aggregates and metrics (following the group columns in level_agg schema)
-        let aggs_offset = level.len();
-        for col in columns.iter().skip(aggs_offset).take(all_agg_exprs.len()) {
+        // 4. Aggregates and metrics (always at the tail of level_agg schema)
+        let aggs_start = columns.len().saturating_sub(all_agg_exprs.len());
+        for col in &columns[aggs_start..] {
             project_exprs.push(Expr::Column(col.clone()));
         }
 
@@ -574,16 +643,12 @@ fn pdb_missing_lit(missing: &Key, field: &PdbAggFieldRef) -> Expr {
 }
 
 fn pdb_key_expr(key: &PdbKeySpec, plan: &RelNode) -> Expr {
-    let source = plan
-        .source_at_plan_position(key.field.plan_position)
-        .unwrap_or_else(|| panic!("no source at plan_position {}", key.field.plan_position));
-    let alias =
-        RelationAlias::new(source.scan_info.alias.as_deref()).execution(source.plan_position);
-    let column = if key.field.is_array {
-        col(format!("{alias}_{}", key.field.field_name))
-    } else {
-        make_col(&alias, &key.field.field_name)
-    };
+    let column = make_plan_position_col_with(
+        plan,
+        key.field.plan_position,
+        &key.field.field_name,
+        key.field.is_array,
+    );
     match &key.missing {
         None => column,
         Some(missing) => coalesce(vec![column, pdb_missing_lit(missing, &key.field)]),
@@ -1107,17 +1172,31 @@ fn is_lateral_unnest(plan: &RelNode, plan_position: usize, field_name: &str) -> 
 
 /// Build a DataFusion column expression for a targetlist ref by its
 /// previously-resolved `plan_position`.
-fn make_plan_position_col(plan: &RelNode, plan_position: usize, field_name: &str) -> Expr {
+fn make_plan_position_col_with(
+    plan: &RelNode,
+    plan_position: usize,
+    field_name: &str,
+    is_unnested: bool,
+) -> Expr {
     let source = plan
         .source_at_plan_position(plan_position)
         .unwrap_or_else(|| panic!("no source at plan_position {plan_position}"));
     let alias =
         RelationAlias::new(source.scan_info.alias.as_deref()).execution(source.plan_position);
-    if is_lateral_unnest(plan, plan_position, field_name) {
+    if is_unnested {
         col(format!("{alias}_{field_name}"))
     } else {
         make_col(&alias, field_name)
     }
+}
+
+fn make_plan_position_col(plan: &RelNode, plan_position: usize, field_name: &str) -> Expr {
+    make_plan_position_col_with(
+        plan,
+        plan_position,
+        field_name,
+        is_lateral_unnest(plan, plan_position, field_name),
+    )
 }
 
 /// Replace an `Expr::AggregateFunction` with the same call but `distinct=true`.

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -32,7 +32,7 @@ use crate::api::{HashMap, SortDirection, pdb_agg_spec};
 use crate::postgres::customscan::CreateUpperPathsHookArgs;
 use crate::postgres::customscan::datafusion::explain::get_attname_safe;
 use crate::postgres::customscan::joinscan::build::RelationAlias;
-use crate::postgres::var::{VarContext, find_one_aggref, find_one_var_and_fieldname};
+use crate::postgres::var::{VarContext, find_one_var_and_fieldname};
 use crate::schema::SearchFieldType;
 use pgrx::PgList;
 use pgrx::pg_sys;
@@ -553,8 +553,10 @@ pub unsafe fn extract_aggregate_targetlist(
                 numeric_scale,
                 transform: GroupingTransform::Identity,
             });
-        } else if let Some(aggref) = find_one_aggref(expr as *mut pg_sys::Node) {
-            // Aggregate function (possibly wrapped in COALESCE, etc.)
+        } else if let Some(aggref) =
+            unsafe { crate::nodecast!(Aggref, T_Aggref, expr as *mut pg_sys::Node) }
+        {
+            // Bare aggregate function (wrapped expressions like COALESCE, casts fall back to Postgres).
             let aggfnoid = (*aggref).aggfnoid.to_u32();
             let has_distinct = !(*aggref).aggdistinct.is_null();
 
@@ -677,7 +679,7 @@ impl PdbAggRoute {
     }
 
     /// A spec reads an array field, which on a single table is handled natively
-    /// by Tantivy and cannot route to DataFusion without mutating relation cardinality.
+    /// by Tantivy.
     pub fn references_array(&self) -> bool {
         self.requests
             .values()
@@ -698,7 +700,9 @@ pub unsafe fn pdb_agg_route(
     let sources = collect_join_agg_sources(root, input_rel);
     let mut requests = HashMap::default();
     for (idx, expr) in shape.target_exprs().iter_ptr().enumerate() {
-        let Some(aggref) = find_one_aggref(expr as *mut pg_sys::Node) else {
+        let Some(aggref) =
+            (unsafe { crate::nodecast!(Aggref, T_Aggref, expr as *mut pg_sys::Node) })
+        else {
             continue;
         };
         if !crate::api::is_agg_funcoid((*aggref).aggfnoid.to_u32()) {

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -32,7 +32,7 @@ use crate::api::{HashMap, SortDirection, pdb_agg_spec};
 use crate::postgres::customscan::CreateUpperPathsHookArgs;
 use crate::postgres::customscan::datafusion::explain::get_attname_safe;
 use crate::postgres::customscan::joinscan::build::RelationAlias;
-use crate::postgres::var::{VarContext, find_one_var_and_fieldname};
+use crate::postgres::var::{VarContext, find_one_aggref, find_one_var_and_fieldname};
 use crate::schema::SearchFieldType;
 use pgrx::PgList;
 use pgrx::pg_sys;
@@ -553,10 +553,8 @@ pub unsafe fn extract_aggregate_targetlist(
                 numeric_scale,
                 transform: GroupingTransform::Identity,
             });
-        } else if let Some(aggref) =
-            unsafe { crate::nodecast!(Aggref, T_Aggref, expr as *mut pg_sys::Node) }
-        {
-            // Bare aggregate function (wrapped expressions like COALESCE, casts fall back to Postgres).
+        } else if let Some(aggref) = unsafe { find_one_aggref(expr as *mut pg_sys::Node) } {
+            // Aggregate function (possibly wrapped in COALESCE, etc.)
             let aggfnoid = (*aggref).aggfnoid.to_u32();
             let has_distinct = !(*aggref).aggdistinct.is_null();
 
@@ -700,9 +698,7 @@ pub unsafe fn pdb_agg_route(
     let sources = collect_join_agg_sources(root, input_rel);
     let mut requests = HashMap::default();
     for (idx, expr) in shape.target_exprs().iter_ptr().enumerate() {
-        let Some(aggref) =
-            (unsafe { crate::nodecast!(Aggref, T_Aggref, expr as *mut pg_sys::Node) })
-        else {
+        let Some(aggref) = (unsafe { find_one_aggref(expr as *mut pg_sys::Node) }) else {
             continue;
         };
         if !crate::api::is_agg_funcoid((*aggref).aggfnoid.to_u32()) {

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -675,6 +675,15 @@ impl PdbAggRoute {
             .flat_map(PdbAggRequest::fields)
             .any(|field| field.field_type.is_numeric())
     }
+
+    /// A spec reads an array field, which on a single table is handled natively
+    /// by Tantivy and cannot route to DataFusion without mutating relation cardinality.
+    pub fn references_array(&self) -> bool {
+        self.requests
+            .values()
+            .flat_map(PdbAggRequest::fields)
+            .any(|field| field.is_array)
+    }
 }
 
 /// Lower every `pdb.agg()` in the grouping output, fields included, to decide
@@ -697,7 +706,11 @@ pub unsafe fn pdb_agg_route(
         }
         requests.insert(idx, lower_pdb_agg(aggref, &sources).ok()?);
     }
-    Some(PdbAggRoute { requests })
+    let route = PdbAggRoute { requests };
+    if route.references_array() {
+        return None;
+    }
+    Some(route)
 }
 
 /// Lower a `pdb.agg()` call into its DataFusion request. The spec must be a
@@ -720,6 +733,7 @@ unsafe fn lower_pdb_agg(
             field_name: resolved.field_name,
             field_type: resolved.field_type,
             plan_position: 0,
+            is_array: resolved.is_array,
         })
     })
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/pdb_agg.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/pdb_agg.rs
@@ -667,6 +667,10 @@ impl PdbAggPlan {
         !self.keys.is_empty()
     }
 
+    pub fn num_outer_group_cols(&self) -> usize {
+        self.num_outer_group_cols
+    }
+
     fn num_group_exprs(&self) -> usize {
         self.num_outer_group_cols + self.keys.len()
     }
@@ -701,7 +705,7 @@ impl PdbAggPlan {
 
     /// The `__grouping_id` DataFusion assigns to a level: one bit per grouping
     /// expression, most significant first, set when the expression is absent.
-    fn grouping_id_for_level(&self, level: usize) -> u64 {
+    pub fn grouping_id_for_level(&self, level: usize) -> u64 {
         let n = self.num_group_exprs();
         (0..n)
             .filter(|position| !self.levels[level].contains(position))

--- a/pg_search/src/postgres/customscan/aggregatescan/pdb_agg.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/pdb_agg.rs
@@ -68,6 +68,7 @@ pub struct PdbAggFieldRef {
     pub field_type: SearchFieldType,
     /// Where the source sits in the plan tree, assigned once the tree exists.
     pub plan_position: usize,
+    pub is_array: bool,
 }
 
 impl PdbAggFieldRef {
@@ -378,6 +379,12 @@ fn check_node(
                 ));
             }
             let field = resolve_field(resolve, fields, name, kind.is_numeric())?;
+            if field.is_array {
+                return Err(format!(
+                    "Field '{name}' is an array, which cannot be used in a `{}` metric aggregation",
+                    variant_name(other)
+                ));
+            }
             check_missing(&field, missing.as_ref())
         }
     }
@@ -1112,6 +1119,7 @@ mod tests {
             field_name: name.to_string(),
             field_type: SearchFieldType::I64(pg_sys::INT8OID),
             plan_position: 0,
+            is_array: false,
         }
     }
 

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -15,9 +15,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use datafusion::common::{Column, JoinType, NullEquality, Result, TableReference};
+use datafusion::common::{
+    Column, JoinType, NullEquality, NullHandling, Result, TableReference, UnnestOptions,
+};
 use datafusion::error::DataFusionError;
-use datafusion::logical_expr::{BinaryExpr, Expr, LogicalPlanBuilder, Operator, col, lit};
+use datafusion::logical_expr::{
+    BinaryExpr, Expr, LogicalPlan, LogicalPlanBuilder, Operator, col, lit,
+};
 use datafusion::prelude::DataFrame;
 use pgrx::pg_sys;
 
@@ -544,11 +548,8 @@ pub fn build_join_df_with_filter(
 /// Apply a lateral unnest operation onto an existing DataFusion DataFrame.
 ///
 /// Resolves the source table's execution alias, applies DataFusion's `unnest_columns_with_options`
-/// (preserving empty arrays for LEFT joins if requested), and re-qualifies the unnested column.
+/// (preserving empty arrays for LEFT joins if requested).
 pub fn apply_relnode_unnest(df: DataFrame, unnest: &UnnestNode) -> Result<DataFrame> {
-    use datafusion::common::{NullHandling, UnnestOptions};
-
-    use datafusion::logical_expr::lit;
     use datafusion::scalar::ScalarValue;
 
     let source = unnest
@@ -595,34 +596,49 @@ pub fn apply_relnode_unnest(df: DataFrame, unnest: &UnnestNode) -> Result<DataFr
         };
     }
 
-    let select_exprs = df
+    let null_handling = if unnest.unnest_info.is_left_join {
+        NullHandling::PreserveAndExpandEmpty
+    } else {
+        NullHandling::Drop
+    };
+    let (session_state, plan) = df.into_parts();
+    let plan = unnest_plan_column(plan, &alias, &unnest.unnest_info.field_name, null_handling)?;
+    Ok(DataFrame::new(session_state, plan))
+}
+
+/// Unnest a single array column from `plan`, aliasing `{source_alias}.{field_name}` to `{source_alias}_{field_name}`
+/// before unnesting with the specified `null_handling`.
+pub fn unnest_plan_column(
+    plan: LogicalPlan,
+    source_alias: &str,
+    field_name: &str,
+    null_handling: NullHandling,
+) -> Result<LogicalPlan> {
+    let unnested_col_name = format!("{source_alias}_{field_name}");
+    let pre_project_exprs: Vec<Expr> = plan
         .schema()
         .iter()
         .map(|(qualifier, field)| {
-            if qualifier.as_ref().map(|q| q.to_string()) == Some(alias.clone())
-                && field.name() == &unnest.unnest_info.field_name
+            let col = Expr::Column(Column::new(qualifier.cloned(), field.name()));
+            if qualifier.as_ref().map(|q| q.to_string()).as_deref() == Some(source_alias)
+                && field.name() == field_name
             {
-                Expr::Column(datafusion::common::Column::new(
-                    qualifier.cloned(),
-                    field.name(),
-                ))
-                .alias(&unnested_col_name)
+                col.alias(&unnested_col_name)
             } else {
-                Expr::Column(datafusion::common::Column::new(
-                    qualifier.cloned(),
-                    field.name(),
-                ))
+                col
             }
         })
-        .collect::<Vec<_>>();
-    let df = df.select(select_exprs)?;
+        .collect();
 
-    let unnest_options = if unnest.unnest_info.is_left_join {
-        UnnestOptions::new().with_null_handling(NullHandling::PreserveAndExpandEmpty)
-    } else {
-        UnnestOptions::new().with_null_handling(NullHandling::Drop)
-    };
-    df.unnest_columns_with_options(&[&unnested_col_name], unnest_options)
+    let pre_unnest = LogicalPlanBuilder::from(plan)
+        .project(pre_project_exprs)?
+        .build()?;
+
+    let unnest_options = UnnestOptions::new().with_null_handling(null_handling);
+    let unnest_col = Column::from_name(&unnested_col_name);
+    LogicalPlanBuilder::from(pre_unnest)
+        .unnest_columns_with_options(vec![unnest_col], unnest_options)?
+        .build()
 }
 
 /// Deserialize a PostgreSQL expression from its `nodeToString` representation

--- a/pg_search/src/postgres/customscan/pullup.rs
+++ b/pg_search/src/postgres/customscan/pullup.rs
@@ -144,13 +144,34 @@ pub fn resolve_fast_field_by_name(
     let schema = index.schema().ok()?;
     let search_field = schema.search_field(field_name)?;
     if search_field.is_fast() {
-        Some(WhichFastField::Named(
-            field_name.to_string(),
-            search_field.field_type(),
-        ))
+        let is_array = schema
+            .categorized_fields()
+            .iter()
+            .find(|(sf, _)| sf == &search_field)
+            .map(|(_, data)| data.is_array)
+            .unwrap_or(false);
+        if is_array {
+            Some(WhichFastField::Array(
+                field_name.to_string(),
+                search_field.field_type(),
+            ))
+        } else {
+            Some(WhichFastField::Named(
+                field_name.to_string(),
+                search_field.field_type(),
+            ))
+        }
     } else {
         None
     }
+}
+
+/// Resolved index field metadata returned by [`resolve_index_field_by_name`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedIndexField {
+    pub attno: pg_sys::AttrNumber,
+    pub field_type: SearchFieldType,
+    pub is_array: bool,
 }
 
 /// Resolve an index field name, dotted for a JSON sub-field, to the heap column it
@@ -158,12 +179,12 @@ pub fn resolve_fast_field_by_name(
 /// has no such fast field, `Err` when it has one the scan cannot read, so the
 /// caller can say why rather than that the field does not exist. Resolution goes
 /// through the index schema because a field name can be an alias of a column.
-/// The gates match [`resolve_fast_field`]: an expression-indexed or array column
+/// The gates match [`resolve_fast_field`]: an expression-indexed column
 /// is turned down, and a JSON column is only reachable through a sub-field.
 pub fn resolve_index_field_by_name(
     index: &PgSearchRelation,
     field: &str,
-) -> Result<Option<(pg_sys::AttrNumber, SearchFieldType)>, String> {
+) -> Result<Option<ResolvedIndexField>, String> {
     let Some(schema) = index.schema().ok() else {
         return Ok(None);
     };
@@ -180,11 +201,6 @@ pub fn resolve_index_field_by_name(
             "Field '{field}' is an expression index, which cannot be read back as a column"
         ));
     };
-    if data.is_array {
-        return Err(format!(
-            "Field '{field}' is an array, which cannot be read as a single column"
-        ));
-    }
     let field_type = if field == root {
         match field_type_for_pullup(search_field.field_type(), false) {
             Some(field_type) => field_type,
@@ -199,7 +215,11 @@ pub fn resolve_index_field_by_name(
         check_json_sub_field_is_text(index, field)?;
         search_field.field_type()
     };
-    Ok(Some((attno as pg_sys::AttrNumber + 1, field_type)))
+    Ok(Some(ResolvedIndexField {
+        attno: attno as pg_sys::AttrNumber + 1,
+        field_type,
+        is_array: data.is_array,
+    }))
 }
 
 /// A columnar scan reads every JSON sub-field as text, while the index stores

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -511,39 +511,6 @@ pub unsafe fn find_one_var(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var> 
     }
 }
 
-/// Find an `Aggref` node in an expression tree using Postgres's `expression_tree_walker`
-/// for robust traversal through all wrapper types (RelabelType, CoerceViaIO, FuncExpr, etc.).
-pub unsafe fn find_one_aggref(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Aggref> {
-    #[pg_guard]
-    unsafe extern "C-unwind" fn walker(
-        node: *mut pg_sys::Node,
-        data: *mut core::ffi::c_void,
-    ) -> bool {
-        if node.is_null() {
-            return false;
-        }
-        if (*node).type_ == pg_sys::NodeTag::T_Aggref {
-            (*(data as *mut Data)).found = node as *mut pg_sys::Aggref;
-            return true;
-        }
-        expression_tree_walker(node, Some(walker), data)
-    }
-
-    struct Data {
-        found: *mut pg_sys::Aggref,
-    }
-
-    let mut data = Data {
-        found: std::ptr::null_mut(),
-    };
-    walker(node, addr_of_mut!(data).cast());
-    if data.found.is_null() {
-        None
-    } else {
-        Some(data.found)
-    }
-}
-
 /// Given a [`pg_sys::Node`] and a [`pg_sys::PlannerInfo`], attempt to find the [`pg_sys::Var`] and
 /// the [`FieldName`] that it references.
 ///

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -511,6 +511,39 @@ pub unsafe fn find_one_var(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var> 
     }
 }
 
+/// Find an `Aggref` node in an expression tree using Postgres's `expression_tree_walker`
+/// for robust traversal through all wrapper types (RelabelType, CoerceViaIO, FuncExpr, etc.).
+pub unsafe fn find_one_aggref(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Aggref> {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        data: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+        if (*node).type_ == pg_sys::NodeTag::T_Aggref {
+            (*(data as *mut Data)).found = node as *mut pg_sys::Aggref;
+            return true;
+        }
+        expression_tree_walker(node, Some(walker), data)
+    }
+
+    struct Data {
+        found: *mut pg_sys::Aggref,
+    }
+
+    let mut data = Data {
+        found: std::ptr::null_mut(),
+    };
+    walker(node, addr_of_mut!(data).cast());
+    if data.found.is_null() {
+        None
+    } else {
+        Some(data.found)
+    }
+}
+
 /// Given a [`pg_sys::Node`] and a [`pg_sys::PlannerInfo`], attempt to find the [`pg_sys::Var`] and
 /// the [`FieldName`] that it references.
 ///

--- a/pg_search/tests/pg_regress/expected/pdb_agg_datafusion.out
+++ b/pg_search/tests/pg_regress/expected/pdb_agg_datafusion.out
@@ -1010,6 +1010,40 @@ WHERE p.title @@@ 'post';
 (1 row)
 
 -- Test 6.3: outer scalar terms with inner array terms
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "a.name", "order": {"_key": "asc"}}, "aggs": {"by_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('pdb.agg'::text)
+   Backend: DataFusion
+   Indexes: pa_posts_idx (p), pa_authors_idx (a)
+   Aggregates: pdb.agg({"aggs":{"by_tag":{"terms":{"field":"p.tags","order":{"_key":"asc"}}}},"terms":{"field":"a.name","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : CoalescePartitionsExec
+     :   ProjectionExec: expr=[__grouping_id@2 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, __pdb_m0@3 as __pdb_m0]
+     :     UnionExec
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, NULL as __pdb_k1, CASE CAST(__grouping_id@1 AS UInt64) WHEN 1 THEN 3 WHEN 0 THEN 1 ELSE 0 END as __grouping_id, __pdb_m0@2 as __pdb_m0]
+     :         AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __grouping_id@1 as __grouping_id], aggr=[count(1) as __pdb_m0]
+     :           AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0), (name@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+     :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[name@1]
+     :               CooperativeExec
+     :                 PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :               CooperativeExec
+     :                 PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, 0 as __grouping_id, __pdb_m0@2 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[name@1 as __pdb_k0, p_0_tags@0 as __pdb_k1], aggr=[count(1) as __pdb_m0]
+     :           UnnestExec
+     :             ProjectionExec: expr=[tags@0 as p_0_tags, name@1 as name]
+     :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@3, name@1]
+     :                 CooperativeExec
+     :                   PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :                 CooperativeExec
+     :                   PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(26 rows)
+
 SELECT pdb.agg('{"terms": {"field": "a.name", "order": {"_key": "asc"}}, "aggs": {"by_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
@@ -1249,6 +1283,48 @@ WHERE p.title @@@ 'post';
                                                                                                          agg                                                                                                          
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"buckets": [{"key": "database", "doc_count": 3}, {"key": "postgres", "doc_count": 2}, {"key": "rust", "doc_count": 2}, {"key": "search", "doc_count": 1}, {"key": null, "doc_count": 2}], "sum_other_doc_count": 0}
+(1 row)
+
+-- Test 6.13: wrapped aggregate and JSON operator on pdb.agg over join
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COALESCE(SUM(p.views), 0), pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')->'buckets'
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: COALESCE(pdb.agg_fn('SUM'::text), '0'::bigint), (pdb.agg_fn('pdb.agg'::text) -> 'buckets'::text)
+   Backend: DataFusion
+   Indexes: pa_posts_idx (p), pa_authors_idx (a)
+   Aggregates: SUM(views), pdb.agg({"terms":{"field":"p.tags","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : CoalescePartitionsExec
+     :   ProjectionExec: expr=[agg_0@2 as agg_0, __grouping_id@1 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_m0@3 as __pdb_m0]
+     :     UnionExec
+     :       ProjectionExec: expr=[NULL as __pdb_k0, 1 as __grouping_id, agg_0@0 as agg_0, __pdb_m0@1 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[], aggr=[sum(p_0.views) as agg_0, count(1) as __pdb_m0]
+     :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[views@2]
+     :             CooperativeExec
+     :               PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :             CooperativeExec
+     :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, 0 as __grouping_id, agg_0@1 as agg_0, __pdb_m0@2 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[p_0_tags@0 as __pdb_k0], aggr=[sum(p_0.views) as agg_0, count(1) as __pdb_m0]
+     :           UnnestExec
+     :             ProjectionExec: expr=[tags@0 as p_0_tags, views@1 as views]
+     :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@2, views@3]
+     :                 CooperativeExec
+     :                   PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :                 CooperativeExec
+     :                   PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(25 rows)
+
+SELECT COALESCE(SUM(p.views), 0), pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')->'buckets'
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+ coalesce |                                                                                                       ?column?                                                                                                       
+----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      895 | {"buckets": [{"key": "database", "doc_count": 3}, {"key": "postgres", "doc_count": 2}, {"key": "rust", "doc_count": 2}, {"key": "search", "doc_count": 1}, {"key": null, "doc_count": 2}], "sum_other_doc_count": 0}
 (1 row)
 
 DROP TABLE pa_posts, pa_authors CASCADE;

--- a/pg_search/tests/pg_regress/expected/pdb_agg_datafusion.out
+++ b/pg_search/tests/pg_regress/expected/pdb_agg_datafusion.out
@@ -902,3 +902,247 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR keyboard';
 
 ROLLBACK;
 DROP TABLE pa_products, pa_tags CASCADE;
+-- =====================================================================
+-- SECTION 6: terms on array fields over joins
+-- =====================================================================
+SET max_parallel_workers_per_gather = 0;
+RESET paradedb.mpp_min_rows;
+DROP TABLE IF EXISTS pa_posts, pa_authors CASCADE;
+CREATE TABLE pa_authors (
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    reputation INTEGER,
+    tags TEXT[]
+);
+CREATE TABLE pa_posts (
+    id SERIAL PRIMARY KEY,
+    author_id INTEGER,
+    title TEXT,
+    category TEXT,
+    tags TEXT[],
+    views INTEGER
+);
+CREATE INDEX pa_authors_idx ON pa_authors
+USING paradedb (id, name, reputation, tags)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "name": {"fast": true},
+        "tags": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }',
+    numeric_fields = '{"reputation": {"fast": true}}'
+);
+CREATE INDEX pa_posts_idx ON pa_posts
+USING paradedb (id, author_id, title, category, tags, views)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"author_id": {"fast": true}, "views": {"fast": true}}',
+    text_fields = '{
+        "title": {},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "tags": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }'
+);
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO pa_authors (name, reputation, tags) VALUES
+    ('Alice', 100, ARRAY['admin', 'moderator']),
+    ('Bob', 80, ARRAY['writer']),
+    ('Charlie', 50, NULL);
+INSERT INTO pa_posts (author_id, title, category, tags, views) VALUES
+    (1, 'Post about databases and rust', 'tech', ARRAY['database', 'rust'], 150),
+    (1, 'Another post on rust', 'tech', ARRAY['rust'], 200),
+    (1, 'Post with empty tags', 'tech', ARRAY[]::TEXT[], 50),
+    (2, 'Post with null tags', 'tech', NULL, 75),
+    (2, 'Post about database indexing', 'db', ARRAY['database', 'postgres'], 300),
+    (3, 'Post with multiple tags', 'db', ARRAY['database', 'postgres', 'search'], 120);
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE pa_authors;
+ANALYZE pa_posts;
+-- Test 6.1: terms on array field over join (explain + execute)
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('pdb.agg'::text)
+   Backend: DataFusion
+   Indexes: pa_posts_idx (p), pa_authors_idx (a)
+   Aggregates: pdb.agg({"terms":{"field":"p.tags","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : ProjectionExec: expr=[__grouping_id@1 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_m0@2 as __pdb_m0]
+     :   AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __grouping_id@1 as __grouping_id], aggr=[count(1) as __pdb_m0]
+     :     AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0), (tags@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+     :       ProjectionExec: expr=[p_0_tags@0 as tags]
+     :         UnnestExec
+     :           ProjectionExec: expr=[tags@0 as p_0_tags]
+     :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@2]
+     :               CooperativeExec
+     :                 PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :               CooperativeExec
+     :                 PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
+
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                         agg                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "database", "doc_count": 3}, {"key": "postgres", "doc_count": 2}, {"key": "rust", "doc_count": 2}, {"key": "search", "doc_count": 1}, {"key": null, "doc_count": 2}], "sum_other_doc_count": 0}
+(1 row)
+
+-- Test 6.2: terms on array field with metric sub-aggregations
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}, "aggs": {"avg_views": {"avg": {"field": "p.views"}}, "total_views": {"sum": {"field": "p.views"}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                                                                                                                                                                                         agg                                                                                                                                                                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "database", "avg_views": {"value": 190.0}, "doc_count": 3, "total_views": {"value": 570.0}}, {"key": "postgres", "avg_views": {"value": 210.0}, "doc_count": 2, "total_views": {"value": 420.0}}, {"key": "rust", "avg_views": {"value": 175.0}, "doc_count": 2, "total_views": {"value": 350.0}}, {"key": "search", "avg_views": {"value": 120.0}, "doc_count": 1, "total_views": {"value": 120.0}}, {"key": null, "avg_views": {"value": 62.5}, "doc_count": 2, "total_views": {"value": 125.0}}], "sum_other_doc_count": 0}
+(1 row)
+
+-- Test 6.3: outer scalar terms with inner array terms
+SELECT pdb.agg('{"terms": {"field": "a.name", "order": {"_key": "asc"}}, "aggs": {"by_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                                                                                                                                                                                                                                agg                                                                                                                                                                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "Alice", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 4}, {"key": "Bob", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 3}, {"key": "Charlie", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 3}], "sum_other_doc_count": 0}
+(1 row)
+
+-- Test 6.4: outer array terms with inner scalar terms
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}, "aggs": {"by_author": {"terms": {"field": "a.name", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                                                                                                                                                                                                                                                                                                                         agg                                                                                                                                                                                                                                                                                                                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "database", "by_author": {"buckets": [{"key": "Alice", "doc_count": 1}, {"key": "Bob", "doc_count": 1}, {"key": "Charlie", "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 3}, {"key": "postgres", "by_author": {"buckets": [{"key": "Bob", "doc_count": 1}, {"key": "Charlie", "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 2}, {"key": "rust", "by_author": {"buckets": [{"key": "Alice", "doc_count": 2}], "sum_other_doc_count": 0}, "doc_count": 2}, {"key": "search", "by_author": {"buckets": [{"key": "Charlie", "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 1}, {"key": null, "by_author": {"buckets": [{"key": "Alice", "doc_count": 1}, {"key": "Bob", "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 2}], "sum_other_doc_count": 0}
+(1 row)
+
+-- Test 6.5: array terms with size and min_doc_count
+SELECT pdb.agg('{"terms": {"field": "p.tags", "size": 2, "min_doc_count": 2, "order": {"_count": "desc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                         agg                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "database", "doc_count": 3}, {"key": "postgres", "doc_count": 2}], "sum_other_doc_count": 4, "doc_count_error_upper_bound": 0}
+(1 row)
+
+-- Test 6.6: array terms alongside SQL GROUP BY and standard aggregates
+SELECT a.name, COUNT(*), pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}') AS tags
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post'
+GROUP BY a.name
+ORDER BY a.name;
+  name   | count |                                                                         tags                                                                         
+---------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Alice   |     4 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}
+ Bob     |     3 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}
+ Charlie |     3 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}
+(3 rows)
+
+-- Test 6.7: metric aggregation on array field returns an error
+SELECT pdb.agg('{"sum": {"field": "p.tags"}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+ERROR:  Cannot execute pdb.agg: field 'p.tags' must be a numeric or date field for this metric aggregation
+-- Test 6.8: nested terms over multiple array fields across joins (sequential unnesting)
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "a.tags", "order": {"_key": "asc"}}, "aggs": {"by_post_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('pdb.agg'::text)
+   Backend: DataFusion
+   Indexes: pa_posts_idx (p), pa_authors_idx (a)
+   Aggregates: pdb.agg({"aggs":{"by_post_tag":{"terms":{"field":"p.tags","order":{"_key":"asc"}}}},"terms":{"field":"a.tags","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : ProjectionExec: expr=[__grouping_id@2 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, __pdb_m0@3 as __pdb_m0]
+     :   AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, __grouping_id@2 as __grouping_id], aggr=[count(1) as __pdb_m0]
+     :     AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0, NULL as __pdb_k1), (tags@1 as __pdb_k0, NULL as __pdb_k1), (tags@1 as __pdb_k0, tags@0 as __pdb_k1)], aggr=[count(1) as __pdb_m0]
+     :       ProjectionExec: expr=[p_0_tags@0 as tags, a_1_tags@1 as tags]
+     :         UnnestExec
+     :           UnnestExec
+     :             ProjectionExec: expr=[tags@0 as p_0_tags, tags@1 as a_1_tags]
+     :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@3, tags@1]
+     :                 CooperativeExec
+     :                   PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :                 CooperativeExec
+     :                   PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT pdb.agg('{"terms": {"field": "a.tags", "order": {"_key": "asc"}}, "aggs": {"by_post_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+                                                                                                                                                                                                                                                                                                                                                                                                                        agg                                                                                                                                                                                                                                                                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "admin", "doc_count": 4, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": "moderator", "doc_count": 4, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": "writer", "doc_count": 3, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": null, "doc_count": 3, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}}], "sum_other_doc_count": 0}
+(1 row)
+
+-- Test 6.9: single-table pdb.agg on array field stays on Tantivy even when
+-- ORDER BY aggregate and LIMIT would otherwise favor DataFusion
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, COUNT(*), pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category
+ORDER BY COUNT(*) DESC
+LIMIT 5;
+                                                                                               QUERY PLAN                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: category, (pdb.agg_fn('COUNT(*)'::text)), (pdb.agg_fn('pdb.agg'::text))
+   ->  Sort
+         Output: category, (pdb.agg_fn('COUNT(*)'::text)), (pdb.agg_fn('pdb.agg'::text))
+         Sort Key: (pdb.agg_fn('COUNT(*)'::text)) DESC
+         ->  Custom Scan (ParadeDB Aggregate Scan) on public.pa_posts
+               Output: category, pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('pdb.agg'::text)
+               Index: pa_posts_idx
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+                 Applies to Aggregates: COUNT(*), CUSTOM_AGG({"terms":{"field":"tags","order":{"_key":"asc"}}})
+                 Group By: category
+                 Limit: 5
+                 TopK Order: COUNT(*) DESC
+                 Aggregate Definition: {"grouped":{"aggs":{"0":{"terms":{"field":"tags","order":{"_key":"asc"}}}},"terms":{"field":"category","order":{"_count":"desc"},"segment_size":65000,"size":5}}}
+(14 rows)
+
+SELECT category, COUNT(*), pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category
+ORDER BY COUNT(*) DESC
+LIMIT 5;
+ category | count |                                                                         agg                                                                          
+----------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------
+ tech     |     4 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 2}], "sum_other_doc_count": 0}
+ db       |     2 | {"buckets": [{"key": "database", "doc_count": 2}, {"key": "postgres", "doc_count": 2}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}
+(2 rows)
+
+-- Test 6.10: single-table pdb.agg on array field stays on Tantivy when
+-- bucket limit is exceeded, because array unnesting cannot lower to DataFusion
+SET paradedb.max_term_agg_buckets TO 1;
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.pa_posts
+   Output: category, pdb.agg_fn('pdb.agg'::text)
+   Index: pa_posts_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: CUSTOM_AGG({"terms":{"field":"tags","order":{"_key":"asc"}}})
+     Group By: category
+     Aggregate Definition: {"grouped":{"aggs":{"0":{"terms":{"field":"tags","order":{"_key":"asc"}}}},"terms":{"field":"category","segment_size":1,"size":1}}}
+(7 rows)
+
+SELECT category, pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category;
+ERROR:  Failed to execute filter aggregation: Aborting aggregation because bucket limit was exceeded. Limit: 1, Current: 4
+RESET paradedb.max_term_agg_buckets;
+DROP TABLE pa_posts, pa_authors CASCADE;

--- a/pg_search/tests/pg_regress/expected/pdb_agg_datafusion.out
+++ b/pg_search/tests/pg_regress/expected/pdb_agg_datafusion.out
@@ -963,26 +963,34 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
 SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('pdb.agg'::text)
    Backend: DataFusion
    Indexes: pa_posts_idx (p), pa_authors_idx (a)
    Aggregates: pdb.agg({"terms":{"field":"p.tags","order":{"_key":"asc"}}})
    DataFusion Physical Plan: 
-     : ProjectionExec: expr=[__grouping_id@1 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_m0@2 as __pdb_m0]
-     :   AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __grouping_id@1 as __grouping_id], aggr=[count(1) as __pdb_m0]
-     :     AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0), (tags@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
-     :       ProjectionExec: expr=[p_0_tags@0 as tags]
-     :         UnnestExec
-     :           ProjectionExec: expr=[tags@0 as p_0_tags]
-     :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@2]
-     :               CooperativeExec
-     :                 PgSearchScan: table=a, segments=1, visibility=eager, query="all"
-     :               CooperativeExec
-     :                 PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
-(17 rows)
+     : CoalescePartitionsExec
+     :   ProjectionExec: expr=[__grouping_id@1 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_m0@2 as __pdb_m0]
+     :     UnionExec
+     :       ProjectionExec: expr=[NULL as __pdb_k0, 1 as __grouping_id, __pdb_m0@0 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[], aggr=[count(1) as __pdb_m0]
+     :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[]
+     :             CooperativeExec
+     :               PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :             CooperativeExec
+     :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, 0 as __grouping_id, __pdb_m0@1 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[p_0_tags@0 as __pdb_k0], aggr=[count(1) as __pdb_m0]
+     :           UnnestExec
+     :             ProjectionExec: expr=[tags@0 as p_0_tags]
+     :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@2]
+     :                 CooperativeExec
+     :                   PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :                 CooperativeExec
+     :                   PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(25 rows)
 
 SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
@@ -1007,7 +1015,7 @@ FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
                                                                                                                                                                                                                                                                                                                 agg                                                                                                                                                                                                                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"buckets": [{"key": "Alice", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 4}, {"key": "Bob", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 3}, {"key": "Charlie", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 3}], "sum_other_doc_count": 0}
+ {"buckets": [{"key": "Alice", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 3}, {"key": "Bob", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 2}, {"key": "Charlie", "by_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}, "doc_count": 1}], "sum_other_doc_count": 0}
 (1 row)
 
 -- Test 6.4: outer array terms with inner scalar terms
@@ -1036,9 +1044,9 @@ GROUP BY a.name
 ORDER BY a.name;
   name   | count |                                                                         tags                                                                         
 ---------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------
- Alice   |     4 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}
- Bob     |     3 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}
- Charlie |     3 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}
+ Alice   |     3 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}
+ Bob     |     2 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}
+ Charlie |     1 | {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}
 (3 rows)
 
 -- Test 6.7: metric aggregation on array field returns an error
@@ -1046,39 +1054,61 @@ SELECT pdb.agg('{"sum": {"field": "p.tags"}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
 ERROR:  Cannot execute pdb.agg: field 'p.tags' must be a numeric or date field for this metric aggregation
+SELECT pdb.agg('{"cardinality": {"field": "p.tags"}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+ERROR:  Cannot execute pdb.agg: Field 'p.tags' is an array, which cannot be used in a `cardinality` metric aggregation
 -- Test 6.8: nested terms over multiple array fields across joins (sequential unnesting)
 EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
 SELECT pdb.agg('{"terms": {"field": "a.tags", "order": {"_key": "asc"}}, "aggs": {"by_post_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
-                                                                                                             QUERY PLAN                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('pdb.agg'::text)
    Backend: DataFusion
    Indexes: pa_posts_idx (p), pa_authors_idx (a)
    Aggregates: pdb.agg({"aggs":{"by_post_tag":{"terms":{"field":"p.tags","order":{"_key":"asc"}}}},"terms":{"field":"a.tags","order":{"_key":"asc"}}})
    DataFusion Physical Plan: 
-     : ProjectionExec: expr=[__grouping_id@2 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, __pdb_m0@3 as __pdb_m0]
-     :   AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, __grouping_id@2 as __grouping_id], aggr=[count(1) as __pdb_m0]
-     :     AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0, NULL as __pdb_k1), (tags@1 as __pdb_k0, NULL as __pdb_k1), (tags@1 as __pdb_k0, tags@0 as __pdb_k1)], aggr=[count(1) as __pdb_m0]
-     :       ProjectionExec: expr=[p_0_tags@0 as tags, a_1_tags@1 as tags]
-     :         UnnestExec
+     : CoalescePartitionsExec
+     :   ProjectionExec: expr=[__grouping_id@2 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, __pdb_m0@3 as __pdb_m0]
+     :     UnionExec
+     :       ProjectionExec: expr=[NULL as __pdb_k0, NULL as __pdb_k1, 3 as __grouping_id, __pdb_m0@0 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[], aggr=[count(1) as __pdb_m0]
+     :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[]
+     :             CooperativeExec
+     :               PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :             CooperativeExec
+     :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, NULL as __pdb_k1, 1 as __grouping_id, __pdb_m0@1 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[a_1_tags@0 as __pdb_k0], aggr=[count(1) as __pdb_m0]
      :           UnnestExec
-     :             ProjectionExec: expr=[tags@0 as p_0_tags, tags@1 as a_1_tags]
-     :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@3, tags@1]
+     :             ProjectionExec: expr=[tags@0 as a_1_tags]
+     :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@1]
      :                 CooperativeExec
      :                   PgSearchScan: table=a, segments=1, visibility=eager, query="all"
      :                 CooperativeExec
      :                   PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+     :       ProjectionExec: expr=[__pdb_k0@0 as __pdb_k0, __pdb_k1@1 as __pdb_k1, 0 as __grouping_id, __pdb_m0@2 as __pdb_m0]
+     :         AggregateExec: mode=Single, gby=[a_1_tags@1 as __pdb_k0, p_0_tags@0 as __pdb_k1], aggr=[count(1) as __pdb_m0]
+     :           UnnestExec
+     :             ProjectionExec: expr=[tags@0 as p_0_tags, a_1_tags@1 as a_1_tags]
+     :               UnnestExec
+     :                 ProjectionExec: expr=[tags@0 as tags, tags@1 as a_1_tags]
+     :                   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@3, tags@1]
+     :                     CooperativeExec
+     :                       PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :                     CooperativeExec
+     :                       PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(36 rows)
 
 SELECT pdb.agg('{"terms": {"field": "a.tags", "order": {"_key": "asc"}}, "aggs": {"by_post_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
                                                                                                                                                                                                                                                                                                                                                                                                                         agg                                                                                                                                                                                                                                                                                                                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"buckets": [{"key": "admin", "doc_count": 4, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": "moderator", "doc_count": 4, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": "writer", "doc_count": 3, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": null, "doc_count": 3, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}}], "sum_other_doc_count": 0}
+ {"buckets": [{"key": "admin", "doc_count": 3, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": "moderator", "doc_count": 3, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "rust", "doc_count": 2}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": "writer", "doc_count": 2, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0}}, {"key": null, "doc_count": 1, "by_post_tag": {"buckets": [{"key": "database", "doc_count": 1}, {"key": "postgres", "doc_count": 1}, {"key": "search", "doc_count": 1}], "sum_other_doc_count": 0}}], "sum_other_doc_count": 0}
 (1 row)
 
 -- Test 6.9: single-table pdb.agg on array field stays on Tantivy even when
@@ -1145,4 +1175,80 @@ WHERE title @@@ 'post'
 GROUP BY category;
 ERROR:  Failed to execute filter aggregation: Aborting aggregation because bucket limit was exceeded. Limit: 1, Current: 4
 RESET paradedb.max_term_agg_buckets;
+-- Test 6.11: plain GROUP BY on array field over join runs on DataFusion
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.tags, COUNT(*)
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post'
+GROUP BY p.tags
+ORDER BY p.tags;
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: p.tags, (count(*))
+   Sort Key: p.tags
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Output: p.tags, (count(*))
+         Backend: DataFusion
+         Indexes: pa_posts_idx (p), pa_authors_idx (a)
+         Group By: tags
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : AggregateExec: mode=Single, gby=[tags@0 as tags], aggr=[count(1) as agg_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@2]
+           :     CooperativeExec
+           :       PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+           :     CooperativeExec
+           :       PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
+
+SELECT p.tags, COUNT(*)
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post'
+GROUP BY p.tags
+ORDER BY p.tags;
+            tags            | count 
+----------------------------+-------
+ {database,postgres}        |     1
+ {database,postgres,search} |     1
+ {database,rust}            |     1
+ {rust}                     |     1
+                            |     2
+(5 rows)
+
+-- Test 6.12: pdb.agg terms on a key that is also LATERAL unnested in FROM
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+LEFT JOIN LATERAL unnest(p.tags) AS u(tag) ON true
+WHERE p.title @@@ 'post';
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('pdb.agg'::text)
+   Backend: DataFusion
+   Indexes: pa_posts_idx (p), pa_authors_idx (a)
+   Aggregates: pdb.agg({"terms":{"field":"p.tags","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : ProjectionExec: expr=[__grouping_id@1 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_m0@2 as __pdb_m0]
+     :   AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __grouping_id@1 as __grouping_id], aggr=[count(1) as __pdb_m0]
+     :     AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0), (p_0_tags@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+     :       UnnestExec
+     :         ProjectionExec: expr=[tags@0 as p_0_tags]
+     :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, author_id@0)], projection=[tags@2]
+     :             CooperativeExec
+     :               PgSearchScan: table=a, segments=1, visibility=eager, query="all"
+     :             CooperativeExec
+     :               PgSearchScan: table=p, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"post","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
+
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+LEFT JOIN LATERAL unnest(p.tags) AS u(tag) ON true
+WHERE p.title @@@ 'post';
+                                                                                                         agg                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "database", "doc_count": 3}, {"key": "postgres", "doc_count": 2}, {"key": "rust", "doc_count": 2}, {"key": "search", "doc_count": 1}, {"key": null, "doc_count": 2}], "sum_other_doc_count": 0}
+(1 row)
+
 DROP TABLE pa_posts, pa_authors CASCADE;

--- a/pg_search/tests/pg_regress/sql/pdb_agg_datafusion.sql
+++ b/pg_search/tests/pg_regress/sql/pdb_agg_datafusion.sql
@@ -510,3 +510,157 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR keyboard';
 ROLLBACK;
 
 DROP TABLE pa_products, pa_tags CASCADE;
+
+-- =====================================================================
+-- SECTION 6: terms on array fields over joins
+-- =====================================================================
+
+SET max_parallel_workers_per_gather = 0;
+RESET paradedb.mpp_min_rows;
+
+DROP TABLE IF EXISTS pa_posts, pa_authors CASCADE;
+CREATE TABLE pa_authors (
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    reputation INTEGER,
+    tags TEXT[]
+);
+CREATE TABLE pa_posts (
+    id SERIAL PRIMARY KEY,
+    author_id INTEGER,
+    title TEXT,
+    category TEXT,
+    tags TEXT[],
+    views INTEGER
+);
+
+CREATE INDEX pa_authors_idx ON pa_authors
+USING paradedb (id, name, reputation, tags)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "name": {"fast": true},
+        "tags": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }',
+    numeric_fields = '{"reputation": {"fast": true}}'
+);
+
+CREATE INDEX pa_posts_idx ON pa_posts
+USING paradedb (id, author_id, title, category, tags, views)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"author_id": {"fast": true}, "views": {"fast": true}}',
+    text_fields = '{
+        "title": {},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "tags": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }'
+);
+
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO pa_authors (name, reputation, tags) VALUES
+    ('Alice', 100, ARRAY['admin', 'moderator']),
+    ('Bob', 80, ARRAY['writer']),
+    ('Charlie', 50, NULL);
+
+INSERT INTO pa_posts (author_id, title, category, tags, views) VALUES
+    (1, 'Post about databases and rust', 'tech', ARRAY['database', 'rust'], 150),
+    (1, 'Another post on rust', 'tech', ARRAY['rust'], 200),
+    (1, 'Post with empty tags', 'tech', ARRAY[]::TEXT[], 50),
+    (2, 'Post with null tags', 'tech', NULL, 75),
+    (2, 'Post about database indexing', 'db', ARRAY['database', 'postgres'], 300),
+    (3, 'Post with multiple tags', 'db', ARRAY['database', 'postgres', 'search'], 120);
+
+RESET paradedb.global_mutable_segment_rows;
+
+ANALYZE pa_authors;
+ANALYZE pa_posts;
+
+-- Test 6.1: terms on array field over join (explain + execute)
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+-- Test 6.2: terms on array field with metric sub-aggregations
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}, "aggs": {"avg_views": {"avg": {"field": "p.views"}}, "total_views": {"sum": {"field": "p.views"}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+-- Test 6.3: outer scalar terms with inner array terms
+SELECT pdb.agg('{"terms": {"field": "a.name", "order": {"_key": "asc"}}, "aggs": {"by_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+-- Test 6.4: outer array terms with inner scalar terms
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}, "aggs": {"by_author": {"terms": {"field": "a.name", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+-- Test 6.5: array terms with size and min_doc_count
+SELECT pdb.agg('{"terms": {"field": "p.tags", "size": 2, "min_doc_count": 2, "order": {"_count": "desc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+-- Test 6.6: array terms alongside SQL GROUP BY and standard aggregates
+SELECT a.name, COUNT(*), pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}') AS tags
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post'
+GROUP BY a.name
+ORDER BY a.name;
+
+-- Test 6.7: metric aggregation on array field returns an error
+SELECT pdb.agg('{"sum": {"field": "p.tags"}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+-- Test 6.8: nested terms over multiple array fields across joins (sequential unnesting)
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "a.tags", "order": {"_key": "asc"}}, "aggs": {"by_post_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+SELECT pdb.agg('{"terms": {"field": "a.tags", "order": {"_key": "asc"}}, "aggs": {"by_post_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+-- Test 6.9: single-table pdb.agg on array field stays on Tantivy even when
+-- ORDER BY aggregate and LIMIT would otherwise favor DataFusion
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, COUNT(*), pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category
+ORDER BY COUNT(*) DESC
+LIMIT 5;
+
+SELECT category, COUNT(*), pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category
+ORDER BY COUNT(*) DESC
+LIMIT 5;
+
+-- Test 6.10: single-table pdb.agg on array field stays on Tantivy when
+-- bucket limit is exceeded, because array unnesting cannot lower to DataFusion
+SET paradedb.max_term_agg_buckets TO 1;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT category, pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category;
+
+SELECT category, pdb.agg('{"terms": {"field": "tags", "order": {"_key": "asc"}}}')
+FROM pa_posts
+WHERE title @@@ 'post'
+GROUP BY category;
+
+RESET paradedb.max_term_agg_buckets;
+
+DROP TABLE pa_posts, pa_authors CASCADE;

--- a/pg_search/tests/pg_regress/sql/pdb_agg_datafusion.sql
+++ b/pg_search/tests/pg_regress/sql/pdb_agg_datafusion.sql
@@ -619,6 +619,10 @@ SELECT pdb.agg('{"sum": {"field": "p.tags"}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
 
+SELECT pdb.agg('{"cardinality": {"field": "p.tags"}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
 -- Test 6.8: nested terms over multiple array fields across joins (sequential unnesting)
 EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
 SELECT pdb.agg('{"terms": {"field": "a.tags", "order": {"_key": "asc"}}, "aggs": {"by_post_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
@@ -662,5 +666,31 @@ WHERE title @@@ 'post'
 GROUP BY category;
 
 RESET paradedb.max_term_agg_buckets;
+
+-- Test 6.11: plain GROUP BY on array field over join runs on DataFusion
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.tags, COUNT(*)
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post'
+GROUP BY p.tags
+ORDER BY p.tags;
+
+SELECT p.tags, COUNT(*)
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post'
+GROUP BY p.tags
+ORDER BY p.tags;
+
+-- Test 6.12: pdb.agg terms on a key that is also LATERAL unnested in FROM
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+LEFT JOIN LATERAL unnest(p.tags) AS u(tag) ON true
+WHERE p.title @@@ 'post';
+
+SELECT pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+LEFT JOIN LATERAL unnest(p.tags) AS u(tag) ON true
+WHERE p.title @@@ 'post';
 
 DROP TABLE pa_posts, pa_authors CASCADE;

--- a/pg_search/tests/pg_regress/sql/pdb_agg_datafusion.sql
+++ b/pg_search/tests/pg_regress/sql/pdb_agg_datafusion.sql
@@ -593,6 +593,11 @@ FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
 
 -- Test 6.3: outer scalar terms with inner array terms
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "a.name", "order": {"_key": "asc"}}, "aggs": {"by_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
 SELECT pdb.agg('{"terms": {"field": "a.name", "order": {"_key": "asc"}}, "aggs": {"by_tag": {"terms": {"field": "p.tags", "order": {"_key": "asc"}}}}}')
 FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 WHERE p.title @@@ 'post';
@@ -693,4 +698,15 @@ FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
 LEFT JOIN LATERAL unnest(p.tags) AS u(tag) ON true
 WHERE p.title @@@ 'post';
 
+-- Test 6.13: wrapped aggregate and JSON operator on pdb.agg over join
+EXPLAIN (FORMAT TEXT, COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COALESCE(SUM(p.views), 0), pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')->'buckets'
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
+SELECT COALESCE(SUM(p.views), 0), pdb.agg('{"terms": {"field": "p.tags", "order": {"_key": "asc"}}}')->'buckets'
+FROM pa_posts p JOIN pa_authors a ON p.author_id = a.id
+WHERE p.title @@@ 'post';
+
 DROP TABLE pa_posts, pa_authors CASCADE;
+

--- a/tests/src/fixtures/querygen/mod.rs
+++ b/tests/src/fixtures/querygen/mod.rs
@@ -804,6 +804,23 @@ impl Sides {
     }
 }
 
+/// Which side of a query comparison is currently being executed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum QuerySide {
+    Baseline,
+    Candidate,
+}
+
+impl QuerySide {
+    pub fn is_candidate(self) -> bool {
+        self == Self::Candidate
+    }
+
+    pub fn is_baseline(self) -> bool {
+        self == Self::Baseline
+    }
+}
+
 /// Run one generated case on `conn`: execute `pg_query` (custom scan off, the known-correct
 /// baseline) and `bm25_query` (with `gucs`), then compare their results.
 pub fn compare_outcome<R, F>(
@@ -816,7 +833,7 @@ pub fn compare_outcome<R, F>(
 ) -> CaseOutcome
 where
     R: Eq + Debug,
-    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+    F: Fn(&str, QuerySide, &mut PgConnection) -> Result<R, sqlx::Error>,
 {
     let sides = Sides::postgres_vs(gucs);
     compare_outcome_on(&sides, pg_query, bm25_query, gucs, conn, setup, run_query)
@@ -835,7 +852,7 @@ pub fn compare_outcome_on<R, F>(
 ) -> CaseOutcome
 where
     R: Eq + Debug,
-    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+    F: Fn(&str, QuerySide, &mut PgConnection) -> Result<R, sqlx::Error>,
 {
     // A panic (vs a returned sqlx::Error) still becomes a Failure, so it trips the oracle and
     // carries a repro script instead of aborting the driver.
@@ -876,7 +893,7 @@ pub fn compare_outcome_retrying<R, F>(
 ) -> CaseOutcome
 where
     R: Eq + Debug,
-    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+    F: Fn(&str, QuerySide, &mut PgConnection) -> Result<R, sqlx::Error>,
 {
     let sides = Sides::postgres_vs(gucs);
     compare_outcome_retrying_on(&sides, pg_query, bm25_query, gucs, pool, setup, run_query)
@@ -894,7 +911,7 @@ pub fn compare_outcome_retrying_on<R, F>(
 ) -> CaseOutcome
 where
     R: Eq + Debug,
-    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+    F: Fn(&str, QuerySide, &mut PgConnection) -> Result<R, sqlx::Error>,
 {
     use crate::fixtures::fault_grace::{Attempt, RetryError};
     let fail = |msg: String| {
@@ -933,7 +950,7 @@ fn compare_outcome_inner<R, F>(
 ) -> CaseOutcome
 where
     R: Eq + Debug,
-    F: Fn(&str, &mut PgConnection) -> Result<R, sqlx::Error>,
+    F: Fn(&str, QuerySide, &mut PgConnection) -> Result<R, sqlx::Error>,
 {
     let mut queries = || -> Result<(R, R), sqlx::Error> {
         sides
@@ -941,14 +958,14 @@ where
             .as_str()
             .execute_result(conn)
             .and_then(|()| conn.deallocate_all())?;
-        let pg_result = run_query(pg_query, conn)?;
+        let pg_result = run_query(pg_query, QuerySide::Baseline, conn)?;
 
         sides
             .candidate
             .as_str()
             .execute_result(conn)
             .and_then(|()| conn.deallocate_all())?;
-        let bm25_result = run_query(bm25_query, conn)?;
+        let bm25_result = run_query(bm25_query, QuerySide::Candidate, conn)?;
         Ok((pg_result, bm25_result))
     };
     let (pg_result, bm25_result) = match queries() {
@@ -1020,9 +1037,14 @@ where
     R: Eq + Debug,
     F: Fn(&str, &mut PgConnection) -> R,
 {
-    match compare_outcome(pg_query, bm25_query, gucs, conn, setup, |query, conn| {
-        Ok::<R, sqlx::Error>(run_query(query, conn))
-    }) {
+    match compare_outcome(
+        pg_query,
+        bm25_query,
+        gucs,
+        conn,
+        setup,
+        |query, _side, conn| Ok::<R, sqlx::Error>(run_query(query, conn)),
+    ) {
         // run_query panics on DB errors here, so a `Transient` means the GUC set failed (and a
         // plain `cargo test` never classifies anything transient anyway).
         CaseOutcome::Transient(_, e) => Err(handle_compare_error(

--- a/tests/src/fixtures/querygen/pdbagggen.rs
+++ b/tests/src/fixtures/querygen/pdbagggen.rs
@@ -83,11 +83,52 @@ pub struct PdbTerm {
     pub is_array: bool,
 }
 
+impl PdbTerm {
+    pub fn sql_key(&self) -> String {
+        if self.is_array {
+            format!("_{}", self.field.replace('.', "_"))
+        } else {
+            self.field.clone()
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OuterAggKind {
+    CountStar,
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OuterAgg {
+    pub kind: OuterAggKind,
+    pub field: Option<String>,
+}
+
+impl OuterAgg {
+    pub fn sql(&self) -> String {
+        match self.kind {
+            OuterAggKind::CountStar => "COUNT(*)".to_string(),
+            OuterAggKind::Count => format!("COUNT({})", self.field.as_ref().unwrap()),
+            OuterAggKind::Sum => format!("SUM({})", self.field.as_ref().unwrap()),
+            OuterAggKind::Avg => format!("AVG({})", self.field.as_ref().unwrap()),
+            OuterAggKind::Min => format!("MIN({})", self.field.as_ref().unwrap()),
+            OuterAggKind::Max => format!("MAX({})", self.field.as_ref().unwrap()),
+        }
+    }
+}
+
 /// One `pdb.agg()` call and the shape of its result.
 #[derive(Clone, Debug)]
 pub struct PdbAggExpr {
     /// A SQL `GROUP BY` column beside the call, which becomes the root grouping set.
     pub outer_group: Option<String>,
+    /// SQL aggregates beside the call.
+    pub outer_aggs: Vec<OuterAgg>,
     /// `terms` levels, outermost first. Empty for a spec that is one metric.
     pub terms: Vec<PdbTerm>,
     /// A `size` cut on one level, under the default `_count desc` order.
@@ -145,13 +186,42 @@ impl PdbAggExpr {
 
     pub fn pdb_query(&self, from_clause: &str, where_clause: &str) -> String {
         let call = self.call();
+        let mut select = Vec::new();
+        if let Some(group) = &self.outer_group {
+            select.push(group.clone());
+        }
+        for agg in &self.outer_aggs {
+            select.push(agg.sql());
+        }
+        select.push(call);
+        let select_clause = select.join(", ");
         match &self.outer_group {
             Some(group) => {
                 format!(
-                    "SELECT {group}, {call} {from_clause} WHERE {where_clause} GROUP BY {group}"
+                    "SELECT {select_clause} {from_clause} WHERE {where_clause} GROUP BY {group}"
                 )
             }
-            None => format!("SELECT {call} {from_clause} WHERE {where_clause}"),
+            None => format!("SELECT {select_clause} {from_clause} WHERE {where_clause}"),
+        }
+    }
+
+    /// The outer group and outer aggregates without unnesting.
+    pub fn pg_outer_query(&self, from_clause: &str, where_clause: &str) -> String {
+        let mut select = Vec::new();
+        if let Some(group) = &self.outer_group {
+            select.push(group.clone());
+        }
+        for agg in &self.outer_aggs {
+            select.push(agg.sql());
+        }
+        let select_clause = select.join(", ");
+        match &self.outer_group {
+            Some(group) => {
+                format!(
+                    "SELECT {select_clause} {from_clause} WHERE {where_clause} GROUP BY {group}"
+                )
+            }
+            None => format!("SELECT {select_clause} {from_clause} WHERE {where_clause}"),
         }
     }
 
@@ -163,7 +233,7 @@ impl PdbAggExpr {
         let mut keys: Vec<String> = self.outer_group.iter().cloned().collect();
         for term in &self.terms {
             if term.is_array {
-                let alias = format!("_{}", term.field.replace('.', "_"));
+                let alias = term.sql_key();
                 // Tantivy and DataFusion (via PreserveAndExpandEmpty) preserve documents
                 // with empty or NULL arrays, assigning them to the NULL/missing bucket
                 // rather than discarding them from the query or outer groupings.
@@ -190,16 +260,24 @@ impl PdbAggExpr {
         if let Some((cut_level, size)) = self.size {
             assert_eq!(cut_level, 0, "SQL can only mirror a cut on the top level");
             // Tantivy breaks count ties on the key and puts the NULL bucket last.
-            let order_key = if self.terms[0].is_array {
-                format!("_{}", self.terms[0].field.replace('.', "_"))
-            } else {
-                self.terms[0].field.clone()
-            };
+            let order_key = self.terms[0].sql_key();
             sql.push_str(&format!(
                 " ORDER BY COUNT(*) DESC, {order_key} ASC NULLS LAST LIMIT {size}",
             ));
         }
         sql
+    }
+
+    /// The outer group and outer aggregates from either `pg_outer_query` or `pdb_query`.
+    /// When `is_pdb` is true, the trailing `pdb.agg()` JSON column is omitted.
+    pub fn outer_rows(&self, rows: Vec<PgRow>, is_pdb: bool) -> Result<Vec<String>, sqlx::Error> {
+        let mut out = Vec::new();
+        for row in rows {
+            let num_cols = if is_pdb { row.len() - 1 } else { row.len() };
+            let cells: Vec<String> = (0..num_cols).map(|i| column_string(&row, i)).collect();
+            out.push(cells.join("|"));
+        }
+        Ok(out)
     }
 
     /// The rows of either query as strings: the SQL result column by column, or
@@ -303,6 +381,8 @@ fn json_string(value: &Value) -> String {
 struct SpecShape {
     /// A SQL `GROUP BY` always sits beside the call.
     grouped: bool,
+    /// Standard SQL aggregates may sit beside the call.
+    allow_outer_aggs: bool,
     /// NUMERIC columns may be metric fields.
     numeric_metrics: bool,
     /// A `size` may cut any level, not only a lone top level under no group.
@@ -366,6 +446,7 @@ pub fn arb_pdb_agg_join(
         arb_joins(join_types, joined.clone(), &key_columns).prop_flat_map(move |join| {
             let shape = SpecShape {
                 grouped: false,
+                allow_outer_aggs: true,
                 numeric_metrics: true,
                 size_anywhere: false,
                 sketch_keys: if join.has_keyless_step() {
@@ -402,6 +483,7 @@ pub fn arb_pdb_agg_single_table() -> impl Strategy<Value = PdbAggExpr> {
         Vec::new(),
         SpecShape {
             grouped: true,
+            allow_outer_aggs: false,
             numeric_metrics: false,
             size_anywhere: true,
             sketch_keys: usize::MAX,
@@ -445,7 +527,7 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
             proptest::sample::select(kinds.to_vec()),
             proptest::sample::select(metric_fields),
         ),
-        1 => (Just(MetricKind::Avg), proptest::sample::select(int_fields)),
+        1 => (Just(MetricKind::Avg), proptest::sample::select(int_fields.clone())),
     ];
     let outer_group = if shape.grouped {
         proptest::sample::select(key_fields.clone())
@@ -453,6 +535,39 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
             .boxed()
     } else {
         proptest::option::weighted(0.3, proptest::sample::select(key_fields.clone())).boxed()
+    };
+
+    let outer_aggs_strat = if shape.allow_outer_aggs {
+        let outer_agg_fields = int_fields.clone();
+        let outer_agg = prop_oneof![
+            Just(OuterAgg {
+                kind: OuterAggKind::CountStar,
+                field: None,
+            }),
+            proptest::sample::select(outer_agg_fields.clone()).prop_map(|f| OuterAgg {
+                kind: OuterAggKind::Sum,
+                field: Some(f),
+            }),
+            proptest::sample::select(outer_agg_fields.clone()).prop_map(|f| OuterAgg {
+                kind: OuterAggKind::Avg,
+                field: Some(f),
+            }),
+            proptest::sample::select(outer_agg_fields.clone()).prop_map(|f| OuterAgg {
+                kind: OuterAggKind::Min,
+                field: Some(f),
+            }),
+            proptest::sample::select(outer_agg_fields).prop_map(|f| OuterAgg {
+                kind: OuterAggKind::Max,
+                field: Some(f),
+            }),
+            proptest::sample::select(key_fields.clone()).prop_map(|f| OuterAgg {
+                kind: OuterAggKind::Count,
+                field: Some(f),
+            }),
+        ];
+        proptest::collection::vec(outer_agg, 0..=2).boxed()
+    } else {
+        Just(vec![]).boxed()
     };
 
     let mut all_terms: Vec<PdbTerm> = key_fields
@@ -471,11 +586,12 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
 
     (
         outer_group,
+        outer_aggs_strat,
         proptest::sample::subsequence(all_terms, 0..=2),
         proptest::option::weighted(0.4, (0..2usize, 1..4u32)),
         proptest::collection::vec(metric, 0..=3),
     )
-        .prop_map(move |(outer_group, terms, size, metrics)| {
+        .prop_map(move |(outer_group, outer_aggs, terms, size, metrics)| {
             let mut metrics: Vec<Metric> = metrics
                 .into_iter()
                 .enumerate()
@@ -510,6 +626,7 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
             });
             PdbAggExpr {
                 outer_group,
+                outer_aggs,
                 terms,
                 size,
                 metrics,
@@ -615,6 +732,7 @@ mod tests {
     fn test_pg_query_unnests_array_terms() {
         let agg = PdbAggExpr {
             outer_group: Some("users.color".to_string()),
+            outer_aggs: vec![],
             terms: vec![
                 PdbTerm {
                     field: "users.tags".to_string(),

--- a/tests/src/fixtures/querygen/pdbagggen.rs
+++ b/tests/src/fixtures/querygen/pdbagggen.rs
@@ -77,13 +77,19 @@ pub struct Metric {
     pub field: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PdbTerm {
+    pub field: String,
+    pub is_array: bool,
+}
+
 /// One `pdb.agg()` call and the shape of its result.
 #[derive(Clone, Debug)]
 pub struct PdbAggExpr {
     /// A SQL `GROUP BY` column beside the call, which becomes the root grouping set.
     pub outer_group: Option<String>,
     /// `terms` levels, outermost first. Empty for a spec that is one metric.
-    pub terms: Vec<String>,
+    pub terms: Vec<PdbTerm>,
     /// A `size` cut on one level, under the default `_count desc` order.
     pub size: Option<(usize, u32)>,
     /// Metrics under the innermost level; the whole spec when there are no levels.
@@ -109,14 +115,14 @@ impl PdbAggExpr {
             return json!({ metric.kind.spec_name(): { "field": metric.field } });
         }
         let mut node = Value::Null;
-        for (level, field) in self.terms.iter().enumerate().rev() {
+        for (level, term) in self.terms.iter().enumerate().rev() {
             let terms = match self.size {
                 // Every segment keeps every term, so the cut is exact and its
                 // error bound zero, the same as a backend that has every group.
                 Some((cut_level, size)) if level == cut_level => {
-                    json!({ "field": field, "size": size, "segment_size": NO_CUT })
+                    json!({ "field": &term.field, "size": size, "segment_size": NO_CUT })
                 }
-                _ => json!({ "field": field, "size": NO_CUT, "order": { "_key": "asc" } }),
+                _ => json!({ "field": &term.field, "size": NO_CUT, "order": { "_key": "asc" } }),
             };
             let aggs = if node.is_null() {
                 Value::Object(self.metric_aggs())
@@ -153,30 +159,44 @@ impl PdbAggExpr {
     /// [`Self::rows`] flattens the JSON into. Only a cut on a lone top level has a
     /// SQL form.
     pub fn pg_query(&self, from_clause: &str, where_clause: &str) -> String {
-        let keys: Vec<&str> = self
-            .outer_group
-            .iter()
-            .chain(self.terms.iter())
-            .map(String::as_str)
-            .collect();
-        let mut select: Vec<String> = keys.iter().map(|k| k.to_string()).collect();
+        let mut from = from_clause.to_string();
+        let mut keys: Vec<String> = self.outer_group.iter().cloned().collect();
+        for term in &self.terms {
+            if term.is_array {
+                let alias = format!("_{}", term.field.replace('.', "_"));
+                // Tantivy and DataFusion (via PreserveAndExpandEmpty) preserve documents
+                // with empty or NULL arrays, assigning them to the NULL/missing bucket
+                // rather than discarding them from the query or outer groupings.
+                // Using `LEFT JOIN LATERAL ... ON true` mimics this: an inner unnest
+                // (e.g. `CROSS JOIN LATERAL`) would drop rows with empty/NULL arrays.
+                from.push_str(&format!(
+                    " LEFT JOIN LATERAL unnest({}) AS {alias} ON true",
+                    term.field
+                ));
+                keys.push(alias);
+            } else {
+                keys.push(term.field.clone());
+            }
+        }
+        let mut select: Vec<String> = keys.clone();
         if !self.terms.is_empty() {
             select.push("COUNT(*)".to_string());
         }
         select.extend(self.metrics.iter().map(|m| m.kind.sql(&m.field)));
-        let mut sql = format!(
-            "SELECT {} {from_clause} WHERE {where_clause}",
-            select.join(", ")
-        );
+        let mut sql = format!("SELECT {} {from} WHERE {where_clause}", select.join(", "));
         if !keys.is_empty() {
             sql.push_str(&format!(" GROUP BY {}", keys.join(", ")));
         }
         if let Some((cut_level, size)) = self.size {
             assert_eq!(cut_level, 0, "SQL can only mirror a cut on the top level");
             // Tantivy breaks count ties on the key and puts the NULL bucket last.
+            let order_key = if self.terms[0].is_array {
+                format!("_{}", self.terms[0].field.replace('.', "_"))
+            } else {
+                self.terms[0].field.clone()
+            };
             sql.push_str(&format!(
-                " ORDER BY COUNT(*) DESC, {} ASC NULLS LAST LIMIT {size}",
-                self.terms[0]
+                " ORDER BY COUNT(*) DESC, {order_key} ASC NULLS LAST LIMIT {size}",
             ));
         }
         sql
@@ -291,6 +311,8 @@ struct SpecShape {
     /// carries its own sketch, and the DataFusion aggregate holds them all in
     /// `work_mem` with no spill.
     sketch_keys: usize,
+    /// Array columns may be used as terms fields.
+    allow_arrays: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -351,6 +373,7 @@ pub fn arb_pdb_agg_join(
                 } else {
                     usize::MAX
                 },
+                allow_arrays: true,
             };
             let agg = arb_pdb_agg(joined.clone(), shape);
             let outer_strat = arb_wheres(vec![joined[0].clone()], &where_cols).boxed();
@@ -382,6 +405,7 @@ pub fn arb_pdb_agg_single_table() -> impl Strategy<Value = PdbAggExpr> {
             numeric_metrics: false,
             size_anywhere: true,
             sketch_keys: usize::MAX,
+            allow_arrays: false,
         },
     )
 }
@@ -399,6 +423,7 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
     };
     // `color` and `quantity` carry NULLs, which become a bucket of their own.
     let key_fields = qualify(&["color", "age", "quantity"]);
+    let array_fields = qualify(&["tags"]);
     let int_fields = qualify(&["age", "quantity"]);
     let metric_fields = if shape.numeric_metrics {
         qualify(&["age", "quantity", "price"])
@@ -430,9 +455,23 @@ fn arb_pdb_agg(tables: Vec<String>, shape: SpecShape) -> impl Strategy<Value = P
         proptest::option::weighted(0.3, proptest::sample::select(key_fields.clone())).boxed()
     };
 
+    let mut all_terms: Vec<PdbTerm> = key_fields
+        .iter()
+        .map(|f| PdbTerm {
+            field: f.clone(),
+            is_array: false,
+        })
+        .collect();
+    if shape.allow_arrays {
+        all_terms.extend(array_fields.iter().map(|f| PdbTerm {
+            field: f.clone(),
+            is_array: true,
+        }));
+    }
+
     (
         outer_group,
-        proptest::sample::subsequence(key_fields, 0..=2),
+        proptest::sample::subsequence(all_terms, 0..=2),
         proptest::option::weighted(0.4, (0..2usize, 1..4u32)),
         proptest::collection::vec(metric, 0..=3),
     )
@@ -569,6 +608,43 @@ mod tests {
         assert!(
             generated_is_null,
             "Expected at least one IS NULL/IS NOT NULL predicate to be generated"
+        );
+    }
+
+    #[test]
+    fn test_pg_query_unnests_array_terms() {
+        let agg = PdbAggExpr {
+            outer_group: Some("users.color".to_string()),
+            terms: vec![
+                PdbTerm {
+                    field: "users.tags".to_string(),
+                    is_array: true,
+                },
+                PdbTerm {
+                    field: "users.age".to_string(),
+                    is_array: false,
+                },
+            ],
+            size: Some((0, 10)),
+            metrics: vec![Metric {
+                name: "m0".to_string(),
+                kind: MetricKind::Sum,
+                field: "users.quantity".to_string(),
+            }],
+        };
+
+        let pg_sql = agg.pg_query("FROM users JOIN products ON users.id = products.id", "TRUE");
+        assert!(
+            pg_sql.contains("LEFT JOIN LATERAL unnest(users.tags) AS _users_tags ON true"),
+            "Expected LEFT JOIN LATERAL unnest for array term, got: {pg_sql}"
+        );
+        assert!(
+            pg_sql.contains("GROUP BY users.color, _users_tags, users.age"),
+            "Expected GROUP BY with unnested alias, got: {pg_sql}"
+        );
+        assert!(
+            pg_sql.contains("ORDER BY COUNT(*) DESC, _users_tags ASC NULLS LAST LIMIT 10"),
+            "Expected ORDER BY with unnested alias for size cut, got: {pg_sql}"
         );
     }
 }

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -1596,6 +1596,8 @@ async fn generated_numeric_range_precision(database: Db) {
 /// the oracle since `pdb.agg()` itself has no native fallback. Covers nested `terms`, a
 /// `size` cut under the default count order, NULL buckets, NUMERIC metrics, `cardinality`,
 /// a SQL `GROUP BY` beside the call, and MPP when the parallel GUCs are on.
+/// TODO: Consider merging this property test with other "aggregate over join" tests
+/// (such as `generated_aggregate_join` and `generated_join_aggregates`) in the future.
 #[rstest]
 #[tokio::test]
 async fn generated_pdb_agg_join(database: Db) {
@@ -1626,6 +1628,25 @@ async fn generated_pdb_agg_join(database: Db) {
         gucs.aggregate_custom_scan = true;
         gucs.join_custom_scan = true;
         gucs.custom_scan = true;
+
+        if !agg.outer_aggs.is_empty() {
+            let pg_outer_query = agg.pg_outer_query(&join_clause, &wheres.pg_where());
+            qgen_oracle!("qgen: generated_pdb_agg_join - outer aggregates match PostgreSQL", compare_outcome_retrying(
+                &pg_outer_query,
+                &bm25_query,
+                &gucs,
+                &pool,
+                &setup_sql,
+                |query, conn| {
+                    "SET work_mem TO '64MB';".execute_result(conn)?;
+                    let rows = query.fetch_dynamic_result(conn)?;
+                    let is_pdb = query.contains("pdb.agg");
+                    let mut rows = agg.outer_rows(rows, is_pdb)?;
+                    rows.sort();
+                    Ok(rows)
+                },
+            ))?;
+        }
 
         qgen_oracle!("qgen: generated_pdb_agg_join - pdb.agg() buckets match PostgreSQL GROUP BY", compare_outcome_retrying(
             &pg_query,

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -25,8 +25,8 @@ use tests::fixtures::querygen::pdbagggen::{arb_pdb_agg_join, arb_pdb_agg_single_
 use tests::fixtures::querygen::wheregen::Expr as WhereExpr;
 use tests::fixtures::querygen::wheregen::arb_wheres;
 use tests::fixtures::querygen::{
-    Column, IndexExpression, PgGucs, Sides, arb_joins_and_wheres, compare_outcome_retrying,
-    compare_outcome_retrying_on, generated_queries_setup,
+    Column, IndexExpression, PgGucs, QuerySide, Sides, arb_joins_and_wheres,
+    compare_outcome_retrying, compare_outcome_retrying_on, generated_queries_setup,
 };
 
 use tests::fixtures::*;
@@ -466,7 +466,7 @@ async fn generated_joins_small(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 "SET work_mem TO '16MB';".execute_result(conn)?;
                 let rows = query.fetch_dynamic_result(conn)?;
                 let mut row_strings: Vec<String> = rows
@@ -479,7 +479,7 @@ async fn generated_joins_small(database: Db) {
                     .collect();
                 row_strings.sort();
                 Ok(row_strings)
-            },
+            }
         ))?;
     });
 }
@@ -509,7 +509,7 @@ async fn generated_single_relation(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 let mut rows = query.fetch_result::<(i64,)>(conn)?;
                 rows.sort();
                 Ok(rows)
@@ -603,7 +603,7 @@ async fn generated_group_by_aggregates(database: Db) {
 
         // Custom result comparator for GROUP BY results
         let compare_results =
-            |query: &str, conn: &mut PgConnection| -> Result<Vec<String>, sqlx::Error> {
+            |query: &str, _: QuerySide, conn: &mut PgConnection| -> Result<Vec<String>, sqlx::Error> {
             // Fetch all rows as dynamic results and convert to string representation
             let rows = query.fetch_dynamic_result(conn)?;
             let string_rows: Vec<String> = rows
@@ -662,7 +662,7 @@ async fn generated_paging_small(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| query.fetch_result::<(i64,)>(conn),
+            |query, _, conn| query.fetch_result::<(i64,)>(conn),
         ))?;
     });
 }
@@ -693,7 +693,7 @@ async fn generated_paging_large(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| query.fetch_result::<(String,)>(conn),
+            |query, _, conn| query.fetch_result::<(String,)>(conn),
         ))?;
     });
 }
@@ -759,7 +759,7 @@ async fn generated_subquery(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| query.fetch_one_result::<(i64,)>(conn),
+            |query, _, conn| query.fetch_one_result::<(i64,)>(conn),
         ))?;
     });
 }
@@ -870,7 +870,7 @@ async fn generated_aggregate_join(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 let rows = query.fetch_dynamic_result(conn)?;
                 let mut string_rows: Vec<String> = rows
                     .into_iter()
@@ -978,7 +978,7 @@ async fn generated_aggregate_join_distinct(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 let rows = query.fetch_dynamic_result(conn)?;
                 let mut string_rows: Vec<String> = rows
                     .into_iter()
@@ -1078,7 +1078,7 @@ async fn generated_group_by_stddev(database: Db) {
 
         // Custom result comparator that rounds f64 values to 6 decimal places
         let compare_results =
-            |query: &str, conn: &mut PgConnection| -> Result<Vec<String>, sqlx::Error> {
+            |query: &str, _: QuerySide, conn: &mut PgConnection| -> Result<Vec<String>, sqlx::Error> {
             let rows = query.fetch_dynamic_result(conn)?;
             let mut string_rows: Vec<String> = rows
                 .into_iter()
@@ -1205,7 +1205,7 @@ async fn generated_join_aggregates(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 let rows = query.fetch_dynamic_result(conn)?;
                 let mut string_rows: Vec<String> = rows
                     .into_iter()
@@ -1296,7 +1296,7 @@ async fn generated_numeric_pushdown(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 let mut rows = query.fetch_result::<(i64,)>(conn)?;
                 rows.sort();
                 Ok(rows)
@@ -1444,7 +1444,7 @@ async fn generated_join_semi_like(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| query.fetch_result::<(i64, String)>(conn),
+            |query, _, conn| query.fetch_result::<(i64, String)>(conn),
         ))?;
     });
 }
@@ -1520,7 +1520,7 @@ async fn generated_numeric_precision(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
+            |query, _, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
         ))?;
     });
 }
@@ -1586,7 +1586,7 @@ async fn generated_numeric_range_precision(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
+            |query, _, conn| Ok(query.fetch_one_result::<(i64,)>(conn)?.0),
         ))?;
     });
 }
@@ -1637,11 +1637,10 @@ async fn generated_pdb_agg_join(database: Db) {
                 &gucs,
                 &pool,
                 &setup_sql,
-                |query, conn| {
+                |query, side, conn| {
                     "SET work_mem TO '64MB';".execute_result(conn)?;
                     let rows = query.fetch_dynamic_result(conn)?;
-                    let is_pdb = query.contains("pdb.agg");
-                    let mut rows = agg.outer_rows(rows, is_pdb)?;
+                    let mut rows = agg.outer_rows(rows, side.is_candidate())?;
                     rows.sort();
                     Ok(rows)
                 },
@@ -1654,7 +1653,7 @@ async fn generated_pdb_agg_join(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 // A keyless join under three bucket keys makes tens of thousands of
                 // buckets, and the DataFusion aggregate cannot spill past `work_mem`.
                 "SET work_mem TO '64MB';".execute_result(conn)?;
@@ -1709,7 +1708,7 @@ async fn generated_pdb_agg_single_table(database: Db) {
             &gucs,
             &pool,
             &setup_sql,
-            |query, conn| {
+            |query, _, conn| {
                 let mut documents = agg.documents(query.fetch_dynamic_result(conn)?)?;
                 documents.sort_by(|a, b| a.0.cmp(&b.0));
                 Ok(documents)


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6215

## What

Adds support for `pdb.agg()` terms aggregations on array fields over joins.

## Why

Previously, `pdb.agg()` over joins only supported scalar fast fields; attempting to reference an array field failed during custom scan path planning or query lowering. For joins, array fields must be unnested into relation rows so that multi-valued terms can participate in grouping and nested aggregations consistent with PostgreSQL join semantics.

## How

- Resolved array fast fields in custom scan planning and permitted them in join terms aggs while rejecting them for metrics.
- In DataFusion, pre-projected array columns to unique temporary names, unnested them sequentially to produce the Cartesian product matching PostgreSQL `LATERAL unnest`, and post-projected back to qualified names.
- Added array term generation and `LEFT JOIN LATERAL unnest` translation to join property tests.

## Tests

- Added Section 6 to `pg_search/tests/pg_regress/sql/pdb_agg_datafusion.sql` testing join terms on array fields, metric sub-aggs, multiple array fields, single-table fallback to Tantivy, and error handling.
- Validated via expanded property tests: `cargo test -p tests --test qgen -- generated_pdb_agg_join`.