### PR TITLE
fix: Mark `pdb.agg` parallel safe.

### DIFF
--- a/.github/actions/test-pg_search-upgrade/schema_snapshot.sql
+++ b/.github/actions/test-pg_search-upgrade/schema_snapshot.sql
@@ -11,9 +11,12 @@
 -- pg_describe_object() renders OID-free, fully-qualified identifiers (e.g.
 -- `function paradedb.verify_index(regclass,boolean,...)`), so the output is
 -- comparable across databases with different OIDs.
-SELECT pg_describe_object(d.classid, d.objid, d.objsubid) AS object
+SELECT
+    pg_describe_object(d.classid, d.objid, d.objsubid)
+    || COALESCE(' [parallel=' || p.proparallel || ']', '') AS object
 FROM pg_depend d
 JOIN pg_extension e ON e.oid = d.refobjid
+LEFT JOIN pg_proc p ON d.classid = 'pg_proc'::regclass AND p.oid = d.objid
 WHERE d.refclassid = 'pg_extension'::regclass
   AND d.deptype = 'e'
   AND e.extname = 'pg_search'

--- a/.github/actions/test-pg_search-upgrade/schema_snapshot.sql
+++ b/.github/actions/test-pg_search-upgrade/schema_snapshot.sql
@@ -13,7 +13,7 @@
 -- comparable across databases with different OIDs.
 SELECT
     pg_describe_object(d.classid, d.objid, d.objsubid)
-    || COALESCE(' [parallel=' || p.proparallel || ']', '') AS object
+    || COALESCE(' [parallel=' || p.proparallel::text || ']', '') AS object
 FROM pg_depend d
 JOIN pg_extension e ON e.oid = d.refobjid
 LEFT JOIN pg_proc p ON d.classid = 'pg_proc'::regclass AND p.oid = d.objid

--- a/docs/changelog/unreleased/6215.performance.mdx
+++ b/docs/changelog/unreleased/6215.performance.mdx
@@ -1,0 +1,5 @@
+---
+header: performance
+---
+
+`pdb.agg()` and its underlying placeholder functions are now marked `PARALLEL SAFE`, allowing queries that use `pdb.agg()` to execute in parallel using MPP (`DistributedExec`).

--- a/docs/changelog/unreleased/6215.performance.mdx
+++ b/docs/changelog/unreleased/6215.performance.mdx
@@ -1,5 +1,0 @@
----
-header: performance
----
-
-`pdb.agg()` and its underlying placeholder functions are now marked `PARALLEL SAFE`, allowing queries that use `pdb.agg()` to execute in parallel using MPP (`DistributedExec`).

--- a/docs/changelog/unreleased/6269.performance.mdx
+++ b/docs/changelog/unreleased/6269.performance.mdx
@@ -1,0 +1,5 @@
+---
+header: performance
+---
+
+`pdb.agg()` is now marked `PARALLEL SAFE`. Queries that use it can run with parallel workers instead of falling back to single-threaded execution.

--- a/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
+++ b/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
@@ -2,10 +2,7 @@
 -- using pdb.agg can be parallelized with MPP (DistributedExec).
 
 -- Overload 1: pdb.agg(jsonb)
