### PR TITLE
perf: pushed down join InList filters on `uuid` keys.

### DIFF
--- a/docs/changelog/unreleased/6278.performance.mdx
+++ b/docs/changelog/unreleased/6278.performance.mdx
@@ -1,0 +1,5 @@
+---
+header: performance
+---
+
+A join whose key is a `uuid` column, or a text column with a tokenizer cast, now pushes the hash-join key set into the tantivy query. Before, only a plain `text` key did, so the other side of the join read every document in the index and filtered afterwards. The `paradedb.hash_join_inlist_pushdown_max_distinct_values` cap is unchanged.

--- a/docs/changelog/unreleased/6278.performance.mdx
+++ b/docs/changelog/unreleased/6278.performance.mdx
@@ -2,4 +2,4 @@
 header: performance
 ---
 
-A join whose key is a `uuid` column, or a text column with a tokenizer cast, now pushes the hash-join key set into the tantivy query. Before, only a plain `text` key did, so the other side of the join read every document in the index and filtered afterwards. The `paradedb.hash_join_inlist_pushdown_max_distinct_values` cap is unchanged.
+A join whose key is a `uuid` column, or a text column with a tokenizer cast, now pushes the hash-join key set into the Tantivy query. Before, only a plain `text` key did, so the other side of the join read every document in the index and filtered afterwards.

--- a/pg_search/src/postgres/pdb_owned_value.rs
+++ b/pg_search/src/postgres/pdb_owned_value.rs
@@ -305,16 +305,22 @@ impl PdbOwnedValue {
                 Some(PdbOwnedValue::Bool(*v))
             }
 
