### PR TITLE
fix: keep AggregateScan Aggref replacements in the plan memory context

### DIFF
--- a/docs/changelog/unreleased/6252.stability.mdx
+++ b/docs/changelog/unreleased/6252.stability.mdx
@@ -1,0 +1,5 @@
+---
+header: stability
+---
+
+Prepared Tantivy `GROUP BY` queries no longer panic on the second `EXECUTE` of a cached generic plan.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -2683,7 +2683,22 @@ unsafe fn detect_join_aggregate_topk(
 /// Replace any T_Aggref expressions in the target list with T_FuncExpr placeholders
 /// This is called at execution time to avoid "Aggref found in non-Agg plan node" errors
 /// Uses expression_tree_mutator to handle nested Aggrefs (e.g., COALESCE(COUNT(*), 0))
+///
+/// The replacement List is allocated in the same memory context as the original
+/// targetlist. A parameterless PREPARE reuses a generic plan across EXECUTE, so
+/// writing a per-query List into that plan leaves a dangling pointer (#6136).
 unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
+    if (*plan).targetlist.is_null() {
+        return;
+    }
+
+    let tlist_ctx = pg_sys::GetMemoryChunkContext((*plan).targetlist.cast());
+    PgMemoryContexts::For(tlist_ctx).switch_to(|_| {
+        replace_aggrefs_in_target_list_in_current_context(plan);
+    });
+}
+
+unsafe fn replace_aggrefs_in_target_list_in_current_context(plan: *mut pg_sys::Plan) {
     use pgrx::pg_guard;
 
     if (*plan).targetlist.is_null() {

--- a/tests/tests/aggregate_custom_scan.rs
+++ b/tests/tests/aggregate_custom_scan.rs
@@ -151,6 +151,47 @@ fn test_group_by(mut conn: PgConnection) {
 }
 
 #[rstest]
+fn test_prepared_tantivy_groupby_survives_reuse(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    "SET paradedb.enable_aggregate_custom_scan TO on;".execute(&mut conn);
+
+    let query = r#"
+        SELECT rating, COUNT(*)
+        FROM paradedb.bm25_search
+        WHERE description @@@ 'shoes'
+        GROUP BY rating
+        ORDER BY rating
+    "#;
+
+    assert_uses_custom_scan(&mut conn, true, query);
+    let (plan,) = format!("EXPLAIN (FORMAT JSON) {query}").fetch_one::<(Value,)>(&mut conn);
+    let plan = plan.to_string();
+    assert!(
+        !plan.contains("DataFusion Physical Plan"),
+        "expected the Tantivy aggregate backend:\n{plan}"
+    );
+
+    let expected: Vec<(i32, i64)> = query.fetch(&mut conn);
+    assert_eq!(expected, vec![(3, 1), (4, 1), (5, 1)]);
+
+    r#"
+        PREPARE group_by_rating AS
+        SELECT rating, COUNT(*)
+        FROM paradedb.bm25_search
+        WHERE description @@@ 'shoes'
+        GROUP BY rating
+        ORDER BY rating
+    "#
+    .execute(&mut conn);
+
+    for _ in 0..8 {
+        let actual: Vec<(i32, i64)> = "EXECUTE group_by_rating".fetch(&mut conn);
+        assert_eq!(actual, expected);
+    }
+}
+
+#[rstest]
 fn test_group_by_null_bucket(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #6136

## What

A prepared Tantivy `GROUP BY` query succeeded on the first `EXECUTE` and failed on the second with `PgList does not contain pointers`.

## Why

Parameterless `PREPARE` caches a generic plan and reuses it. For grouped aggregates, `replace_aggrefs_in_target_list` runs at `CreateCustomScanState` and wrote the replacement targetlist into the per-query memory context. After that query ended, the cached plan still pointed at the freed `List`. The next `EXECUTE` walked it as a `PgList` of pointers and panicked.

Scalar aggregates were already safe because they replace Aggrefs at plan time (see `corrupt_targetlist`). Grouped aggregates deferred replacement so `make_sort_from_pathkeys` can still see the original Aggrefs, which is how this hole remained.

## How

Allocate the replacement targetlist in the same memory context as the original list (the cached plan context). The first `EXECUTE` still rewrites Aggrefs to `pdb.agg_fn` placeholders; later `EXECUTE`s find a live list instead of a dangling one.

## Tests

- `tests/tests/aggregate_custom_scan.rs`: `test_prepared_tantivy_groupby_survives_reuse` prepares a Tantivy `GROUP BY rating` query and `EXECUTE`s it eight times.

I could not run `cargo pgrx` / the integration suite on this Windows checkout (no pgrx-managed Postgres). Please treat CI as the verification gate for this change.

Made with [Cursor](https://cursor.com)