### PR TITLE
chore: bump tantivy for stacked IVF cover-check fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7130,7 +7130,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "bitpacking",
 ]
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7257,7 +7257,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d40cd042967b355da33af8daa9f7f744dba9f7ae#d40cd042967b355da33af8daa9f7f744dba9f7ae"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0a6c6cb70df92853a755e9f4e22bda0c26ff90a#a0a6c6cb70df92853a755e9f4e22bda0c26ff90a"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ overflow-checks = true
 [workspace.dependencies]
 pgrx = "=0.19.2"
 pgrx-tests = "=0.19.2"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "d40cd042967b355da33af8daa9f7f744dba9f7ae", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "a0a6c6cb70df92853a755e9f4e22bda0c26ff90a", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -78,7 +78,7 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "d40cd042967b355da33af8daa9f7f744dba9f7ae" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "a0a6c6cb70df92853a755e9f4e22bda0c26ff90a" }
 
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-YCwWZbDAEHUHPFlot9vvVtYjdDsIAXfOmloW3Kqqj3I=";
+  cargoHash = "sha256-p+jzNSGuZf8EhztIrf5uAR4MKGv33UtauPzmg+GBfNs=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
## Summary
- Bump tantivy (and `tantivy-tokenizer-api`) to `a0a6c6cb` ([paradedb/tantivy#226](https://github.com/paradedb/tantivy/pull/226)).
- Picks up the stacked IVF `ranges_cover_members` fix so indexes with empty L0 router lists (e.g. higher `centroid_ratio`) open cleanly in `paradedb.vector_info` / search.

## Test plan
- [ ] CI green (nix `cargoHash` may be auto-bumped by the bot)
- [ ] Rebuild pg_search against this branch and re-run `pdbench build` with `centroid_ratio=0.02` — `vector_info` should succeed (existing index OK without rebuild)