### PR TITLE
fix: folded JoinScan predicates on an anti join's pruned side to NULL.

### DIFF
--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -622,7 +622,12 @@ impl<'a> PredicateTranslator<'a> {
 
     pub(crate) unsafe fn translate_const(&self, c: *mut pg_sys::Const) -> Option<Expr> {
         if (*c).constisnull {
-            return Some(lit(ScalarValue::Null));
+            // A boolean NULL must stay boolean: DataFusion's `Filter` only accepts a
+            // boolean predicate, and a folded clause can be nothing but this constant.
+            return Some(match (*c).consttype {
+                pg_sys::BOOLOID => lit(ScalarValue::Boolean(None)),
+                _ => lit(ScalarValue::Null),
+            });
         }
 
         let type_oid = (*c).consttype;

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -41,7 +41,7 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::utils::{expr_collect_rtis, expr_collect_vars, expr_contains_any_operator};
 use crate::query::SearchQueryInput;
-use pgrx::{PgList, pg_sys};
+use pgrx::{PgList, pg_guard, pg_sys};
 
 /// Extract join-level conditions from the restrict list and transform them into
 /// a `JoinLevelExpr` tree.
@@ -133,6 +133,8 @@ pub unsafe fn extract_join_level_conditions(
         if already_present {
             continue;
         }
+        let clause: *mut pg_sys::Expr =
+            null_out_pruned_vars(root, clause.cast(), &join_clause.plan).cast();
         let has_search_op = expr_contains_any_operator(clause.cast(), &[search_op]);
 
         if has_search_op {
@@ -227,6 +229,7 @@ pub unsafe fn extract_join_level_conditions(
                     continue;
                 }
 
+                let conjunct = null_out_pruned_vars(root, conjunct, &join_clause.plan);
                 let has_search_op = expr_contains_any_operator(conjunct.cast(), &[search_op]);
                 if has_search_op {
                     if let Some(expr) = transform_to_search_expr(
@@ -427,8 +430,12 @@ pub unsafe fn transform_to_search_expr(
         return None;
     }
 
-    // If this is a post-join expression WITHOUT search predicate, create MultiTablePredicate
-    if !has_search_op && !referenced_source_indices.is_empty() {
+    // If this is a post-join expression WITHOUT search predicate, create MultiTablePredicate.
+    // A bare constant qualifies too: `null_out_pruned_vars` can fold a whole arm of an
+    // OR down to NULL, and that arm still has to take part in the three-valued result.
+    if !has_search_op
+        && (!referenced_source_indices.is_empty() || node_type == pg_sys::NodeTag::T_Const)
+    {
         if !all_vars_are_fast_fields_recursive(node, sources, None) {
             return None;
         }
@@ -576,40 +583,28 @@ pub(super) unsafe fn lower_absorbed_search_clauses(
             } = *j;
             let left = lower_absorbed_search_clauses(root, left, multi_table_predicate_clauses)?;
             let right = lower_absorbed_search_clauses(root, right, multi_table_predicate_clauses)?;
+            let join_node = RelNode::Join(Box::new(JoinNode {
+                join_type,
+                left,
+                right,
+                equi_keys,
+                filter,
+                subplan_id,
+                absorbed_search_clauses: Vec::new(),
+            }));
 
             if absorbed_search_clauses.is_empty() {
-                return Ok(RelNode::Join(Box::new(JoinNode {
-                    join_type,
-                    left,
-                    right,
-                    equi_keys,
-                    filter,
-                    subplan_id,
-                    absorbed_search_clauses: Vec::new(),
-                })));
+                return Ok(join_node);
             }
-
-            // PG anchors `RestrictInfo`s against RTIs from the sub-tree, so
-            // resolve against everything reachable below this join.
-            let mut sub_sources = left.sources();
-            sub_sources.extend(right.sources());
 
             let predicate = build_absorbed_filter(
                 root,
-                &sub_sources,
+                &join_node,
                 &absorbed_search_clauses,
                 multi_table_predicate_clauses,
             )?;
             Ok(RelNode::Filter(Box::new(FilterNode {
-                input: RelNode::Join(Box::new(JoinNode {
-                    join_type,
-                    left,
-                    right,
-                    equi_keys,
-                    filter,
-                    subplan_id,
-                    absorbed_search_clauses: Vec::new(),
-                })),
+                input: join_node,
                 predicate,
             })))
         }
@@ -628,10 +623,9 @@ pub(super) unsafe fn lower_absorbed_search_clauses(
             if absorbed_clauses.is_empty() {
                 return Ok(unnest_node);
             }
-            let sub_sources = unnest_node.sources();
             let predicate = build_absorbed_filter(
                 root,
-                &sub_sources,
+                &unnest_node,
                 &absorbed_clauses,
                 multi_table_predicate_clauses,
             )?;
@@ -649,10 +643,13 @@ pub(super) unsafe fn lower_absorbed_search_clauses(
 /// blows up the test suite instead of producing wrong rows.
 unsafe fn build_absorbed_filter(
     root: *mut pg_sys::PlannerInfo,
-    sub_sources: &[&JoinSource],
+    input: &RelNode,
     absorbed: &[*mut pg_sys::RestrictInfo],
     multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
 ) -> Result<JoinLevelExpr, String> {
+    // PG anchors `RestrictInfo`s against RTIs from the sub-tree, so
+    // resolve against everything reachable below this node.
+    let sub_sources = input.sources();
     let expr_trees: Vec<JoinLevelExpr> = absorbed
         .iter()
         .copied()
@@ -664,19 +661,18 @@ unsafe fn build_absorbed_filter(
             if clause.is_null() {
                 return Err("absorbed search clause has a null clause".to_string());
             }
-            transform_to_search_expr(
-                root,
-                clause.cast(),
-                sub_sources,
-                multi_table_predicate_clauses,
-            )
-            .ok_or_else(|| {
-                let formatted = crate::postgres::deparse::deparse_planner_expr(root, clause.cast())
-                    .unwrap_or_else(|| {
-                        crate::postgres::deparse::node_to_string_without_context(clause.cast())
-                    });
-                format!("Failed to lower absorbed search clause: {}", formatted)
-            })
+            let clause = null_out_pruned_vars(root, clause.cast(), input);
+            transform_to_search_expr(root, clause, &sub_sources, multi_table_predicate_clauses)
+                .ok_or_else(|| {
+                    let formatted =
+                        crate::postgres::deparse::deparse_planner_expr(root, clause.cast())
+                            .unwrap_or_else(|| {
+                                crate::postgres::deparse::node_to_string_without_context(
+                                    clause.cast(),
+                                )
+                            });
+                    format!("Failed to lower absorbed search clause: {}", formatted)
+                })
         })
         .collect::<Result<_, _>>()?;
 
@@ -689,6 +685,65 @@ unsafe fn build_absorbed_filter(
         1 => Ok(expr_trees.into_iter().next().unwrap()),
         _ => Ok(JoinLevelExpr::And(expr_trees)),
     }
+}
+
+/// Replaces every `Var` of a relation that `plan` prunes (the inner side of a
+/// Semi/Anti/Mark join) with a typed NULL constant and folds the result.
+///
+/// Postgres projects the inner side of an Anti join null-extended, so a clause
+/// evaluated above the join sees NULL in those columns. Rewriting the clause
+/// keeps that value without asking the pruned scan for a column, or a match
+/// tag, that never reaches the join output. The strict `@@@` operator then
+/// folds to NULL on its own, and an `OR` around it keeps its three-valued
+/// result. Returns `clause` as is when it names no pruned relation.
+unsafe fn null_out_pruned_vars(
+    root: *mut pg_sys::PlannerInfo,
+    clause: *mut pg_sys::Node,
+    plan: &RelNode,
+) -> *mut pg_sys::Node {
+    let pruned_rtis: Vec<pg_sys::Index> = expr_collect_vars(clause, false)
+        .into_iter()
+        .map(|v| v.rti)
+        .filter(|&rti| plan.contains_rti(rti) && !plan.contains_output_rti(rti))
+        .collect();
+    if pruned_rtis.is_empty() {
+        return clause;
+    }
+
+    #[pg_guard]
+    unsafe extern "C-unwind" fn pruned_var_mutator(
+        node: *mut pg_sys::Node,
+        context: *mut core::ffi::c_void,
+    ) -> *mut pg_sys::Node {
+        if node.is_null() {
+            return std::ptr::null_mut();
+        }
+        if (*node).type_ == pg_sys::NodeTag::T_Var {
+            let var = node.cast::<pg_sys::Var>();
+            let pruned_rtis = &*(context as *const Vec<pg_sys::Index>);
+            if pruned_rtis.contains(&((*var).varno as pg_sys::Index)) {
+                return pg_sys::makeNullConst((*var).vartype, (*var).vartypmod, (*var).varcollid)
+                    .cast();
+            }
+        }
+
+        #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
+        {
+            let fnptr = pruned_var_mutator as *const ();
+            let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
+                std::mem::transmute(fnptr);
+            pg_sys::expression_tree_mutator(node, Some(mutator), context)
+        }
+
+        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+        {
+            pg_sys::expression_tree_mutator_impl(node, Some(pruned_var_mutator), context)
+        }
+    }
+
+    let context = std::ptr::addr_of!(pruned_rtis) as *mut core::ffi::c_void;
+    let rewritten = pruned_var_mutator(clause, context);
+    pg_sys::eval_const_expressions(root, rewritten)
 }
 
 /// Check if all Var references in an expression are fast fields.

--- a/pg_search/tests/pg_regress/expected/joinscan_anti_join_pruned_side.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_anti_join_pruned_side.out
@@ -1,0 +1,331 @@
+-- A `LEFT JOIN` whose `ON` clause is strict in a column that `WHERE` tests with
+-- `IS NULL` becomes an Anti join, and the inner side leaves the join output.
+-- Postgres still evaluates a `WHERE` clause that names that side above the join,
+-- where its columns are null-extended. The JoinScan must see the same NULL there
+-- instead of asking the pruned scan for a column or a match tag.
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS categories CASCADE;
+CREATE TABLE users      (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE products   (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE orders     (id SERIAL8 PRIMARY KEY, age INTEGER, note TEXT);
+CREATE TABLE categories (id SERIAL8 PRIMARY KEY, label TEXT);
+CREATE INDEX idxusers ON users USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxorders ON orders USING bm25 (id, age, note)
+  WITH (key_field='id', text_fields='{"note":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxcategories ON categories USING bm25 (id, label)
+  WITH (key_field='id', text_fields='{"label":{"fast":true}}');
+-- `alice` has a NULL age, so `users.age >= products.age` never matches her and
+-- product 1 survives the Anti join. `bob` matches product 2, which drops it.
+INSERT INTO users (name, age)      VALUES ('alice', NULL), ('bob', 5), ('carol', 1);
+INSERT INTO products (name, age)   VALUES ('alice', 3), ('bob', 4), ('carol', 9), ('dave', 2);
+INSERT INTO orders (age, note)     VALUES (7, 'urgent'), (8, 'later'), (10, 'urgent later'), (1, 'later');
+INSERT INTO categories (label)     VALUES ('food'), ('toys'), ('books'), ('games');
+SET paradedb.enable_join_custom_scan TO on;
+-- The reported shape: two `FULL JOIN`s that the planner reduces to an Anti join
+-- under an inner join.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM users
+FULL JOIN products ON users.name = products.name AND users.age >= products.age
+FULL JOIN orders ON products.id = orders.id
+WHERE ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND users.age IS NULL
+  AND products.age <= orders.age
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                                       QUERY PLAN                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: orders INNER (products ANTI users)
+               Join Cond: products.id = orders.id, users.name = products.name
+               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, id@4]
+                 :           FilterExec: __orders_0_tag_0@3 OR NULL, projection=[ctid_0@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}}
+                 :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(name@0, name@3)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=users, segments=1, visibility=eager, query="all"
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+(26 rows)
+
+SELECT users.id, products.id, orders.id
+FROM users
+FULL JOIN products ON users.name = products.name AND users.age >= products.age
+FULL JOIN orders ON products.id = orders.id
+WHERE ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND users.age IS NULL
+  AND products.age <= orders.age
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+    |  1 |  1
+    |  3 |  3
+(2 rows)
+
+-- The pruned arm is NULL, so the `OR` only keeps rows the other arm matches.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                                       QUERY PLAN                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: orders INNER (products ANTI users)
+               Join Cond: products.id = orders.id, users.name = products.name
+               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, id@4]
+                 :           FilterExec: __orders_0_tag_0@3 OR NULL, projection=[ctid_0@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}}
+                 :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(name@0, name@3)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=users, segments=1, visibility=eager, query="all"
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+(26 rows)
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+    |  3 |  3
+(1 row)
+
+-- `NOT (FALSE OR NULL)` is NULL, not TRUE: no row may come back.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND NOT ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: users INNER (orders INNER products)
+               Join Cond: products.name = users.name, products.id = orders.id
+               Join Filter: (users.age >= products.age) AND (products.age <= orders.age)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@4 as col_1, NULL as col_2, id@2 as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2]
+                 :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[users, orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, id@1)], filter=age@0 <= age@1, projection=[ctid_0@0, ctid_1@4, id@5, ctid_2@1, id@3]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(name@1, name@1)], filter=age@0 >= age@1, projection=[ctid_0@0, ctid_2@3, age@5, id@6]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=users, segments=1, query={"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"age"}}]}},{"with_index":{"query":{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"name"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"name","query_string":"alice","lenient":null,"conjunction_mode":null}}]}}}}}}]}}
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=orders, segments=1, dynamic_filters=2, query={"with_index":{"query":{"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"note"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}]}}}}}}
+(24 rows)
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND NOT ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+(0 rows)
+
+-- A plain comparison on the pruned side is NULL as well.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.age > 0))
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                                       QUERY PLAN                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: orders INNER (products ANTI users)
+               Join Cond: products.id = orders.id, users.name = products.name
+               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, id@4]
+                 :           FilterExec: __orders_0_tag_0@3 OR NULL, projection=[ctid_0@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}}
+                 :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(name@0, name@3)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=users, segments=1, visibility=eager, query="all"
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+(26 rows)
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.age > 0))
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+    |  3 |  3
+(1 row)
+
+-- The Anti join sits two levels down, under another inner join.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id, categories.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+JOIN categories ON categories.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND categories.label @@@ 'food OR books'
+ORDER BY 2, 3, 4
+LIMIT 10;
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id, categories.id
+   ->  Result
+         Output: users.id, products.id, orders.id, categories.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id, categories.id
+               Relation Tree: (categories INNER orders) INNER (products ANTI users)
+               Join Cond: products.id = orders.id, orders.id = categories.id, users.name = products.name
+               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@5 as col_1, NULL as col_2, id@3 as col_3, id@1 as col_4, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
+                 :   SortExec: TopK(fetch=10), expr=[id@5 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[categories, orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1, ctid_2]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@2, id@3, ctid_2@5, id@6]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], projection=[ctid_0@3, id@4, ctid_1@0, id@1, age@2]
+                 :             FilterExec: __orders_1_tag_0@3 OR NULL, projection=[ctid_1@0, id@1, age@2]
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=orders, segments=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}}
+                 :             CooperativeExec
+                 :               PgSearchScan: table=categories, segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"label","query_string":"food OR books","lenient":null,"conjunction_mode":null}}}}
+                 :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(name@0, name@3)], filter=age@1 >= age@0, projection=[ctid_2@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=users, segments=1, visibility=eager, query="all"
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+(29 rows)
+
+SELECT users.id, products.id, orders.id, categories.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+JOIN categories ON categories.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND categories.label @@@ 'food OR books'
+ORDER BY 2, 3, 4
+LIMIT 10;
+ id | id | id | id 
+----+----+----+----
+    |  1 |  1 |  1
+    |  3 |  3 |  3
+(2 rows)
+
+DROP TABLE categories CASCADE;
+DROP TABLE orders CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE users CASCADE;
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_columnar_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/joinscan_anti_join_pruned_side.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_anti_join_pruned_side.sql
@@ -1,0 +1,157 @@
+-- A `LEFT JOIN` whose `ON` clause is strict in a column that `WHERE` tests with
+-- `IS NULL` becomes an Anti join, and the inner side leaves the join output.
+-- Postgres still evaluates a `WHERE` clause that names that side above the join,
+-- where its columns are null-extended. The JoinScan must see the same NULL there
+-- instead of asking the pruned scan for a column or a match tag.
+
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS categories CASCADE;
+
+CREATE TABLE users      (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE products   (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE orders     (id SERIAL8 PRIMARY KEY, age INTEGER, note TEXT);
+CREATE TABLE categories (id SERIAL8 PRIMARY KEY, label TEXT);
+
+CREATE INDEX idxusers ON users USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxorders ON orders USING bm25 (id, age, note)
+  WITH (key_field='id', text_fields='{"note":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxcategories ON categories USING bm25 (id, label)
+  WITH (key_field='id', text_fields='{"label":{"fast":true}}');
+
+-- `alice` has a NULL age, so `users.age >= products.age` never matches her and
+-- product 1 survives the Anti join. `bob` matches product 2, which drops it.
+INSERT INTO users (name, age)      VALUES ('alice', NULL), ('bob', 5), ('carol', 1);
+INSERT INTO products (name, age)   VALUES ('alice', 3), ('bob', 4), ('carol', 9), ('dave', 2);
+INSERT INTO orders (age, note)     VALUES (7, 'urgent'), (8, 'later'), (10, 'urgent later'), (1, 'later');
+INSERT INTO categories (label)     VALUES ('food'), ('toys'), ('books'), ('games');
+
+SET paradedb.enable_join_custom_scan TO on;
+
+-- The reported shape: two `FULL JOIN`s that the planner reduces to an Anti join
+-- under an inner join.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM users
+FULL JOIN products ON users.name = products.name AND users.age >= products.age
+FULL JOIN orders ON products.id = orders.id
+WHERE ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND users.age IS NULL
+  AND products.age <= orders.age
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM users
+FULL JOIN products ON users.name = products.name AND users.age >= products.age
+FULL JOIN orders ON products.id = orders.id
+WHERE ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND users.age IS NULL
+  AND products.age <= orders.age
+ORDER BY 2, 3
+LIMIT 10;
+
+-- The pruned arm is NULL, so the `OR` only keeps rows the other arm matches.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+
+-- `NOT (FALSE OR NULL)` is NULL, not TRUE: no row may come back.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND NOT ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND NOT ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+
+-- A plain comparison on the pruned side is NULL as well.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.age > 0))
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'later') OR (users.age > 0))
+ORDER BY 2, 3
+LIMIT 10;
+
+-- The Anti join sits two levels down, under another inner join.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id, categories.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+JOIN categories ON categories.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND categories.label @@@ 'food OR books'
+ORDER BY 2, 3, 4
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id, categories.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+JOIN categories ON categories.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+  AND categories.label @@@ 'food OR books'
+ORDER BY 2, 3, 4
+LIMIT 10;
+
+DROP TABLE categories CASCADE;
+DROP TABLE orders CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE users CASCADE;
+
+\i common/common_cleanup.sql


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #6309

