### PR TITLE
chore: Extract an action to retry apt-get.

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,44 @@
+name: APT Install with Retry
+description: Install APT packages with retry, exponential backoff, and index refresh
+
+inputs:
+  packages:
+    description: "APT packages to install"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install APT packages
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        sudo=""
+        if [ "$(id -u)" -ne 0 ]; then
+          sudo="sudo"
+        fi
+
+        # Re-run `apt-get update` on each retry: if an upstream package was superseded,
+        # a stale index causes `apt-get install` to 404 on the purged .deb. Updating
+        # fetches the current package list so install requests the new version.
+        delay=5
+        for attempt in $(seq 1 5); do
+          if [ "$attempt" -gt 1 ]; then
+            echo "Package installation failed (attempt $((attempt - 1))/5); retrying in ${delay}s..."
+            sleep "$delay"
+            delay=$((delay * 2))
+          fi
+
+          if $sudo DEBIAN_FRONTEND=noninteractive apt-get update && \
+             $sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+               -o Acquire::Retries=3 \
+               ${{ inputs.packages }}; then
+            break
+          fi
+
+          if [ "$attempt" -eq 5 ]; then
+            echo "Package installation failed after 5 attempts" >&2
+            exit 1
+          fi
+        done

--- a/.github/actions/setup-benchmark-cluster/action.yml
+++ b/.github/actions/setup-benchmark-cluster/action.yml
@@ -95,8 +95,9 @@ runs:
         cargo pgrx start pg${{ inputs.pg_version }}
 
     - name: Install pgBackRest
-      shell: bash
-      run: sudo apt-get update && sudo apt-get install -y pgbackrest
+      uses: ./.github/actions/apt-install
+      with:
+        packages: pgbackrest
 
     # VectorChord (vchordrq) binary for the "cohere / vchord" index variant. Installs the extension
     # only; it depends on pgvector's `vector` type (installed above). CREATE EXTENSION happens at

--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Configure PGDG APT repository and install PostgreSQL
+    - name: Configure PGDG APT repository
       shell: bash
       run: |
         set -euo pipefail
@@ -22,9 +22,15 @@ runs:
           | sudo tee /usr/share/keyrings/postgresql.asc >/dev/null
         echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
           | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-        sudo DEBIAN_FRONTEND=noninteractive apt-get update
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-          "postgresql-${{ inputs.pg_version }}" \
-          "postgresql-server-dev-${{ inputs.pg_version }}" \
+
+    - name: Install PostgreSQL Packages
+      uses: ./.github/actions/apt-install
+      with:
+        packages: >-
+          postgresql-${{ inputs.pg_version }}
+          postgresql-server-dev-${{ inputs.pg_version }}
           ${{ inputs.extra_packages }}
-        echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> "$GITHUB_PATH"
+
+    - name: Configure PostgreSQL PATH
+      shell: bash
+      run: echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -192,22 +192,34 @@ jobs:
             echo "build=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install Dependencies
-        if: steps.guard.outputs.build == 'true'
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base lld
-
       - name: Checkout Git Repository
         if: steps.guard.outputs.build == 'true'
         uses: actions/checkout@v7
 
+      - name: Install Dependencies
+        if: steps.guard.outputs.build == 'true'
+        uses: ./.github/actions/apt-install
+        with:
+          packages: >-
+            sudo wget git ca-certificates curl gnupg gpg lsb-release
+            pkg-config libssl-dev jq gettext-base lld
+
       # Used to upload the release to GitHub Releases
-      - name: Install GitHub CLI
+      - name: Configure GitHub CLI Repository
         if: steps.guard.outputs.build == 'true'
         run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y gh
-          gh --version
+
+      - name: Install GitHub CLI
+        if: steps.guard.outputs.build == 'true'
+        uses: ./.github/actions/apt-install
+        with:
+          packages: gh
+
+      - name: Verify GitHub CLI
+        if: steps.guard.outputs.build == 'true'
+        run: gh --version
 
       - name: Install Rust
         if: steps.guard.outputs.build == 'true'

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -195,19 +195,29 @@ jobs:
             arch: arm64
 
     steps:
-      - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base lld
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
+      - name: Install Dependencies
+        uses: ./.github/actions/apt-install
+        with:
+          packages: >-
+            sudo wget git ca-certificates curl gnupg gpg lsb-release
+            pkg-config libssl-dev jq gettext-base lld
+
       # Used to upload the release to GitHub Releases
-      - name: Install GitHub CLI
+      - name: Configure GitHub CLI Repository
         run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y gh
-          gh --version
+
+      - name: Install GitHub CLI
+        uses: ./.github/actions/apt-install
+        with:
+          packages: gh
+
+      - name: Verify GitHub CLI
+        run: gh --version
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test-dst-crate.yml
+++ b/.github/workflows/test-dst-crate.yml
@@ -43,7 +43,9 @@ jobs:
       # .cargo/config.toml links Linux builds with LLD. The GitHub-hosted image
       # currently ships it, but install it explicitly rather than depend on that.
       - name: Install LLD
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lld
+        uses: ./.github/actions/apt-install
+        with:
+          packages: --no-install-recommends lld
 
       # With `enabled` off the DST crate compiles to nothing — this is what pg_search ships,
       # and it is the half the workspace-wide runs in lint-rust never see, since stressgres

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -69,8 +69,9 @@ jobs:
           save-if: false
 
       - name: Install System Dependencies
-        run: |
-          sudo apt-get update && sudo apt-get install -y libsecret-1-dev libopenblas-dev lld
+        uses: ./.github/actions/apt-install
+        with:
+          packages: libsecret-1-dev libopenblas-dev lld
 
       - name: Install .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -126,13 +126,15 @@ jobs:
       COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
     steps:
-      - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo git ca-certificates curl gnupg lsb-release binutils
-
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Dependencies
+        uses: ./.github/actions/apt-install
+        with:
+          packages: sudo git ca-certificates curl gnupg lsb-release binutils
 
       - name: Configure RunsOn Caching
         uses: runs-on/action@v2

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -106,8 +106,9 @@ jobs:
           install_cargo_pgrx: "false"
 
       - name: Install required system tools
-        run: |
-          sudo apt-get update && sudo apt-get install -y lsof libopenblas-dev lld
+        uses: ./.github/actions/apt-install
+        with:
+          packages: lsof libopenblas-dev lld
 
       - name: Install & Configure Supported PostgreSQL Version
         uses: ./.github/actions/setup-postgres

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -104,10 +104,12 @@ jobs:
           cache_save: ${{ github.event_name == 'schedule' && github.ref_name == github.event.repository.default_branch }}
 
       - name: Install required system tools
-        run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            lsof build-essential clang lld flex bison pkg-config ca-certificates git \
-            libreadline-dev zlib1g-dev libssl-dev libkrb5-dev liblz4-dev libzstd-dev \
+        uses: ./.github/actions/apt-install
+        with:
+          packages: >-
+            --no-install-recommends
+            lsof build-essential clang lld flex bison pkg-config ca-certificates git
+            libreadline-dev zlib1g-dev libssl-dev libkrb5-dev liblz4-dev libzstd-dev
             libcurl4-openssl-dev libopenblas-dev
 
       - name: Install llvm-tools-preview


### PR DESCRIPTION
We've seen flakiness in `apt-get` recently, including spurious 404s.

Extract an action to do retry, ensuring that `apt-get update` (which does not reliably fail for unreachable repositories) is inside of the retry loop.