### PR TITLE
ci: add Spot retry merge-gate to test-pg_search

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -387,7 +387,7 @@ jobs:
   # Spot interruptions used to finish as cancelled, so RunsOn skipped retries and
   # the merge queue could eject the PR. Gate publishes merge-gate / pass normally,
   # or merge-gate / interrupted (pending) on attempts 1–2 with an EC2 Spot
-  # interruption annotation so the queue waits for the retry (#6255).
+  # interruption annotation so the queue waits for the retry.
   # Requires RunsOn control plane v3.3.0+ for that annotation.
   merge-gate:
     if: ${{ always() }}

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -21,6 +21,9 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "rust-toolchain.toml"
+  # Merge queue must see the same Spot jobs + merge-gate so an interrupted
+  # attempt can stay pending while RunsOn retries.
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -380,3 +383,18 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Spot interruptions used to finish as cancelled, so RunsOn skipped retries and
+  # the merge queue could eject the PR. Gate publishes merge-gate / pass normally,
+  # or merge-gate / interrupted (pending) on attempts 1–2 with an EC2 Spot
+  # interruption annotation so the queue waits for the retry (#6255).
+  # Requires RunsOn control plane v3.3.0+ for that annotation.
+  merge-gate:
+    if: ${{ always() }}
+    needs: [test-pg_search]
+    permissions:
+      actions: read
+      checks: read
+    uses: runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@v1
+    with:
+      job_results: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- Spot-interrupted `test-pg_search` jobs can finish as cancelled, miss RunsOn retries, and eject a PR from the merge queue before a retry completes.
- Pilot `runs-on/spot-retry-gate` in `test-pg_search.yml` and run the workflow on `merge_group` as well as `pull_request`.
- On a normal run the gate publishes `merge-gate / pass`. On attempts 1–2 with an `EC2 Spot interruption` annotation it publishes `merge-gate / interrupted` so the required check can stay pending while RunsOn retries.

Closes #6255

## Where the problem shows up
File: `.github/workflows/test-pg_search.yml`

1. Job `test-pg_search` runs on **RunsOn Spot** (`runs-on: ... family=...`).
2. Before this PR the workflow had **no merge-gate** and **no `merge_group` trigger**.
3. When Spot killed a runner, the job could look **cancelled** → no auto-retry → merge queue treated a required check as failed and **ejected the PR**.

## What this PR does (in-repo)
- Add `merge_group:` trigger.
- Add `merge-gate` job:
  - `if: always()`
  - `needs: [test-pg_search]`
  - `permissions: actions: read, checks: read`
  - `uses: runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@v1`
  - `job_results: ${{ toJSON(needs) }}`

## Philippe — please do these (we cannot from a fork)

### 1) Upgrade RunsOn control plane to v3.3.0
The gate needs the `EC2 Spot interruption` annotation from RunsOn **v3.3.0+**.

- Follow: https://runs-on.com/docs/maintenance/upgrades/
- CloudFormation template: `https://runs-on.s3.eu-west-1.amazonaws.com/cloudformation/template-v3.3.0.yaml`
- Keep existing parameters.
- Confirm version on a new job’s runner details.
- Release notes: https://github.com/runs-on/runs-on/releases/tag/v3.3.0

### 2) After the gate looks good in CI, update the branch ruleset
- Require **`merge-gate / pass`** instead of the individual Spot `Test pg_search on PostgreSQL …` checks covered by this workflow.
- Keep unrelated required checks as they are.
- Give the merge queue enough **status-check timeout** for attempt finish + retry (RunsOn retries after attempts 1 and 2; attempt 3 is final).

### 3) Validate (Spot simulation, not hard kill)
- Normal green run → `merge-gate / pass`.
- Controlled Spot interruption → annotation + `merge-gate / interrupted`, required `pass` stays pending, auto-retry, PR stays in queue.
- Successful retry → `pass` succeeds.
- Ordinary failure / exhausted retries → `pass` fails.
- Prefer RunsOn’s Spot interruption simulation. Hard-terminating the instance before the annotation is written can make the gate fail the normal check.

Docs: https://github.com/runs-on/spot-retry-gate

## Test plan
- [ ] PR CI shows `merge-gate / pass` on a successful `test-pg_search` matrix.
- [ ] Philippe: confirm RunsOn control plane is on v3.3.0+.
- [ ] Philippe: ruleset switch to `merge-gate / pass` after validation.
- [ ] Philippe: Spot interruption simulation in merge queue (no eject on retryable interrupt).