### PR TITLE
fix: resolve Drizzle dependencies in docs smoke tests

### DIFF
--- a/.github/scripts/smoke_test_code_snippets.sh
+++ b/.github/scripts/smoke_test_code_snippets.sh
@@ -243,9 +243,11 @@ drizzle_pass_count=0
 drizzle_fail_count=0
 if [[ $ORMS =~ "drizzle" ]]; then
   echo "Installing @paradedb/drizzle-paradedb from npm..."
-  npm --prefix "$JAVASCRIPT_ENV_DIR" install --silent \
+  # Keep the Drizzle version aligned with the integration's peer dependency.
+  # Skip peer resolution for Drizzle's unused optional integrations (e.g. effect).
+  npm --prefix "$JAVASCRIPT_ENV_DIR" install --legacy-peer-deps \
     "@paradedb/drizzle-paradedb@0.5.0" \
-    "drizzle-orm" \
+    "drizzle-orm@1.0.0-rc.4" \
     "postgres" \
     "tsx"
 


### PR DESCRIPTION
## What

Fix dependency installation in the documentation snippet smoke tests. Pin `drizzle-orm@1.0.0-rc.4`, use `--legacy-peer-deps`, and remove `--silent` so npm errors appear in CI.

## Why

The docs jobs on #6288 exit during the Drizzle npm install before running its snippets. A local reproduction reports `ERESOLVE` on Drizzle's optional `effect` peer dependency. Pinning Drizzle alone still fails.

## How

Explicitly match the Drizzle version required by `@paradedb/drizzle-paradedb@0.5.0` and bypass peer resolution for unused integrations. This bypass applies to all peers in this temporary snippet environment; the required ParadeDB/Drizzle pairing is pinned directly.

## Tests

- Reproduced `ERESOLVE` with the original dependency list and with the Drizzle pin alone.
- Dependency resolution succeeds with the pin and `--legacy-peer-deps` (`npm install --package-lock-only --ignore-scripts` in a temporary directory).
- `bash -n .github/scripts/smoke_test_code_snippets.sh` and `git diff --check` pass.
- Full database-backed snippet tests were not run locally; CI validation is pending.