-            // String/Text types
-            (ScalarValue::Utf8(Some(v)), SearchFieldType::Text(_)) => {
-                Some(PdbOwnedValue::Str(v.clone()))
-            }
-            (ScalarValue::LargeUtf8(Some(v)), SearchFieldType::Text(_)) => {
-                Some(PdbOwnedValue::Str(v.clone()))
-            }
-            (ScalarValue::Utf8View(Some(v)), SearchFieldType::Text(_)) => {
-                Some(PdbOwnedValue::Str(v.clone()))
-            }
+            // String/Text types. `Uuid` indexes the whole value as one text term and
+            // `Tokenized` is a text column carrying an explicit tokenizer, so both take
+            // the same `Str` representation as `Text`.
+            //
+            // The other Utf8View-backed types are deliberately absent. `Inet` stores as a
+            // tantivy IP field, and `Json`, `Range` and `Ltree` carry path, bound or facet
+            // encoding. A bare string cannot reproduce any of those, and a term built the
+            // wrong way silently drops the rows it should match.
+            (
+                ScalarValue::Utf8(Some(v))
+                | ScalarValue::LargeUtf8(Some(v))
+                | ScalarValue::Utf8View(Some(v)),
+                SearchFieldType::Text(_)
+                | SearchFieldType::Tokenized(..)
+                | SearchFieldType::Uuid(_),
+            ) => Some(PdbOwnedValue::Str(v.clone())),
 
             // Numeric64 (scaled integers)
             (ScalarValue::Int64(Some(v)), SearchFieldType::Numeric64(_, scale)) => {

--- a/pg_search/tests/pg_regress/expected/join_dynamic_filter_string_keys.out
+++ b/pg_search/tests/pg_regress/expected/join_dynamic_filter_string_keys.out
@@ -1,0 +1,177 @@
+-- Hash-join InList dynamic filters on string-backed join keys.
+--
+-- `uuid` and tokenizer-cast text columns both store as Utf8View, the same
+-- as a plain `text` field, but only `text` used to convert the join-derived
+-- InList into a TermSetQuery. The others fell back to a post-search pre-filter,
+-- so the probe side read every document in the index.
+--
+-- The `dynamic_filter_pushdown_*` token plus a small `rows_scanned` on the probe
+-- scan is what proves the term set reached tantivy. A `uuid` foreign key is the
+-- common shape here, so it gets the widest coverage.
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan = on;
+DROP TABLE IF EXISTS strkey_probe CASCADE;
+DROP TABLE IF EXISTS strkey_build CASCADE;
+-- The build side keeps 20 of the 5,000 keys, so an index-driven term set reads
+-- ~20 documents while the pre-filter fallback reads all 5,000.
+CREATE TABLE strkey_build (
+    id       uuid PRIMARY KEY,
+    id_txt   text NOT NULL,
+    keep     boolean NOT NULL,
+    ordinal  bigint NOT NULL
+);
+INSERT INTO strkey_build (id, id_txt, keep, ordinal)
+SELECT md5('k' || i)::uuid,
+       md5('k' || i),
+       i <= 20,
+       i
+FROM generate_series(1, 5000) i;
+CREATE TABLE strkey_probe (
+    id        bigserial PRIMARY KEY,
+    fk_uuid   uuid NOT NULL,
+    fk_txt    text NOT NULL,
+    amount    bigint NOT NULL
+);
+INSERT INTO strkey_probe (fk_uuid, fk_txt, amount)
+SELECT md5('k' || i)::uuid,
+       md5('k' || i),
+       i
+FROM generate_series(1, 5000) i;
+CREATE INDEX strkey_build_idx ON strkey_build
+USING bm25 (id, (id_txt::pdb.literal), keep, ordinal)
+WITH (key_field = 'id');
+CREATE INDEX strkey_probe_idx ON strkey_probe
+USING bm25 (id, fk_uuid, (fk_txt::pdb.literal), amount)
+WITH (key_field = 'id');
+ANALYZE strkey_build;
+ANALYZE strkey_probe;
+-- =============================================================================
+-- TEST 1: uuid join key
+-- =============================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_uuid = b.id
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: p INNER b
+         Join Cond: b.id = p.fk_uuid
+         Limit: 10
+         Order By: b.ordinal asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[ordinal@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[ordinal@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[ordinal@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[p, b], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk_uuid@1)], projection=[ctid_0@3, ctid_1@0, ordinal@2], metrics=[output_rows=20, output_bytes=192.0 KB, output_batches=1, build_mem_used=2.3 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=20, input_batches=1, input_rows=20, avg_fanout=100% (20/20), probe_hit_rate=100% (20/20)]
+           :           CooperativeExec
+           :             PgSearchScan: table=b, segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"keep","value":true}}]}}, metrics=[output_rows=20, output_bytes=1792.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :           CooperativeExec
+           :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"range":{"field":"amount","lower_bound":{"included":0},"upper_bound":null}}, metrics=[output_rows=20, output_bytes=1632.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=20]
+(16 rows)
+
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_uuid = b.id
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+ ordinal 
+---------
+       1
+       2
+       3
+       4
+       5
+       6
+       7
+       8
+       9
+      10
+(10 rows)
+
+-- =============================================================================
+-- TEST 2: tokenizer-cast text join key
+-- =============================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_txt = b.id_txt
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: p INNER b
+         Join Cond: b.id_txt = p.fk_txt
+         Limit: 10
+         Order By: b.ordinal asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[ordinal@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[ordinal@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[ordinal@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[p, b], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id_txt@1, fk_txt@1)], projection=[ctid_0@3, ctid_1@0, ordinal@2], metrics=[output_rows=20, output_bytes=192.0 KB, output_batches=1, build_mem_used=2.2 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=20, input_batches=1, input_rows=20, avg_fanout=100% (20/20), probe_hit_rate=100% (20/20)]
+           :           CooperativeExec
+           :             PgSearchScan: table=b, segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"keep","value":true}}]}}, metrics=[output_rows=20, output_bytes=1664.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :           CooperativeExec
+           :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"range":{"field":"amount","lower_bound":{"included":0},"upper_bound":null}}, metrics=[output_rows=20, output_bytes=1504.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=20]
+(16 rows)
+
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_txt = b.id_txt
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+ ordinal 
+---------
+       1
+       2
+       3
+       4
+       5
+       6
+       7
+       8
+       9
+      10
+(10 rows)
+
+-- =============================================================================
+-- TEST 3: pushdown disabled, so the pre-filter fallback still gives the same rows
+-- =============================================================================
+SET paradedb.hash_join_inlist_pushdown_max_distinct_values = 0;
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_uuid = b.id
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+ ordinal 
+---------
+       1
+       2
+       3
+       4
+       5
+       6
+       7
+       8
+       9
+      10
+(10 rows)
+
+RESET paradedb.hash_join_inlist_pushdown_max_distinct_values;
+DROP TABLE strkey_probe;
+DROP TABLE strkey_build;

