### PR TITLE
fix: derive deferred placement uniqueness from heap indexes

### DIFF
--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -15,11 +15,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //! Provides a reference-counted wrapper around an open Postgres [`pg_sys::Relation`].
+use crate::api::HashSet;
 use crate::api::version::Version;
 use crate::index::mvcc::MvccSatisfies;
 use crate::postgres::build::is_bm25_index;
 use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::storage::metadata::MetaPage;
+use crate::postgres::utils::FieldSource;
 use crate::schema::SearchIndexSchema;
 use pgrx::pg_sys::WalLevel::WAL_LEVEL_REPLICA;
 use pgrx::{PgList, PgTupleDesc, name_data_to_str, pg_sys};
@@ -420,6 +422,56 @@ impl PgSearchRelation {
             .map(|oid| PgSearchRelation::with_lock(oid, lockmode))
             .collect::<Vec<_>>()
             .into_iter()
+    }
+
+    /// Zero-based heap attributes that a single-column unique index proves unique. The
+    /// filter is the one `relation_has_unique_index_for` applies, minus partial indexes,
+    /// whose predicate the query would have to imply. A deferrable constraint allows
+    /// duplicates inside a transaction, so `indimmediate` is required as well.
+    pub fn unique_column_attnos(&self) -> HashSet<usize> {
+        self.indices(pg_sys::AccessShareLock as _)
+            .filter_map(|index| unsafe {
+                // SAFETY: rd_index is set for every index relation and lives as long as it.
+                let info = &*index.rd_index;
+                if !info.indisunique
+                    || !info.indisvalid
+                    || !info.indimmediate
+                    || info.indnkeyatts != 1
+                    || !pg_sys::RelationGetIndexPredicate(index.as_ptr()).is_null()
+                {
+                    return None;
+                }
+                // An expression key has no attribute number.
+                let attno = *info.indkey.values.as_ptr();
+                usize::try_from(attno - 1).ok()
+            })
+            .collect()
+    }
+
+    /// Search fields whose columnar value is unique across the heap. A normalizer folds
+    /// distinct heap values onto one term and an array field emits one term per element, so
+    /// neither carries the heap's constraint over; an expression field has no heap column to
+    /// carry it from.
+    pub fn unique_fields(&self) -> HashSet<String> {
+        let heap = self.heap_relation().expect("relation must be an index");
+        let unique_attnos = heap.unique_column_attnos();
+        let schema = self.schema().expect("relation must be a bm25 index");
+        let options = self.options();
+        options
+            .attributes()
+            .iter()
+            .filter_map(|(name, attr)| {
+                let FieldSource::Heap { attno } = attr.source else {
+                    return None;
+                };
+                (unique_attnos.contains(&attno)
+                    && !options.is_multi_valued(name)
+                    && schema
+                        .search_field(name)
+                        .is_some_and(|f| f.is_raw_sortable()))
+                .then(|| name.to_string())
+            })
+            .collect()
     }
 
     pub fn options(&self) -> &BM25IndexOptions {

--- a/pg_search/src/scan/deferred_placement_rule.rs
+++ b/pg_search/src/scan/deferred_placement_rule.rs
@@ -79,7 +79,6 @@ use crate::gucs::{self, DeferredPlacement};
 use crate::index::fast_fields_helper::FFIndex;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::utils::FieldSource;
 use crate::scan::deferred_lookup::PhysicalDeferredField;
 use crate::scan::execution_plan::PgSearchScanPlan;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
@@ -204,7 +203,7 @@ impl Decision {
 struct Context {
     fetch_auto: bool,
     decode_auto: bool,
-    /// Fields backed by an immediate, non-partial unique index on the heap.
+    /// Per index, since every join key asks the same question of the same scan.
     unique_fields: HashMap<u32, HashSet<String>>,
     /// Per column of per scan, since each one has its own consumer and its own path, so its
     /// own point to stop at.
@@ -216,49 +215,11 @@ impl Context {
         self.unique_fields
             .entry(indexrelid)
             .or_insert_with(|| {
+                // A placeholder scan has no index to ask.
                 if indexrelid == 0 {
                     return HashSet::default();
                 }
-                let rel = PgSearchRelation::open(pg_sys::Oid::from(indexrelid));
-                let heap = rel.heap_relation().expect("scan relation must be an index");
-                let tuple_desc = heap.tuple_desc();
-                let unique_attributes: HashSet<usize> = heap
-                    .indices(pg_sys::AccessShareLock as _)
-                    .filter_map(|index| unsafe {
-                        let info = &*index.rd_index;
-                        if !info.indisunique
-                            || !info.indisvalid
-                            || !info.indimmediate
-                            || info.indnkeyatts != 1
-                            || !pg_sys::RelationGetIndexPredicate(index.as_ptr()).is_null()
-                        {
-                            return None;
-                        }
-                        let attno = *info.indkey.values.as_ptr();
-                        if attno <= 0 {
-                            return None;
-                        }
-                        let attno = (attno - 1) as usize;
-                        (tuple_desc.get(attno)?.attnotnull || info.indnullsnotdistinct)
-                            .then_some(attno)
-                    })
-                    .collect();
-                let schema = rel.schema().expect("scan relation must have a schema");
-                rel.options()
-                    .attributes()
-                    .iter()
-                    .filter_map(|(name, attr)| {
-                        let FieldSource::Heap { attno } = attr.source else {
-                            return None;
-                        };
-                        (unique_attributes.contains(&attno)
-                            && !rel.options().is_multi_valued(name)
-                            && schema
-                                .search_field(name)
-                                .is_some_and(|f| f.is_raw_sortable()))
-                        .then(|| name.to_string())
-                    })
-                    .collect()
+                PgSearchRelation::open(pg_sys::Oid::from(indexrelid)).unique_fields()
             })
             .contains(field_name)
     }
@@ -473,13 +434,15 @@ fn equi_join_expansion<'a>(
     }
 }
 
-/// Whether `col` holds at most one row per value where `plan` emits it.
+/// Whether `col` holds at most one row per non-null value where `plan` emits it. `NULL` does
+/// not count: an equi-join key never matches it, so a nullable unique column is as good as a
+/// primary key here.
 ///
 /// Read from constraints and the plan's shape, never from a row count. A group key is unique
-/// because the aggregate emits one row per group, and a node that only
-/// drops rows passes uniqueness through. A join keeps one side's uniqueness exactly while the
-/// other side's join keys are unique on that side, which is this same question one level
-/// down, so a three-table join gets an answer instead of a shrug.
+/// because the aggregate emits one row per group, and a node that only drops rows passes
+/// uniqueness through. A join keeps one side's uniqueness exactly while the other side's join
+/// keys are unique on that side, which is this same question one level down, so a
+/// three-table join gets an answer instead of a shrug.
 fn is_unique(plan: &Arc<dyn ExecutionPlan>, col: usize, ctx: &mut Context) -> bool {
     if let Some(scan) = plan.downcast_ref::<PgSearchScanPlan>() {
         let schema = plan.schema();
@@ -814,7 +777,7 @@ mod tests {
                 title text,
                 other bigint UNIQUE NOT NULL,
                 nullable bigint UNIQUE,
-                nulls_equal bigint UNIQUE NULLS NOT DISTINCT,
+                tags text[] UNIQUE NOT NULL,
                 deferred bigint NOT NULL UNIQUE DEFERRABLE INITIALLY DEFERRED,
                 partial bigint NOT NULL,
                 composite_a bigint NOT NULL,
@@ -826,7 +789,7 @@ mod tests {
             CREATE UNIQUE INDEX placement_include ON placement_unique (id) INCLUDE (title);
             CREATE UNIQUE INDEX placement_expression ON placement_unique (lower(title));
             CREATE INDEX placement_search ON placement_unique USING bm25
-                (title, id, other, nullable, nulls_equal, deferred, partial, composite_a, composite_b, normalized)
+                (title, id, other, nullable, tags, deferred, partial, composite_a, composite_b, normalized)
                 WITH (key_field = 'id', text_fields = '{"title":{"fast":true},"normalized":{"fast":true,"normalizer":"lowercase"}}');
             CREATE TABLE placement_alias (key bigint PRIMARY KEY, id text UNIQUE NOT NULL);
             CREATE INDEX placement_alias_search ON placement_alias USING bm25
@@ -845,11 +808,11 @@ mod tests {
             !is_unique(&scan, 1, &mut ctx),
             "the first indexed column is not"
         );
-        for field in ["other", "nulls_equal"] {
+        for field in ["other", "nullable"] {
             assert!(ctx.is_unique_field(indexrelid, field), "{field}");
         }
         for field in [
-            "nullable",
+            "tags",
             "deferred",
             "partial",
             "composite_a",

--- a/pg_search/src/scan/deferred_placement_rule.rs
+++ b/pg_search/src/scan/deferred_placement_rule.rs
@@ -29,8 +29,8 @@
 //!   that case the scan decodes the column and no union is carried at all.
 //!
 //! Row multiplication is read from the join keys, not from cardinality estimates: a source's
-//! rows fan out through an equi-join when the other side's key is not that side's unique key
-//! field, and through any non-equi or cross join. Estimates move between machines and would
+//! rows fan out through an equi-join when the other side's join key is not known to be
+//! unique, and through any non-equi or cross join. Estimates move between machines and would
 //! flip plans between runs; the key shape does not. The price of that is a join whose other
 //! side is far more selective than the keys suggest: the scan then decodes rows the join
 //! would have dropped. The join key `InList` pushed down into the probe scan covers the
@@ -79,6 +79,7 @@ use crate::gucs::{self, DeferredPlacement};
 use crate::index::fast_fields_helper::FFIndex;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
 use crate::postgres::rel::PgSearchRelation;
+use crate::postgres::utils::FieldSource;
 use crate::scan::deferred_lookup::PhysicalDeferredField;
 use crate::scan::execution_plan::PgSearchScanPlan;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
@@ -107,7 +108,7 @@ impl PhysicalOptimizerRule for DeferredPlacementRule {
         let mut ctx = Context {
             fetch_auto: gucs::defer_column_fetch() == DeferredPlacement::Auto,
             decode_auto: gucs::defer_string_decode() == DeferredPlacement::Auto,
-            key_fields: HashMap::default(),
+            unique_fields: HashMap::default(),
             decisions: HashMap::default(),
         };
         if !ctx.fetch_auto && !ctx.decode_auto {
@@ -203,25 +204,63 @@ impl Decision {
 struct Context {
     fetch_auto: bool,
     decode_auto: bool,
-    /// Key field per index, or `None` when the index cannot be opened (a placeholder scan).
-    key_fields: HashMap<u32, Option<String>>,
+    /// Fields backed by an immediate, non-partial unique index on the heap.
+    unique_fields: HashMap<u32, HashSet<String>>,
     /// Per column of per scan, since each one has its own consumer and its own path, so its
     /// own point to stop at.
     decisions: HashMap<DeferredSource, Decision>,
 }
 
 impl Context {
-    fn key_field(&mut self, indexrelid: u32) -> Option<String> {
-        self.key_fields
+    fn is_unique_field(&mut self, indexrelid: u32, field_name: &str) -> bool {
+        self.unique_fields
             .entry(indexrelid)
             .or_insert_with(|| {
                 if indexrelid == 0 {
-                    return None;
+                    return HashSet::default();
                 }
                 let rel = PgSearchRelation::open(pg_sys::Oid::from(indexrelid));
-                Some(rel.options().key_field_name().to_string())
+                let heap = rel.heap_relation().expect("scan relation must be an index");
+                let tuple_desc = heap.tuple_desc();
+                let unique_attributes: HashSet<usize> = heap
+                    .indices(pg_sys::AccessShareLock as _)
+                    .filter_map(|index| unsafe {
+                        let info = &*index.rd_index;
+                        if !info.indisunique
+                            || !info.indisvalid
+                            || !info.indimmediate
+                            || info.indnkeyatts != 1
+                            || !pg_sys::RelationGetIndexPredicate(index.as_ptr()).is_null()
+                        {
+                            return None;
+                        }
+                        let attno = *info.indkey.values.as_ptr();
+                        if attno <= 0 {
+                            return None;
+                        }
+                        let attno = (attno - 1) as usize;
+                        (tuple_desc.get(attno)?.attnotnull || info.indnullsnotdistinct)
+                            .then_some(attno)
+                    })
+                    .collect();
+                let schema = rel.schema().expect("scan relation must have a schema");
+                rel.options()
+                    .attributes()
+                    .iter()
+                    .filter_map(|(name, attr)| {
+                        let FieldSource::Heap { attno } = attr.source else {
+                            return None;
+                        };
+                        (unique_attributes.contains(&attno)
+                            && !rel.options().is_multi_valued(name)
+                            && schema
+                                .search_field(name)
+                                .is_some_and(|f| f.is_raw_sortable()))
+                        .then(|| name.to_string())
+                    })
+                    .collect()
             })
-            .clone()
+            .contains(field_name)
     }
 }
 
@@ -409,8 +448,8 @@ fn rebuilds_with_new_types(node: &Arc<dyn ExecutionPlan>) -> bool {
         || node.is::<TantivyDecodeExec>()
 }
 
-/// A source's rows fan out through an equi-join unless one of the other side's keys is that
-/// side's unique key field. A key that cannot be traced to a scan (the other side is itself a
+/// A source's rows fan out through an equi-join unless one of the other side's keys is
+/// known to be unique. A key that cannot be traced to a scan (the other side is itself a
 /// join, or the key is an expression) leaves the answer open.
 fn equi_join_expansion<'a>(
     other: &Arc<dyn ExecutionPlan>,
@@ -436,17 +475,18 @@ fn equi_join_expansion<'a>(
 
 /// Whether `col` holds at most one row per value where `plan` emits it.
 ///
-/// Read from the plan's shape alone, never from a row count. A scan's key field is unique, a
-/// group key is unique because the aggregate emits one row per group, and a node that only
+/// Read from constraints and the plan's shape, never from a row count. A group key is unique
+/// because the aggregate emits one row per group, and a node that only
 /// drops rows passes uniqueness through. A join keeps one side's uniqueness exactly while the
 /// other side's join keys are unique on that side, which is this same question one level
 /// down, so a three-table join gets an answer instead of a shrug.
 fn is_unique(plan: &Arc<dyn ExecutionPlan>, col: usize, ctx: &mut Context) -> bool {
     if let Some(scan) = plan.downcast_ref::<PgSearchScanPlan>() {
         let schema = plan.schema();
-        return schema.fields().get(col).is_some_and(|field| {
-            ctx.key_field(scan.indexrelid).as_deref() == Some(field.name().as_str())
-        });
+        return schema
+            .fields()
+            .get(col)
+            .is_some_and(|field| ctx.is_unique_field(scan.indexrelid, field.name()));
     }
 
     if let Some(proj) = plan.downcast_ref::<ProjectionExec>() {
@@ -656,7 +696,7 @@ mod tests {
         Context {
             fetch_auto,
             decode_auto,
-            key_fields: HashMap::default(),
+            unique_fields: HashMap::default(),
             decisions: HashMap::default(),
         }
     }
@@ -758,25 +798,80 @@ mod tests {
         )) as Arc<dyn ExecutionPlan>
     }
 
-    fn ctx_with_key_field(indexrelid: u32) -> Context {
+    fn ctx_with_unique_field(indexrelid: u32) -> Context {
         let mut ctx = ctx(true, true);
-        ctx.key_fields.insert(indexrelid, Some("id".to_string()));
+        ctx.unique_fields
+            .insert(indexrelid, HashSet::from_iter(["id".to_string()]));
         ctx
     }
 
     #[pg_test]
-    fn a_scan_is_unique_only_on_its_key_field() {
-        let scan = scan_of(7, 1);
-        let mut ctx = ctx_with_key_field(7);
-        assert!(is_unique(&scan, 0, &mut ctx), "the key field is unique");
-        assert!(!is_unique(&scan, 1, &mut ctx), "a text column is not");
+    fn a_scan_is_unique_only_on_a_proven_unique_field() {
+        Spi::run(
+            r#"
+            CREATE TABLE placement_unique (
+                id bigint PRIMARY KEY,
+                title text,
+                other bigint UNIQUE NOT NULL,
+                nullable bigint UNIQUE,
+                nulls_equal bigint UNIQUE NULLS NOT DISTINCT,
+                deferred bigint NOT NULL UNIQUE DEFERRABLE INITIALLY DEFERRED,
+                partial bigint NOT NULL,
+                composite_a bigint NOT NULL,
+                composite_b bigint NOT NULL,
+                normalized text UNIQUE NOT NULL,
+                UNIQUE (composite_a, composite_b)
+            );
+            CREATE UNIQUE INDEX placement_partial ON placement_unique (partial) WHERE partial > 0;
+            CREATE UNIQUE INDEX placement_include ON placement_unique (id) INCLUDE (title);
+            CREATE UNIQUE INDEX placement_expression ON placement_unique (lower(title));
+            CREATE INDEX placement_search ON placement_unique USING bm25
+                (title, id, other, nullable, nulls_equal, deferred, partial, composite_a, composite_b, normalized)
+                WITH (key_field = 'id', text_fields = '{"title":{"fast":true},"normalized":{"fast":true,"normalizer":"lowercase"}}');
+            CREATE TABLE placement_alias (key bigint PRIMARY KEY, id text UNIQUE NOT NULL);
+            CREATE INDEX placement_alias_search ON placement_alias USING bm25
+                (key, (lower(id)::pdb.literal('alias=id'))) WITH (key_field = 'key');
+            "#,
+        )
+        .unwrap();
+        let indexrelid = Spi::get_one::<pg_sys::Oid>("SELECT 'placement_search'::regclass::oid")
+            .unwrap()
+            .unwrap()
+            .to_u32();
+        let scan = scan_of(indexrelid, 1);
+        let mut ctx = ctx(true, true);
+        assert!(is_unique(&scan, 0, &mut ctx), "the primary key is unique");
+        assert!(
+            !is_unique(&scan, 1, &mut ctx),
+            "the first indexed column is not"
+        );
+        for field in ["other", "nulls_equal"] {
+            assert!(ctx.is_unique_field(indexrelid, field), "{field}");
+        }
+        for field in [
+            "nullable",
+            "deferred",
+            "partial",
+            "composite_a",
+            "composite_b",
+            "normalized",
+        ] {
+            assert!(!ctx.is_unique_field(indexrelid, field), "{field}");
+        }
+        let expression_index =
+            Spi::get_one::<pg_sys::Oid>("SELECT 'placement_alias_search'::regclass::oid")
+                .unwrap()
+                .unwrap()
+                .to_u32();
+        assert!(!ctx.is_unique_field(expression_index, "id"));
+        assert!(!ctx.is_unique_field(0, "id"));
     }
 
     /// The answer a join asks of its other side is the same answer one level down, so a key
     /// that a join below already multiplied stops counting as unique.
     #[pg_test]
     fn a_join_keeps_uniqueness_only_while_the_other_side_has_it() {
-        let mut ctx = ctx_with_key_field(7);
+        let mut ctx = ctx_with_unique_field(7);
         let left = scan_of(7, 1);
         let right = scan_of(7, 2);
 
@@ -792,7 +887,7 @@ mod tests {
         let key_join = hash_join(Arc::clone(&left), Arc::clone(&right), on_key);
         assert!(
             is_unique(&key_join, 0, &mut ctx),
-            "the left key field survives a join on the right key field"
+            "the left unique field survives a join on the right unique field"
         );
 
         let text_join = hash_join(left, right, on_text);

--- a/pg_search/tests/pg_regress/expected/late_materialization_placement.out
+++ b/pg_search/tests/pg_regress/expected/late_materialization_placement.out
@@ -1,6 +1,6 @@
 -- The placement rule decides per source where the two halves of a late-materialized
 -- string lookup run. A build side comes back out of doc order, and a join key that is not
--- the other side's key field fans the rows out; either moves the fetch into the scan. A
+-- unique on the other side fans the rows out; either moves the fetch into the scan. A
 -- fan-out with nothing above that stops after a fixed number of rows moves the decode into
 -- the scan as well.
 CREATE EXTENSION IF NOT EXISTS pg_search;
@@ -10,6 +10,7 @@ SET paradedb.enable_join_custom_scan = on;
 SET paradedb.enable_aggregate_custom_scan = on;
 DROP TABLE IF EXISTS lmp_comments CASCADE;
 DROP TABLE IF EXISTS lmp_posts CASCADE;
+DROP TABLE IF EXISTS lmp_profiles CASCADE;
 CREATE TABLE lmp_posts (
     id SERIAL PRIMARY KEY,
     title TEXT,
@@ -67,8 +68,8 @@ SHOW paradedb.defer_string_decode;
 -- =============================================================================
 -- Top-K: the consumer is bounded, so the decode stays deferred either way
 -- =============================================================================
--- The sort key is on the build side, and `post_id` is not the key field of the comments
--- index: the posts scan resolves the ordinals itself.
+-- The sort key is on the build side, and `post_id` is not unique in the comments table:
+-- the posts scan resolves the ordinals itself.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT p.id, p.title
 FROM lmp_posts p JOIN lmp_comments c ON c.post_id = p.id
@@ -110,7 +111,7 @@ LIMIT 5;
  30 | Post 030
 (5 rows)
 
--- The sort key is on the probe side, and `id` is the key field of the posts index: the
+-- The sort key is on the probe side, and `id` is the primary key of the posts table: the
 -- rows reach the decode point in doc order and at most once, so the fetch stays deferred.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT c.id, c.author
@@ -419,6 +420,106 @@ LIMIT 5;
 (5 rows)
 
 -- =============================================================================
+-- Uniqueness is read from the heap's unique indexes
+-- =============================================================================
+CREATE TABLE lmp_profiles (
+    id INTEGER,
+    handle INTEGER UNIQUE NOT NULL,
+    bio TEXT
+);
+CREATE INDEX lmp_profiles_idx ON lmp_profiles USING bm25 (id, handle, bio)
+WITH (key_field = 'id', numeric_fields = '{"handle": {"fast": true}}');
+INSERT INTO lmp_profiles (id, handle, bio)
+SELECT i, i, CASE WHEN i % 3 = 0 THEN 'alpha profile' ELSE 'beta profile' END
+FROM generate_series(1, 30) AS i;
+-- `handle` is not the key field, but its unique index proves that each comment matches at
+-- most one profile: the fetch stays deferred.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.handle
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.author
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: c.id, c.author
+         Relation Tree: c INNER p
+         Join Cond: p.handle = c.post_id
+         Limit: 5
+         Order By: c.author asc, c.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, author@1 as col_2, ctid_0@0 as ctid_0, ctid_1@3 as ctid_1]
+           :   TantivyDecodeExec: decode=[author]
+           :     TantivyFetchExec: fetch=[author]
+           :       SegmentedTopKExec: expr=[author@1 ASC NULLS LAST, id@2 ASC NULLS LAST], k=5, visibility_checks=[c, p]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(handle@1, post_id@1)], projection=[ctid_0@2, author@4, id@5, ctid_1@0]
+           :           CooperativeExec
+           :             PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"bio","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: table=c, segments=2, dynamic_filters=2, query="all"
+(18 rows)
+
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.handle
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+ id  |  author   
+-----+-----------
+  33 | author 00
+  66 | author 00
+  99 | author 00
+ 132 | author 00
+  30 | author 01
+(5 rows)
+
+-- The key field alone proves nothing: `id` has no unique index, so the join may fan the
+-- comments out, and the comments scan resolves the ordinals itself.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.id
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.author
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: c.id, c.author
+         Relation Tree: c INNER p
+         Join Cond: p.id = c.post_id
+         Limit: 5
+         Order By: c.author asc, c.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, author@1 as col_2, ctid_0@0 as ctid_0, ctid_1@3 as ctid_1]
+           :   TantivyDecodeExec: decode=[author]
+           :     SegmentedTopKExec: expr=[author@1 ASC NULLS LAST, id@2 ASC NULLS LAST], k=5, visibility_checks=[c, p]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, post_id@1)], projection=[ctid_0@2, author@4, id@5, ctid_1@0]
+           :         CooperativeExec
+           :           PgSearchScan: table=p, segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"bio","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: table=c, segments=2, fetch=[author], dynamic_filters=2, query="all"
+(17 rows)
+
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.id
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+ id  |  author   
+-----+-----------
+  33 | author 00
+  66 | author 00
+  99 | author 00
+ 132 | author 00
+  30 | author 01
+(5 rows)
+
+-- =============================================================================
 -- Aggregates: nothing above bounds the rows, so a fan-out decodes in the scan
 -- =============================================================================
 SET paradedb.enable_aggregate_late_materialization = on;
@@ -521,7 +622,7 @@ LIMIT 5;
 -- =============================================================================
 -- A self-join reads one index through two scans, and each one gets its own
 -- answer. The build side comes back out of doc order, so it resolves its
--- ordinals in the scan. The probe side joins on the build side's key field, so
+-- ordinals in the scan. The probe side joins on the build side's primary key, so
 -- its rows arrive in doc order and at most once, and both halves stay deferred.
 -- =============================================================================
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
@@ -891,5 +992,6 @@ LIMIT 5;
 (5 rows)
 
 RESET paradedb.enable_aggregate_late_materialization;
+DROP TABLE lmp_profiles;
 DROP TABLE lmp_comments;
 DROP TABLE lmp_posts;

--- a/pg_search/tests/pg_regress/sql/late_materialization_placement.sql
+++ b/pg_search/tests/pg_regress/sql/late_materialization_placement.sql
@@ -1,6 +1,6 @@
 -- The placement rule decides per source where the two halves of a late-materialized
 -- string lookup run. A build side comes back out of doc order, and a join key that is not
--- the other side's key field fans the rows out; either moves the fetch into the scan. A
+-- unique on the other side fans the rows out; either moves the fetch into the scan. A
 -- fan-out with nothing above that stops after a fixed number of rows moves the decode into
 -- the scan as well.
 
@@ -13,6 +13,7 @@ SET paradedb.enable_aggregate_custom_scan = on;
 
 DROP TABLE IF EXISTS lmp_comments CASCADE;
 DROP TABLE IF EXISTS lmp_posts CASCADE;
+DROP TABLE IF EXISTS lmp_profiles CASCADE;
 
 CREATE TABLE lmp_posts (
     id SERIAL PRIMARY KEY,
@@ -73,8 +74,8 @@ SHOW paradedb.defer_string_decode;
 -- Top-K: the consumer is bounded, so the decode stays deferred either way
 -- =============================================================================
 
--- The sort key is on the build side, and `post_id` is not the key field of the comments
--- index: the posts scan resolves the ordinals itself.
+-- The sort key is on the build side, and `post_id` is not unique in the comments table:
+-- the posts scan resolves the ordinals itself.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT p.id, p.title
 FROM lmp_posts p JOIN lmp_comments c ON c.post_id = p.id
@@ -88,7 +89,7 @@ WHERE p.body @@@ 'alpha'
 ORDER BY p.title DESC, p.id ASC
 LIMIT 5;
 
--- The sort key is on the probe side, and `id` is the key field of the posts index: the
+-- The sort key is on the probe side, and `id` is the primary key of the posts table: the
 -- rows reach the decode point in doc order and at most once, so the fetch stays deferred.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT c.id, c.author
@@ -198,6 +199,53 @@ ORDER BY c.author ASC, c.id ASC, c2.id ASC
 LIMIT 5;
 
 -- =============================================================================
+-- Uniqueness is read from the heap's unique indexes
+-- =============================================================================
+
+CREATE TABLE lmp_profiles (
+    id INTEGER,
+    handle INTEGER UNIQUE NOT NULL,
+    bio TEXT
+);
+
+CREATE INDEX lmp_profiles_idx ON lmp_profiles USING bm25 (id, handle, bio)
+WITH (key_field = 'id', numeric_fields = '{"handle": {"fast": true}}');
+
+INSERT INTO lmp_profiles (id, handle, bio)
+SELECT i, i, CASE WHEN i % 3 = 0 THEN 'alpha profile' ELSE 'beta profile' END
+FROM generate_series(1, 30) AS i;
+
+-- `handle` is not the key field, but its unique index proves that each comment matches at
+-- most one profile: the fetch stays deferred.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.handle
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.handle
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+
+-- The key field alone proves nothing: `id` has no unique index, so the join may fan the
+-- comments out, and the comments scan resolves the ordinals itself.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.id
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+
+SELECT c.id, c.author
+FROM lmp_profiles p JOIN lmp_comments c ON c.post_id = p.id
+WHERE p.bio @@@ 'alpha'
+ORDER BY c.author ASC, c.id ASC
+LIMIT 5;
+
+-- =============================================================================
 -- Aggregates: nothing above bounds the rows, so a fan-out decodes in the scan
 -- =============================================================================
 
@@ -236,7 +284,7 @@ LIMIT 5;
 -- =============================================================================
 -- A self-join reads one index through two scans, and each one gets its own
 -- answer. The build side comes back out of doc order, so it resolves its
--- ordinals in the scan. The probe side joins on the build side's key field, so
+-- ordinals in the scan. The probe side joins on the build side's primary key, so
 -- its rows arrive in doc order and at most once, and both halves stay deferred.
 -- =============================================================================
 
@@ -374,5 +422,6 @@ LIMIT 5;
 
 RESET paradedb.enable_aggregate_late_materialization;
 
+DROP TABLE lmp_profiles;
 DROP TABLE lmp_comments;
 DROP TABLE lmp_posts;


### PR DESCRIPTION
This PR reads a join column's uniqueness from the heap's unique indexes instead of the BM25 key field, which #6221 removes.

`PgSearchRelation::unique_fields()` keeps a search field when a valid, immediate, non-partial, single-column unique index backs its heap column and the index stores the value as is (no normalizer, no array). `NULL` needs no special case, since an equi-join key never matches it. Primary-key join plans do not change; a key field without a unique index now counts as a fan-out.

All review findings are fixed: the catalog walk moved onto `PgSearchRelation`, the `NOT NULL` gate is gone, the filters carry their reasons, and `late_materialization_placement` covers a join on a non-key `UNIQUE NOT NULL` column and one on a key field without a unique index.
