### PR TITLE
fix: evaluated an anti join's pushed-down WHERE clauses after the join.

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -874,19 +874,24 @@ unsafe fn collect_join_sources_join_rel(
             parsed_jointype,
             build::JoinType::Left | build::JoinType::Right | build::JoinType::Full
         );
+        let is_anti = matches!(
+            parsed_jointype,
+            build::JoinType::Anti { .. } | build::JoinType::RightAnti
+        );
 
         // Absorbed search clauses lower to `RelNode::Filter` sitting immediately
         // above the absorbing `JoinNode`. With predicate tagging (#6010), both sides
         // of Inner and Outer (Left/Right/Full) joins preserve their match-tag columns,
         // allowing DataFusion to evaluate the filter with 3-valued boolean logic.
-        // However, for outer joins (Left/Right/Full), only WHERE-clause predicates
-        // (`is_pushed_down == true`) can be evaluated above the join: an outer join's
+        // However, for outer and anti joins, only WHERE-clause predicates
+        // (`is_pushed_down == true`) can be evaluated above the join: the join's
         // ON-clause predicate (`is_pushed_down == false`) dictates whether rows match
         // to produce join pairs, and evaluating it post-join would incorrectly drop
-        // null-extended rows.
-        // Pruned-side joins (Semi/Anti/Mark, both directions) would leave Vars/tags
-        // unresolved against the pruned schema; UniqueOuter/UniqueInner aren't
-        // lowerable to DataFusion at all.
+        // null-extended rows. Above an anti join the pruned side is null-extended,
+        // and lowering the filter folds its columns to NULL, so a WHERE clause that
+        // names that side still gets the value Postgres would give it.
+        // Semi/Mark joins would leave Vars/tags unresolved against the pruned
+        // schema; UniqueOuter/UniqueInner aren't lowerable to DataFusion at all.
         if !absorbed_search_clauses.is_empty() {
             if !matches!(
                 parsed_jointype,
@@ -894,10 +899,12 @@ unsafe fn collect_join_sources_join_rel(
                     | build::JoinType::Left
                     | build::JoinType::Right
                     | build::JoinType::Full
+                    | build::JoinType::Anti { .. }
+                    | build::JoinType::RightAnti
             ) {
                 return None;
             }
-            if is_outer
+            if (is_outer || is_anti)
                 && absorbed_search_clauses
                     .iter()
                     .any(|&ri| !(*ri).is_pushed_down)

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -831,6 +831,15 @@ pub unsafe fn resolve_join_conditions(
     let is_semi_or_anti = is_semi_or_anti || jointype == pg_sys::JoinType::JOIN_RIGHT_ANTI;
     #[cfg(feature = "pg18")]
     let is_semi_or_anti = is_semi_or_anti || jointype == pg_sys::JoinType::JOIN_RIGHT_SEMI;
+    let is_anti = jointype == pg_sys::JoinType::JOIN_ANTI;
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    let is_anti = is_anti || jointype == pg_sys::JoinType::JOIN_RIGHT_ANTI;
+    // Only the ON clauses of an outer or anti join decide which pairs match. A
+    // pushed-down clause there is a WHERE clause that Postgres evaluates on the
+    // join's output rows, null-extended side included, so it has to stay
+    // post-join. A semi join's own conditions are pushed-down too, so it is
+    // left out of this rule.
+    let pushed_down_stays_post_join = is_outer || is_anti;
 
     let search_op = anyelement_query_input_opoid();
     let mut absorbed_clauses: Vec<*mut pg_sys::Node> = Vec::new();
@@ -844,9 +853,7 @@ pub unsafe fn resolve_join_conditions(
             unabsorbed.push(ri);
             continue;
         }
-        // For outer joins, only absorb ON-clause conditions (is_pushed_down == false);
-        // WHERE-clause conditions (is_pushed_down == true) stay as post-join filters.
-        if is_outer && (*ri).is_pushed_down {
+        if pushed_down_stays_post_join && (*ri).is_pushed_down {
             unabsorbed.push(ri);
             continue;
         }
@@ -887,20 +894,24 @@ pub unsafe fn resolve_join_conditions(
     };
 
     // Identify unabsorbed conditions that cannot be evaluated post-join:
-    // - Outer joins: ON conditions (is_pushed_down == false) must be evaluated during the join.
-    // - Semi / Anti joins: inner columns are not projected post-join, so all conditions must be evaluated during the join.
+    // - Outer / Anti joins: ON conditions (is_pushed_down == false) must be evaluated during the join.
+    // - Semi joins: inner columns are not projected post-join, so all conditions must be evaluated during the join.
     // - Keyless joins: when equi_keys is empty, at least one condition must be absorbed as a join filter.
-    let (illegal_residuals, context) = if is_outer {
+    let (illegal_residuals, context) = if pushed_down_stays_post_join {
         (
             unabsorbed
                 .iter()
                 .copied()
                 .filter(|&ri| !(*ri).is_pushed_down)
                 .collect::<Vec<_>>(),
-            "outer join ON clauses",
+            if is_outer {
+                "outer join ON clauses"
+            } else {
+                "anti join ON clauses"
+            },
         )
     } else if is_semi_or_anti {
-        (unabsorbed.clone(), "semi/anti join conditions")
+        (unabsorbed.clone(), "semi join conditions")
     } else if equi_keys.is_empty() && !other_conditions.is_empty() && filter.is_none() {
         (unabsorbed.clone(), "join conditions")
     } else {

--- a/pg_search/tests/pg_regress/expected/joinscan_anti_join_pruned_side.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_anti_join_pruned_side.out
@@ -44,34 +44,34 @@ WHERE ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
   AND products.age <= orders.age
 ORDER BY 2, 3
 LIMIT 10;
-                                                                                                                       QUERY PLAN                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: users.id, products.id, orders.id
    ->  Result
          Output: users.id, products.id, orders.id
          ->  Custom Scan (ParadeDB Join Scan)
                Output: products.id, users.id, orders.id
-               Relation Tree: orders INNER (products ANTI users)
-               Join Cond: products.id = orders.id, users.name = products.name
-               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Relation Tree: (products INNER orders) ANTI users
+               Join Cond: users.name = products.name, products.id = orders.id
+               Join Filter: (users.age >= products.age) AND (products.age <= orders.age)
                Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
                Limit: 10
                Order By: products.id asc
                DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[orders, products]
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, id@3 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[products, orders]
                  :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, id@4]
-                 :           FilterExec: __orders_0_tag_0@3 OR NULL, projection=[ctid_0@0, id@1, age@2]
+                 :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, name@0)], filter=age@1 >= age@0, projection=[ctid_0@0, id@3, ctid_1@4, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@3)], filter=age@0 <= age@1, projection=[ctid_0@3, name@4, age@5, id@6, ctid_1@0, id@1]
+                 :             FilterExec: __orders_1_tag_0@3 OR NULL, projection=[ctid_1@0, id@1, age@2]
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=orders, segments=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}}
                  :             CooperativeExec