--- a/pg_search/tests/pg_regress/sql/join_dynamic_filter_string_keys.sql
+++ b/pg_search/tests/pg_regress/sql/join_dynamic_filter_string_keys.sql
@@ -1,0 +1,117 @@
+-- Hash-join InList dynamic filters on string-backed join keys.
+--
+-- `uuid` and tokenizer-cast text columns both store as Utf8View, the same
+-- as a plain `text` field, but only `text` used to convert the join-derived
+-- InList into a TermSetQuery. The others fell back to a post-search pre-filter,
+-- so the probe side read every document in the index.
+--
+-- The `dynamic_filter_pushdown_*` token plus a small `rows_scanned` on the probe
+-- scan is what proves the term set reached tantivy. A `uuid` foreign key is the
+-- common shape here, so it gets the widest coverage.
+
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_join_custom_scan = on;
+
+DROP TABLE IF EXISTS strkey_probe CASCADE;
+DROP TABLE IF EXISTS strkey_build CASCADE;
+
+-- The build side keeps 20 of the 5,000 keys, so an index-driven term set reads
+-- ~20 documents while the pre-filter fallback reads all 5,000.
+CREATE TABLE strkey_build (
+    id       uuid PRIMARY KEY,
+    id_txt   text NOT NULL,
+    keep     boolean NOT NULL,
+    ordinal  bigint NOT NULL
+);
+
+INSERT INTO strkey_build (id, id_txt, keep, ordinal)
+SELECT md5('k' || i)::uuid,
+       md5('k' || i),
+       i <= 20,
+       i
+FROM generate_series(1, 5000) i;
+
+CREATE TABLE strkey_probe (
+    id        bigserial PRIMARY KEY,
+    fk_uuid   uuid NOT NULL,
+    fk_txt    text NOT NULL,
+    amount    bigint NOT NULL
+);
+
+INSERT INTO strkey_probe (fk_uuid, fk_txt, amount)
+SELECT md5('k' || i)::uuid,
+       md5('k' || i),
+       i
+FROM generate_series(1, 5000) i;
+
+CREATE INDEX strkey_build_idx ON strkey_build
+USING bm25 (id, (id_txt::pdb.literal), keep, ordinal)
+WITH (key_field = 'id');
+
+CREATE INDEX strkey_probe_idx ON strkey_probe
+USING bm25 (id, fk_uuid, (fk_txt::pdb.literal), amount)
+WITH (key_field = 'id');
+
+ANALYZE strkey_build;
+ANALYZE strkey_probe;
+
+-- =============================================================================
+-- TEST 1: uuid join key
+-- =============================================================================
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_uuid = b.id
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_uuid = b.id
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 2: tokenizer-cast text join key
+-- =============================================================================
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_txt = b.id_txt
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_txt = b.id_txt
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 3: pushdown disabled, so the pre-filter fallback still gives the same rows
+-- =============================================================================
+
+SET paradedb.hash_join_inlist_pushdown_max_distinct_values = 0;
+
+SELECT b.ordinal
+FROM strkey_build b
+JOIN strkey_probe p ON p.fk_uuid = b.id
+WHERE b.id @@@ paradedb.all() AND b.keep = true AND p.amount >= 0
+ORDER BY b.ordinal ASC
+LIMIT 10;
+
+RESET paradedb.hash_join_inlist_pushdown_max_distinct_values;
+
+DROP TABLE strkey_probe;
+DROP TABLE strkey_build;


### PR DESCRIPTION
## Ticket(s) Closed

- Partially closes #6276

## What

This PR makes the hash-join `InList` dynamic filter reach tantivy when the join key is a `uuid` or a tokenizer-cast text column.

## Why

`PdbOwnedValue::from_scalar` mapped the Utf8 family onto `SearchFieldType::Text` only. `Uuid` and `Tokenized` store as `Utf8View` too, so the join-derived `InList` produced no term and `try_convert_in_list_to_query` gave up. The predicate showed up only as a post-search pre-filter, which drops rows after the scan has already read and materialized them. So the probe side read every document in the index.

`Inet`, `Json`, `Range` and `Ltree` are `Utf8View`-backed as well but are not checked here. `Inet` stores as a tantivy IP field and the other three carry path, bound or facet encoding. The pushdown rewrites the DataFusion filter to `lit(true)`, so nothing rechecks the term. A term built the wrong way would silently drop rows that should match.

The `paradedb.hash_join_inlist_pushdown_max_distinct_values` cap still applies, so a build side above it keeps the old behaviour.

## How

Widen the string arm in `from_scalar` to accept `Text`, `Tokenized` and `Uuid`.

## Tests

`pg_search/tests/pg_regress/sql/join_dynamic_filter_string_keys.sql`

On a 5,000 row probe with 20 build keys, `rows_scanned` drops from 5,000 to 20.

Step 1, build the fixture from #6276 and pick the group below the cap.

```sql
SET max_parallel_workers_per_gather = 0;

EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
SELECT parent.* FROM parent
JOIN child ON child.parent_id = parent.id
WHERE parent.id @@@ paradedb.all()
  AND parent.deleted_at IS NULL
  AND parent.group_id = md5('g2')::uuid
  AND parent.active = true
  AND child.amount >= 0
ORDER BY parent.created_at DESC, parent.id DESC
LIMIT 25;
```

Step 2, read `rows_scanned` on the `child` scan. It goes from `1.00 M` to `10.18 K`.

Issue #6276 stays open. The join still materializes every matching row before the Top-K, so it does work proportional to the build side rather than to the 25 rows asked for. That part needs an ordered outer scan with early exit, which is not in here.
