### PR TITLE
feat: read only the top rows of a join's ordered side.

### DIFF
--- a/docs/changelog/unreleased/6281.performance.mdx
+++ b/docs/changelog/unreleased/6281.performance.mdx
@@ -1,0 +1,5 @@
+---
+header: performance
+---
+
+A join with `ORDER BY` and `LIMIT` now reads only the leading rows of the side the sort keys belong to, when every sort key belongs to one side of an inner join. Before, it built its hash table from every matching row and probed the whole other side before keeping the page of rows asked for. The smaller key set also stays under `paradedb.hash_join_inlist_pushdown_max_distinct_values`, so the other side is read through the index rather than scanned. A join that drops too many rows to fill the `LIMIT` runs again unbounded, so results do not change. Set `paradedb.enable_join_bounded_topn` to `off` to disable it, and `paradedb.join_bounded_topn_multiplier` (default 16) to change how many rows it reads.

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -54,6 +54,15 @@ static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true)
 /// Allows the user to toggle range co-partitioning for joins.
 static ENABLE_RANGE_PARTITIONED_JOIN: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+/// Lets a join whose ORDER BY belongs to one side try that side bounded first.
+static ENABLE_JOIN_BOUNDED_TOPN: GucSetting<bool> = GucSetting::<bool>::new(true);
+
+/// How many rows the bounded attempt reads from the ordered side, as a multiple
+/// of `LIMIT + OFFSET`. The join drops rows that find no match, so the bound
+/// needs slack over the row count the query asks for. Too small wastes the
+/// attempt, too large gives back the savings.
+static JOIN_BOUNDED_TOPN_MULTIPLIER: GucSetting<i32> = GucSetting::<i32>::new(16);
+
 static ENABLE_AGGREGATE_LATE_MATERIALIZATION: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 /// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
