### PR TITLE
fix: preserve join filter column positions through deferred lookups

### DIFF
--- a/docs/changelog/unreleased/6254.stability.mdx
+++ b/docs/changelog/unreleased/6254.stability.mdx
@@ -1,0 +1,5 @@
+---
+header: stability
+---
+
+Fixes missing rows in joins where runtime filters could be applied to the wrong column when multiple tables shared the same column name.

--- a/pg_search/src/scan/filter_pushdown.rs
+++ b/pg_search/src/scan/filter_pushdown.rs
@@ -415,6 +415,82 @@ mod tests {
     use super::*;
     use datafusion::logical_expr::col;
 
+    #[rstest::rstest]
+    #[case::fetch(false)]
+    #[case::decode(true)]
+    fn lookup_dynamic_filter_preserves_duplicate_column_positions(#[case] decode: bool) {
+        use arrow_array::{BooleanArray, Int64Array, RecordBatch};
+        use arrow_schema::{DataType, Field, Schema};
+        use datafusion::physical_expr::expressions::{
+            BinaryExpr, Column, DynamicFilterPhysicalExpr, lit,
+        };
+        use datafusion::physical_plan::ExecutionPlan;
+        use datafusion::physical_plan::empty::EmptyExec;
+        use datafusion::physical_plan::filter_pushdown::{FilterPushdownPhase, PushedDown};
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("id", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 11])),
+                Arc::new(Int64Array::from(vec![1, 1])),
+            ],
+        )
+        .unwrap();
+        let input = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+        let lookup: Arc<dyn ExecutionPlan> = if decode {
+            Arc::new(
+                crate::scan::tantivy_decode_exec::TantivyDecodeExec::new(
+                    input,
+                    vec![],
+                    Default::default(),
+                )
+                .unwrap(),
+            )
+        } else {
+            Arc::new(
+                crate::scan::tantivy_fetch_exec::TantivyFetchExec::new(
+                    input,
+                    vec![],
+                    Default::default(),
+                    vec![],
+                )
+                .unwrap(),
+            )
+        };
+        let column = Arc::new(Column::new("id", 1)) as Arc<dyn PhysicalExpr>;
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::clone(&column)],
+            lit(true),
+        ));
+        let description = lookup
+            .gather_filters_for_pushdown(
+                FilterPushdownPhase::Post,
+                vec![filter.clone()],
+                &Default::default(),
+            )
+            .unwrap();
+        let filters = description.parent_filters();
+        assert!(matches!(filters[0][0].discriminant, PushedDown::Yes));
+
+        filter
+            .update(Arc::new(BinaryExpr::new(column, Operator::Eq, lit(1_i64))))
+            .unwrap();
+        let mask = filters[0][0]
+            .predicate
+            .evaluate(&batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .unwrap();
+        assert_eq!(
+            mask.as_any().downcast_ref::<BooleanArray>().unwrap(),
+            &BooleanArray::from(vec![true, true])
+        );
+    }
+
     #[test]
     fn test_flip_operator() {
         assert_eq!(flip_operator(Operator::Eq), Some(Operator::Eq));

--- a/pg_search/src/scan/tantivy_decode_exec.rs
+++ b/pg_search/src/scan/tantivy_decode_exec.rs
@@ -47,8 +47,7 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::filter_pushdown::{
-    ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
-    FilterPushdownPropagation,
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
 };
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet, RecordOutput,
@@ -262,7 +261,11 @@ impl ExecutionPlan for TantivyDecodeExec {
                 &self.children(),
             ));
         }
-        let child_desc = ChildFilterDescription::from_child(&parent_filters, &self.input)?;
+        let child_desc = crate::scan::filter_pushdown::schema_preserving_child_filter_description(
+            &parent_filters,
+            &self.input.schema(),
+            None,
+        )?;
         Ok(FilterDescription::new().with_child(child_desc))
     }
 

--- a/pg_search/src/scan/tantivy_fetch_exec.rs
+++ b/pg_search/src/scan/tantivy_fetch_exec.rs
@@ -51,8 +51,7 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::filter_pushdown::{
-    ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
-    FilterPushdownPropagation,
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
 };
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet, RecordOutput,
@@ -369,7 +368,11 @@ impl ExecutionPlan for TantivyFetchExec {
                 &self.children(),
             ));
         }
-        let child_desc = ChildFilterDescription::from_child(&parent_filters, &self.input)?;
+        let child_desc = crate::scan::filter_pushdown::schema_preserving_child_filter_description(
+            &parent_filters,
+            &self.input.schema(),
+            None,
+        )?;
         Ok(FilterDescription::new().with_child(child_desc))
     }
 

--- a/pg_search/tests/pg_regress/expected/join_outer_edge.out
+++ b/pg_search/tests/pg_regress/expected/join_outer_edge.out
@@ -163,8 +163,8 @@ SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.t
 -- =============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: a.id, b.id
    ->  Custom Scan (ParadeDB Join Scan)
@@ -182,7 +182,7 @@ SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.pri
            :           CooperativeExec
            :             PgSearchScan: table=b, segments=1, visibility=eager, query={"range":{"field":"price","lower_bound":{"excluded":100},"upper_bound":null}}
            :           CooperativeExec
-           :             PgSearchScan: table=a, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: table=a, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
@@ -203,8 +203,8 @@ SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.pri
 -- =============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: a.id, b.id
    ->  Custom Scan (ParadeDB Join Scan)
@@ -223,7 +223,7 @@ SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id 
            :           CooperativeExec
            :             PgSearchScan: table=b, segments=1, visibility=eager, query="all"
            :           CooperativeExec