-                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}}
-                 :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(name@0, name@3)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1, age@2]
-                 :             CooperativeExec
-                 :               PgSearchScan: table=users, segments=1, visibility=eager, query="all"
-                 :             CooperativeExec
-                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=2, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (26 rows)
 
 SELECT users.id, products.id, orders.id
@@ -100,34 +100,34 @@ WHERE users.age IS NULL
   AND ((orders.note @@@ 'later') OR (users.name @@@ 'alice'))
 ORDER BY 2, 3
 LIMIT 10;
-                                                                                                                       QUERY PLAN                                                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: users.id, products.id, orders.id
    ->  Result
          Output: users.id, products.id, orders.id
          ->  Custom Scan (ParadeDB Join Scan)
                Output: products.id, users.id, orders.id
-               Relation Tree: orders INNER (products ANTI users)
-               Join Cond: products.id = orders.id, users.name = products.name
-               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Relation Tree: (products INNER orders) ANTI users
+               Join Cond: users.name = products.name, products.id = orders.id
+               Join Filter: (users.age >= products.age) AND (products.age <= orders.age)
                Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
                Limit: 10
                Order By: products.id asc
                DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[orders, products]
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, id@3 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[products, orders]
                  :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, id@4]
-                 :           FilterExec: __orders_0_tag_0@3 OR NULL, projection=[ctid_0@0, id@1, age@2]
+                 :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, name@0)], filter=age@1 >= age@0, projection=[ctid_0@0, id@3, ctid_1@4, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@3)], filter=age@0 <= age@1, projection=[ctid_0@3, name@4, age@5, id@6, ctid_1@0, id@1]
+                 :             FilterExec: __orders_1_tag_0@3 OR NULL, projection=[ctid_1@0, id@1, age@2]
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=orders, segments=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}}
                  :             CooperativeExec
-                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}}
-                 :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(name@0, name@3)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1, age@2]
-                 :             CooperativeExec
-                 :               PgSearchScan: table=users, segments=1, visibility=eager, query="all"
-                 :             CooperativeExec
-                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=2, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (26 rows)
 
 SELECT users.id, products.id, orders.id
@@ -207,34 +207,34 @@ WHERE users.age IS NULL
   AND ((orders.note @@@ 'later') OR (users.age > 0))
 ORDER BY 2, 3
 LIMIT 10;