@@ -347,6 +356,26 @@ pub fn init() {
         c"Enable ParadeDB's join custom scan",
         c"Enable ParadeDB's join custom scan, which pushes eligible joins down into the ParadeDB executor. Default is true.",
         &ENABLE_JOIN_CUSTOM_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_join_bounded_topn",
+        c"Try the ordered side of a join bounded before joining everything",
+        c"When a join has ORDER BY and LIMIT and every sort key belongs to one side, read only the top rows of that side first. Falls back to the full join when the bounded attempt returns too few rows. Default is true.",
+        &ENABLE_JOIN_BOUNDED_TOPN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.join_bounded_topn_multiplier",
+        c"Rows the bounded join attempt reads, as a multiple of LIMIT plus OFFSET",
+        c"Rows the bounded join attempt reads from the ordered side, as a multiple of LIMIT plus OFFSET. Raise it when joins keep falling back because too few rows survive.",
+        &JOIN_BOUNDED_TOPN_MULTIPLIER,
+        1,
+        i32::MAX,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -806,6 +835,14 @@ pub fn enable_join_custom_scan() -> bool {
 
 pub fn enable_range_partitioned_join() -> bool {
     ENABLE_RANGE_PARTITIONED_JOIN.get()
+}
+
+pub fn enable_join_bounded_topn() -> bool {
+    ENABLE_JOIN_BOUNDED_TOPN.get()
+}
+
+pub fn join_bounded_topn_multiplier() -> i32 {
+    JOIN_BOUNDED_TOPN_MULTIPLIER.get()
 }
 
 pub fn enable_aggregate_late_materialization() -> bool {

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -25,7 +25,7 @@
 //! Note: ORDER BY score pushdown is implemented via pathkeys on CustomPath at planning
 //! time. See `pathkey_uses_scores_from_source()` in planning.rs.
 
-use crate::api::OrderByInfo;
+use crate::api::{OrderByFeature, OrderByInfo};
 use crate::postgres::utils::ExprContextGuard;
 use crate::query::SearchQueryInput;
 pub use crate::scan::ScanInfo;
@@ -1920,6 +1920,25 @@ pub struct JoinCSClause {
     pub output_projection: Option<Vec<ChildProjection>>,
     /// Distinct mode for this join: absent, executed by JoinScan, or deferred to parent.
     pub distinct: DistinctMode,
+    /// Set only on the execution-time clone that drives a bounded attempt. The
+    /// planning-time clause never carries it, so the serialized plan is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bounded_topn: Option<BoundedTopN>,
+}
+
+/// Reads only the top `limit` rows of one source before the join, ordered by the
+/// query's own ORDER BY.
+///
+/// Sound because every output row takes its sort key from a row of this source.
+/// Rows left behind sort at or below the last row kept, so they cannot beat a
+/// full result set. A join that drops rows can still under-deliver, which the
+/// caller detects by counting and then runs the unbounded plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoundedTopN {
+    pub plan_position: usize,
+    pub limit: usize,
+    /// The query's ORDER BY expressed against this source alone.
+    pub order_by: Vec<OrderByInfo>,
 }
 
 impl JoinCSClause {
@@ -1930,6 +1949,7 @@ impl JoinCSClause {
             order_by: Vec::new(),
             output_projection: None,
             distinct: DistinctMode::None,
+            bounded_topn: None,
         };
         for (i, source) in clause.plan.sources_mut().into_iter().enumerate() {
             source.plan_position = i;
@@ -1952,6 +1972,200 @@ impl JoinCSClause {
         self
     }
 
+    pub fn with_bounded_topn(mut self, bounded: Option<BoundedTopN>) -> Self {
+        self.bounded_topn = bounded;
+        self
+    }
+
+    /// The source a bounded attempt may read top-first, when the query shape makes
+    /// that sound.
+    ///
+    /// Every sort key has to come from one source, so each output row takes its sort
+    /// key from a row of that source. Rows the bound leaves behind then sort at or
+    /// below the last row it kept, and cannot belong in a full result.
+    ///
+    /// Inner joins only. Any outer join null-extends rows, and a null-extended row
+    /// carries a sort key that no source row produced, which breaks that reasoning.
+    pub fn bounded_topn_source(&self) -> Option<usize> {
+        self.bounded_topn_plan().map(|(pos, _)| pos)
+    }
+
+    /// The target source plus the ORDER BY rewritten to reference only that source.
+    ///
+    /// Postgres rewrites a sort key through an equivalence class, so `ORDER BY a.pk`
+    /// can arrive as `b.fk`. On an inner equi-join the two compare equal in every
+    /// output row, so the rewritten key ranks the rows the same way. The source-level
+    /// sort has to name the target's own column, which is what this recovers.
+    pub fn bounded_topn_plan(&self) -> Option<(usize, Vec<OrderByInfo>)> {
+        if self.order_by.is_empty() || !matches!(self.distinct, DistinctMode::None) {
+            return None;
+        }
+        if !relnode_is_inner_only(&self.plan) {
+            return None;
+        }
+
+        let sources = self.plan.sources();
+        let join_keys = self.plan.join_keys();
+
+        // The first key has no equivalence to fall back on, so it picks the target.
+        let lead_rti = orderby_single_rti(&self.order_by.first()?.feature)?;
+        let target = sources.iter().position(|s| s.contains_rti(lead_rti))?;
+        let target_source = sources.get(target)?;
+
+        let mut rewritten = Vec::with_capacity(self.order_by.len());
+        for info in &self.order_by {
+            let rti = orderby_single_rti(&info.feature)?;
+            if target_source.contains_rti(rti) {
+                rewritten.push(info.clone());
+                continue;
+            }
+            let attno = orderby_attno(&info.feature, &sources)?;
+            let local_attno = equi_partner_attno(&join_keys, rti, attno, target_source)?;
+            rewritten.push(OrderByInfo {
+                feature: OrderByFeature::Var {
+                    rti: target_source.scan_info.heap_rti,
+                    attno: local_attno,
+                    name: target_source.column_name(local_attno),
+                },
+                direction: info.direction,
+            });
+        }
+
+        // A string or bytes fast field is emitted as a segment-local ordinal unless
+        // something else already needs its value early. Ordering on the ordinal at the
+        // source would order by a number that means nothing across segments.
+        let early = early_column_names(&self.plan, target_source);
+        for info in &rewritten {
+            let name = orderby_column_name(&info.feature, target_source)?;
+            if source_column_is_deferrable(target_source, &name) && !early.contains(&name) {
+                return None;
+            }
+        }
+
+        Some((target, rewritten))
+    }
+}
+
+/// Rejects anything but a tree of inner joins over plain scans.
+fn relnode_is_inner_only(node: &RelNode) -> bool {
+    match node {
+        RelNode::Scan(_) => true,
+        RelNode::Join(join) => {
+            matches!(join.join_type, JoinType::Inner)
+                && relnode_is_inner_only(&join.left)
+                && relnode_is_inner_only(&join.right)
+        }
+        RelNode::Filter(filter) => relnode_is_inner_only(&filter.input),
+        RelNode::Unnest(_) => false,
+    }
+}
+
+/// The single relation a sort key reads. `None` for a key with no one relation
+/// behind it, such as a summed score, or one this path does not handle.
+fn orderby_single_rti(feature: &OrderByFeature) -> Option<pg_sys::Index> {
+    match feature {
+        OrderByFeature::Field { rti, .. } => Some(*rti),
+        OrderByFeature::Var { rti, .. } => Some(*rti),
+        OrderByFeature::NullTest { inner, .. } => orderby_single_rti(inner),
+        OrderByFeature::Score { .. }
+        | OrderByFeature::ScoreSum { .. }
+        | OrderByFeature::VectorDistance { .. } => None,
+    }
+}
+
+/// Attribute number a sort key reads, resolved against whichever source owns it.
+fn orderby_attno(feature: &OrderByFeature, sources: &[&JoinSource]) -> Option<pg_sys::AttrNumber> {
+    match feature {
+        OrderByFeature::Var { attno, .. } => Some(*attno),
+        OrderByFeature::Field { name, rti } => {
+            let source = sources.iter().find(|s| s.contains_rti(*rti))?;
+            source
+                .scan_info
+                .fields
+                .iter()
+                .find(|f| f.field.name() == name.as_ref())
+                .map(|f| f.attno)
+        }
+        OrderByFeature::NullTest { inner, .. } => orderby_attno(inner, sources),
+        _ => None,
+    }
+}
+
+/// The column on `target` that an equi-join holds equal to `(rti, attno)`.
+fn equi_partner_attno(
+    join_keys: &[JoinKeyPair],
+    rti: pg_sys::Index,
+    attno: pg_sys::AttrNumber,
+    target: &JoinSource,
+) -> Option<pg_sys::AttrNumber> {
+    join_keys.iter().find_map(|jk| {
+        if jk.outer_rti == rti && jk.outer_attno == attno && target.contains_rti(jk.inner_rti) {
+            Some(jk.inner_attno)
+        } else if jk.inner_rti == rti
+            && jk.inner_attno == attno
+            && target.contains_rti(jk.outer_rti)
+        {
+            Some(jk.outer_attno)
+        } else {
+            None
+        }
+    })
+}
+
+fn orderby_column_name(feature: &OrderByFeature, source: &JoinSource) -> Option<String> {
+    match feature {
+        OrderByFeature::Field { name, .. } => Some(name.as_ref().to_string()),
+        OrderByFeature::Var { attno, .. } => source.column_name(*attno),
+        OrderByFeature::NullTest { inner, .. } => orderby_column_name(inner, source),
+        _ => None,
+    }
+}
+
+/// Columns of `source` that the plan already forces into their real values before
+/// the join runs. Mirrors what the scan builder marks as required early.
+fn early_column_names(plan: &RelNode, source: &JoinSource) -> crate::api::HashSet<String> {
+    let mut early: crate::api::HashSet<String> = Default::default();
+    for jk in plan.join_keys() {
+        if source.contains_rti(jk.outer_rti)
+            && let Some(col) = source.column_name(jk.outer_attno)
+        {
+            early.insert(col);
+        }
+        if source.contains_rti(jk.inner_rti)
+            && let Some(col) = source.column_name(jk.inner_attno)
+        {
+            early.insert(col);
+        }
+    }
+    for (rti, attno) in plan.filter_input_vars() {
+        if source.contains_rti(rti)
+            && let Some(col) = source.column_name(attno)
+        {
+            early.insert(col);
+        }
+    }
+    early
+}
+
+/// True when the column would be emitted as a term ordinal rather than its value.
+fn source_column_is_deferrable(source: &JoinSource, name: &str) -> bool {
+    use crate::index::fast_fields_helper::WhichFastField;
+    source.scan_info.fields.iter().any(|f| match &f.field {
+        WhichFastField::Named(field_name, field_type) => {
+            field_name == name
+                && matches!(
+                    field_type.arrow_data_type(),
+                    arrow_schema::DataType::Utf8View
+                        | arrow_schema::DataType::BinaryView
+                        | arrow_schema::DataType::LargeUtf8
+                        | arrow_schema::DataType::LargeBinary
+                )
+        }
+        _ => false,
+    })
+}
+
+impl JoinCSClause {
     pub fn has_distinct(&self) -> bool {
         self.distinct == DistinctMode::Active
     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -993,8 +993,106 @@ impl JoinScan {
         Self::rebake_from_custom_exprs_string(state, true)
     }
 
-    unsafe fn rebake_from_custom_exprs_string(
+    /// Run the join with the ordered side capped, and keep the result only when it
+    /// fills the LIMIT.
+    ///
+    /// A short result proves nothing: rows can drop in the join, so the missing ones
+    /// might sit past the cap. A full result is the real answer, because anything left
+    /// behind sorts at or below what came back. See `JoinCSClause::bounded_topn_source`.
+    ///
+    /// Returns the executed plan with its rows, so the caller treats it like any other
+    /// plan for ctid wiring, output columns and EXPLAIN ANALYZE.
+    unsafe fn try_bounded_topn(
         state: &mut CustomScanStateWrapper<Self>,
+        runtime: &tokio::runtime::Runtime,
+        runtime_fetch: Option<usize>,
+        planstate: *mut pg_sys::PlanState,
+        runtime_context: *mut pg_sys::ExprContext,
+        source_manifests: &[SearchIndexManifest],
+    ) -> Option<(
+        Arc<dyn ExecutionPlan>,
+        datafusion::execution::SendableRecordBatchStream,
+    )> {
+        if !crate::gucs::enable_join_bounded_topn() {
+            return None;
+        }
+
+        let mut clause = state.custom_state().join_clause.clone();
+        let (target, order_by) = clause.bounded_topn_plan()?;
+
+        let limit_offset = clause.limit_offset.as_ref();
+        let fetch = runtime_fetch.or_else(|| limit_offset.and_then(|lo| lo.static_fetch()))?;
+        if fetch == 0 {
+            return None;
+        }
+        // `static_fetch` already folds OFFSET into the count.
+        let multiplier = crate::gucs::join_bounded_topn_multiplier().max(1) as usize;
+        let cap = fetch.checked_mul(multiplier)?;
+
+        // The gain comes from the other side reading only the keys the bound kept, which
+        // needs the key set to reach tantivy as a term set. Past this cap it does not,
+        // and the attempt would read that whole index for nothing.
+        if cap > crate::gucs::hash_join_inlist_pushdown_max_distinct_values() as usize {
+            return None;
+        }
+
+        clause.bounded_topn = Some(build::BoundedTopN {
+            plan_position: target,
+            limit: cap,
+            order_by,
+        });
+
+        let bytes = Self::rebake_with_clause(state, clause, true);
+        let ctx = create_datafusion_session_context();
+        let logical_plan = deserialize_logical_plan_with_runtime(
+            &bytes,
+            &ctx.task_ctx(),
+            None,
+            Some(runtime_context),
+            Some(planstate),
+            source_manifests.to_vec(),
+        )
+        .ok()?;
+        let logical_plan = match runtime_fetch {
+            Some(f) => datafusion::logical_expr::LogicalPlanBuilder::from(logical_plan)
+                .limit(0, Some(f))
+                .ok()?
+                .build()
+                .ok()?,
+            None => logical_plan,
+        };
+        let plan = runtime
+            .block_on(build_physical_plan(&ctx, logical_plan))
+            .ok()?;
+
+        let task_ctx = build_task_context(
+            &ctx,
+            &plan,
+            pg_sys::work_mem as usize * 1024,
+            pg_sys::hash_mem_multiplier,
+        );
+        let batches = {
+            let _guard = runtime.enter();
+            let stream = plan.execute(0, task_ctx).ok()?;
+            runtime
+                .block_on(datafusion::physical_plan::common::collect(stream))
+                .ok()?
+        };
+
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        if rows < fetch {
+            return None;
+        }
+
+        let schema = plan.schema();
+        let stream =
+            datafusion::physical_plan::memory::MemoryStream::try_new(batches, schema, None).ok()?;
+        Some((plan, Box::pin(stream)))
+    }
+
+    unsafe fn rebake_with_clause(
+        state: &mut CustomScanStateWrapper<Self>,
+        clause: crate::postgres::customscan::joinscan::build::JoinCSClause,
         force_serial: bool,
     ) -> Vec<u8> {
         let custom_exprs: *mut pg_sys::List = match &state.custom_state().custom_exprs_string {
@@ -1006,10 +1104,7 @@ impl JoinScan {
             None => std::ptr::null_mut(),
         };
 
-        let mut private_data = PrivateData::new(
-            state.custom_state().join_clause.clone(),
-            state.custom_state().parallel_mode_ok,
-        );
+        let mut private_data = PrivateData::new(clause, state.custom_state().parallel_mode_ok);
         private_data.output_columns = state.custom_state().output_columns.clone();
 
         bake_logical_plan(&mut private_data, custom_exprs, force_serial);
@@ -1017,6 +1112,14 @@ impl JoinScan {
             .logical_plan
             .expect("rebaking must produce serialized logical plan bytes")
             .to_vec()
+    }
+
+    unsafe fn rebake_from_custom_exprs_string(
+        state: &mut CustomScanStateWrapper<Self>,
+        force_serial: bool,
+    ) -> Vec<u8> {
+        let clause = state.custom_state().join_clause.clone();
+        Self::rebake_with_clause(state, clause, force_serial)
     }
 
     /// Join the MPP producer workers and destroy the parallel context once nothing
@@ -1635,95 +1738,118 @@ impl CustomScan for JoinScan {
                             .expect("Failed to create execution plan")
                     };
 
-                let mpp_pending = state.custom_state_mut().mpp.take_pending();
-                // Leader session context: on an MPP attempt, layer the DF-D fork's
-                // distributed-planner knobs over the Join profile so the resulting physical
-                // plan is a `DistributedExec`, with `producer_worker_cap()` acting as the
-                // planner's ceiling. The mesh and the dispatch source are execute-time
-                // concerns; the exec session below carries them once the workers are committed.
-                let plan_ctx = if mpp_pending {
-                    Self::build_mpp_session_context(None)
-                } else {
-                    create_datafusion_session_context()
-                };
-                let t_plan = std::time::Instant::now();
-                let plan = build_plan(&plan_ctx);
-                launch_us.plan_us = t_plan.elapsed().as_micros() as u64;
-
-                // On a launch fallback (nothing to distribute, or too few attached workers) no
-                // workers remain and the `DistributedExec` shape has no mesh to read from, so
-                // replan serially.
-                let (ctx, plan) = if mpp_pending {
-                    match Self::launch_mpp(state, &plan) {
-                        Some(leader) => {
-                            let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
-                            let exec_ctx = Self::build_mpp_session_context(Some(Arc::clone(
-                                &leader.session.mesh,
-                            )))
-                            .with_distributed_dispatch_plan_source(source);
-                            launch_us.prepare_us = leader.timing.prepare_us;
-                            launch_us.payload_us = leader.timing.payload_us;
-                            launch_us.attach_us = leader.timing.attach_us;
-                            launch_us.leader_setup_us = leader.timing.leader_setup_us;
-                            launch_us.workers = leader.timing.workers;
-                            state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
-                            (exec_ctx, plan)
-                        }
-                        None => {
-                            // Short-launch decline: rebuild the logical plan with serial provider
-                            // metadata. Merely changing SessionContext would replan the existing
-                            // MPP-shaped logical providers without rewriting their source fields.
-                            let serial_ctx = create_datafusion_session_context();
-                            let fallback_bytes = Self::rebake_for_mpp_fallback(state);
-                            let logical_plan = deserialize_logical_plan_with_runtime(
-                                &fallback_bytes,
-                                &serial_ctx.task_ctx(),
-                                None,
-                                Some(runtime_context),
-                                Some(planstate),
-                                source_manifests.clone(),
-                            )
-                            .expect("Failed to deserialize serial fallback logical plan");
-                            let logical_plan = match runtime_fetch {
-                                Some(fetch) => {
-                                    use datafusion::logical_expr::LogicalPlanBuilder;
-                                    LogicalPlanBuilder::from(logical_plan)
-                                        .limit(0, Some(fetch))
-                                        .expect("failed to add Limit to logical plan")
-                                        .build()
-                                        .expect("failed to build logical plan with Limit")
-                                }
-                                None => logical_plan,
-                            };
-                            let plan = runtime
-                                .block_on(build_physical_plan(&serial_ctx, logical_plan))
-                                .expect("Failed to create execution plan from serial fallback");
-                            // Keep custom_state's logical_plan in sync: a later rescan reads it
-                            // (see maybe_solve_and_rebake / JoinScanState::reset), and it should
-                            // reflect the serial shape actually executed here, not the MPP-shaped
-                            // bytes this fallback declined to use.
-                            state.custom_state_mut().logical_plan =
-                                Some(bytes::Bytes::from(fallback_bytes));
-                            (serial_ctx, plan)
-                        }
-                    }
-                } else {
-                    (plan_ctx, plan)
-                };
-
-                let task_ctx = build_task_context(
-                    &ctx,
-                    &plan,
-                    pg_sys::work_mem as usize * 1024,
-                    pg_sys::hash_mem_multiplier,
+                // A bounded attempt reads only the leading rows of the ordered side. It
+                // stays serial: the row cap keeps it small, and nothing is launched yet
+                // when it under-delivers, so the fallback below has no workers to unwind.
+                let bounded = Self::try_bounded_topn(
+                    state,
+                    &runtime,
+                    runtime_fetch,
+                    planstate,
+                    runtime_context,
+                    &source_manifests,
                 );
-                let t_exec = std::time::Instant::now();
-                let stream = {
-                    let _guard = runtime.enter();
-                    plan.execute(0, task_ctx)
-                        .expect("Failed to execute DataFusion plan")
+
+                let (plan, stream) = match bounded {
+                    Some(pair) => {
+                        state.custom_state_mut().mpp.take_pending();
+                        pair
+                    }
+                    None => {
+                        let mpp_pending = state.custom_state_mut().mpp.take_pending();
+                        // Leader session context: on an MPP attempt, layer the DF-D fork's
+                        // distributed-planner knobs over the Join profile so the resulting physical
+                        // plan is a `DistributedExec`, with `producer_worker_cap()` acting as the
+                        // planner's ceiling. The mesh and the dispatch source are execute-time
+                        // concerns; the exec session below carries them once the workers are committed.
+                        let plan_ctx = if mpp_pending {
+                            Self::build_mpp_session_context(None)
+                        } else {
+                            create_datafusion_session_context()
+                        };
+                        let t_plan = std::time::Instant::now();
+                        let plan = build_plan(&plan_ctx);
+                        launch_us.plan_us = t_plan.elapsed().as_micros() as u64;
+
+                        // On a launch fallback (nothing to distribute, or too few attached workers) no
+                        // workers remain and the `DistributedExec` shape has no mesh to read from, so
+                        // replan serially.
+                        let (ctx, plan) = if mpp_pending {
+                            match Self::launch_mpp(state, &plan) {
+                                Some(leader) => {
+                                    let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
+                                    let exec_ctx = Self::build_mpp_session_context(Some(
+                                        Arc::clone(&leader.session.mesh),
+                                    ))
+                                    .with_distributed_dispatch_plan_source(source);
+                                    launch_us.prepare_us = leader.timing.prepare_us;
+                                    launch_us.payload_us = leader.timing.payload_us;
+                                    launch_us.attach_us = leader.timing.attach_us;
+                                    launch_us.leader_setup_us = leader.timing.leader_setup_us;
+                                    launch_us.workers = leader.timing.workers;
+                                    state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
+                                    (exec_ctx, plan)
+                                }
+                                None => {
+                                    // Short-launch decline: rebuild the logical plan with serial provider
+                                    // metadata. Merely changing SessionContext would replan the existing
+                                    // MPP-shaped logical providers without rewriting their source fields.
+                                    let serial_ctx = create_datafusion_session_context();
+                                    let fallback_bytes = Self::rebake_for_mpp_fallback(state);
+                                    let logical_plan = deserialize_logical_plan_with_runtime(
+                                        &fallback_bytes,
+                                        &serial_ctx.task_ctx(),
+                                        None,
+                                        Some(runtime_context),
+                                        Some(planstate),
+                                        source_manifests.clone(),
+                                    )
+                                    .expect("Failed to deserialize serial fallback logical plan");
+                                    let logical_plan = match runtime_fetch {
+                                        Some(fetch) => {
+                                            use datafusion::logical_expr::LogicalPlanBuilder;
+                                            LogicalPlanBuilder::from(logical_plan)
+                                                .limit(0, Some(fetch))
+                                                .expect("failed to add Limit to logical plan")
+                                                .build()
+                                                .expect("failed to build logical plan with Limit")
+                                        }
+                                        None => logical_plan,
+                                    };
+                                    let plan = runtime
+                                        .block_on(build_physical_plan(&serial_ctx, logical_plan))
+                                        .expect(
+                                            "Failed to create execution plan from serial fallback",
+                                        );
+                                    // Keep custom_state's logical_plan in sync: a later rescan reads it
+                                    // (see maybe_solve_and_rebake / JoinScanState::reset), and it should
+                                    // reflect the serial shape actually executed here, not the MPP-shaped
+                                    // bytes this fallback declined to use.
+                                    state.custom_state_mut().logical_plan =
+                                        Some(bytes::Bytes::from(fallback_bytes));
+                                    (serial_ctx, plan)
+                                }
+                            }
+                        } else {
+                            (plan_ctx, plan)
+                        };
+
+                        let task_ctx = build_task_context(
+                            &ctx,
+                            &plan,
+                            pg_sys::work_mem as usize * 1024,
+                            pg_sys::hash_mem_multiplier,
+                        );
+                        let t_exec = std::time::Instant::now();
+                        let stream = {
+                            let _guard = runtime.enter();
+                            plan.execute(0, task_ctx)
+                                .expect("Failed to execute DataFusion plan")
+                        };
+                        launch_us.exec_us = t_exec.elapsed().as_micros() as u64;
+                        (plan, stream)
+                    }
                 };
-                launch_us.exec_us = t_exec.elapsed().as_micros() as u64;
 
                 // Retain the executed plan so EXPLAIN ANALYZE can extract metrics. Record the
                 // launch timing only when the query actually ran distributed (workers attached);

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -543,6 +543,12 @@ fn build_relnode_df<'a>(
                 let alias =
                     RelationAlias::new(source.scan_info.alias.as_deref()).execution(plan_position);
                 df = df.alias(&alias)?;
+                if let Some(bounded) = &rctx.join_clause.bounded_topn
+                    && bounded.plan_position == plan_position
+                {
+                    df =
+                        apply_bounded_topn(df, rctx.join_clause, &bounded.order_by, bounded.limit)?;
+                }
                 Ok(df)
             }
             RelNode::Join(join) => {
@@ -950,17 +956,42 @@ fn resolve_orderby_feature(
 /// Apply the join clause's `ORDER BY` to the data frame, choosing column
 /// references from `distinct_col_map` when DISTINCT is active and from the
 /// per-source resolution paths otherwise.
+/// Order one source by the query's ORDER BY and keep only the first `limit` rows,
+/// before it reaches the join.
+///
+/// Uses the same sort expressions as the final sort, null placement included, so
+/// the rows kept here are the same rows the final sort would rank first.
+fn apply_bounded_topn(
+    df: DataFrame,
+    join_clause: &JoinCSClause,
+    order_by: &[crate::api::OrderByInfo],
+    limit: usize,
+) -> Result<DataFrame> {
+    let empty = DistinctColMap::default();
+    let df = apply_sort_keys(df, join_clause, order_by, &empty)?;
+    df.limit(0, Some(limit))
+}
+
 fn apply_sort(
     df: DataFrame,
     join_clause: &JoinCSClause,
     distinct_col_map: &DistinctColMap,
 ) -> Result<DataFrame> {
-    if join_clause.order_by.is_empty() {
+    apply_sort_keys(df, join_clause, &join_clause.order_by, distinct_col_map)
+}
+
+fn apply_sort_keys(
+    df: DataFrame,
+    join_clause: &JoinCSClause,
+    order_by: &[crate::api::OrderByInfo],
+    distinct_col_map: &DistinctColMap,
+) -> Result<DataFrame> {
+    if order_by.is_empty() {
         return Ok(df);
     }
 
     let mut sort_exprs = Vec::new();
-    for info in &join_clause.order_by {
+    for info in order_by {
         let expr = match &info.feature {
             OrderByFeature::NullTest {
                 inner,

--- a/pg_search/tests/pg_regress/expected/join_bounded_topn.out
+++ b/pg_search/tests/pg_regress/expected/join_bounded_topn.out
@@ -1,0 +1,359 @@
+-- Bounded Top-N attempt for a join whose ORDER BY belongs to one side.
+--
+-- The join reads only the leading rows of the ordered side, then keeps that
+-- result when it fills the LIMIT. A short result proves nothing, because rows
+-- drop in the join, so the query re-runs unbounded.
+--
+-- What the probe scan reads is the thing to watch. Bounded, it reads about the
+-- cap; unbounded, it reads the whole index. Results must not move either way.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan = on;
+DROP TABLE IF EXISTS btn_probe CASCADE;
+DROP TABLE IF EXISTS btn_ordered CASCADE;
+-- A `uuid` key is the shape this targets: the key set reaches tantivy as a term
+-- set, so the probe side reads only the keys the bound kept.
+CREATE TABLE btn_ordered (
+    id      uuid PRIMARY KEY,
+    grp     bigint      NOT NULL,
+    made_at timestamptz NOT NULL
+);
+INSERT INTO btn_ordered (id, grp, made_at)
+SELECT md5('k' || i)::uuid,
+       CASE WHEN i <= 4000 THEN 1 ELSE 2 END,
+       timestamptz '2024-01-01' + (i || ' seconds')::interval
+FROM generate_series(1, 20000) i;
+CREATE TABLE btn_probe (
+    id        bigserial PRIMARY KEY,
+    fk        uuid   NOT NULL,
+    amount    bigint NOT NULL
+);
+INSERT INTO btn_probe (fk, amount)
+SELECT md5('k' || i)::uuid, i % 100
+FROM generate_series(1, 20000) i;
+CREATE INDEX btn_ordered_idx ON btn_ordered
+USING bm25 (id, grp, made_at) WITH (key_field = 'id');
+CREATE INDEX btn_probe_idx ON btn_probe
+USING bm25 (id, fk, amount) WITH (key_field = 'id');
+ANALYZE btn_ordered;
+ANALYZE btn_probe;
+-- =============================================================================
+-- TEST 1: the bound holds, so the probe scan stays near the cap
+-- =============================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: p INNER o
+         Join Cond: o.id = p.fk
+         Limit: 10
+         Order By: o.made_at desc, p.fk desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, made_at@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=8.4 KB, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[made_at@4 DESC, fk@1 DESC], preserve_partitioning=[false], filter=[made_at@4 IS NULL OR made_at@4 > 757415191000000 OR made_at@4 = 757415191000000 AND (fk@1 IS NULL OR fk@1 > b5ea7838-d13f-0903-1d1a-bbd075557459)], metrics=[output_rows=10, output_bytes=17.5 KB, output_batches=1, row_replacements=160]
+           :     VisibilityFilterExec: tables=[p], metrics=[output_rows=160, output_bytes=402.2 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0], metrics=[output_rows=160, output_bytes=402.2 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@3, fk@4, ctid_1@0, id@1, made_at@2], metrics=[output_rows=160, output_bytes=465.0 KB, output_batches=1, build_mem_used=153.3 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=160, input_batches=1, input_rows=160, avg_fanout=100% (160/160), probe_hit_rate=100% (160/160)]
+           :           SortExec: TopK(fetch=160), expr=[made_at@2 DESC, id@1 DESC], preserve_partitioning=[false], filter=[made_at@2 IS NULL OR made_at@2 > 757415041000000 OR made_at@2 = 757415041000000 AND (id@1 IS NULL OR id@1 > 4f695deb-43f8-8fc2-b247-d95683160376)], metrics=[output_rows=160, output_bytes=149.0 KB, output_batches=1, row_replacements=4.00 K]
+           :             CooperativeExec
+           :               PgSearchScan: table=o, segments=1, dynamic_filters=1, visibility=eager, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"grp","value":1}}]}}, metrics=[output_rows=4.00 K, output_bytes=269.0 KB, output_batches=1, rows_pruned=0, rows_scanned=4.00 K]
+           :           CooperativeExec
+           :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"range":{"field":"amount","lower_bound":{"included":0},"upper_bound":null}}, metrics=[output_rows=160, output_bytes=12.8 KB, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=160]
+(17 rows)
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                  id                  
+--------------------------------------
+ 79d9d415-9199-8168-8580-686f461c2f60
+ 9eb3d578-1884-770b-fa48-110fbbd003de
+ 5bf1d182-2d90-cc14-08f5-8222c62c6522
+ e4e42de0-dc5b-2cb6-1a32-6523aa860aff
+ 36bf0ec4-d33d-a51d-0f79-c4b5c5d27dbb
+ edb51459-ed2c-d68d-97f2-c1bf9a0ad7c1
+ a44c8813-43f6-65b7-2865-fdf371d5bafa
+ e8587a8c-b939-761b-7900-e12a15228867
+ 65dd5254-24c5-9664-7858-147aae4c491a
+ b5ea7838-d13f-0903-1d1a-bbd075557459
+(10 rows)
+
+-- Same query with the feature off, for the rows and for the contrast in what
+-- the probe scan reads.
+SET paradedb.enable_join_bounded_topn = off;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: p INNER o
+         Join Cond: o.id = p.fk
+         Limit: 10
+         Order By: o.made_at desc, p.fk desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, made_at@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=144.4 KB, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[made_at@4 DESC, fk@1 DESC], preserve_partitioning=[false], filter=[made_at@4 IS NULL OR made_at@4 > 757415191000000 OR made_at@4 = 757415191000000 AND (fk@1 IS NULL OR fk@1 > b5ea7838-d13f-0903-1d1a-bbd075557459)], metrics=[output_rows=10, output_bytes=288.5 KB, output_batches=1, row_replacements=4.00 K]
+           :     VisibilityFilterExec: tables=[p, o], metrics=[output_rows=4.00 K, output_bytes=670.5 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=4.00 K, output_bytes=670.5 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@3, fk@4, ctid_1@0, id@1, made_at@2], metrics=[output_rows=4.00 K, output_bytes=736.0 KB, output_batches=1, build_mem_used=405.1 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=4.00 K, input_batches=1, input_rows=4.00 K, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
+           :           CooperativeExec
+           :             PgSearchScan: table=o, segments=1, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"grp","value":1}}]}}, metrics=[output_rows=4.00 K, output_bytes=269.0 KB, output_batches=1]
+           :           CooperativeExec
+           :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"range":{"field":"amount","lower_bound":{"included":0},"upper_bound":null}}, metrics=[output_rows=4.00 K, output_bytes=237.8 KB, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=4.00 K]
+(16 rows)
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                  id                  
+--------------------------------------
+ 79d9d415-9199-8168-8580-686f461c2f60
+ 9eb3d578-1884-770b-fa48-110fbbd003de
+ 5bf1d182-2d90-cc14-08f5-8222c62c6522
+ e4e42de0-dc5b-2cb6-1a32-6523aa860aff
+ 36bf0ec4-d33d-a51d-0f79-c4b5c5d27dbb
+ edb51459-ed2c-d68d-97f2-c1bf9a0ad7c1
+ a44c8813-43f6-65b7-2865-fdf371d5bafa
+ e8587a8c-b939-761b-7900-e12a15228867
+ 65dd5254-24c5-9664-7858-147aae4c491a
+ b5ea7838-d13f-0903-1d1a-bbd075557459
+(10 rows)
+
+RESET paradedb.enable_join_bounded_topn;
+-- =============================================================================
+-- TEST 2: OFFSET, and a sort key Postgres rewrites to the other side
+-- =============================================================================
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at ASC, o.id ASC
+LIMIT 5 OFFSET 7;
+                  id                  
+--------------------------------------
+ 0304e802-6876-3562-dd0b-89268dbd0d33
+ 533f4c9b-5413-d9ec-bf62-84f110a9789a
+ e2586f3a-4757-14f9-959f-74986e64ee13
+ ff5e2c3e-7cff-28f4-d962-d00130315149
+ 1904741e-e54b-3282-7d04-0cbf5929b9fb
+(5 rows)
+
+SET paradedb.enable_join_bounded_topn = off;
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at ASC, o.id ASC
+LIMIT 5 OFFSET 7;
+                  id                  
+--------------------------------------
+ 0304e802-6876-3562-dd0b-89268dbd0d33
+ 533f4c9b-5413-d9ec-bf62-84f110a9789a
+ e2586f3a-4757-14f9-959f-74986e64ee13
+ ff5e2c3e-7cff-28f4-d962-d00130315149
+ 1904741e-e54b-3282-7d04-0cbf5929b9fb
+(5 rows)
+
+RESET paradedb.enable_join_bounded_topn;
+-- =============================================================================
+-- TEST 3: too few rows survive the join, so the bounded attempt is discarded
+-- =============================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                                                                                                                                                                         QUERY PLAN                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: p INNER o
+         Join Cond: o.id = p.fk
+         Limit: 10
+         Order By: o.made_at desc, p.fk desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, made_at@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=2.6 KB, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[made_at@4 DESC, fk@1 DESC], preserve_partitioning=[false], filter=[made_at@4 IS NULL OR made_at@4 > 757414203000000 OR made_at@4 = 757414203000000 AND (fk@1 IS NULL OR fk@1 > f2d52623-1870-b54d-305a-dd244a5ec3dc)], metrics=[output_rows=10, output_bytes=10.8 KB, output_batches=1, row_replacements=40]
+           :     VisibilityFilterExec: tables=[p, o], metrics=[output_rows=40, output_bytes=330.9 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=40, output_bytes=330.9 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, id@1)], metrics=[output_rows=40, output_bytes=458.2 KB, output_batches=1, build_mem_used=18.0 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=200, input_batches=1, input_rows=40, avg_fanout=100% (40/40), probe_hit_rate=100% (40/40)]
+           :           CooperativeExec
+           :             PgSearchScan: table=p, segments=1, query={"term":{"field":"amount","value":3}}, metrics=[output_rows=200, output_bytes=13.7 KB, output_batches=1]
+           :           CooperativeExec
+           :             PgSearchScan: table=o, segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"grp","value":1}}]}}, metrics=[output_rows=40, output_bytes=3.5 KB, output_batches=1, dynamic_filter_pushdown_automaton=1, rows_pruned=0, rows_scanned=40]
+(16 rows)
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                  id                  
+--------------------------------------
+ ebc2601a-ffe9-8fe5-f81f-79d36fad49f4
+ ede8eab2-bff2-deeb-6ea6-d09c2b9553e5
+ 88bc28a6-3cf5-d107-a3f3-03d8617e65a9
+ b3c8eb0a-351c-2620-8e41-9fa6b477d1e1
+ ded21d74-a365-123c-64ab-a579ff52e94d
+ 257d3311-dcac-1eea-bc86-4ba2223ffc9c
+ 1edc869d-1a42-eb72-8ebd-93be8b7a46e1
+ b2d9cb61-1fa0-ecaf-6f4f-a2d3773d9f80
+ 15dbc83d-7482-01c7-cc48-d52cec0fabc1
+ f2d52623-1870-b54d-305a-dd244a5ec3dc
+(10 rows)
+
+SET paradedb.enable_join_bounded_topn = off;
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                  id                  
+--------------------------------------
+ ebc2601a-ffe9-8fe5-f81f-79d36fad49f4
+ ede8eab2-bff2-deeb-6ea6-d09c2b9553e5
+ 88bc28a6-3cf5-d107-a3f3-03d8617e65a9
+ b3c8eb0a-351c-2620-8e41-9fa6b477d1e1
+ ded21d74-a365-123c-64ab-a579ff52e94d
+ 257d3311-dcac-1eea-bc86-4ba2223ffc9c
+ 1edc869d-1a42-eb72-8ebd-93be8b7a46e1
+ b2d9cb61-1fa0-ecaf-6f4f-a2d3773d9f80
+ 15dbc83d-7482-01c7-cc48-d52cec0fabc1
+ f2d52623-1870-b54d-305a-dd244a5ec3dc
+(10 rows)
+
+RESET paradedb.enable_join_bounded_topn;
+-- =============================================================================
+-- TEST 4: fewer rows exist than the LIMIT asks for
+-- =============================================================================
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 1000;
+                  id                  
+--------------------------------------
+ ebc2601a-ffe9-8fe5-f81f-79d36fad49f4
+ ede8eab2-bff2-deeb-6ea6-d09c2b9553e5
+ 88bc28a6-3cf5-d107-a3f3-03d8617e65a9
+ b3c8eb0a-351c-2620-8e41-9fa6b477d1e1
+ ded21d74-a365-123c-64ab-a579ff52e94d
+ 257d3311-dcac-1eea-bc86-4ba2223ffc9c
+ 1edc869d-1a42-eb72-8ebd-93be8b7a46e1
+ b2d9cb61-1fa0-ecaf-6f4f-a2d3773d9f80
+ 15dbc83d-7482-01c7-cc48-d52cec0fabc1
+ f2d52623-1870-b54d-305a-dd244a5ec3dc
+ 7e858207-6e0f-5a43-38f1-bce7b6091591
+ 5d541475-055b-7877-a48e-03407da1f469
+ 4c1f24a9-6e23-2128-b237-c628d6564b3c
+ ef7624b4-35c0-a849-f722-aab90c5415e2
+ 6410272c-bfc3-7008-6fd9-ffc65d1dcf3f
+ 873e6520-63b1-f6bf-a3d5-bd2ceae36cc8
+ ea941adf-12dd-c083-072f-83608b15dc56
+ 266ad330-a2a7-9a4f-c761-bb69bc721c3c
+ 059b1bbb-d0af-94b7-d4ac-264ca816ad4f
+ 898e2148-e803-ac92-6b0f-54ac85ab4e78
+ 17eaae24-8656-3d12-dee3-644d3bc0e685
+ 94153f27-85ce-972d-c1a9-532e5c53a3ae
+ 8a8d58fb-4258-7fad-9e66-b2f006cc8627
+ 404139e3-fa65-1618-df6e-39f213555946
+ 0f1a9328-3c0b-0b34-8c7c-6131a28ca4cb
+ 21c7b9a8-921b-53ab-368d-938de8f6928d
+ 7da08dec-7c16-cf53-c530-5539999d534a
+ 0c55eabc-40c1-5df6-8471-64708cdb1ae1
+ aca797a8-d2af-58aa-27fd-80f2d8a85275
+ 4b47b47e-d447-a7ee-a155-beb326644ce4
+ fdb903f0-eaa5-1405-f077-743ab0409dff
+ 4143cd9b-7076-a3a7-55d4-11f188d69302
+ 4a4d83ee-146d-b6d2-2cc9-3bab5cc2fb6b
+ 278aea54-d402-d169-3b31-fac9f0469d1d
+ 346ad66f-e763-ed52-131a-545075296add
+ 38a10f4f-17f7-c44f-4ca0-406c4a33aa78
+ 3955902a-212c-8e63-dcfc-6f8e268c0397
+ 3917d0e0-f220-5c46-6dfb-1f16f1029ec7
+ b2236af2-1778-a2cb-2d2e-cfb0e3671634
+ f7ab469d-1dc7-9166-fc87-4dadcc0dd854
+(40 rows)
+
+-- =============================================================================
+-- TEST 5: shapes the bound has to decline
+-- =============================================================================
+-- Sort keys from both sides.
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, p.amount DESC
+LIMIT 10;
+                  id                  
+--------------------------------------
+ 79d9d415-9199-8168-8580-686f461c2f60
+ 9eb3d578-1884-770b-fa48-110fbbd003de
+ 5bf1d182-2d90-cc14-08f5-8222c62c6522
+ e4e42de0-dc5b-2cb6-1a32-6523aa860aff
+ 36bf0ec4-d33d-a51d-0f79-c4b5c5d27dbb
+ edb51459-ed2c-d68d-97f2-c1bf9a0ad7c1
+ a44c8813-43f6-65b7-2865-fdf371d5bafa
+ e8587a8c-b939-761b-7900-e12a15228867
+ 65dd5254-24c5-9664-7858-147aae4c491a
+ b5ea7838-d13f-0903-1d1a-bbd075557459
+(10 rows)
+
+-- An outer join null-extends rows, so a sort key can come from no source row.
+SELECT o.id
+FROM btn_ordered o
+LEFT JOIN btn_probe p ON p.fk = o.id AND p.amount >= 0
+WHERE o.id @@@ paradedb.all() AND o.grp = 1
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+                  id                  
+--------------------------------------
+ 79d9d415-9199-8168-8580-686f461c2f60
+ 9eb3d578-1884-770b-fa48-110fbbd003de
+ 5bf1d182-2d90-cc14-08f5-8222c62c6522
+ e4e42de0-dc5b-2cb6-1a32-6523aa860aff
+ 36bf0ec4-d33d-a51d-0f79-c4b5c5d27dbb
+ edb51459-ed2c-d68d-97f2-c1bf9a0ad7c1
+ a44c8813-43f6-65b7-2865-fdf371d5bafa
+ e8587a8c-b939-761b-7900-e12a15228867
+ 65dd5254-24c5-9664-7858-147aae4c491a
+ b5ea7838-d13f-0903-1d1a-bbd075557459
+(10 rows)
+
+-- No LIMIT, so there is nothing to bound.
+SELECT count(*)
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0;
+ count 
+-------
+  4000
+(1 row)
+
+DROP TABLE btn_probe;
+DROP TABLE btn_ordered;