## What

This PR fixes a `JoinScan` planner crash on a join-level predicate that names the pruned side of an Anti join.

Postgres turns `products LEFT JOIN users ON ... AND users.age >= products.age WHERE users.age IS NULL` into an Anti join, because the `ON` term is strict in `users.age`. The `users` columns leave the join output, but a `WHERE` clause such as `orders.note @@@ 'urgent' OR users.name @@@ 'alice'` is still evaluated above the join, where Postgres sees `users.name` as NULL. The `JoinScan` kept the `users` arm as a match tag on the `users` scan, and DataFusion failed with `FieldNotFound` for `__users_2_tag_0`.

## Why

Every column of an Anti join's inner side is NULL above the join, so a predicate on such a column has a fixed value. The query should neither crash nor lose the `JoinScan` because of it.

## How

Before a join-level clause is classified, `null_out_pruned_vars` replaces each `Var` of a relation the plan prunes with a typed NULL constant and runs `eval_const_expressions` on the result. `@@@` is strict, so `NULL @@@ q` folds to NULL and the `OR` keeps its three-valued result: `NOT (x OR NULL)` still drops every row. A bare constant now lowers to a `MultiTablePredicate`, and a boolean NULL constant translates to a typed NULL so DataFusion accepts it in a filter. The rewrite runs on the top-level restrict list, on the parse-tree fallback, and on absorbed sub-join clauses.

## Tests

`joinscan_anti_join_pruned_side` covers it.