-                                                                                                                       QUERY PLAN                                                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: users.id, products.id, orders.id
    ->  Result
          Output: users.id, products.id, orders.id
          ->  Custom Scan (ParadeDB Join Scan)
                Output: products.id, users.id, orders.id
-               Relation Tree: orders INNER (products ANTI users)
-               Join Cond: products.id = orders.id, users.name = products.name
-               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Relation Tree: (products INNER orders) ANTI users
+               Join Cond: users.name = products.name, products.id = orders.id
+               Join Filter: (users.age >= products.age) AND (products.age <= orders.age)
                Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
                Limit: 10
                Order By: products.id asc
                DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[orders, products]
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, id@3 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[products, orders]
                  :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, id@4]
-                 :           FilterExec: __orders_0_tag_0@3 OR NULL, projection=[ctid_0@0, id@1, age@2]
+                 :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, name@0)], filter=age@1 >= age@0, projection=[ctid_0@0, id@3, ctid_1@4, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@3)], filter=age@0 <= age@1, projection=[ctid_0@3, name@4, age@5, id@6, ctid_1@0, id@1]
+                 :             FilterExec: __orders_1_tag_0@3 OR NULL, projection=[ctid_1@0, id@1, age@2]
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=orders, segments=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}}
                  :             CooperativeExec
-                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"later","lenient":null,"conjunction_mode":null}}}}}}
-                 :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(name@0, name@3)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1, age@2]
-                 :             CooperativeExec
-                 :               PgSearchScan: table=users, segments=1, visibility=eager, query="all"
-                 :             CooperativeExec
-                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=2, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
 (26 rows)
 
 SELECT users.id, products.id, orders.id