--- a/pg_search/tests/pg_regress/expected/join_dynamic_filter_string_keys.out
+++ b/pg_search/tests/pg_regress/expected/join_dynamic_filter_string_keys.out
@@ -69,14 +69,15 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[ordinal@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[ordinal@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[ordinal@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
-           :     VisibilityFilterExec: tables=[p, b], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
-           :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
+           :     VisibilityFilterExec: tables=[p], metrics=[output_rows=20, output_bytes=128.2 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0], metrics=[output_rows=20, output_bytes=128.2 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk_uuid@1)], projection=[ctid_0@3, ctid_1@0, ordinal@2], metrics=[output_rows=20, output_bytes=192.0 KB, output_batches=1, build_mem_used=2.3 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=20, input_batches=1, input_rows=20, avg_fanout=100% (20/20), probe_hit_rate=100% (20/20)]
-           :           CooperativeExec
-           :             PgSearchScan: table=b, segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"keep","value":true}}]}}, metrics=[output_rows=20, output_bytes=1792.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :           SortExec: TopK(fetch=160), expr=[ordinal@2 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=20, output_bytes=1792.0 B, output_batches=1, row_replacements=20]
+           :             CooperativeExec
+           :               PgSearchScan: table=b, segments=1, dynamic_filters=1, visibility=eager, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"keep","value":true}}]}}, metrics=[output_rows=20, output_bytes=1792.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
            :           CooperativeExec
            :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"range":{"field":"amount","lower_bound":{"included":0},"upper_bound":null}}, metrics=[output_rows=20, output_bytes=1632.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=20]
