### PR TITLE
feat: made a columnar scan read in a requested sort order.

### DIFF
--- a/docs/changelog/unreleased/6295.features.mdx
+++ b/docs/changelog/unreleased/6295.features.mdx
@@ -1,0 +1,5 @@
+---
+header: features
+---
+
+Added `paradedb.enable_ordered_scan`, which lets a columnar scan retrieve in a requested sort order and skip the sort above it. A `LIMIT` can then stop the read early. It covers numeric, date, timestamp and boolean columns, and applies only when the scan sits directly below the sort.

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -158,6 +158,7 @@ static DEFER_COLUMN_FETCH: GucSetting<bool> = GucSetting::<bool>::new(true);
 /// When enabled, Top K queries on deferred (late-materialized) string/bytes columns
 /// use per-segment ordinal pruning to reduce dictionary decoding.
 static ENABLE_SEGMENTED_TOPK: GucSetting<bool> = GucSetting::<bool>::new(true);
+static ENABLE_ORDERED_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// When on, `mpp_log!()` routes through `pgrx::warning!()` so runtime traces appear in
 /// the Postgres server log (and in CI benchmark logs). When off, `mpp_log!()` is a no-op.
@@ -635,6 +636,18 @@ pub fn init() {
         GucFlags::default(),
     );
 
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_ordered_scan",
+        c"Let a columnar scan read in a requested sort order",
+        c"When enabled, a scan asked for an ORDER BY over its own columnar fields reads \
+          through the index's Top K collector and declares that order, so the sort above it \
+          can be dropped and a LIMIT can stop the read early. Declined for deferred, text and \
+          bytes keys, for range-partitioned scans, and for distributed tasks.",
+        &ENABLE_ORDERED_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
     GucRegistry::define_int_guc(
         c"paradedb.hash_join_inlist_pushdown_max_size",
         c"The maximum size in bytes of an InList that can be pushed down to a TermSet Query.",
@@ -985,6 +998,10 @@ pub fn dynamic_filter_batch_size() -> i32 {
 
 pub fn enable_segmented_topk() -> bool {
     ENABLE_SEGMENTED_TOPK.get()
+}
+
+pub fn enable_ordered_scan() -> bool {
+    ENABLE_ORDERED_SCAN.get()
 }
 
 pub fn defer_column_fetch() -> bool {

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -18,7 +18,7 @@
 use crate::index::fast_fields_helper::{
     FFHelper, FFType, WhichFastField, ords_to_bytes_array, ords_to_string_array,
 };
-use crate::index::reader::index::MultiSegmentSearchResults;
+use crate::index::reader::index::{MultiSegmentSearchResults, SearchIndexScore};
 use crate::postgres::heap::VisibilityChecker;
 use arrow_array::builder::{BooleanBuilder, UInt64Builder};
 use arrow_array::{
@@ -29,7 +29,7 @@ use arrow_schema::SchemaRef;
 use datafusion::arrow::compute;
 use std::sync::Arc;
 use tantivy::query::Scorer;
-use tantivy::{DocId, DocSet, Score, SegmentOrdinal};
+use tantivy::{DocAddress, DocId, DocSet, Score, Searcher, SegmentOrdinal};
 
 /// The maximum number of rows to batch materialize in memory while iterating over a result set.
 ///
@@ -147,12 +147,48 @@ impl Batch {
     }
 }
 
+/// Where a [`Scanner`] takes its doc ids from.
+///
+/// Both arms hand out one segment per batch. Every fast-field read below
+/// [`Scanner::next`] addresses a single segment, so a batch that spanned segments would
+/// read the wrong column.
+pub enum ScannerResults {
+    /// Doc order, one segment drained at a time.
+    Unordered(MultiSegmentSearchResults),
+    /// Sort order, which interleaves segments. A batch therefore ends at the first
+    /// segment change. The run is short, but so is the read: sort order is only asked
+    /// for when a fetch bounds it.
+    Ordered {
+        searcher: Searcher,
+        docs: std::vec::IntoIter<(SearchIndexScore, DocAddress)>,
+        /// Pulled from `docs` to see its segment, and consumed by the next batch.
+        pending: Option<(SearchIndexScore, DocAddress)>,
+    },
+}
+
+impl ScannerResults {
+    pub fn ordered(searcher: Searcher, docs: Vec<(SearchIndexScore, DocAddress)>) -> Self {
+        Self::Ordered {
+            searcher,
+            docs: docs.into_iter(),
+            pending: None,
+        }
+    }
+
+    fn searcher(&self) -> &Searcher {
+        match self {
+            Self::Unordered(results) => results.searcher(),
+            Self::Ordered { searcher, .. } => searcher,
+        }
+    }
+}
+
 /// A scanner that iterates over search results in batches, fetching fast fields.
 ///
 /// This scanner consumes [`WhichFastField`] column selectors, which represent "widened" Postgres types
 /// (e.g. storage types), and produces Arrow arrays corresponding to those widened types.
 pub struct Scanner {
-    search_results: MultiSegmentSearchResults,
+    search_results: ScannerResults,
     batch_size: usize,
     which_fast_fields: Vec<WhichFastField>,
     table_oid: u32,
@@ -269,7 +305,7 @@ impl Scanner {
     /// should be `None` to allow the default batch size to be used, which is optimized for
     /// columnar string lookups.
     pub fn new(
-        search_results: MultiSegmentSearchResults,
+        search_results: ScannerResults,
         batch_size_hint: Option<usize>,
         which_fast_fields: Vec<WhichFastField>,
         table_oid: u32,
@@ -318,6 +354,22 @@ impl Scanner {
             tagged_queries: Vec::new(),
             current_segment_ord: None,
             active_tag_scorers: Vec::new(),
+        }
+    }
+
+    /// Hand a drained ordered scanner its next chunk.
+    ///
+    /// The scanner is reused rather than rebuilt so that its row counters and column
+    /// configuration survive a refill.
+    pub fn reload_ordered(&mut self, next_docs: Vec<(SearchIndexScore, DocAddress)>) {
+        match &mut self.search_results {
+            ScannerResults::Ordered { docs, pending, .. } => {
+                *docs = next_docs.into_iter();
+                *pending = None;
+            }
+            ScannerResults::Unordered(_) => {
+                unreachable!("only an ordered scanner refills")
+            }
         }
     }
 
@@ -387,22 +439,66 @@ impl Scanner {
     }
 
     fn try_get_batch_ids(&mut self) -> Option<(SegmentOrdinal, Vec<Score>, Vec<DocId>)> {
+        match &mut self.search_results {
+            ScannerResults::Unordered(_) => self.try_get_batch_ids_unordered(),
+            ScannerResults::Ordered { .. } => self.try_get_batch_ids_ordered(),
+        }
+    }
+
+    /// Take the next run of same-segment docs off a sort-ordered result.
+    ///
+    /// The run ends at a segment change so that the batch names one segment, which the
+    /// fast-field reads below require. Sort order is preserved because the runs are
+    /// consumed in order and each run keeps its own.
+    fn try_get_batch_ids_ordered(&mut self) -> Option<(SegmentOrdinal, Vec<Score>, Vec<DocId>)> {
+        let batch_size = self.batch_size;
+        let ScannerResults::Ordered { docs, pending, .. } = &mut self.search_results else {
+            unreachable!("caller dispatched on the ordered arm")
+        };
+
+        let (first_score, first_addr) = pending.take().or_else(|| docs.next())?;
+        let segment_ord = first_addr.segment_ord;
+
+        let mut scores = vec![first_score.bm25];
+        let mut ids = vec![first_addr.doc_id];
+
+        while ids.len() < batch_size {
+            let Some((score, addr)) = docs.next() else {
+                break;
+            };
+            if addr.segment_ord != segment_ord {
+                *pending = Some((score, addr));
+                break;
+            }
+            scores.push(score.bm25);
+            ids.push(addr.doc_id);
+        }
+
+        Some((segment_ord, scores, ids))
+    }
+
+    fn try_get_batch_ids_unordered(&mut self) -> Option<(SegmentOrdinal, Vec<Score>, Vec<DocId>)> {
         let can_pushdown = self.can_pushdown_score_threshold();
+        let batch_size = self.batch_size;
+        let score_threshold = self.score_threshold;
+        let ScannerResults::Unordered(search_results) = &mut self.search_results else {
+            unreachable!("caller dispatched on the unordered arm")
+        };
         // Collect a batch of ids for a single segment.
         loop {
-            let scorer_iter = self.search_results.current_segment()?;
+            let scorer_iter = search_results.current_segment()?;
             let segment_ord = scorer_iter.segment_ord();
-            if can_pushdown && let Some(threshold) = self.score_threshold {
+            if can_pushdown && let Some(threshold) = score_threshold {
                 scorer_iter.set_threshold(threshold);
             }
 
             // Collect a batch of ids/scores for this segment.
-            let mut scores = Vec::with_capacity(self.batch_size);
-            let mut ids = Vec::with_capacity(self.batch_size);
-            while ids.len() < self.batch_size {
+            let mut scores = Vec::with_capacity(batch_size);
+            let mut ids = Vec::with_capacity(batch_size);
+            while ids.len() < batch_size {
                 let Some((score, id)) = scorer_iter.next() else {
                     // No more results for the current segment: remove it.
-                    self.search_results.current_segment_pop();
+                    search_results.current_segment_pop();
                     break;
                 };
                 // TODO: Further decompose `ScorerIter` to avoid (re)constructing a `DocAddress`.

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -31,7 +31,7 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use arrow_array::RecordBatch;
-use arrow_schema::{SchemaRef, SortOptions};
+use arrow_schema::{DataType, SchemaRef, SortOptions};
 use datafusion::common::stats::{ColumnStatistics, Precision};
 use datafusion::common::{DataFusionError, Result, Statistics};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
@@ -46,6 +46,7 @@ use datafusion::physical_plan::metrics::{
 };
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SortOrderPushdownResult,
 };
 use datafusion_distributed::{
     DesiredTaskCountEvent, DesiredTaskCountEventResponse, ScaleUpLeafNodeEvent,
@@ -58,10 +59,11 @@ use futures::Stream;
 use pgrx::pg_sys;
 use tantivy::Score;
 
+use crate::api::{FieldName, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::FFHelper;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::mvcc::MvccSatisfies;
-use crate::index::reader::index::SearchIndexReader;
+use crate::index::reader::index::{MAX_TOPK_FEATURES, SearchIndexReader, TopKSearch};
 use crate::index::stats::segments_for_partition;
 use crate::postgres::ParallelScanState;
 use crate::postgres::customscan::explain::ExplainFormat;
@@ -71,6 +73,7 @@ use crate::postgres::options::{SortByDirection, SortByField};
 use crate::postgres::rel::PgSearchRelation;
 use crate::query::SearchQueryInput;
 use crate::scan::Scanner;
+use crate::scan::batch_scanner::ScannerResults;
 use crate::scan::deferred_encode::is_deferred_field;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
 use crate::scan::late_materialization::DeferredField;
@@ -192,6 +195,12 @@ pub struct PgSearchScanPlan {
     /// Sort order preserved across `with_filter_pushdown` rebuilds so the
     /// rebuilt plan keeps its equivalence properties.
     sort_order: Option<SortByField>,
+    /// A sort order the scan was asked to produce, already resolved to
+    /// `OrderByFeature::Field` so the index reader takes it as-is.
+    ordered_by: Option<Vec<OrderByInfo>>,
+    /// Row bound from the consumer. In ordered mode it sizes the first read; without it
+    /// the scan would collect a top-K over the whole match set to return the first row.
+    fetch: Option<usize>,
     range_split_points: Option<RangeSplitPoints>,
     /// Global partition selected for a task-specialized variant. When present, this plan
     /// exposes one local partition and maps `execute(0)` back to this global partition.
@@ -218,6 +227,8 @@ impl Clone for PgSearchScanPlan {
             table_alias: self.table_alias.clone(),
             deferred_ctid_plan_position: self.deferred_ctid_plan_position,
             sort_order: self.sort_order.clone(),
+            ordered_by: self.ordered_by.clone(),
+            fetch: self.fetch,
             range_split_points: self.range_split_points.clone(),
             assigned_partition: self.assigned_partition,
             scan_mode: self.scan_mode.clone(),
@@ -276,7 +287,7 @@ impl PgSearchScanPlan {
             .map(|s| s.build(partition_count));
         let partitioning =
             declared_partitioning(&schema, partition_count, range_boundaries.as_ref());
-        let eq_properties = build_equivalence_properties(schema, sort_order);
+        let eq_properties = build_equivalence_properties(schema, sort_order, None);
 
         let properties = Arc::new(PlanProperties::new(
             eq_properties,
@@ -346,6 +357,8 @@ impl PgSearchScanPlan {
             table_alias: String::new(),
             deferred_ctid_plan_position,
             sort_order: sort_order.cloned(),
+            ordered_by: None,
+            fetch: None,
             range_split_points,
             assigned_partition: None,
             scan_mode,
@@ -454,6 +467,8 @@ impl PgSearchScanPlan {
             table_alias: self.table_alias.clone(),
             deferred_ctid_plan_position: self.deferred_ctid_plan_position,
             sort_order: self.sort_order.clone(),
+            ordered_by: self.ordered_by.clone(),
+            fetch: self.fetch,
             range_split_points: self.range_split_points.clone(),
             assigned_partition: self.assigned_partition,
             scan_mode: self.scan_mode.clone(),
@@ -571,6 +586,8 @@ impl PgSearchScanPlan {
             dynamic_filters,
             score_needed: scanner_config.score_needed,
             sort_order: self.sort_order.clone(),
+            ordered_by: self.ordered_by.clone(),
+            fetch: self.fetch,
             indexrelid: self.indexrelid,
             table_alias: self.table_alias.clone(),
             deferred_fields: self.deferred_fields.clone(),
@@ -753,6 +770,11 @@ struct ScanDispatchDescriptor {
     dynamic_filters: Vec<Vec<u8>>,
     score_needed: bool,
     sort_order: Option<SortByField>,
+    /// Carried so a dispatched task keeps producing the order the leader's plan promised.
+    #[serde(default)]
+    ordered_by: Option<Vec<OrderByInfo>>,
+    #[serde(default)]
+    fetch: Option<usize>,
     indexrelid: u32,
     #[serde(default)]
     table_alias: String,
@@ -801,11 +823,124 @@ fn declared_partitioning(
 /// If `sort_order` is `Some`, the returned properties will declare that the
 /// data is sorted by the specified field in the specified direction.
 /// If `sort_order` is `None`, returns empty equivalence properties.
+/// Drives an ordered read of the index in growing chunks.
+///
+/// A chunk is a fresh Top K with a larger limit and a carried offset, not a continuation of
+/// the last one. The chunk therefore grows, to keep the number of re-reads down when the
+/// consumer keeps pulling.
+struct OrderedRead {
+    orderby_info: Vec<OrderByInfo>,
+    /// Fixed before the first read. A later chunk over a different segment set would make
+    /// the carried offset name different rows.
+    segment_ids: Vec<tantivy::index::SegmentId>,
+    offset: usize,
+    chunk: usize,
+    exhausted: bool,
+}
+
+impl OrderedRead {
+    fn new(
+        orderby_info: Vec<OrderByInfo>,
+        segment_ids: Vec<tantivy::index::SegmentId>,
+        fetch: Option<usize>,
+    ) -> Self {
+        // Without a fetch the first chunk is a guess. Rows drop above the scan, so guessing
+        // small and growing costs less than collecting a Top K over the whole match set.
+        let chunk = fetch
+            .unwrap_or(crate::gucs::dynamic_filter_batch_size().max(1) as usize)
+            .max(1);
+        Self {
+            orderby_info,
+            segment_ids,
+            offset: 0,
+            chunk,
+            exhausted: false,
+        }
+    }
+
+    /// Read the next chunk, or `None` once the index has no more rows to give.
+    fn next_chunk(
+        &mut self,
+        reader: &SearchIndexReader,
+    ) -> Option<
+        Vec<(
+            crate::index::reader::index::SearchIndexScore,
+            tantivy::DocAddress,
+        )>,
+    > {
+        if self.exhausted {
+            return None;
+        }
+
+        let TopKSearch { results, .. } = reader.search_top_k_in_segments(
+            self.segment_ids.iter().copied(),
+            &self.orderby_info,
+            self.chunk,
+            self.offset,
+            None,
+            None,
+        );
+
+        let returned = results.original_len();
+        // A short read means the collector ran out, so there is nothing behind this chunk.
+        self.exhausted = returned < self.chunk;
+        self.offset += self.chunk;
+        self.chunk = self
+            .chunk
+            .saturating_mul(crate::gucs::topk_retry_scale_factor().max(1) as usize)
+            .min(crate::gucs::max_topk_chunk_size().max(1) as usize);
+
+        (returned > 0).then(|| results.collect())
+    }
+}
+
+/// Translate a requested order into the sort expressions a plan declares.
+///
+/// Returns `None` when any key is missing from `schema`, because a partly declared
+/// ordering is a wrong claim rather than a weaker one.
+fn ordering_from_orderby_info(
+    schema: &SchemaRef,
+    ordered_by: &[OrderByInfo],
+) -> Option<Vec<PhysicalSortExpr>> {
+    ordered_by
+        .iter()
+        .map(|info| {
+            let OrderByFeature::Field { name, .. } = &info.feature else {
+                return None;
+            };
+            let (col_idx, _) = schema.column_with_name(name.as_ref())?;
+            Some(PhysicalSortExpr {
+                expr: Arc::new(Column::new(name.as_ref(), col_idx)),
+                options: SortOptions {
+                    descending: matches!(
+                        info.direction,
+                        SortDirection::DescNullsFirst | SortDirection::DescNullsLast
+                    ),
+                    nulls_first: matches!(
+                        info.direction,
+                        SortDirection::AscNullsFirst | SortDirection::DescNullsFirst
+                    ),
+                },
+            })
+        })
+        .collect()
+}
+
 fn build_equivalence_properties(
     schema: SchemaRef,
     sort_order: Option<&SortByField>,
+    ordered_by: Option<&Vec<OrderByInfo>>,
 ) -> EquivalenceProperties {
     let mut eq_properties = EquivalenceProperties::new(schema.clone());
+
+    // A requested order wins over the index's own: it is what the consumer asked for, and
+    // the scan reads through the top-K collector to produce it.
+    if let Some(ordered_by) = ordered_by {
+        if let Some(ordering) = ordering_from_orderby_info(&schema, ordered_by) {
+            eq_properties.add_ordering(ordering);
+        }
+        return eq_properties;
+    }
 
     if let Some(sort_field) = sort_order {
         // Find the column index for the sort field
@@ -934,6 +1069,89 @@ impl DisplayAs for PgSearchScanPlan {
             }
         }
         Ok(())
+    }
+}
+
+impl PgSearchScanPlan {
+    /// Decide whether the scan can read in `order` itself.
+    ///
+    /// Every decline is a case where the index read cannot reproduce what Postgres asked
+    /// for. An ordering the scan does not hold is a wrong answer, not a slow one.
+    fn ordered_scan_request(&self, order: &[PhysicalSortExpr]) -> Option<Vec<OrderByInfo>> {
+        if !crate::gucs::enable_ordered_scan() {
+            return None;
+        }
+        if order.is_empty() || order.len() > MAX_TOPK_FEATURES {
+            return None;
+        }
+        // Range mode declares a partitioning on its own column and reads per-partition
+        // bounds. A second ordering on an unrelated column needs a merge nothing builds.
+        if self.range_split_points.is_some() {
+            return None;
+        }
+        // A distributed task claims its own segments, so the per-worker Top Ks would need
+        // a merge above the network boundary that nothing builds either.
+        if self.global_partition_count > 1 || self.assigned_partition.is_some() {
+            return None;
+        }
+        // A tagged scan accumulates per-segment scores through a scorer that the ordered
+        // read does not drive.
+        if !matches!(self.scan_mode, crate::scan::ScanMode::Standard { .. }) {
+            return None;
+        }
+
+        // The scan's own bookkeeping columns are backed by fast fields too, so a plain
+        // type check would let `ctid` or `score` through. Only a column of the table can
+        // carry a user's ORDER BY.
+        let state = self.state.lock().ok()?;
+        let which_fast_fields = match &*state {
+            ExecutionState::Shared { scan_state, .. }
+            | ExecutionState::RangePartitioned { scan_state, .. } => {
+                scan_state.0.scanner_config.which_fast_fields.clone()
+            }
+            ExecutionState::Consumed | ExecutionState::Uninitialized => return None,
+        };
+        drop(state);
+
+        let schema = self.schema();
+        let mut ordered_by = Vec::with_capacity(order.len());
+        for sort_expr in order {
+            let col = sort_expr.expr.downcast_ref::<Column>()?;
+            let (col_idx, field) = schema.column_with_name(col.name())?;
+            match which_fast_fields.get(col_idx)? {
+                WhichFastField::Named(name, _) if name == col.name() => {}
+                _ => return None,
+            }
+
+            // Text and bytes keys are out on two counts. Late materialization emits a
+            // segment-local term ordinal, which does not compare across segments, and
+            // tantivy orders text by bytes, which is not every collation's order.
+            if !matches!(
+                field.data_type(),
+                DataType::Int64
+                    | DataType::UInt64
+                    | DataType::Float64
+                    | DataType::Boolean
+                    | DataType::Timestamp(_, _)
+            ) {
+                return None;
+            }
+
+            ordered_by.push(OrderByInfo {
+                feature: OrderByFeature::Field {
+                    name: FieldName::from(col.name().to_string()),
+                    rti: 0,
+                },
+                direction: match (sort_expr.options.descending, sort_expr.options.nulls_first) {
+                    (true, true) => SortDirection::DescNullsFirst,
+                    (true, false) => SortDirection::DescNullsLast,
+                    (false, true) => SortDirection::AscNullsFirst,
+                    (false, false) => SortDirection::AscNullsLast,
+                },
+            });
+        }
+
+        Some(ordered_by)
     }
 }
 
@@ -1089,6 +1307,8 @@ impl ExecutionPlan for PgSearchScanPlan {
             .filter(|d| d.fetch_at_scan)
             .map(|d| d.name.clone())
             .collect();
+        let ordered_by = self.ordered_by.clone();
+        let fetch = self.fetch;
 
         let stream_gen = async_stream::try_stream! {
             // Create a local copy of the reader if the query changed
@@ -1113,16 +1333,23 @@ impl ExecutionPlan for PgSearchScanPlan {
                 false
             };
 
-            let search_results = if let Some(range_boundaries) = &range_boundaries {
+            let mut ordered_read = ordered_by
+                .map(|orderby_info| OrderedRead::new(orderby_info, reader.segment_ids(), fetch));
+
+            let search_results = if let Some(ordered_read) = &mut ordered_read {
+                let searcher = reader.searcher().clone();
+                let docs = ordered_read.next_chunk(&reader).unwrap_or_default();
+                ScannerResults::ordered(searcher, docs)
+            } else if let Some(range_boundaries) = &range_boundaries {
                 // Range partitioned mode has no shared scan state: each partition searches the
                 // segments its bounds can reach, per their `.stats`. The query above still
                 // filters the rows, so a segment kept in doubt costs time, not correctness.
                 let segment_ids =
                     segments_for_partition(&reader, range_boundaries, target_partition);
-                reader.search_segments(segment_ids.into_iter())
+                ScannerResults::Unordered(reader.search_segments(segment_ids.into_iter()))
             } else {
                 // Standard mode delegates to the parallel state if present
-                match parallel_state {
+                ScannerResults::Unordered(match parallel_state {
                     Some(ps) => reader.search_lazy(ps, source_idx, planner_estimated_rows),
                     // No shared scan state even though the plan may carry per-source claim
                     // markers: the serial fallback (size gate, short launch). The plan was
@@ -1133,7 +1360,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                     // MPP-dispatched fragments cannot land here: their decode always injects
                     // the state, and the worker entrypoint errors when the DSM lacks it.
                     None => reader.search(),
-                }
+                })
             };
             let need_scores = scanner_config
                 .which_fast_fields
@@ -1211,6 +1438,14 @@ impl ExecutionPlan for PgSearchScanPlan {
                         yield record_batch.record_output(&baseline_metrics);
                     }
                     None => {
+                        // The consumer's back-pressure is what ends an ordered read: it
+                        // stops polling once satisfied, so no row budget is tracked here.
+                        if let Some(ordered_read) = &mut ordered_read
+                            && let Some(docs) = ordered_read.next_chunk(&reader)
+                        {
+                            scanner.reload_ordered(docs);
+                            continue;
+                        }
                         if pushed && !pushdown_metric_recorded {
                             let tag = strategy_sink.load(Ordering::Relaxed);
                             let strategy = tantivy::query::StrategyTag::try_from(tag)
@@ -1244,6 +1479,41 @@ impl ExecutionPlan for PgSearchScanPlan {
             UnsafeSendStream::new(stream_gen, self.properties.eq_properties.schema().clone())
         };
         Ok(Box::pin(stream))
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.fetch
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let mut plan = self.clone();
+        plan.fetch = limit;
+        Some(Arc::new(plan))
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> Result<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        let Some(ordered_by) = self.ordered_scan_request(order) else {
+            return Ok(SortOrderPushdownResult::Unsupported);
+        };
+
+        let mut plan = self.clone();
+        plan.properties = Arc::new(PlanProperties::new(
+            build_equivalence_properties(
+                self.schema(),
+                self.sort_order.as_ref(),
+                Some(&ordered_by),
+            ),
+            self.properties.output_partitioning().clone(),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        plan.ordered_by = Some(ordered_by);
+        Ok(SortOrderPushdownResult::Exact {
+            inner: Arc::new(plan),
+        })
     }
 
     fn metrics(&self) -> Option<MetricsSet> {

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -58,6 +58,132 @@ mod tests {
         (heap_oid, index_oid)
     }
 
+    /// The scan reads in a requested order, and declines an order it cannot reproduce.
+    #[pg_test]
+    fn test_ordered_scan_pushdown() {
+        use datafusion::physical_expr::PhysicalSortExpr;
+        use datafusion::physical_plan::SortOrderPushdownResult;
+        use datafusion::physical_plan::expressions::Column;
+
+        let (heap_oid, index_oid) = get_relation_oids();
+        let heap_rel = PgSearchRelation::open(heap_oid);
+        let index_rel = PgSearchRelation::open(index_oid);
+
+        let reader = SearchIndexReader::open(
+            &index_rel,
+            SearchQueryInput::All,
+            false,
+            MvccSatisfies::Snapshot,
+        )
+        .unwrap();
+
+        let fields = vec![
+            WhichFastField::Ctid,
+            WhichFastField::Named("id".to_string(), SearchFieldType::I64(pg_sys::INT4OID)),
+        ];
+        let ffhelper = FFHelper::with_fields(&reader, &fields);
+
+        push_active_snapshot();
+        let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
+        let visibility = HeapVisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
+
+        let schema = build_arrow_schema(&fields);
+        let partition = crate::scan::execution_plan::ScanState {
+            source_idx: None,
+            planner_estimated_rows: 0,
+            scanner_config: crate::scan::execution_plan::ScannerConfig {
+                which_fast_fields: fields.clone(),
+                heap_relid: heap_oid.into(),
+                batch_size_hint: None,
+                score_needed: false,
+                scan_mode: crate::scan::ScanMode::all(),
+            },
+            ffhelper: ffhelper.into(),
+            visibility: Box::new(visibility),
+            reader: reader.clone(),
+        };
+
+        let plan = PgSearchScanPlan::new(
+            Some(partition),
+            schema.clone(),
+            SearchQueryInput::All,
+            None,
+            Vec::new(),
+            None,
+            0,
+            None,
+            1,
+            None,
+            None,
+        );
+
+        let id_idx = schema.index_of("id").unwrap();
+        let descending = |idx: usize, name: &str| PhysicalSortExpr {
+            expr: Arc::new(Column::new(name, idx)),
+            options: arrow_schema::SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+        };
+
+        // A ctid key is not a sortable columnar value, so the scan declines rather than
+        // promise an order it would not hold.
+        let ctid_idx = schema.index_of(&WhichFastField::Ctid.name()).unwrap();
+        assert!(matches!(
+            plan.try_pushdown_sort(&[descending(ctid_idx, &WhichFastField::Ctid.name())])
+                .unwrap(),
+            SortOrderPushdownResult::Unsupported
+        ));
+
+        // More keys than the index reader can compose.
+        let too_many: Vec<_> = (0..6).map(|_| descending(id_idx, "id")).collect();
+        assert!(matches!(
+            plan.try_pushdown_sort(&too_many).unwrap(),
+            SortOrderPushdownResult::Unsupported
+        ));
+
+        let SortOrderPushdownResult::Exact { inner } =
+            plan.try_pushdown_sort(&[descending(id_idx, "id")]).unwrap()
+        else {
+            panic!("expected an exact ordering on a columnar bigint key");
+        };
+
+        let declared = inner
+            .properties()
+            .output_ordering()
+            .expect("ordered mode declares its ordering");
+        let key = declared.iter().next().unwrap();
+        assert_eq!(key.expr.to_string(), format!("id@{id_idx}"));
+        assert!(key.options.descending);
+
+        let inner = inner.with_fetch(Some(10)).expect("the scan takes a fetch");
+        let mut stream = inner.execute(0, Arc::new(TaskContext::default())).unwrap();
+
+        let mut ids = Vec::new();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            while let Some(batch) = stream.next().await {
+                let batch = batch.unwrap();
+                let col = batch
+                    .column(id_idx)
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .expect("id is a bigint column");
+                ids.extend(col.iter().flatten());
+            }
+        });
+
+        // The whole table comes back, because nothing above the scan stops the pull. What
+        // matters is that it arrives in the order the scan promised.
+        assert_eq!(ids.len(), 100);
+        assert_eq!(ids.first(), Some(&100));
+        let mut sorted = ids.clone();
+        sorted.sort_by(|a, b| b.cmp(a));
+        assert_eq!(ids, sorted, "rows did not arrive in the declared order");
+    }
+
     #[pg_test]
     fn test_datafusion_scan() {
         let (heap_oid, index_oid) = get_relation_oids();


### PR DESCRIPTION
## Ticket(s) Closed

- Part of #6276

## What

This PR lets `PgSearchScan` read in a requested sort order.

The scan answers `try_pushdown_sort`, reads through the index's Top K collector instead of in doc order, declares the order, and takes a fetch. `paradedb.enable_ordered_scan` turns it off.

DataFusion's `PushdownSort` is the requester, and it only reaches a scan directly under the sort. In JoinScan plans the deferred-lookup nodes sit between, so no plan moves yet and no expected files change. The requester comes next.

## Why

A scan reads in doc order, so the operator above has to see every row before it can sort. For `ORDER BY ... LIMIT` that is the whole match set for a handful of rows. The index can already retrieve in sort order, which `BaseScan` uses for its Top N, but the columnar path had no way to ask.

This is the stream a lookup join needs. It does not fix #6276 by itself: there the ordered relation is the hash join's build side, and `HashJoinExec` keeps only its right input's ordering. I checked on a running build, and the plan is identical with this on and off.

## How

`try_pushdown_sort` returns `Exact`, so `EnsureRequirements` and `PushdownSort` decide whether the sort goes. A rule removing it by hand would run after `SanityCheckPlan` and escape validation.

Sort order interleaves segments, but every columnar read below is keyed on one `segment_ord`, so a batch ends at the first segment change. The runs are short, which is affordable because a fetch is what makes the order worth asking for. A chunk is a fresh Top K with a carried offset rather than a continuation, so it grows. Nothing else bounds the read: the consumer stops pulling once it has enough, which is also what keeps it right when rows drop above the scan. Ordered mode fixes its segment list before the first read, since `search_lazy` records nothing about what it claimed and a chunk over a different set would make the carried offset name different rows.

Declines, each one a case the index read cannot reproduce: text and bytes keys, because tantivy orders bytes and a late-materialized column carries a segment-local ordinal; more than five keys; range-partitioned scans; distributed tasks, whose per-worker Top Ks have no merge above the network boundary; and anything that is not a column of the table, since `ctid` is backed by a fast field too.

`SegmentedTopKExec` fires only on a deferred string or bytes key, which is what this declines, so the two stay disjoint.

## Tests

A unit test drives `try_pushdown_sort` directly: rows come back in the declared order, the plan declares it, the scan takes a fetch, and a bookkeeping column and an over-long key list are declined.