--- a/pg_search/tests/pg_regress/expected/joinscan_anti_join_pushed_down_qual.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_anti_join_pushed_down_qual.out
@@ -1,0 +1,317 @@
+-- A `WHERE` clause that Postgres delays to an Anti join level is not a join
+-- condition. Postgres evaluates it on the join's output rows, where the inner side
+-- is null-extended. Folding it into the anti condition changes which pairs match
+-- and lets rows through that Postgres drops.
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+CREATE TABLE users    (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE products (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE orders   (id SERIAL8 PRIMARY KEY, age INTEGER, note TEXT);
+CREATE INDEX idxusers ON users USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxorders ON orders USING bm25 (id, age, note)
+  WITH (key_field='id', text_fields='{"note":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+-- `bob` matches product 2 on the anti condition alone, so Postgres drops it.
+INSERT INTO users (name, age)    VALUES ('alice', NULL), ('bob', 5);
+INSERT INTO products (name, age) VALUES ('alice', 3), ('bob', 4);
+INSERT INTO orders (age, note)   VALUES (7, 'urgent'), (8, 'later');
+SET paradedb.enable_join_custom_scan TO on;
+-- The reported query. `COALESCE(users.age, 0) = 0` is TRUE on every output row.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, 0) = 0
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: (orders INNER products) ANTI users
+               Join Cond: users.name = products.name, products.id = orders.id
+               Join Filter: (users.age >= products.age) AND (products.age <= orders.age)
+               Join Predicate: heap:true
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@3, name@0)], filter=age@1 >= age@0, projection=[ctid_0@0, id@1, ctid_1@2, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@3)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, name@4, age@5, id@6]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent OR later","lenient":null,"conjunction_mode":null}}}}
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
+(25 rows)
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, 0) = 0
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+    |  1 |  1
+(1 row)
+
+-- The delayed clause names both sides. Above the join it reduces to a filter on
+-- `products.age`, which rejects product 1.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: (orders INNER products) ANTI users
+               Join Cond: users.name = products.name, products.id = orders.id
+               Join Filter: (users.age >= products.age) AND (products.age <= orders.age)
+               Join Predicate: heap:(COALESCE(products.age) > 3)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@3, name@0)], filter=age@1 >= age@0, projection=[ctid_0@0, id@1, ctid_1@2, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@3)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, name@4, age@5, id@6]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=orders, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent OR later","lenient":null,"conjunction_mode":null}}}}
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query={"boolean":{"must":["all",{"range":{"field":"age","lower_bound":{"excluded":3},"upper_bound":null}}]}}
+                 :           CooperativeExec
+                 :             PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
+(25 rows)
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+(0 rows)
+
+-- A search predicate in the delayed clause, with its other arm on the pruned side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: (products INNER orders) ANTI users
+               Join Cond: users.name = products.name, products.id = orders.id
+               Join Filter: (users.age >= products.age) AND (products.age <= orders.age)
+               Join Predicate: (orders:{"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}} OR heap:NULL::boolean)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, id@3 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[products, orders]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, name@0)], filter=age@1 >= age@0, projection=[ctid_0@0, id@3, ctid_1@4, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@3)], filter=age@0 <= age@1, projection=[ctid_0@3, name@4, age@5, id@6, ctid_1@0, id@1]
+                 :             FilterExec: __orders_1_tag_0@3 OR NULL, projection=[ctid_1@0, id@1, age@2]
+                 :               CooperativeExec
+                 :                 PgSearchScan: table=orders, segments=1, tag_0={"with_index":{"query":{"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent","lenient":null,"conjunction_mode":null}}}}}}
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=2, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
+(26 rows)
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+    |  1 |  1
+(1 row)
+
+-- The Anti join planned as a sub-join, so its delayed clause is absorbed during
+-- path reconstruction instead of at the top level. The clause rejects product 1,
+-- so a dropped clause would show up as an extra row.
+SET join_collapse_limit = 1;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM (products LEFT JOIN users ON users.name = products.name AND users.age >= products.age)
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: users.id, products.id, orders.id
+   ->  Result
+         Output: users.id, products.id, orders.id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: products.id, users.id, orders.id
+               Relation Tree: orders INNER (products ANTI users)
+               Join Cond: products.id = orders.id, users.name = products.name
+               Join Filter: (products.age <= orders.age) AND (users.age >= products.age)
+               Limit: 10
+               Order By: products.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[orders, products]
+                 :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)], filter=age@1 <= age@0, projection=[ctid_0@0, id@1, ctid_1@3, id@4]
+                 :           CooperativeExec
+                 :             PgSearchScan: table=orders, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent OR later","lenient":null,"conjunction_mode":null}}}}
+                 :           HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@3, name@0)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1, age@2]
+                 :             CooperativeExec
+                 :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query={"boolean":{"must":["all",{"range":{"field":"age","lower_bound":{"excluded":3},"upper_bound":null}}]}}
+                 :             CooperativeExec
+                 :               PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
+(24 rows)
+
+SELECT users.id, products.id, orders.id
+FROM (products LEFT JOIN users ON users.name = products.name AND users.age >= products.age)
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+ id | id | id 
+----+----+----
+(0 rows)
+
+RESET join_collapse_limit;
+-- A `NOT EXISTS` anti join keeps its own conditions in the join.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT products.id, orders.id
+FROM products
+JOIN orders ON products.id = orders.id
+WHERE orders.note @@@ 'urgent OR later'
+  AND NOT EXISTS (
+    SELECT 1 FROM users
+    WHERE users.name = products.name AND users.age >= products.age
+  )
+ORDER BY 1, 2
+LIMIT 10;
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: products.id, orders.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: products.id, orders.id
+         Relation Tree: orders INNER (products ANTI users)
+         Join Cond: products.id = orders.id, users.name = products.name
+         Join Filter: (users.age >= products.age)
+         Limit: 10
+         Order By: products.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[orders, products]
+           :       TantivyFetchExec: fetch=[ctid_0, ctid_1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
+           :           CooperativeExec
+           :             PgSearchScan: table=orders, segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"note","query_string":"urgent OR later","lenient":null,"conjunction_mode":null}}}}
+           :           HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@2, name@0)], filter=age@1 >= age@0, projection=[ctid_1@0, id@1]
+           :             CooperativeExec
+           :               PgSearchScan: table=products, segments=1, dynamic_filters=1, query="all"
+           :             CooperativeExec
+           :               PgSearchScan: table=users, segments=1, dynamic_filters=1, visibility=eager, query="all"
+(22 rows)
+
+SELECT products.id, orders.id
+FROM products
+JOIN orders ON products.id = orders.id
+WHERE orders.note @@@ 'urgent OR later'
+  AND NOT EXISTS (
+    SELECT 1 FROM users
+    WHERE users.name = products.name AND users.age >= products.age
+  )
+ORDER BY 1, 2
+LIMIT 10;
+ id | id 
+----+----
+  1 |  1
+(1 row)
+
+DROP TABLE orders CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE users CASCADE;
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_columnar_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/joinscan_anti_join_pushed_down_qual.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_anti_join_pushed_down_qual.sql
@@ -1,0 +1,157 @@
+-- A `WHERE` clause that Postgres delays to an Anti join level is not a join
+-- condition. Postgres evaluates it on the join's output rows, where the inner side
+-- is null-extended. Folding it into the anti condition changes which pairs match
+-- and lets rows through that Postgres drops.
+
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+
+CREATE TABLE users    (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE products (id SERIAL8 PRIMARY KEY, name TEXT, age INTEGER);
+CREATE TABLE orders   (id SERIAL8 PRIMARY KEY, age INTEGER, note TEXT);
+
+CREATE INDEX idxusers ON users USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age)
+  WITH (key_field='id', text_fields='{"name":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+CREATE INDEX idxorders ON orders USING bm25 (id, age, note)
+  WITH (key_field='id', text_fields='{"note":{"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+
+-- `bob` matches product 2 on the anti condition alone, so Postgres drops it.
+INSERT INTO users (name, age)    VALUES ('alice', NULL), ('bob', 5);
+INSERT INTO products (name, age) VALUES ('alice', 3), ('bob', 4);
+INSERT INTO orders (age, note)   VALUES (7, 'urgent'), (8, 'later');
+
+SET paradedb.enable_join_custom_scan TO on;
+
+-- The reported query. `COALESCE(users.age, 0) = 0` is TRUE on every output row.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, 0) = 0
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, 0) = 0
+ORDER BY 2, 3
+LIMIT 10;
+
+-- The delayed clause names both sides. Above the join it reduces to a filter on
+-- `products.age`, which rejects product 1.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+
+-- A search predicate in the delayed clause, with its other arm on the pruned side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM products
+LEFT JOIN users ON users.name = products.name AND users.age >= products.age
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND ((orders.note @@@ 'urgent') OR (users.name @@@ 'alice'))
+ORDER BY 2, 3
+LIMIT 10;
+
+-- The Anti join planned as a sub-join, so its delayed clause is absorbed during
+-- path reconstruction instead of at the top level. The clause rejects product 1,
+-- so a dropped clause would show up as an extra row.
+SET join_collapse_limit = 1;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT users.id, products.id, orders.id
+FROM (products LEFT JOIN users ON users.name = products.name AND users.age >= products.age)
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+
+SELECT users.id, products.id, orders.id
+FROM (products LEFT JOIN users ON users.name = products.name AND users.age >= products.age)
+JOIN orders ON products.id = orders.id
+WHERE users.age IS NULL
+  AND products.age <= orders.age
+  AND orders.note @@@ 'urgent OR later'
+  AND COALESCE(users.age, products.age) > 3
+ORDER BY 2, 3
+LIMIT 10;
+
+RESET join_collapse_limit;
+
+-- A `NOT EXISTS` anti join keeps its own conditions in the join.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT products.id, orders.id
+FROM products
+JOIN orders ON products.id = orders.id
+WHERE orders.note @@@ 'urgent OR later'
+  AND NOT EXISTS (
+    SELECT 1 FROM users
+    WHERE users.name = products.name AND users.age >= products.age
+  )
+ORDER BY 1, 2
+LIMIT 10;
+
+SELECT products.id, orders.id
+FROM products
+JOIN orders ON products.id = orders.id
+WHERE orders.note @@@ 'urgent OR later'
+  AND NOT EXISTS (
+    SELECT 1 FROM users
+    WHERE users.name = products.name AND users.age >= products.age
+  )
+ORDER BY 1, 2
+LIMIT 10;
+
+DROP TABLE orders CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE users CASCADE;
+
+\i common/common_cleanup.sql


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #6311