-(16 rows)
+(17 rows)
 
 SELECT b.ordinal
 FROM strkey_build b
@@ -119,14 +120,15 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[ordinal@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[ordinal@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[ordinal@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
-           :     VisibilityFilterExec: tables=[p, b], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
-           :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=20, output_bytes=64.3 KB, output_batches=1]
+           :     VisibilityFilterExec: tables=[p], metrics=[output_rows=20, output_bytes=128.2 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0], metrics=[output_rows=20, output_bytes=128.2 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id_txt@1, fk_txt@1)], projection=[ctid_0@3, ctid_1@0, ordinal@2], metrics=[output_rows=20, output_bytes=192.0 KB, output_batches=1, build_mem_used=2.2 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=20, input_batches=1, input_rows=20, avg_fanout=100% (20/20), probe_hit_rate=100% (20/20)]
-           :           CooperativeExec
-           :             PgSearchScan: table=b, segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"keep","value":true}}]}}, metrics=[output_rows=20, output_bytes=1664.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :           SortExec: TopK(fetch=160), expr=[ordinal@2 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=20, output_bytes=1664.0 B, output_batches=1, row_replacements=20]
+           :             CooperativeExec
+           :               PgSearchScan: table=b, segments=1, dynamic_filters=1, visibility=eager, query={"boolean":{"must":[{"with_index":{"query":"all"}},{"term":{"field":"keep","value":true}}]}}, metrics=[output_rows=20, output_bytes=1664.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
            :           CooperativeExec
            :             PgSearchScan: table=p, segments=1, dynamic_filters=1, query={"range":{"field":"amount","lower_bound":{"included":0},"upper_bound":null}}, metrics=[output_rows=20, output_bytes=1504.0 B, output_batches=1, dynamic_filter_pushdown_bitset_from_postings=1, rows_pruned=0, rows_scanned=20]
-(16 rows)
+(17 rows)
 
 SELECT b.ordinal
 FROM strkey_build b

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -35,8 +35,8 @@ JOIN hash_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Result (actual rows=10.00 loops=1)
          ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
@@ -46,15 +46,16 @@ LIMIT 10;
                Order By: t1.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
-                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=1.00 K, output_bytes=79.6 KB, output_batches=1]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=1.00 K, output_bytes=79.6 KB, output_batches=1]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3], metrics=[output_rows=1.00 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=19.5 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=1.00 K, input_batches=1, input_rows=1.00 K, avg_fanout=100% (1.00 K/1.00 K), probe_hit_rate=100% (1.00 K/1.00 K)]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=11]
+                 :     VisibilityFilterExec: tables=[t2], metrics=[output_rows=160, output_bytes=129.2 KB, output_batches=1]
+                 :       TantivyFetchExec: fetch=[ctid_0], metrics=[output_rows=160, output_bytes=129.2 KB, output_batches=1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=160, output_bytes=192.0 KB, output_batches=1, build_mem_used=3.1 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=160, input_batches=1, input_rows=160, avg_fanout=100% (160/160), probe_hit_rate=100% (160/160)]
+                 :           SortExec: TopK(fetch=160), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 160], metrics=[output_rows=160, output_bytes=2.5 KB, output_batches=1, row_replacements=160]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=t1, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
                  :           CooperativeExec