-           :             PgSearchScan: table=a, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: table=a, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
 (19 rows)
 
 SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -224,6 +224,77 @@ fn joinscan_self_join_matches_fallback(mut conn: PgConnection) -> Result<(), sql
 }
 
 #[rstest]
+fn joinscan_nested_join_filter_preserves_duplicate_ids(mut conn: PgConnection) {
+    r#"
+    SET max_parallel_workers_per_gather = 0;
+    SET paradedb.enable_custom_scan = off;
+    SET paradedb.enable_join_custom_scan = on;
+    SET enable_seqscan = off;
+    SET enable_indexscan = off;
+
+    CREATE TABLE users (id bigint PRIMARY KEY, name text, quantity integer);
+    CREATE TABLE products (id bigint PRIMARY KEY, name text, tags text[]);
+    CREATE TABLE orders (id bigint PRIMARY KEY, color text);
+
+    INSERT INTO users VALUES
+        (1, 'bob', 7), (2, 'sally', 99), (3, 'anchovy', 86),
+        (4, 'brisket', 72), (5, 'brisket', 19), (6, 'anchovy', 56),
+        (7, 'brisket', 7), (8, 'brisket', 95), (9, 'sally', 4),
+        (10, 'brisket', 19), (11, 'bob', 8);
+    INSERT INTO products VALUES
+        (1, 'bob', ARRAY['alpha', 'beta']), (2, 'sally', NULL),
+        (3, 'bob', ARRAY['delta', 'epsilon', 'zeta']), (4, 'sally', ARRAY['gamma']),
+        (5, 'cloe', NULL), (6, 'brisket', ARRAY['alpha', 'beta']),
+        (7, 'alice', ARRAY[]::text[]), (8, 'brandy', NULL),
+        (9, 'bob', ARRAY['delta', 'epsilon', 'zeta']),
+        (10, 'sally', ARRAY[]::text[]), (11, 'bob', ARRAY['gamma']);
+    INSERT INTO orders VALUES
+        (1, 'blue'), (2, 'orange'), (3, 'red'), (4, 'purple'),
+        (5, 'blue'), (6, 'pink'), (7, 'blue'), (8, 'red'),
+        (9, 'red'), (10, NULL), (11, 'green');
+
+    CREATE INDEX ON users USING paradedb (id, (name::pdb.literal), quantity)
+        WITH (key_field = 'id');
+    CREATE INDEX ON products USING paradedb (id, (name::pdb.literal), (tags::pdb.literal))
+        WITH (key_field = 'id');
+    CREATE INDEX ON orders USING paradedb (id, (color::pdb.literal))
+        WITH (key_field = 'id');
+    ANALYZE users;
+    ANALYZE products;
+    ANALYZE orders;
+    "#
+    .execute(&mut conn);
+
+    let query = r#"
+        SELECT users.id, users.name, products_tags
+        FROM users
+        JOIN products ON users.name = products.name
+        RIGHT JOIN orders ON products.id = orders.id
+        CROSS JOIN LATERAL unnest(products.tags) AS products_tags
+        WHERE orders.color @@@ 'blue'
+        ORDER BY users.quantity IS NULL, users.quantity, users.id,
+                 products.id, orders.id, products_tags
+        LIMIT 8
+    "#;
+    let (plan,) = format!("EXPLAIN (FORMAT JSON) {query}").fetch_one::<(Value,)>(&mut conn);
+    assert!(plan.to_string().contains("ParadeDB Join Scan"), "{plan:#}");
+
+    let actual = query.fetch::<(i64, String, String)>(&mut conn);
+    "SET paradedb.enable_join_custom_scan = off;".execute(&mut conn);
+    let expected = query.fetch::<(i64, String, String)>(&mut conn);
+    assert_eq!(
+        expected,
+        vec![
+            (1, "bob".into(), "alpha".into()),
+            (1, "bob".into(), "beta".into()),
+            (11, "bob".into(), "alpha".into()),
+            (11, "bob".into(), "beta".into()),
+        ]
+    );
+    assert_eq!(actual, expected);
+}
+
+#[rstest]
 fn joinscan_self_join_duplicate_name_sort_matches_fallback(
     mut conn: PgConnection,
 ) -> Result<(), sqlx::Error> {


### PR DESCRIPTION
Nested joins with same-named columns can silently discard valid rows when a runtime filter passes through deferred lookups. In the failing three-table join, a filter for `products.id` was rebound to `users.id`, returning two rows instead of PostgreSQL's four.

Reuse the existing position-preserving filter helper in `TantivyFetchExec` and `TantivyDecodeExec`. Add regression tests for both execution nodes, including filters updated after pushdown, and an integration test for the failing join. Update two expected plans where filters can now reach the correct table.

Found while investigating `generated_joins_small` failures in #6201. This is an existing `main` bug: the original CI query also fails on unmodified `350dbfbcf3db71cf4495fb1ee2afc34855e4d78e`, without #6201. Both CI failures return PostgreSQL's complete results with this fix (4 and 12 rows respectively).

Validation on PostgreSQL 18:

- Both new execution-node regression cases and the new integration test fail before the fix and pass afterward.
- All 6 filter-pushdown unit tests and 7 join integration tests pass.
- All 16 generated-query tests pass with 256 cases each and seed 6201.
- All 9 selected join/dynamic-filter SQL regression suites pass.
- Repository commit hooks pass, including formatting, workspace Clippy, check, and documentation builds.