## What

This PR moves a `WHERE` clause that Postgres delays to an Anti join level out of the `JoinScan`'s anti condition and evaluates it on the join's output rows.

## Why

Postgres turns `products LEFT JOIN users ON ... AND users.age >= products.age WHERE users.age IS NULL` into an Anti join. A second non-strict clause on `users`, such as `COALESCE(users.age, 0) = 0`, can't go below the join, so Postgres keeps it at the join level as a pushed-down qual and evaluates it after the anti join, with the `users` columns null-extended. The `JoinScan` absorbed every clause of a Semi/Anti join into the join filter, so `bob`'s pair failed the extra term, product 2 counted as unmatched, and the query returned a row Postgres drops.

## How

`resolve_join_conditions` now treats an Anti join like an outer join: only its ON clauses (`is_pushed_down == false`) go into `JoinNode.filter`, and pushed-down clauses stay post-join. Above the join the pruned side folds to NULL (from #6310), so `COALESCE(NULL, 0) = 0` becomes `TRUE` and `COALESCE(users.age, products.age) > 3` becomes a filter on `products.age`. Sub-join reconstruction accepts pushed-down clauses on an Anti join for the same reason. Semi joins keep the old rule, because their own conditions are pushed-down quals too.

Stacked on #6310.

## Tests

`joinscan_anti_join_pushed_down_qual` and `joinscan_anti_join_pruned_side`.