-                 :             PgSearchScan: table=t2, segments=1, query="all", metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1]
-                 :           CooperativeExec
-                 :             PgSearchScan: table=t1, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
-(17 rows)
+                 :             PgSearchScan: table=t2, segments=1, dynamic_filters=1, query="all", metrics=[output_rows=160, output_bytes=2.5 KB, output_batches=1, rows_pruned=840, rows_scanned=1.00 K]
+(18 rows)
 
 SELECT t1.val, t2.val
 FROM hash_t1 t1
@@ -123,8 +124,8 @@ JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Result (actual rows=10.00 loops=1)
          ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
@@ -135,14 +136,15 @@ LIMIT 10;
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
                  :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
-                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=29.3 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :     VisibilityFilterExec: tables=[t2], metrics=[output_rows=320, output_bytes=130.5 KB, output_batches=1]
+                 :       TantivyFetchExec: fetch=[ctid_0], metrics=[output_rows=320, output_bytes=130.5 KB, output_batches=1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=320, output_bytes=192.0 KB, output_batches=1, build_mem_used=3.1 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=160, input_batches=1, input_rows=320, avg_fanout=100% (320/320), probe_hit_rate=100% (320/320)]
+                 :           SortExec: TopK(fetch=160), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 160], metrics=[output_rows=160, output_bytes=2.5 KB, output_batches=1, row_replacements=160]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=t1, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :           CooperativeExec
-                 :             PgSearchScan: table=t1, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
-                 :           CooperativeExec
-                 :             PgSearchScan: table=t2, segments=1, dynamic_filters=1, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
-(17 rows)
+                 :             PgSearchScan: table=t2, segments=1, dynamic_filters=1, query="all", metrics=[output_rows=320, output_bytes=5.0 KB, output_batches=1, rows_pruned=1.68 K, rows_scanned=2.00 K]
+(18 rows)
 
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -174,8 +176,8 @@ JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Result (actual rows=10.00 loops=1)
          ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