-DROP AGGREGATE IF EXISTS pdb.agg(jsonb);
-DROP FUNCTION IF EXISTS pdb.agg_placeholder_agg_placeholder_state(this internal, arg_one jsonb);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_agg_placeholder_state(this internal, arg_one jsonb) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_state_wrapper' LANGUAGE c PARALLEL SAFE;
-DROP FUNCTION IF EXISTS pdb.agg_placeholder_agg_placeholder_finalize(this internal);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_agg_placeholder_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
 
 CREATE OR REPLACE AGGREGATE pdb.agg (
@@ -19,10 +16,7 @@ CREATE OR REPLACE AGGREGATE pdb.agg (
 );
 
 -- Overload 2: pdb.agg(jsonb, bool)
-DROP AGGREGATE IF EXISTS pdb.agg(jsonb, bool);
-DROP FUNCTION IF EXISTS pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state(this internal, arg_one jsonb, arg_two bool);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state(this internal, arg_one jsonb, arg_two bool) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state_wrapper' LANGUAGE c PARALLEL SAFE;
-DROP FUNCTION IF EXISTS pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize(this internal);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
 
 CREATE OR REPLACE AGGREGATE pdb.agg (
@@ -37,10 +31,7 @@ CREATE OR REPLACE AGGREGATE pdb.agg (
 );
 
 -- Overload 3: pdb.agg(jsonb, text)
-DROP AGGREGATE IF EXISTS pdb.agg(jsonb, text);
-DROP FUNCTION IF EXISTS pdb.agg_placeholder_visibility_agg_placeholder_visibility_state(this internal, arg_one jsonb, arg_two text);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_visibility_agg_placeholder_visibility_state(this internal, arg_one jsonb, arg_two text) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_state_wrapper' LANGUAGE c PARALLEL SAFE;
-DROP FUNCTION IF EXISTS pdb.agg_placeholder_visibility_agg_placeholder_visibility_finalize(this internal);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_visibility_agg_placeholder_visibility_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
 
 CREATE OR REPLACE AGGREGATE pdb.agg (

--- a/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
+++ b/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
@@ -2,6 +2,7 @@
 -- using pdb.agg can be parallelized with MPP (DistributedExec).
 
 -- Overload 1: pdb.agg(jsonb)
+DROP AGGREGATE IF EXISTS pdb.agg(jsonb);
 DROP FUNCTION IF EXISTS pdb.agg_placeholder_agg_placeholder_state(this internal, arg_one jsonb);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_agg_placeholder_state(this internal, arg_one jsonb) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_state_wrapper' LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS pdb.agg_placeholder_agg_placeholder_finalize(this internal);
@@ -18,6 +19,7 @@ CREATE OR REPLACE AGGREGATE pdb.agg (
 );
 
 -- Overload 2: pdb.agg(jsonb, bool)
+DROP AGGREGATE IF EXISTS pdb.agg(jsonb, bool);
 DROP FUNCTION IF EXISTS pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state(this internal, arg_one jsonb, arg_two bool);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state(this internal, arg_one jsonb, arg_two bool) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state_wrapper' LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize(this internal);
@@ -35,6 +37,7 @@ CREATE OR REPLACE AGGREGATE pdb.agg (
 );
 
 -- Overload 3: pdb.agg(jsonb, text)
+DROP AGGREGATE IF EXISTS pdb.agg(jsonb, text);
 DROP FUNCTION IF EXISTS pdb.agg_placeholder_visibility_agg_placeholder_visibility_state(this internal, arg_one jsonb, arg_two text);
 CREATE OR REPLACE FUNCTION pdb.agg_placeholder_visibility_agg_placeholder_visibility_state(this internal, arg_one jsonb, arg_two text) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_state_wrapper' LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS pdb.agg_placeholder_visibility_agg_placeholder_visibility_finalize(this internal);

--- a/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
+++ b/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
@@ -1,10 +1,7 @@
--- Make pdb.agg and its placeholder functions parallel safe so that queries
--- using pdb.agg can be parallelized with MPP (DistributedExec).
+-- Make pdb.agg parallel safe so that queries using pdb.agg can be
+-- parallelized with MPP (DistributedExec).
 
 -- Overload 1: pdb.agg(jsonb)
-CREATE OR REPLACE FUNCTION pdb.agg_placeholder_agg_placeholder_state(this internal, arg_one jsonb) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_state_wrapper' LANGUAGE c PARALLEL SAFE;
-CREATE OR REPLACE FUNCTION pdb.agg_placeholder_agg_placeholder_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
-
 CREATE OR REPLACE AGGREGATE pdb.agg (
 	jsonb
 )
@@ -16,9 +13,6 @@ CREATE OR REPLACE AGGREGATE pdb.agg (
 );
 
 -- Overload 2: pdb.agg(jsonb, bool)
-CREATE OR REPLACE FUNCTION pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state(this internal, arg_one jsonb, arg_two bool) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state_wrapper' LANGUAGE c PARALLEL SAFE;
-CREATE OR REPLACE FUNCTION pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
-
 CREATE OR REPLACE AGGREGATE pdb.agg (
 	jsonb,
 	bool
@@ -31,9 +25,6 @@ CREATE OR REPLACE AGGREGATE pdb.agg (
 );
 
 -- Overload 3: pdb.agg(jsonb, text)
-CREATE OR REPLACE FUNCTION pdb.agg_placeholder_visibility_agg_placeholder_visibility_state(this internal, arg_one jsonb, arg_two text) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_state_wrapper' LANGUAGE c PARALLEL SAFE;
-CREATE OR REPLACE FUNCTION pdb.agg_placeholder_visibility_agg_placeholder_visibility_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
-
 CREATE OR REPLACE AGGREGATE pdb.agg (
 	jsonb,
 	text

--- a/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
+++ b/pg_search/sql/unreleased/6269.make_pdb_agg_parallel_safe.sql
@@ -1,0 +1,52 @@
+-- Make pdb.agg and its placeholder functions parallel safe so that queries
+-- using pdb.agg can be parallelized with MPP (DistributedExec).
+
+-- Overload 1: pdb.agg(jsonb)
+DROP FUNCTION IF EXISTS pdb.agg_placeholder_agg_placeholder_state(this internal, arg_one jsonb);
+CREATE OR REPLACE FUNCTION pdb.agg_placeholder_agg_placeholder_state(this internal, arg_one jsonb) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_state_wrapper' LANGUAGE c PARALLEL SAFE;
+DROP FUNCTION IF EXISTS pdb.agg_placeholder_agg_placeholder_finalize(this internal);
+CREATE OR REPLACE FUNCTION pdb.agg_placeholder_agg_placeholder_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
+
+CREATE OR REPLACE AGGREGATE pdb.agg (
+	jsonb
+)
+(
+	SFUNC = pdb."agg_placeholder_agg_placeholder_state",
+	STYPE = internal,
+	FINALFUNC = pdb."agg_placeholder_agg_placeholder_finalize",
+	PARALLEL = SAFE
+);
+
+-- Overload 2: pdb.agg(jsonb, bool)
+DROP FUNCTION IF EXISTS pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state(this internal, arg_one jsonb, arg_two bool);
+CREATE OR REPLACE FUNCTION pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state(this internal, arg_one jsonb, arg_two bool) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state_wrapper' LANGUAGE c PARALLEL SAFE;
+DROP FUNCTION IF EXISTS pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize(this internal);
+CREATE OR REPLACE FUNCTION pdb.agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
+
+CREATE OR REPLACE AGGREGATE pdb.agg (
+	jsonb,
+	bool
+)
+(
+	SFUNC = pdb."agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state",
+	STYPE = internal,
+	FINALFUNC = pdb."agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize",
+	PARALLEL = SAFE
+);
+
+-- Overload 3: pdb.agg(jsonb, text)
+DROP FUNCTION IF EXISTS pdb.agg_placeholder_visibility_agg_placeholder_visibility_state(this internal, arg_one jsonb, arg_two text);
+CREATE OR REPLACE FUNCTION pdb.agg_placeholder_visibility_agg_placeholder_visibility_state(this internal, arg_one jsonb, arg_two text) RETURNS internal AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_state_wrapper' LANGUAGE c PARALLEL SAFE;
+DROP FUNCTION IF EXISTS pdb.agg_placeholder_visibility_agg_placeholder_visibility_finalize(this internal);
+CREATE OR REPLACE FUNCTION pdb.agg_placeholder_visibility_agg_placeholder_visibility_finalize(this internal) RETURNS jsonb AS 'MODULE_PATHNAME', 'agg_placeholder_visibility_agg_placeholder_visibility_finalize_wrapper' LANGUAGE c PARALLEL SAFE;
+
+CREATE OR REPLACE AGGREGATE pdb.agg (
+	jsonb,
+	text
+)
+(
+	SFUNC = pdb."agg_placeholder_visibility_agg_placeholder_visibility_state",
+	STYPE = internal,
+	FINALFUNC = pdb."agg_placeholder_visibility_agg_placeholder_visibility_finalize",
+	PARALLEL = SAFE
+);

--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -193,8 +193,8 @@ pub fn aggregate(
 
 #[pgrx::pg_schema]
 mod pdb {
-    use pgrx::aggregate::Aggregate;
-    use pgrx::{Internal, JsonB, pg_extern};
+    use pgrx::aggregate::{Aggregate, ParallelOption};
+    use pgrx::{Internal, JsonB, pg_extern, pgrx};
 
     /// Placeholder aggregate for `pdb.agg(jsonb)`.
     ///
@@ -213,12 +213,14 @@ mod pdb {
     #[aggregate_name = "agg"]
     pub struct AggPlaceholder;
 
-    #[pgrx::pg_aggregate(parallel_safe)]
+    #[pgrx::pg_aggregate]
     impl Aggregate<AggPlaceholder> for AggPlaceholder {
+        const PARALLEL: Option<ParallelOption> = Some(ParallelOption::Safe);
         type Args = JsonB;
         type State = Internal;
         type Finalize = JsonB;
 
+        #[pgrx(parallel_safe)]
         fn state(
             _current: Self::State,
             _arg: Self::Args,
@@ -232,6 +234,7 @@ mod pdb {
             )
         }
 
+        #[pgrx(parallel_safe)]
         fn finalize(
             _current: Self::State,
             _direct_arg: Self::OrderedSetArgs,
@@ -257,12 +260,14 @@ mod pdb {
     #[aggregate_name = "agg"]
     pub struct AggPlaceholderWithMvcc;
 
-    #[pgrx::pg_aggregate(parallel_safe)]
+    #[pgrx::pg_aggregate]
     impl Aggregate<AggPlaceholderWithMvcc> for AggPlaceholderWithMvcc {
+        const PARALLEL: Option<ParallelOption> = Some(ParallelOption::Safe);
         type Args = (JsonB, bool);
         type State = Internal;
         type Finalize = JsonB;
 
+        #[pgrx(parallel_safe)]
         fn state(
             _current: Self::State,
             _arg: Self::Args,
@@ -276,6 +281,7 @@ mod pdb {
             )
         }
 
+        #[pgrx(parallel_safe)]
         fn finalize(
             _current: Self::State,
             _direct_arg: Self::OrderedSetArgs,
@@ -304,12 +310,14 @@ mod pdb {
     #[aggregate_name = "agg"]
     pub struct AggPlaceholderVisibility;
 
-    #[pgrx::pg_aggregate(parallel_safe)]
+    #[pgrx::pg_aggregate]
     impl Aggregate<AggPlaceholderVisibility> for AggPlaceholderVisibility {
+        const PARALLEL: Option<ParallelOption> = Some(ParallelOption::Safe);
         type Args = (JsonB, String);
         type State = Internal;
         type Finalize = JsonB;
 
+        #[pgrx(parallel_safe)]
         fn state(
             _current: Self::State,
             _arg: Self::Args,
@@ -323,6 +331,7 @@ mod pdb {
             )
         }
 
+        #[pgrx(parallel_safe)]
         fn finalize(
             _current: Self::State,
             _direct_arg: Self::OrderedSetArgs,

--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -194,12 +194,15 @@ pub fn aggregate(
 #[pgrx::pg_schema]
 mod pdb {
     use pgrx::aggregate::{Aggregate, ParallelOption};
-    use pgrx::{Internal, JsonB, pg_extern, pgrx};
+    use pgrx::{Internal, JsonB, pg_extern};
 
     /// Placeholder aggregate for `pdb.agg(jsonb)`.
     ///
     /// This aggregate should never actually execute - it's intercepted at planning time
     /// for window functions or by AggregateScan for (GROUP BY) aggregate queries.
+    ///
+    /// It is marked `PARALLEL SAFE` so that queries containing `pdb.agg()` can
+    /// be parallelized by PostgreSQL with MPP (`DistributedExec`).
     ///
     /// Usage:
     /// ```sql
@@ -220,7 +223,6 @@ mod pdb {
         type State = Internal;
         type Finalize = JsonB;
 
-        #[pgrx(parallel_safe)]
         fn state(
             _current: Self::State,
             _arg: Self::Args,
@@ -234,7 +236,6 @@ mod pdb {
             )
         }
 
-        #[pgrx(parallel_safe)]
         fn finalize(
             _current: Self::State,
             _direct_arg: Self::OrderedSetArgs,
@@ -267,7 +268,6 @@ mod pdb {
         type State = Internal;
         type Finalize = JsonB;
 
-        #[pgrx(parallel_safe)]
         fn state(
             _current: Self::State,
             _arg: Self::Args,
@@ -281,7 +281,6 @@ mod pdb {
             )
         }
 
-        #[pgrx(parallel_safe)]
         fn finalize(
             _current: Self::State,
             _direct_arg: Self::OrderedSetArgs,
@@ -317,7 +316,6 @@ mod pdb {
         type State = Internal;
         type Finalize = JsonB;
 
-        #[pgrx(parallel_safe)]
         fn state(
             _current: Self::State,
             _arg: Self::Args,
@@ -331,7 +329,6 @@ mod pdb {
             )
         }
 
-        #[pgrx(parallel_safe)]
         fn finalize(
             _current: Self::State,
             _direct_arg: Self::OrderedSetArgs,

--- a/pg_search/src/api/builder_fns/pdb.rs
+++ b/pg_search/src/api/builder_fns/pdb.rs
@@ -603,6 +603,7 @@ mod pdb {
         PdbOwnedValue::Date(PostgresDateTime::try_from_raw(0).unwrap())
     );
 
+    // TODO: Remove deprecated `pdb.term_set` aggregate in a future release.
     #[derive(pgrx::AggregateName, Default)]
     #[aggregate_name = "term_set"]
     pub struct TermSetAggI64;

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -194,6 +194,84 @@ LIMIT 5;
  file-102
 (5 rows)
 
+-- pdb.agg: scalar terms aggregation over join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('pdb.agg'::text)
+   Backend: DataFusion
+   Indexes: mpp_files_idx (f), mpp_pages_idx (p)
+   Aggregates: pdb.agg({"terms":{"size":5,"field":"title","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : ProjectionExec: expr=[__grouping_id@1 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_m0@2 as __pdb_m0]
+     :   AggregateExec: mode=Final, gby=[__pdb_k0@0 as __pdb_k0, __grouping_id@1 as __grouping_id], aggr=[count(1) as __pdb_m0]
+     :     AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0), (title@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1]
+     :         CooperativeExec
+     :           PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :         CooperativeExec
+     :           PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+(14 rows)
+
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+                                                                                                               agg                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "file-1", "doc_count": 5}, {"key": "file-10", "doc_count": 5}, {"key": "file-100", "doc_count": 5}, {"key": "file-101", "doc_count": 5}, {"key": "file-102", "doc_count": 5}], "sum_other_doc_count": 975}
+(1 row)
+
+-- pdb.agg: terms aggregation with GROUP BY
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.title, (pdb.agg('{"terms": {"field": "title"}}'::jsonb))
+   ->  Sort
+         Output: f.title, (pdb.agg('{"terms": {"field": "title"}}'::jsonb))
+         Sort Key: f.title
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Output: f.title, (pdb.agg('{"terms": {"field": "title"}}'::jsonb))
+               Backend: DataFusion
+               Indexes: mpp_files_idx (f), mpp_pages_idx (p)
+               Group By: title
+               Aggregates: pdb.agg({"terms":{"field":"title"}})
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[title@0 as title, __grouping_id@2 as __grouping_id, __pdb_k0@1 as __pdb_k0, __pdb_m0@3 as __pdb_m0]
+                 :   AggregateExec: mode=Final, gby=[title@0 as title, __pdb_k0@1 as __pdb_k0, __grouping_id@2 as __grouping_id], aggr=[count(1) as __pdb_m0]
+                 :     AggregateExec: mode=Partial, gby=[(title@0 as title, NULL as __pdb_k0), (title@0 as title, title@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1]
+                 :         CooperativeExec
+                 :           PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+(20 rows)
+
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+  title   |                                                      agg                                                       
+----------+----------------------------------------------------------------------------------------------------------------
+ file-1   | {"buckets": [{"key": "file-1", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-10  | {"buckets": [{"key": "file-10", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-100 | {"buckets": [{"key": "file-100", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-101 | {"buckets": [{"key": "file-101", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-102 | {"buckets": [{"key": "file-102", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+(5 rows)
+
 -- =====================================================================
 -- Pass 2: MPP path (max_parallel_workers_per_gather = 3). Same queries, same expected results.
 --
@@ -382,6 +460,120 @@ LIMIT 5;
  file-102
 (5 rows)
 
+-- pdb.agg: scalar terms aggregation under MPP
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('pdb.agg'::text)
+   Backend: DataFusion
+   Indexes: mpp_files_idx (f), mpp_pages_idx (p)
+   Aggregates: pdb.agg({"terms":{"size":5,"field":"title","order":{"_key":"asc"}}})
+   DataFusion Physical Plan: 
+     : ┌───── DistributedExec
+     : │ CoalescePartitionsExec
+     : │   [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+     : └──────────────────────────────────────────────────
+     :   ┌───── Stage 3 ── tasks=2, partitions=3
+     :   │ ProjectionExec: expr=[__grouping_id@1 as __grouping_id, __pdb_k0@0 as __pdb_k0, __pdb_m0@2 as __pdb_m0]
+     :   │   AggregateExec: mode=FinalPartitioned, gby=[__pdb_k0@0 as __pdb_k0, __grouping_id@1 as __grouping_id], aggr=[count(1) as __pdb_m0]
+     :   │     [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+     :   └──────────────────────────────────────────────────
+     :     ┌───── Stage 2 ── tasks=2, partitions=6
+     :     │ RepartitionExec: partitioning=Hash([__pdb_k0@0, __grouping_id@1], 6), input_partitions=3
+     :     │   AggregateExec: mode=Partial, gby=[(NULL as __pdb_k0), (title@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+     :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1]
+     :     │       CoalescePartitionsExec
+     :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+     :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+     :     │         DistributedLeafExec:
+     :     │           t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :     │           t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+     :     └──────────────────────────────────────────────────
+     :       ┌───── Stage 1 ── tasks=2, partitions=4
+     :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
+     :       │   DistributedLeafExec:
+     :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       └──────────────────────────────────────────────────
+(32 rows)
+
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+                                                                                                               agg                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "file-1", "doc_count": 5}, {"key": "file-10", "doc_count": 5}, {"key": "file-100", "doc_count": 5}, {"key": "file-101", "doc_count": 5}, {"key": "file-102", "doc_count": 5}], "sum_other_doc_count": 975}
+(1 row)
+
+-- pdb.agg: terms aggregation with GROUP BY under MPP
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.title, (pdb.agg('{"terms": {"field": "title"}}'::jsonb))
+   ->  Sort
+         Output: f.title, (pdb.agg('{"terms": {"field": "title"}}'::jsonb))
+         Sort Key: f.title
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Output: f.title, (pdb.agg('{"terms": {"field": "title"}}'::jsonb))
+               Backend: DataFusion
+               Indexes: mpp_files_idx (f), mpp_pages_idx (p)
+               Group By: title
+               Aggregates: pdb.agg({"terms":{"field":"title"}})
+               DataFusion Physical Plan: 
+                 : ┌───── DistributedExec
+                 : │ CoalescePartitionsExec
+                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+                 : └──────────────────────────────────────────────────
+                 :   ┌───── Stage 3 ── tasks=2, partitions=3
+                 :   │ ProjectionExec: expr=[title@0 as title, __grouping_id@2 as __grouping_id, __pdb_k0@1 as __pdb_k0, __pdb_m0@3 as __pdb_m0]
+                 :   │   AggregateExec: mode=FinalPartitioned, gby=[title@0 as title, __pdb_k0@1 as __pdb_k0, __grouping_id@2 as __grouping_id], aggr=[count(1) as __pdb_m0]
+                 :   │     [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+                 :   └──────────────────────────────────────────────────
+                 :     ┌───── Stage 2 ── tasks=2, partitions=6
+                 :     │ RepartitionExec: partitioning=Hash([title@0, __pdb_k0@1, __grouping_id@2], 6), input_partitions=3
+                 :     │   AggregateExec: mode=Partial, gby=[(title@0 as title, NULL as __pdb_k0), (title@0 as title, title@0 as __pdb_k0)], aggr=[count(1) as __pdb_m0]
+                 :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1]
+                 :     │       CoalescePartitionsExec
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=2, input_tasks=2
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     │           t1: PgSearchScan: table=p, segments=2, dynamic_filters=1, visibility=eager, query="all"
+                 :     └──────────────────────────────────────────────────
+                 :       ┌───── Stage 1 ── tasks=2, partitions=4
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=2, output_partitions=2
+                 :       │   DistributedLeafExec:
+                 :       │     t0: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: table=f, segments=2, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       └──────────────────────────────────────────────────
+(38 rows)
+
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+  title   |                                                      agg                                                       
+----------+----------------------------------------------------------------------------------------------------------------
+ file-1   | {"buckets": [{"key": "file-1", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-10  | {"buckets": [{"key": "file-10", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-100 | {"buckets": [{"key": "file-100", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-101 | {"buckets": [{"key": "file-101", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ file-102 | {"buckets": [{"key": "file-102", "doc_count": 5}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+(5 rows)
+
 -- =====================================================================
 -- Pass 3: the size gate falls back to serial execution for the aggregate
 -- path too, and the results match the serial baseline.
@@ -423,6 +615,26 @@ LIMIT 5;
  file-101 |     5 |  9732
  file-102 |     5 |  9817
 (5 rows)
+
+SELECT count(*) = 0 AS gated_no_distributed_exec_pdb_agg
+FROM mpp_agg_explain_analyze_lines(
+  $$SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+    FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'$$
+) AS line
+WHERE line LIKE '%DistributedExec%';
+ gated_no_distributed_exec_pdb_agg 
+-----------------------------------
+ t
+(1 row)
+
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+                                                                                                               agg                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "file-1", "doc_count": 5}, {"key": "file-10", "doc_count": 5}, {"key": "file-100", "doc_count": 5}, {"key": "file-101", "doc_count": 5}, {"key": "file-102", "doc_count": 5}], "sum_other_doc_count": 975}
+(1 row)
 
 DROP FUNCTION mpp_agg_explain_analyze_lines(text);
 RESET paradedb.mpp_min_rows;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate.sql
@@ -134,6 +134,32 @@ WHERE f.content @@@ 'Section'
 ORDER BY f.title
 LIMIT 5;
 
+-- pdb.agg: scalar terms aggregation over join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+-- pdb.agg: terms aggregation with GROUP BY
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+
 -- =====================================================================
 -- Pass 2: MPP path (max_parallel_workers_per_gather = 3). Same queries, same expected results.
 --
@@ -191,6 +217,32 @@ WHERE f.content @@@ 'Section'
 ORDER BY f.title
 LIMIT 5;
 
+-- pdb.agg: scalar terms aggregation under MPP
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+-- pdb.agg: terms aggregation with GROUP BY under MPP
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+
+SELECT f.title, pdb.agg('{"terms": {"field": "title"}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.title
+ORDER BY f.title
+LIMIT 5;
+
 -- =====================================================================
 -- Pass 3: the size gate falls back to serial execution for the aggregate
 -- path too, and the results match the serial baseline.
@@ -223,6 +275,18 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
+
+SELECT count(*) = 0 AS gated_no_distributed_exec_pdb_agg
+FROM mpp_agg_explain_analyze_lines(
+  $$SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+    FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'$$
+) AS line
+WHERE line LIKE '%DistributedExec%';
+
+SELECT pdb.agg('{"terms": {"field": "title", "order": {"_key": "asc"}, "size": 5}}')
+FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
 
 DROP FUNCTION mpp_agg_explain_analyze_lines(text);
 RESET paradedb.mpp_min_rows;


### PR DESCRIPTION
## What

Marks `pdb.agg` and its underlying placeholder C functions (`state` and `finalize`) as `PARALLEL SAFE` / `PARALLEL = SAFE`, and adds MPP regression test cases for `pdb.agg` in `mpp_aggregate`.

## Why

In PR #6181, MPP execution was gated on `PlannerInfo.glob.parallelModeOK`. Because `pdb.agg` and its placeholder functions were declared without parallel safety markings in the catalog (`proparallel = 'u'`), PostgreSQL set `parallelModeOK = false`. This forced all queries containing `pdb.agg` to silently bypass `DistributedExec` and fall back to single-threaded serial execution (`CooperativeExec`).

## How

- In `pg_search/src/api/aggregate.rs`, added `const PARALLEL: Option<ParallelOption> = Some(ParallelOption::Safe);` to the `Aggregate` trait implementations and annotated `fn state` and `fn finalize` with `#[pgrx(parallel_safe)]` across all three overloads (`AggPlaceholder`, `AggPlaceholderWithMvcc`, and `AggPlaceholderVisibility`).

## Tests

- In `pg_search/tests/pg_regress/sql/mpp_aggregate.sql`, added scalar and `GROUP BY` `pdb.agg` test cases across Pass 1 (serial baseline), Pass 2 (MPP path exercising `DistributedExec`), and Pass 3 (size-gating fallback).