@@ -186,14 +188,15 @@ LIMIT 10;
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
                  :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
-                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
-                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=29.3 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :     VisibilityFilterExec: tables=[t2], metrics=[output_rows=320, output_bytes=130.5 KB, output_batches=1]
+                 :       TantivyFetchExec: fetch=[ctid_0], metrics=[output_rows=320, output_bytes=130.5 KB, output_batches=1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=320, output_bytes=192.0 KB, output_batches=1, build_mem_used=3.1 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=160, input_batches=1, input_rows=320, avg_fanout=100% (320/320), probe_hit_rate=100% (320/320)]
+                 :           SortExec: TopK(fetch=160), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 160], metrics=[output_rows=160, output_bytes=2.5 KB, output_batches=1, row_replacements=160]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=t1, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :           CooperativeExec
-                 :             PgSearchScan: table=t1, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
-                 :           CooperativeExec
-                 :             PgSearchScan: table=t2, segments=1, dynamic_filters=1, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=2.00 K]
-(17 rows)
+                 :             PgSearchScan: table=t2, segments=1, dynamic_filters=1, query="all", metrics=[output_rows=320, output_bytes=5.0 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=320]
+(18 rows)
 
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -133,8 +133,8 @@ JOIN t2_a ON t1.fk_a = t2_a.fk
 WHERE t1.body @@@ 'doc'
 ORDER BY t1.id
 LIMIT 10;
-                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: t2_a INNER t1
@@ -143,15 +143,16 @@ LIMIT 10;
          Order By: t1.id asc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
-           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=51]
-           :     VisibilityFilterExec: tables=[t2_a, t1], metrics=[output_rows=1.10 K, output_bytes=81.2 KB, output_batches=1]
-           :       TantivyFetchExec: fetch=[ctid_0, ctid_1], metrics=[output_rows=1.10 K, output_bytes=81.2 KB, output_batches=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, id@4], metrics=[output_rows=1.10 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=51.2 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[t2_a], metrics=[output_rows=160, output_bytes=129.2 KB, output_batches=1]
+           :       TantivyFetchExec: fetch=[ctid_0], metrics=[output_rows=160, output_bytes=129.2 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_a@1, fk@1)], projection=[ctid_0@3, ctid_1@0, id@2], metrics=[output_rows=160, output_bytes=192.0 KB, output_batches=1, build_mem_used=8.1 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=160, input_batches=1, input_rows=1.09 K, avg_fanout=100% (160/160), probe_hit_rate=14.67% (160/1.09 K)]
+           :           SortExec: TopK(fetch=160), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 160], metrics=[output_rows=160, output_bytes=3.8 KB, output_batches=1, row_replacements=983]
+           :             CooperativeExec
+           :               PgSearchScan: table=t1, segments=1, dynamic_filters=1, visibility=eager, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.46 K, output_bytes=198.4 KB, output_batches=4, rows_pruned=21.54 K, rows_scanned=30.00 K]
            :           CooperativeExec
-           :             PgSearchScan: table=t2_a, segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
-           :           CooperativeExec
-           :             PgSearchScan: table=t1, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=25.8 KB, output_batches=1, dynamic_filter_pushdown_gallop=1, rows_pruned=0, rows_scanned=1.10 K]
-(16 rows)
+           :             PgSearchScan: table=t2_a, segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.09 K, output_bytes=17.0 KB, output_batches=1, rows_pruned=9, rows_scanned=1.10 K]
+(17 rows)
 
 -- Block B: correctness. Run the same query with gallop disabled and
 -- enabled, materialize each result into a TEMP TABLE, then compare row

--- a/pg_search/tests/pg_regress/sql/join_bounded_topn.sql
+++ b/pg_search/tests/pg_regress/sql/join_bounded_topn.sql
@@ -1,0 +1,179 @@
+-- Bounded Top-N attempt for a join whose ORDER BY belongs to one side.
+--
+-- The join reads only the leading rows of the ordered side, then keeps that
+-- result when it fills the LIMIT. A short result proves nothing, because rows
+-- drop in the join, so the query re-runs unbounded.
+--
+-- What the probe scan reads is the thing to watch. Bounded, it reads about the
+-- cap; unbounded, it reads the whole index. Results must not move either way.
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_join_custom_scan = on;
+
+DROP TABLE IF EXISTS btn_probe CASCADE;
+DROP TABLE IF EXISTS btn_ordered CASCADE;
+
+-- A `uuid` key is the shape this targets: the key set reaches tantivy as a term
+-- set, so the probe side reads only the keys the bound kept.
+CREATE TABLE btn_ordered (
+    id      uuid PRIMARY KEY,
+    grp     bigint      NOT NULL,
+    made_at timestamptz NOT NULL
+);
+
+INSERT INTO btn_ordered (id, grp, made_at)
+SELECT md5('k' || i)::uuid,
+       CASE WHEN i <= 4000 THEN 1 ELSE 2 END,
+       timestamptz '2024-01-01' + (i || ' seconds')::interval
+FROM generate_series(1, 20000) i;
+
+CREATE TABLE btn_probe (
+    id        bigserial PRIMARY KEY,
+    fk        uuid   NOT NULL,
+    amount    bigint NOT NULL
+);
+
+INSERT INTO btn_probe (fk, amount)
+SELECT md5('k' || i)::uuid, i % 100
+FROM generate_series(1, 20000) i;
+
+CREATE INDEX btn_ordered_idx ON btn_ordered
+USING bm25 (id, grp, made_at) WITH (key_field = 'id');
+
+CREATE INDEX btn_probe_idx ON btn_probe
+USING bm25 (id, fk, amount) WITH (key_field = 'id');
+
+ANALYZE btn_ordered;
+ANALYZE btn_probe;
+
+-- =============================================================================
+-- TEST 1: the bound holds, so the probe scan stays near the cap
+-- =============================================================================
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+
+-- Same query with the feature off, for the rows and for the contrast in what
+-- the probe scan reads.
+SET paradedb.enable_join_bounded_topn = off;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+
+RESET paradedb.enable_join_bounded_topn;
+
+-- =============================================================================
+-- TEST 2: OFFSET, and a sort key Postgres rewrites to the other side
+-- =============================================================================
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at ASC, o.id ASC
+LIMIT 5 OFFSET 7;
+
+SET paradedb.enable_join_bounded_topn = off;
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at ASC, o.id ASC
+LIMIT 5 OFFSET 7;
+RESET paradedb.enable_join_bounded_topn;
+
+-- =============================================================================
+-- TEST 3: too few rows survive the join, so the bounded attempt is discarded
+-- =============================================================================
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_bounded_topn = off;
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+RESET paradedb.enable_join_bounded_topn;
+
+-- =============================================================================
+-- TEST 4: fewer rows exist than the LIMIT asks for
+-- =============================================================================
+
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount = 3
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 1000;
+
+-- =============================================================================
+-- TEST 5: shapes the bound has to decline
+-- =============================================================================
+
+-- Sort keys from both sides.
+SELECT o.id
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0
+ORDER BY o.made_at DESC, p.amount DESC
+LIMIT 10;
+
+-- An outer join null-extends rows, so a sort key can come from no source row.
+SELECT o.id
+FROM btn_ordered o
+LEFT JOIN btn_probe p ON p.fk = o.id AND p.amount >= 0
+WHERE o.id @@@ paradedb.all() AND o.grp = 1
+ORDER BY o.made_at DESC, o.id DESC
+LIMIT 10;
+
+-- No LIMIT, so there is nothing to bound.
+SELECT count(*)
+FROM btn_ordered o
+JOIN btn_probe p ON p.fk = o.id
+WHERE o.id @@@ paradedb.all() AND o.grp = 1 AND p.amount >= 0;
+
+DROP TABLE btn_probe;
+DROP TABLE btn_ordered;


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #6276

## What

This PR makes a join with `ORDER BY` and `LIMIT` read only the leading rows of the side the sort keys belong to.

Stacked on #6278, which is what gets a `uuid` key set to tantivy at all.

## Why

`JoinScan` built its hash table from every matching row, probed the whole other side, then kept 25. The work tracked the table sizes, not the `LIMIT`.

Bounding also drops the key count below `paradedb.hash_join_inlist_pushdown_max_distinct_values`, so the other side gets an index-driven term set instead of a full scan. The reported workload has 174,700 rows on the ordered side, above that cap, so #6278 alone does not reach it.

## How

Every sort key comes from one source, so each output row takes its sort key from a row of that source. Rows past the cap sort at or below the last row kept, and cannot belong in the result. A short result proves nothing, because a join drops rows, so the query re-runs unbounded.

The attempt stays serial. The cap keeps it small, and nothing is launched when it under-delivers, so the fallback has no workers to unwind.

Postgres rewrites sort keys through equivalence classes, so `ORDER BY o.id` can arrive as `p.fk`. On an inner equi-join the two are equal in every output row, so the key is rewritten back to the target's own column.

Declined shapes: sort keys spanning both sides, anything but an inner join, `DISTINCT`, `UNNEST`, and a string sort key that is not also a join key. That last one is a segment-local ordinal, so ordering on it means nothing across segments.

`paradedb.enable_join_bounded_topn` turns it off. `paradedb.join_bounded_topn_multiplier` sets the slack over `LIMIT` plus `OFFSET`, default 16.

## Tests

Added `join_bounded_topn.sql`.

To measure, take the fixture from #6276 and toggle `paradedb.enable_join_bounded_topn`. On 1M rows a side, debug build, `child` `rows_scanned` drops from 1,000,000 to 400 and the query from 3568 ms to 753 ms. In the regress fixture it goes from 4,000 to 160.

A tiny ordered side gets slower, 244 ms against 140 ms on a 186-row group, since the attempt is serial and reads the whole side anyway. I did not gate on the planner row estimate. It read 234 for a group holding 10,186 rows, so it would switch the optimization off where it pays.
